### PR TITLE
docs(cron): correct stale trigger reference in expire-subscriptions (#313)

### DIFF
--- a/app/api/cron/expire-subscriptions/route.ts
+++ b/app/api/cron/expire-subscriptions/route.ts
@@ -12,8 +12,8 @@ function getSupabaseAdmin() {
  * Cron job: expire subscriptions whose billing period has ended.
  *
  * Run daily via Vercel Cron (configured in vercel.json).
- * The DB trigger `trigger_deactivate_enrollments_on_subscription_end`
- * automatically disables linked enrollments when status → 'expired'.
+ * The DB trigger `on_subscription_status_change` (handle_subscription_status_change)
+ * automatically revokes linked entitlements when status → 'expired' / 'canceled'.
  *
  * Secured by CRON_SECRET env var (set the same value in Vercel dashboard).
  */


### PR DESCRIPTION
## What

Corrects a stale doc comment in the expire-subscriptions cron route. Comment-only — **no behavior change**.

The JSDoc referenced a trigger `trigger_deactivate_enrollments_on_subscription_end` that "disables linked enrollments." That trigger does not exist. The actual trigger is `on_subscription_status_change` → `handle_subscription_status_change()`, and since the entitlements migration it **revokes entitlements** (not enrollments) when a subscription goes `expired` / `canceled`.

## Why now

Found while QA-testing the subscription lifecycle (#313). The cron logic itself is correct — verified locally:

- Renewed sub (period_end past, end_date future) → `{"expired":0}` (correctly skipped)
- Truly ended sub → `{"expired":1}`, status → `expired`, all 3 linked entitlements revoked (`status=expired`, `revoked_at` set)
- Status flipped back to `active` → entitlements re-activated. Seed restored pristine.

Full QA writeup in #313 (also flags an unrelated `handle_new_subscription` auto-enroll discrepancy for a separate decision).

Refs #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)
