### PR TITLE
Improved some responsive issues

### DIFF
--- a/actions/dashboard/courseActions.ts
+++ b/actions/dashboard/courseActions.ts
@@ -93,8 +93,6 @@ export async function enrollUserToCourseAction ({
         return createResponse('error', 'Error getting user subscription', null, userSubscription.error.message)
     }
 
-    console.log(userSubscription.data)
-
     const enrollmentData = await supabase.from('enrollments').insert([{
         course_id: courseId,
         subscription_id: userSubscription.data.subscription_id,
@@ -108,7 +106,7 @@ export async function enrollUserToCourseAction ({
     }
 
     revalidatePath('/dashboard/student/courses', 'layout')
-    return createResponse('success', 'User enrolled to course successfully', null, null)
+    return createResponse('success', 'userEnrolled', null, null)
 }
 
 export async function updateCourseAction(prevDate: any, data: FormData) {

--- a/app/[locale]/dashboard/student/courses/[courseId]/lessons/page.tsx
+++ b/app/[locale]/dashboard/student/courses/[courseId]/lessons/page.tsx
@@ -108,7 +108,6 @@ function LessonCard({
     courseId,
     lessonId,
     completedText,
-    notStartedText,
     img
 }: {
     number: number
@@ -136,7 +135,7 @@ function LessonCard({
                     className="transition-transform duration-300 hover:scale-105"
                 />
                 <div className="absolute top-2 left-2 bg-white dark:bg-gray-800 rounded-full px-2 py-1 text-sm font-semibold">
-                    {`Lesson ${number}`}
+                   <p>{`Lesson ${number}`}</p>
                 </div>
             </div>
             <div className="p-6">

--- a/app/locales/es/components.ts
+++ b/app/locales/es/components.ts
@@ -531,6 +531,9 @@ Si tienes dudas, intenta diciendo: "Could you give me a fake scenario to practic
         enrollPrompt: '¡Estás a solo un paso de acceder a este increíble curso! Inscríbete ahora para desbloquear todas las lecciones y comenzar tu viaje de aprendizaje.',
         aboutThisCourse: 'Sobre este curso:',
         enrollNow: 'Inscribirse Ahora',
+        enrolling: 'Inscribiendo...',
+        userEnrolled: 'Se ha inscrito con éxito',
+        errorEnrollingUser: 'Error al inscribir al usuario',
     },
     NoCourseOrSubAlert: {
         unlockLearningJourney: 'Desbloquea Tu Viaje de Aprendizaje',

--- a/components/dashboards/student/course/CourseDashboard.tsx
+++ b/components/dashboards/student/course/CourseDashboard.tsx
@@ -42,16 +42,8 @@ const CourseCard = ({
     ).length
 
     return (
-        <Card
-            className={`${
-                view === 'grid' ? 'h-full' : 'flex flex-row'
-            } overflow-hidden transition-all hover:shadow-lg`}
-        >
-            <div
-                className={`${
-                    view === 'grid' ? 'h-48' : 'w-48 h-full'
-                } relative`}
-            >
+        <Card className={`${view === 'grid' ? 'h-full' : 'flex flex-row'} overflow-hidden transition-all hover:shadow-lg h-full flex flex-col`}>
+            <div className={`${view === 'grid' ? 'h-48' : 'w-48 h-full'} relative`}>
                 <Image
                     src={course.course.thumbnail_url || '/placeholder.svg'}
                     alt={course.course.title}
@@ -59,7 +51,7 @@ const CourseCard = ({
                     objectFit="cover"
                 />
             </div>
-            <div className="flex flex-col flex-grow p-4">
+            <div className="flex flex-col flex-grow p-4 justify-between">
                 <CardHeader>
                     <CardTitle className="text-xl">
                         {course.course.title}
@@ -68,53 +60,56 @@ const CourseCard = ({
                         {course.course.description}
                     </CardDescription>
                 </CardHeader>
-                <CardContent>
-                    <div className="space-y-2">
-                        <div className="flex justify-between text-sm">
-                            <span>{t('lessons')}</span>
-                            <span>
-                                {completedLessons}/{totalLessons}
-                            </span>
+                <div className='flex flex-col'>
+
+                    <CardContent>
+                        <div className="space-y-2">
+                            <div className="flex justify-between text-sm">
+                                <span>{t('lessons')}</span>
+                                <span>
+                                    {completedLessons}/{totalLessons}
+                                </span>
+                            </div>
+                            <Progress
+                                value={(completedLessons / totalLessons) * 100}
+                            />
+                            <div className="flex justify-between text-sm">
+                                <span>{t('exams')}</span>
+                                <span>
+                                    {completedExams}/{totalExams}
+                                </span>
+                            </div>
+                            <Progress value={(completedExams / totalExams) * 100} />
+                            <div className="flex justify-between text-sm">
+                                <span>{t('exercises')}</span>
+                                <span>
+                                    {completedExercises}/{totalExercises}
+                                </span>
+                            </div>
+                            <Progress
+                                value={(completedExercises / totalExercises) * 100}
+                            />
                         </div>
-                        <Progress
-                            value={(completedLessons / totalLessons) * 100}
-                        />
-                        <div className="flex justify-between text-sm">
-                            <span>{t('exams')}</span>
-                            <span>
-                                {completedExams}/{totalExams}
-                            </span>
+                    </CardContent>
+                    <CardFooter className="flex justify-between flex-wrap items-center gap-4">
+                        <Button asChild variant="default">
+                            <Link
+                                href={`/dashboard/student/courses/${course.course.course_id}`}
+                            >
+                                {t('continueCourse')}{' '}
+                                <ChevronRight className="ml-2 h-4 w-4" />
+                            </Link>
+                        </Button>
+                        <div className="flex space-x-2">
+                            <Badge variant="secondary">
+                                {totalLessons} {t('lessons')}
+                            </Badge>
+                            <Badge variant="secondary">
+                                {totalExams} {t('exams')}
+                            </Badge>
                         </div>
-                        <Progress value={(completedExams / totalExams) * 100} />
-                        <div className="flex justify-between text-sm">
-                            <span>{t('exercises')}</span>
-                            <span>
-                                {completedExercises}/{totalExercises}
-                            </span>
-                        </div>
-                        <Progress
-                            value={(completedExercises / totalExercises) * 100}
-                        />
-                    </div>
-                </CardContent>
-                <CardFooter className="flex justify-between flex-wrap md:flex-nowrap items-center gap-4">
-                    <Button asChild variant="default">
-                        <Link
-                            href={`/dashboard/student/courses/${course.course.course_id}`}
-                        >
-                            {t('continueCourse')}{' '}
-                            <ChevronRight className="ml-2 h-4 w-4" />
-                        </Link>
-                    </Button>
-                    <div className="flex space-x-2">
-                        <Badge variant="secondary">
-                            {totalLessons} {t('lessons')}
-                        </Badge>
-                        <Badge variant="secondary">
-                            {totalExams} {t('exams')}
-                        </Badge>
-                    </div>
-                </CardFooter>
+                    </CardFooter>
+                </div>
             </div>
         </Card>
     )
@@ -136,12 +131,9 @@ const CourseDashboard: React.FC<{ userCourses: any[] }> = ({ userCourses }) => {
     )
 
     return (
-        <div
-            className='md:container'
-        >
+        <div className='md:container'>
             <h1 className="text-3xl font-bold mb-8">{t('yourCourses')}</h1>
-
-            <div className="flex justify-between items-center mb-6">
+            <div className="flex justify-between items-center mb-6 space-x-2">
                 <div className="relative w-full max-w-sm">
                     <Input
                         type="text"
@@ -182,11 +174,10 @@ const CourseDashboard: React.FC<{ userCourses: any[] }> = ({ userCourses }) => {
                 </TabsList>
                 <TabsContent value="inProgress">
                     <div
-                        className={`grid gap-6 ${
-                            view === 'grid'
-                                ? 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3'
-                                : 'grid-cols-1'
-                        }`}
+                        className={`grid gap-6 ${view === 'grid'
+                            ? 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3'
+                            : 'grid-cols-1'
+                            }`}
                     >
                         {filteredCourses
                             .filter((course) => {
@@ -217,11 +208,10 @@ const CourseDashboard: React.FC<{ userCourses: any[] }> = ({ userCourses }) => {
                 </TabsContent>
                 <TabsContent value="completed">
                     <div
-                        className={`grid gap-6 ${
-                            view === 'grid'
-                                ? 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3'
-                                : 'grid-cols-1'
-                        }`}
+                        className={`grid gap-6 ${view === 'grid'
+                            ? 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3'
+                            : 'grid-cols-1'
+                            }`}
                     >
                         {filteredCourses
                             .filter((course) => {
@@ -249,11 +239,10 @@ const CourseDashboard: React.FC<{ userCourses: any[] }> = ({ userCourses }) => {
                 </TabsContent>
                 <TabsContent value="all">
                     <div
-                        className={`grid gap-6 ${
-                            view === 'grid'
-                                ? 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3'
-                                : 'grid-cols-1'
-                        }`}
+                        className={`grid gap-6 ${view === 'grid'
+                            ? 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3'
+                            : 'grid-cols-1'
+                            }`}
                     >
                         {filteredCourses.map((course) => (
                             <CourseCard

--- a/components/dashboards/student/course/EnrollButton.tsx
+++ b/components/dashboards/student/course/EnrollButton.tsx
@@ -5,10 +5,13 @@ import { useState } from 'react'
 import { enrollUserToCourseAction } from '@/actions/dashboard/courseActions'
 import { Button } from '@/components/ui/button'
 import { useToast } from '@/components/ui/use-toast'
+import { useScopedI18n } from '@/app/locales/client'
 
 export default function EnrollButton ({ courseId }: { courseId: number }) {
     const { toast } = useToast()
     const [loading, setLoading] = useState(false)
+
+    const t = useScopedI18n('NotEnrolledMessage')
 
     return (
         <Button
@@ -29,11 +32,11 @@ export default function EnrollButton ({ courseId }: { courseId: number }) {
                     }
 
                     toast({
-                        title: enrollUser.message
+                        title: t(enrollUser.message),
                     })
                 } catch (error) {
                     toast({
-                        title: 'Error enrolling user',
+                        title: t('errorEnrollingUser'),
                         description: error.message,
                         variant: 'destructive'
                     })
@@ -43,7 +46,7 @@ export default function EnrollButton ({ courseId }: { courseId: number }) {
             }
             }
         >
-            {loading ? 'Enrolling...' : 'Enroll Now'}
+            {loading ? t('enrolling') : t('enrollNow')}
         </Button>
     )
 }

--- a/components/dashboards/student/course/EnrollCard.tsx
+++ b/components/dashboards/student/course/EnrollCard.tsx
@@ -29,6 +29,7 @@ export default function NotEnrolledMessage({
     courseThumbnail,
 }: NotEnrolledMessageProps) {
     const t = useScopedI18n('NotEnrolledMessage')
+    
     return (
         <div className="container mx-auto px-4 py-8">
             <motion.div

--- a/components/dashboards/student/course/ItemCard.tsx
+++ b/components/dashboards/student/course/ItemCard.tsx
@@ -23,7 +23,6 @@ const ItemCard: React.FC<ItemCardProps> = ({
     title,
     description,
     status,
-    courseId,
     actionLink,
     actionLabel,
     Icon,
@@ -36,32 +35,36 @@ const ItemCard: React.FC<ItemCardProps> = ({
         animate={{ opacity: 1, y: 0 }}
         exit={{ opacity: 0, y: -20 }}
         transition={{ duration: 0.3 }}
+        className='h-full'
     >
-        <Card className="mb-4 hover:shadow-lg transition-shadow duration-300">
+        <Card className="mb-4 hover:shadow-lg transition-shadow duration-300 h-full flex flex-col justify-between">
             {image && (
                 <div className="relative h-48">
                     <Image src={image} alt={title} layout="fill" objectFit="cover" />
                 </div>
             )}
-            <CardHeader>
-                <CardTitle className="flex items-center justify-between">
+            <CardHeader className='px-6 pt-6 pb-4'>
+                <CardTitle className="flex items-center justify-between flex-wrap space-y-4">
                     <span>{title}</span>
-                    <StatusBadge status={status} t={(key) => key} /> {/* Adjust the translation function as needed */}
+                    <StatusBadge status={status} t={(key) => key} />
                 </CardTitle>
-                {headerDescription && <CardDescription>{headerDescription}</CardDescription>}
+                {headerDescription && <CardDescription className='pt-2'>{headerDescription}</CardDescription>}
             </CardHeader>
-            <CardContent>
-                <p className="text-sm text-gray-500 dark:text-gray-400 mb-2">{description}</p>
-                {additionalContent}
-            </CardContent>
-            <CardFooter>
-                <ActionButton
-                    status={status}
-                    href={actionLink}
-                    label={actionLabel}
-                    icon={Icon}
-                />
-            </CardFooter>
+            <div className='flex flex-col'>
+                <CardContent>
+                    <p className="text-sm text-gray-500 dark:text-gray-400 mb-2 line-clamp-4">{description}</p>
+                    {additionalContent}
+                </CardContent>
+                <CardFooter>
+                    <ActionButton
+                        status={status}
+                        href={actionLink}
+                        label={actionLabel}
+                        icon={Icon}
+                    />
+                </CardFooter>
+            </div>
+
         </Card>
     </motion.div>
 )

--- a/components/dashboards/student/course/StatusBadge.tsx
+++ b/components/dashboards/student/course/StatusBadge.tsx
@@ -47,7 +47,7 @@ const StatusBadge: React.FC<StatusBadgeProps> = ({ status }) => {
     return (
         <Badge variant={getVariant()}>
             {getIcon()}
-            {getText()}
+            <p>{getText()}</p>
         </Badge>
     )
 }


### PR DESCRIPTION
Set same height for lessons, also description will always show a max of 4 lines
Before:
![image](https://github.com/user-attachments/assets/857c0c27-e55f-42b7-a531-a0cd52415365)
After
![image](https://github.com/user-attachments/assets/098af6a2-7810-46fd-8dc7-63dd3cf50829)

Same for exams:
Before:
![image](https://github.com/user-attachments/assets/6f270a88-8c7d-45dd-aa1c-4edac7ea844c)
After:
![image](https://github.com/user-attachments/assets/5f23fd1e-2ab4-4a83-a71b-7ad8990b2f9d)

(Also I added flex-wrap on the badge)

On the courses dashboard, I added a flex-wrap on the bottom badges
![image](https://github.com/user-attachments/assets/4a791343-965e-4af5-a8bb-f0d5a13040b5)

These changes are a simple but unbreakable spell that works for both responsive desktop and mobile