### PR TITLE
Refactor global CSS to update text color on dark theme

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -215,7 +215,7 @@ html.dark .prose {
     font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
     --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   
-    color: var(--foreground);
+    color: #e6edf3;
     --basePageBg: var(--background);
     background: var(--basePageBg);
 }


### PR DESCRIPTION
This pull request includes a small change to the `app/globals.css` file to update the text color for the dark theme.

* [`app/globals.css`](diffhunk://#diff-79e0914d9fee5ca4432bdb002a24d700d31b5577265f4de3f90d5c292b9f1392L218-R218): Changed the text color in the `html.dark .prose` class from `var(--foreground)` to `#e6edf3`.