### PR TITLE
198 bug permite a un usuario que envió un examen volverlo a visualizar al volver a la página anterior pudiendo volver a responderlo

### DIFF
--- a/app/[locale]/dashboard/student/courses/[courseId]/exams/[examId]/page.tsx
+++ b/app/[locale]/dashboard/student/courses/[courseId]/exams/[examId]/page.tsx
@@ -107,6 +107,7 @@ export default async function StudentExamCoursePage ({
                     singleSelectQuestions={singleSelectQuestions}
                     examId={parseFloat(params.examId)}
                     courseId={parseFloat(params.courseId)}
+                    userId={userData.data?.user?.id }
                 />
             </div>
         </>

--- a/components/dashboards/student/course/exams/AIReview.tsx
+++ b/components/dashboards/student/course/exams/AIReview.tsx
@@ -59,7 +59,9 @@ const AIReview = ({ aiData, aiLoading }) => {
                     </div>
                 ))}
             </CardContent>
-            <CardFooter>
+            <CardFooter
+                className='flex flex-col items-start gap-4 border-t pt-4'
+            >
                 <h3 className="font-semibold text-lg mb-2">
                     {t('overallFeedback')}
                 </h3>


### PR DESCRIPTION
This pull request includes several changes to enhance the functionality and user experience of the student exam dashboard. The most significant updates involve adding user identification to the `StudentExamCoursePage` and `ExamSubmissionForm` components, and implementing a check to redirect users who have already submitted an exam.

### Enhancements to user identification and exam submission handling:

* `app/[locale]/dashboard/student/courses/[courseId]/exams/[examId]/page.tsx`: Added `userId` prop to pass user information to the `StudentExamCoursePage` component. ([app/[locale]/dashboard/student/courses/[courseId]/exams/[examId]/page.tsxR110](diffhunk://#diff-86031cda7da66bb8a7ef8446d9ed8e83bb98e3baebe82543c33c4b9e5d1919a7R110))
* `components/dashboards/student/ExamSubmissionForm.tsx`: 
  * Added `userId` prop to the `ExamsSubmissionForm` component and its props interface. [[1]](diffhunk://#diff-40167f32771faeca9590ad79ba5edd5afc3a83c9bdad2172202d1e743e255f2cR42) [[2]](diffhunk://#diff-40167f32771faeca9590ad79ba5edd5afc3a83c9bdad2172202d1e743e255f2cR51)
  * Implemented a `useEffect` hook to check if the user has already submitted the exam and redirect them to the review page if they have.
  * Imported `createClient` from `@/utils/supabase/client` to facilitate the exam submission check.

### Other improvements:

* [`components/dashboards/student/ExamSubmissionForm.tsx`](diffhunk://#diff-40167f32771faeca9590ad79ba5edd5afc3a83c9bdad2172202d1e743e255f2cL5-R5): Added `useEffect` to manage side effects and imported it at the top of the file.
* [`components/dashboards/student/course/exams/AIReview.tsx`](diffhunk://#diff-fc4ad82a1e1ffa6bd5eee1c7a94bf11dcf4e27e2c5238a15db5f474acc8be205L62-R64): Updated `CardFooter` styling to improve layout and readability.