### PR TITLE
fix(mcp): add urlencoded body parser for consent form callback

### DIFF
--- a/mcp-server/src/http-server-oauth.ts
+++ b/mcp-server/src/http-server-oauth.ts
@@ -112,8 +112,9 @@ app.use(
   })
 );
 
-// JSON body parsing (after auth router, which has its own parsing)
+// Body parsing (after auth router, which has its own parsing)
 app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
 
 // Bearer auth middleware for /mcp endpoint
 const bearerAuth = requireBearerAuth({


### PR DESCRIPTION
The consent form submits via HTML form (application/x-www-form-urlencoded) but only express.json() was registered. Add express.urlencoded() so the /auth/callback POST handler can parse form-encoded bodies.