### PR TITLE
fix(mcp-server): include source files in Docker build context

### DIFF
--- a/mcp-server/.dockerignore
+++ b/mcp-server/.dockerignore
@@ -1,12 +1,9 @@
-# Dependencies
+# Dependencies (installed fresh via npm ci)
 node_modules
 npm-debug.log
-package-lock.json
 
-# Source files (only ship built code)
-src
-*.ts
-tsconfig.json
+# Build output (rebuilt in builder stage)
+build
 
 # Environment files
 .env
@@ -20,7 +17,6 @@ __tests__
 *.spec.ts
 
 # Documentation
-*.md
 docs
 
 # Git
@@ -33,6 +29,6 @@ docs
 *.swp
 *.swo
 
-# Build artifacts
+# Misc
 *.log
 .DS_Store


### PR DESCRIPTION
The .dockerignore was excluding src/, *.ts, and tsconfig.json which are needed by the builder stage to compile TypeScript. Only exclude build output and dev files instead.