### PR TITLE
fix(mcp): use next.config rewrites for .well-known OAuth paths

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -5,6 +5,21 @@ const withNextIntl = createNextIntlPlugin('./i18n.ts');
 
 const nextConfig: NextConfig = {
   output: 'standalone',
+  async rewrites() {
+    return [
+      // RFC 9728: OAuth metadata at well-known paths for MCP
+      // Claude Desktop fetches /.well-known/oauth-protected-resource/api/mcp
+      // Rewrite to our catch-all proxy which serves tenant-aware metadata
+      {
+        source: '/.well-known/oauth-protected-resource/:path*',
+        destination: '/api/mcp/.well-known/oauth-protected-resource',
+      },
+      {
+        source: '/.well-known/oauth-authorization-server/:path*',
+        destination: '/api/mcp/.well-known/oauth-authorization-server',
+      },
+    ];
+  },
 };
 
 export default withNextIntl(nextConfig);

--- a/proxy.ts
+++ b/proxy.ts
@@ -80,22 +80,6 @@ export default async function proxy(request: NextRequest) {
     return NextResponse.next()
   }
 
-  // --- OAuth well-known metadata (RFC 9728 path-aware format) ---
-  // Claude Desktop looks for:
-  //   /.well-known/oauth-protected-resource/api/mcp
-  //   /.well-known/oauth-authorization-server/api/mcp
-  // Rewrite these to our catch-all proxy at /api/mcp/.well-known/*
-  if (pathname.startsWith('/.well-known/oauth-protected-resource/api/mcp') ||
-      pathname.startsWith('/.well-known/oauth-authorization-server/api/mcp')) {
-    // Extract which well-known type: oauth-protected-resource or oauth-authorization-server
-    const wellKnownType = pathname.startsWith('/.well-known/oauth-protected-resource')
-      ? 'oauth-protected-resource'
-      : 'oauth-authorization-server'
-    const rewriteUrl = request.nextUrl.clone()
-    rewriteUrl.pathname = `/api/mcp/.well-known/${wellKnownType}`
-    return NextResponse.rewrite(rewriteUrl)
-  }
-
   // --- Tenant Resolution (runs for ALL routes including /api) ---
   const host = request.headers.get('host') || ''
   const tenantSlug = getTenantSlugFromHost(host)


### PR DESCRIPTION
Middleware doesn't reliably match dotted paths like /.well-known/*. Move the RFC 9728 rewrite rules to next.config.ts rewrites, which run at the server level and handle dotted paths correctly.

Maps /.well-known/oauth-protected-resource/* and
/.well-known/oauth-authorization-server/* to the catch-all proxy.