### PR TITLE
fix(mcp): add dedicated API routes for RFC 9728 well-known metadata

### DIFF
--- a/app/api/well-known/oauth-authorization-server/route.ts
+++ b/app/api/well-known/oauth-authorization-server/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+/**
+ * RFC 9728 OAuth Authorization Server Metadata
+ * Rewritten from /.well-known/oauth-authorization-server/api/mcp
+ */
+export async function GET(request: NextRequest) {
+  const proto = request.headers.get('x-forwarded-proto') || 'https';
+  const host = request.headers.get('host') || 'localhost:3000';
+  const origin = `${proto}://${host}`;
+  const mcpBase = `${origin}/api/mcp`;
+
+  return NextResponse.json({
+    issuer: mcpBase,
+    authorization_endpoint: `${mcpBase}/auth/authorize`,
+    token_endpoint: `${mcpBase}/auth/token`,
+    registration_endpoint: `${mcpBase}/auth/register`,
+    response_types_supported: ['code'],
+    grant_types_supported: ['authorization_code', 'refresh_token'],
+    token_endpoint_auth_methods_supported: ['none', 'client_secret_post'],
+    code_challenge_methods_supported: ['S256'],
+    scopes_supported: ['mcp:tools'],
+    revocation_endpoint: `${mcpBase}/auth/revoke`,
+  }, {
+    headers: {
+      'cache-control': 'public, max-age=3600',
+      'access-control-allow-origin': '*',
+    },
+  });
+}

--- a/app/api/well-known/oauth-protected-resource/route.ts
+++ b/app/api/well-known/oauth-protected-resource/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+/**
+ * RFC 9728 OAuth Protected Resource Metadata
+ * Rewritten from /.well-known/oauth-protected-resource/api/mcp
+ */
+export async function GET(request: NextRequest) {
+  const proto = request.headers.get('x-forwarded-proto') || 'https';
+  const host = request.headers.get('host') || 'localhost:3000';
+  const origin = `${proto}://${host}`;
+  const mcpBase = `${origin}/api/mcp`;
+
+  return NextResponse.json({
+    resource: mcpBase,
+    authorization_servers: [mcpBase],
+    scopes_supported: ['mcp:tools'],
+    bearer_methods_supported: ['header'],
+    resource_name: 'LMS MCP Server',
+  }, {
+    headers: {
+      'cache-control': 'public, max-age=3600',
+      'access-control-allow-origin': '*',
+    },
+  });
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -6,19 +6,24 @@ const withNextIntl = createNextIntlPlugin('./i18n.ts');
 const nextConfig: NextConfig = {
   output: 'standalone',
   async rewrites() {
-    return [
-      // RFC 9728: OAuth metadata at well-known paths for MCP
-      // Claude Desktop fetches /.well-known/oauth-protected-resource/api/mcp
-      // Rewrite to our catch-all proxy which serves tenant-aware metadata
-      {
-        source: '/.well-known/oauth-protected-resource/:path*',
-        destination: '/api/mcp/.well-known/oauth-protected-resource',
-      },
-      {
-        source: '/.well-known/oauth-authorization-server/:path*',
-        destination: '/api/mcp/.well-known/oauth-authorization-server',
-      },
-    ];
+    return {
+      // beforeFiles rewrites run before filesystem routes AND middleware
+      beforeFiles: [
+        // RFC 9728: OAuth metadata at well-known paths for MCP
+        // Claude Desktop fetches /.well-known/oauth-protected-resource/api/mcp
+        // Rewrite to API route that serves tenant-aware metadata
+        {
+          source: '/.well-known/oauth-protected-resource/:path*',
+          destination: '/api/well-known/oauth-protected-resource',
+        },
+        {
+          source: '/.well-known/oauth-authorization-server/:path*',
+          destination: '/api/well-known/oauth-authorization-server',
+        },
+      ],
+      afterFiles: [],
+      fallback: [],
+    };
   },
 };
 


### PR DESCRIPTION
The intl middleware was intercepting rewritten /.well-known/* paths and adding locale prefixes. Fix by using beforeFiles rewrites that target dedicated /api/well-known/* routes, which bypass middleware.

- /api/well-known/oauth-protected-resource — resource metadata
- /api/well-known/oauth-authorization-server — auth server metadata
- Both construct tenant-aware URLs from the request Host header