### PR TITLE
fix(money): invoice 404 + past_due enum value (#315)

### DIFF
--- a/app/api/invoices/[invoiceNumber]/route.ts
+++ b/app/api/invoices/[invoiceNumber]/route.ts
@@ -23,11 +23,6 @@ export async function GET(
       .from('payment_requests')
       .select(`
         *,
-        user:profiles!payment_requests_user_id_fkey(
-          id,
-          full_name,
-          email
-        ),
         product:products(
           name,
           description,

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -224,8 +224,8 @@ export async function POST(req: NextRequest) {
           }
 
           // Cancel subscription if plan purchase.
-          // The DB trigger `trigger_deactivate_enrollments_on_subscription_end`
-          // automatically disables linked enrollments when status → 'canceled'.
+          // The DB trigger `on_subscription_status_change` automatically revokes
+          // linked entitlements when status → 'canceled'.
           if (transaction.plan_id) {
             await getSupabaseAdmin()
               .from('subscriptions')
@@ -282,7 +282,7 @@ export async function POST(req: NextRequest) {
 
     // Fired when Stripe permanently ends a subscription after failed payment retries
     // or explicit cancellation via Stripe dashboard/API.
-    // The DB trigger deactivates linked enrollments automatically.
+    // The DB trigger `on_subscription_status_change` revokes linked entitlements automatically.
     case 'customer.subscription.deleted': {
       const stripeSub = event.data.object as Stripe.Subscription
       const stripeSubId = stripeSub.id

--- a/supabase/migrations/20260530140000_add_past_due_subscription_status.sql
+++ b/supabase/migrations/20260530140000_add_past_due_subscription_status.sql
@@ -1,0 +1,15 @@
+-- Add 'past_due' to the subscription_status enum.
+--
+-- The Stripe Connect webhook (app/api/stripe/webhook/route.ts, invoice.payment_failed)
+-- updates subscriptions.subscription_status to 'past_due' so access continues during
+-- Stripe's dunning/retry window. But the enum only had
+-- (active, canceled, expired, renewed), so every such update failed with
+-- "invalid input value for enum subscription_status: 'past_due'". The error was
+-- swallowed (the update's error wasn't checked), so failed recurring payments were
+-- never reflected — the subscription stayed 'active'.
+--
+-- 'past_due' is intentionally NOT in the revoke set of handle_subscription_status_change()
+-- (which only revokes entitlements on 'canceled' / 'expired'), so marking a sub past_due
+-- keeps the student's access alive during retries, as intended.
+
+alter type subscription_status add value if not exists 'past_due';


### PR DESCRIPTION
Fixes two real defects found while QA-testing the money paths (#315).

## 1. Invoice download 404'd for every invoice ❌

`app/api/invoices/[invoiceNumber]/route.ts` embedded `user:profiles!payment_requests_user_id_fkey(id, full_name, email)` in its PostgREST select. **`profiles` has no `email` column**, so PostgREST rejected the whole query and the route returned `404 Invoice not found` for any invoice number. The `user` embed is unused — the invoice renders from `payment_requests.contact_*`. Dropped it.

Proven locally:
```
broken select → {"code":"42703","message":"column profiles_1.email does not exist"}
fixed  select → 200, row returned
```

## 2. Connect webhook could never mark a sub `past_due` ❌

`invoice.payment_failed` in the Connect webhook sets `subscription_status: 'past_due'` (behind an `as any`), but the `subscription_status` enum was `(active, canceled, expired, renewed)`. Every update failed:
```
ERROR: invalid input value for enum subscription_status: "past_due"
```
…and the error wasn't checked, so a failed recurring payment silently left the sub `active`. Migration `20260530140000` adds `past_due`. It's deliberately **not** in the entitlement-revoke trigger (`on_subscription_status_change` revokes only on `canceled`/`expired`), so access continues during Stripe's retry window — matching the handler's documented intent. (The platform webhook's `past_due` was already fine: `platform_subscriptions.status` is a plain varchar.)

## 3. Stale comments ⚠️

Corrected two webhook comments referencing a non-existent trigger `trigger_deactivate_enrollments_on_subscription_end` → it's `on_subscription_status_change`, and it revokes **entitlements**, not enrollments.

## Verification
PostgREST broken/fixed select; psql enum reject→accept across the migration; `tsc --noEmit` clean. Seed restored to pristine (temp invoice_number cleared, all sub mutations rolled back).

Closes #315

🤖 Generated with [Claude Code](https://claude.com/claude-code)
