### PR TITLE
fix(proxy): locale-less redirects no longer flash /join-school (#282, #287)

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -186,7 +186,31 @@ export default async function proxy(request: NextRequest) {
   // --- Path normalization ---
   const segments = pathname.split('/')
   const locale = segments[1]
-  const cleanPath = locales.includes(locale as any)
+  const hasValidLocale = locales.includes(locale as any)
+
+  // --- Guarantee a locale prefix before any auth / membership logic ---
+  // Server Actions and RSC navigations can reach the middleware on a locale-less
+  // URL — the codebase convention is `redirect('/dashboard/...')` (no locale).
+  // With localePrefix 'always', next-intl REWRITES those (not redirects) to keep
+  // the RSC payload intact, so they fall through to the guards below with
+  // `segments[1]` being a route segment (e.g. "dashboard"), not a locale. That made
+  // the membership guard run on a malformed path and build the join-school URL from
+  // a garbage locale — briefly bouncing valid members to /join-school (#282, #287).
+  // Force the canonical localized URL so every downstream check sees a well-formed
+  // path. /api, /.well-known and /monitoring already returned above, so this only
+  // touches real app routes.
+  if (!hasValidLocale) {
+    // Preserve the visitor's active locale (next-intl's NEXT_LOCALE cookie),
+    // falling back to the default — so a Spanish user isn't flipped to English
+    // after a locale-less server-action redirect.
+    const cookieLocale = request.cookies.get('NEXT_LOCALE')?.value
+    const targetLocale = locales.includes(cookieLocale as any) ? cookieLocale : defaultLocale
+    const localizedUrl = new URL(`/${targetLocale}${pathname}`, request.url)
+    localizedUrl.search = request.nextUrl.search
+    return NextResponse.redirect(localizedUrl)
+  }
+
+  const cleanPath = hasValidLocale
     ? `/${segments.slice(2).join('/')}`
     : pathname
   const normalizedPath = cleanPath === '' ? '/' : cleanPath


### PR DESCRIPTION
## Problem

Two QA reports (#282, #287) hit the same intermittent bug: after a teacher saved an exam-score override, they **briefly landed on `/join-school`** before re-navigating to the correct submissions list. Flagged as "pre-existing / not reproducible."

## Root cause (systemic, not per-page)

- Server actions across the app redirect with `redirect('/dashboard/...')` — **locale-less**, the established codebase convention (50+ call sites).
- With next-intl `localePrefix: 'always'`, a plain browser GET to a locale-less path is **redirected** to add the locale. But **RSC / server-action requests are REWRITTEN instead** (to keep the RSC payload intact).
- `proxy.ts` treats the rewrite case as "continue" and falls through to the tenant-membership guard with `segments[1]` = `"dashboard"` (a route segment), not a locale. The guard then:
  1. evaluates membership against a malformed path, and
  2. builds the bounce URL as `/${locale}/join-school` from that garbage locale.
- Net effect: a valid member momentarily bounced to `/join-school`.

## Fix

One central guard in `proxy.ts` — **before** any auth/membership logic, if the path has no valid locale prefix, 307-redirect to the canonical localized URL. The visitor's active locale is preserved via the `NEXT_LOCALE` cookie (default fallback), so a Spanish user isn't flipped to English. `/api`, `/.well-known`, `/monitoring` already return earlier, so this only touches real app routes.

This fixes every locale-less redirect in one place instead of editing 50+ call sites.

## Verification

```
# RSC request, locale-less protected path
HTTP/1.1 307 Temporary Redirect
location: /en/dashboard/teacher/courses/10006/exams/1/submissions

# RSC prefetch, locale-less        -> 307 /en/dashboard/teacher/.../submissions
# locale-less + NEXT_LOCALE=es      -> 307 /es/dashboard/teacher/.../submissions
# root /                            -> 307 /en   (unchanged)
```

No fall-through to the membership/join-school guard. `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)