### PR TITLE
feat(puck): 5 vertical landing-page template packs

### DIFF
--- a/components/admin/landing-page/template-picker.tsx
+++ b/components/admin/landing-page/template-picker.tsx
@@ -41,6 +41,10 @@ const CATEGORY_COLORS: Record<string, string> = {
   creative: 'bg-violet-500/10 text-violet-600 dark:text-violet-400 border-violet-500/20',
   business: 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border-emerald-500/20',
   'code-school': 'bg-sky-500/10 text-sky-600 dark:text-sky-400 border-sky-500/20',
+  'language-school': 'bg-teal-500/10 text-teal-600 dark:text-teal-400 border-teal-500/20',
+  fitness: 'bg-orange-500/10 text-orange-600 dark:text-orange-400 border-orange-500/20',
+  music: 'bg-fuchsia-500/10 text-fuchsia-600 dark:text-fuchsia-400 border-fuchsia-500/20',
+  design: 'bg-rose-500/10 text-rose-600 dark:text-rose-400 border-rose-500/20',
 }
 
 export function TemplatePicker({ open, onClose, templates, onSelect, loading }: Props) {

--- a/lib/puck/templates/_shared.ts
+++ b/lib/puck/templates/_shared.ts
@@ -1,0 +1,48 @@
+import type { Data } from '@measured/puck'
+import { sectionSpacingDefaults } from '../utils/section-spacing'
+
+export interface PuckTemplate {
+  name: string
+  description: string
+  category: string
+  puck_data: Data
+  sort_order: number
+  pageType: string
+}
+
+// LMS component types that use section spacing — these get the shared
+// spacing defaults injected so vertical templates render with consistent
+// vertical rhythm without repeating the spacing props on every block.
+const SPACED_COMPONENTS = new Set([
+  'FeaturesGrid', 'CourseGrid', 'TestimonialGrid', 'CtaBlock',
+  'PricingTable', 'FaqAccordion', 'StatsCounter', 'ContactForm',
+  'LogoCloud', 'Banner', 'TeamGrid', 'ImageGallery', 'SocialProof',
+])
+
+// Module-level counter for stable, unique build-time IDs. Real per-instance
+// IDs are regenerated when a template is applied (see deepCloneWithFreshIds).
+let idCounter = 0
+
+/** Build a Puck content node with an auto-generated id + spacing defaults. */
+export function c(type: string, props: Record<string, unknown>, id?: string) {
+  const spacing = SPACED_COMPONENTS.has(type) ? sectionSpacingDefaults : {}
+  return { type, props: { id: id || `${type}-tpl-${++idCounter}`, ...spacing, ...props } }
+}
+
+/** Deep-clone a template's puck_data and assign fresh random IDs to all components. */
+export function deepCloneWithFreshIds(data: Data): Data {
+  const cloned = JSON.parse(JSON.stringify(data)) as Data
+  for (const item of cloned.content) {
+    if (item.props?.id) {
+      item.props.id = `${item.type}-${Math.random().toString(36).slice(2, 10)}`
+    }
+  }
+  for (const zoneItems of Object.values(cloned.zones || {})) {
+    for (const item of zoneItems as Array<{ type: string; props: Record<string, unknown> }>) {
+      if (item.props?.id) {
+        item.props.id = `${item.type}-${Math.random().toString(36).slice(2, 10)}`
+      }
+    }
+  }
+  return cloned
+}

--- a/lib/puck/templates/business-coaching.ts
+++ b/lib/puck/templates/business-coaching.ts
@@ -1,0 +1,314 @@
+import { c, type PuckTemplate } from './_shared'
+
+// ─── Business / Marketing Coaching ───────────────────────────────────────────
+// Multi-page pack for solo creators, consultants, and coaching businesses
+// (marketing, entrepreneurship, freelancing). Pages: Home, About, FAQ, Contact.
+
+const LOGO = '🚀 Momentum'
+const FOOTER_COLUMNS = [
+  { title: 'Programs', links: [{ label: 'All Courses', href: '/courses' }, { label: 'Coaching', href: '#pricing' }, { label: 'Pricing', href: '/pricing' }] },
+  { title: 'Company', links: [{ label: 'About', href: '#about' }, { label: 'Results', href: '#results' }, { label: 'Contact', href: '#contact' }] },
+  { title: 'Legal', links: [{ label: 'Terms', href: '/terms' }, { label: 'Privacy', href: '/privacy' }] },
+]
+
+function header(navLinks: { label: string; href: string }[]) {
+  return c('Header', {
+    logo: '', logoText: LOGO, navLinks,
+    ctaLabel: 'Book a Free Call', ctaHref: '#contact',
+    showLogin: true, sticky: true, transparent: false,
+  })
+}
+
+function footer() {
+  return c('Footer', {
+    description: 'Practical coaching and courses to grow your business, land clients, and build a brand that sells.',
+    columns: FOOTER_COLUMNS,
+    socialLinks: [{ platform: 'LinkedIn', url: '#' }, { platform: 'YouTube', url: '#' }, { platform: 'Twitter', url: '#' }],
+    copyright: '© 2026 Momentum. All rights reserved.',
+  })
+}
+
+const homeTemplate: PuckTemplate = {
+  name: 'Business Coaching — Home',
+  description: 'High-conversion landing page for business, marketing, and entrepreneurship coaches.',
+  category: 'business',
+  sort_order: 50,
+  pageType: 'home',
+  puck_data: {
+    root: { props: {} },
+    content: [
+      header([
+        { label: 'Courses', href: '/courses' },
+        { label: 'Results', href: '#results' },
+        { label: 'Pricing', href: '#pricing' },
+        { label: 'About', href: '#about' },
+        { label: 'FAQ', href: '#faq' },
+      ]),
+      c('HeroBlock', {
+        title: 'Build the Business You Actually Want',
+        subtitle: 'Proven frameworks for getting clients, growing revenue, and reclaiming your time. Courses and 1-on-1 coaching for founders, freelancers, and creators.',
+        primaryCtaLabel: 'Book a Free Strategy Call',
+        primaryCtaHref: '#contact',
+        secondaryCtaLabel: 'See Programs',
+        secondaryCtaHref: '/courses',
+        backgroundImage: '', alignment: 'center', overlayOpacity: 60, minHeight: '520px',
+      }),
+      c('SocialProof', {
+        text: 'Trusted by 3,500+ founders and creators worldwide',
+        rating: 5,
+        reviewCount: 'Based on 900+ reviews',
+        avatarCount: 5,
+      }),
+      c('StatsCounter', {
+        items: [
+          { value: '3,500', label: 'Clients Coached', prefix: '', suffix: '+' },
+          { value: '40', label: 'Avg. Revenue Growth', prefix: '', suffix: '%' },
+          { value: '12', label: 'Years Experience', prefix: '', suffix: '+' },
+          { value: '4.9', label: 'Client Rating', prefix: '', suffix: '/5' },
+        ],
+        alignment: 'center',
+      }),
+      c('FeaturesGrid', {
+        title: 'What You Will Master',
+        subtitle: 'The exact systems behind sustainable, profitable growth.',
+        items: [
+          { icon: '🎯', title: 'Find Your Niche', description: 'Position yourself so the right clients find you — and happily pay premium rates.' },
+          { icon: '🧲', title: 'Attract Clients', description: 'Build a marketing engine that brings in leads consistently, without burnout.' },
+          { icon: '💰', title: 'Sell With Confidence', description: 'Close deals without feeling pushy using a clear, repeatable sales process.' },
+          { icon: '⚙️', title: 'Systemize & Scale', description: 'Turn chaos into systems so your business runs without you in every detail.' },
+          { icon: '📈', title: 'Grow Revenue', description: 'Pricing, offers, and upsells that increase income without more hours.' },
+          { icon: '⏳', title: 'Reclaim Your Time', description: 'Delegate, automate, and focus on the work that actually moves the needle.' },
+        ],
+        columns: '3',
+      }),
+      c('CourseGrid', {
+        title: 'Programs & Courses',
+        subtitle: 'Self-paced programs to build skills on your schedule.',
+        maxItems: 6, columns: '3', showPrice: true, showDescription: true,
+      }),
+      c('PricingTable', {
+        title: 'Ways to Work Together',
+        subtitle: 'Start with a course or go all-in with private coaching.',
+        items: [
+          { name: 'Courses', price: '$199', period: 'one-time', description: 'Self-paced programs', features: 'Lifetime course access\nTemplates & frameworks\nWorkbooks & checklists\nCommunity access\nCertificate', highlighted: false, ctaLabel: 'Browse Courses', ctaHref: '/courses' },
+          { name: 'Group Coaching', price: '$299', period: '/month', description: 'Learn with a cohort', features: 'All courses included\nWeekly group calls\nHot-seat coaching\nAccountability pods\nPrivate community', highlighted: true, ctaLabel: 'Join the Group', ctaHref: '#contact' },
+          { name: 'Private 1-on-1', price: 'Custom', period: '', description: 'Fully tailored coaching', features: 'Everything in Group\nBiweekly 1-on-1 calls\nCustom growth plan\nDirect message access\nDone-with-you strategy', highlighted: false, ctaLabel: 'Apply Now', ctaHref: '#contact' },
+        ],
+      }),
+      c('TestimonialGrid', {
+        title: 'Results That Speak',
+        subtitle: 'What clients achieved after working together.',
+        items: [
+          { name: 'Sara D.', role: 'Freelance Designer', quote: 'I doubled my rates and filled my calendar in 90 days. The positioning work alone was worth every penny.', rating: 5 },
+          { name: 'Marcus L.', role: 'Agency Founder', quote: 'We went from feast-or-famine to predictable revenue. The client-attraction system completely changed our business.', rating: 5 },
+          { name: 'Aisha K.', role: 'Online Coach', quote: 'I finally have systems instead of chaos. I work fewer hours and earn more than ever. Game changer.', rating: 5 },
+        ],
+      }),
+      c('FaqAccordion', {
+        title: 'Common Questions',
+        subtitle: '',
+        items: [
+          { question: 'Who is this for?', answer: 'Freelancers, consultants, coaches, and small business owners who want more clients, higher revenue, and better systems — without working themselves into the ground.' },
+          { question: 'Do I need an established business?', answer: 'No. We have programs for people just starting out and advanced coaching for those ready to scale. We will help you find the right starting point.' },
+          { question: 'How is coaching delivered?', answer: 'Through live group calls, private 1-on-1 sessions, and a community — plus on-demand courses you can work through anytime.' },
+          { question: 'What if it does not work for me?', answer: 'Our courses come with a 30-day money-back guarantee, and coaching includes a satisfaction check-in. We only succeed when you do.' },
+        ],
+      }),
+      c('CtaBlock', {
+        title: 'Ready to Build Momentum?',
+        subtitle: 'Book a free strategy call and leave with a clear next step for your business — no pressure, no pitch.',
+        primaryCtaLabel: 'Book Your Free Call',
+        primaryCtaHref: '#contact',
+        secondaryCtaLabel: 'View Programs',
+        secondaryCtaHref: '/courses',
+        style: 'gradient',
+      }),
+      footer(),
+    ],
+    zones: {},
+  },
+}
+
+const aboutTemplate: PuckTemplate = {
+  name: 'Business Coaching — About',
+  description: 'About page for a business coach: story, philosophy, and credentials.',
+  category: 'business',
+  sort_order: 51,
+  pageType: 'about',
+  puck_data: {
+    root: { props: {} },
+    content: [
+      header([
+        { label: 'Home', href: '/' },
+        { label: 'Courses', href: '/courses' },
+        { label: 'FAQ', href: '#faq' },
+        { label: 'Contact', href: '#contact' },
+      ]),
+      c('HeroBlock', {
+        title: 'Hi, I Help Founders Build Businesses That Last',
+        subtitle: 'After 12 years of building, scaling, and occasionally crashing my own companies, I distilled what actually works into frameworks anyone can follow.',
+        primaryCtaLabel: '', primaryCtaHref: '', secondaryCtaLabel: '', secondaryCtaHref: '',
+        backgroundImage: '', alignment: 'center', overlayOpacity: 55, minHeight: '400px',
+      }),
+      c('TextBlock', {
+        content: 'I started my first business at 24 with more ambition than strategy. I made every mistake in the book — undercharging, chasing the wrong clients, drowning in work that did not grow anything. Eventually I figured out the systems that turn hustle into a real, profitable business.\n\nSince then I have coached over 3,500 founders, freelancers, and creators to do the same: find their niche, attract clients consistently, charge what they are worth, and build a company that runs without burning them out. No hype, no get-rich-quick promises — just practical frameworks that work, delivered through courses and coaching that meet you where you are.',
+        alignment: 'center', color: '', maxWidth: '768px', fontSize: '1.125rem',
+      }),
+      c('StatsCounter', {
+        items: [
+          { value: '3,500', label: 'Clients Coached', prefix: '', suffix: '+' },
+          { value: '$50M', label: 'Client Revenue Added', prefix: '', suffix: '' },
+          { value: '12', label: 'Years Experience', prefix: '', suffix: '+' },
+          { value: '30', label: 'Countries', prefix: '', suffix: '+' },
+        ],
+        alignment: 'center',
+      }),
+      c('FeaturesGrid', {
+        title: 'How I Work',
+        subtitle: 'The principles behind every program and call.',
+        items: [
+          { icon: '🧭', title: 'Strategy Over Hacks', description: 'No fleeting tactics. We build durable systems that compound over years, not weeks.' },
+          { icon: '🤝', title: 'Honest & Direct', description: 'You get real feedback, even when it is hard to hear. That is how you actually grow.' },
+          { icon: '📐', title: 'Frameworks, Not Theory', description: 'Every concept comes with templates and steps you can apply the same day.' },
+          { icon: '🌱', title: 'Sustainable Growth', description: 'We build a business that supports your life — not one that consumes it.' },
+        ],
+        columns: '2',
+      }),
+      c('TeamGrid', {
+        title: 'The Team',
+        subtitle: 'Coaches and specialists who support your growth.',
+        members: [
+          { name: 'Jordan Reyes', role: 'Founder & Lead Coach', bio: 'Built and sold two companies. Coached 3,500+ founders over 12 years.', avatar: '' },
+          { name: 'Tara Mbeki', role: 'Marketing Coach', bio: 'Helps clients build lead engines that bring in customers on autopilot.', avatar: '' },
+          { name: 'Sam Whitfield', role: 'Sales Coach', bio: 'Former enterprise sales leader. Teaches authentic, high-conversion selling.', avatar: '' },
+          { name: 'Lily Chen', role: 'Operations Coach', bio: 'Systems specialist who turns busy founders into calm CEOs.', avatar: '' },
+        ],
+      }),
+      c('CtaBlock', {
+        title: 'Let’s Build Something That Lasts',
+        subtitle: 'Book a free strategy call and see if we are a fit.',
+        primaryCtaLabel: 'Book a Free Call',
+        primaryCtaHref: '#contact',
+        secondaryCtaLabel: 'See Programs',
+        secondaryCtaHref: '/courses',
+        style: 'gradient',
+      }),
+      footer(),
+    ],
+    zones: {},
+  },
+}
+
+const faqTemplate: PuckTemplate = {
+  name: 'Business Coaching — FAQ',
+  description: 'FAQ page for a business coach covering programs, format, results, and pricing.',
+  category: 'business',
+  sort_order: 52,
+  pageType: 'faq',
+  puck_data: {
+    root: { props: {} },
+    content: [
+      header([
+        { label: 'Home', href: '/' },
+        { label: 'Courses', href: '/courses' },
+        { label: 'Pricing', href: '/pricing' },
+        { label: 'Contact', href: '#contact' },
+      ]),
+      c('HeroBlock', {
+        title: 'Frequently Asked Questions',
+        subtitle: 'Everything you need to know about the programs, coaching, and results.',
+        primaryCtaLabel: '', primaryCtaHref: '', secondaryCtaLabel: '', secondaryCtaHref: '',
+        backgroundImage: '', alignment: 'center', overlayOpacity: 55, minHeight: '300px',
+      }),
+      c('FaqAccordion', {
+        title: 'Is This Right for Me?',
+        subtitle: '',
+        items: [
+          { question: 'Who do you work with?', answer: 'Freelancers, consultants, coaches, agency owners, and creators who want more clients, higher revenue, and better systems without burning out.' },
+          { question: 'I am just starting out. Is that okay?', answer: 'Yes. We have foundational programs for new businesses and advanced coaching for scaling. We help you start exactly where you are.' },
+          { question: 'What industries do you cover?', answer: 'The frameworks are industry-agnostic and proven across services, coaching, creative, and digital businesses. The principles of positioning, marketing, and sales apply everywhere.' },
+          { question: 'How much time does it take?', answer: 'Courses are self-paced. Group coaching is about 2–3 hours per week. Private coaching flexes around your schedule.' },
+        ],
+      }),
+      c('FaqAccordion', {
+        title: 'Format & Delivery',
+        subtitle: '',
+        items: [
+          { question: 'How is the coaching delivered?', answer: 'Through live group calls, private 1-on-1 sessions, a member community, and on-demand courses you can work through anytime.' },
+          { question: 'Are the calls recorded?', answer: 'Yes. All group calls are recorded and added to your library so you never miss anything.' },
+          { question: 'Do I get templates and resources?', answer: 'Every program includes proven templates, scripts, checklists, and workbooks you can use immediately.' },
+          { question: 'Can I upgrade from a course to coaching?', answer: 'Absolutely. Many clients start with a course and upgrade to group or private coaching as they grow. Your course investment can be credited toward coaching.' },
+        ],
+      }),
+      c('FaqAccordion', {
+        title: 'Results & Guarantee',
+        subtitle: '',
+        items: [
+          { question: 'What kind of results can I expect?', answer: 'Results vary by effort and starting point, but clients commonly raise their rates, build consistent lead flow, and reclaim hours each week. Average revenue growth is around 40%.' },
+          { question: 'Do you guarantee results?', answer: 'No ethical coach can guarantee revenue — too much depends on you. But our courses include a 30-day money-back guarantee, and coaching includes satisfaction check-ins.' },
+          { question: 'How fast will I see progress?', answer: 'Most clients see early wins — clarity on positioning, a better offer, first new leads — within the first few weeks. Bigger results compound over months.' },
+          { question: 'Can I get a refund?', answer: 'Courses come with a 30-day money-back guarantee. Coaching terms are covered in your agreement and discussed openly on your strategy call.' },
+        ],
+      }),
+      c('CtaBlock', {
+        title: 'Still Have Questions?',
+        subtitle: 'Book a free call and we will answer everything — and map your next step.',
+        primaryCtaLabel: 'Book a Free Call',
+        primaryCtaHref: '#contact',
+        secondaryCtaLabel: 'Browse Courses',
+        secondaryCtaHref: '/courses',
+        style: 'bordered',
+      }),
+      footer(),
+    ],
+    zones: {},
+  },
+}
+
+const contactTemplate: PuckTemplate = {
+  name: 'Business Coaching — Contact',
+  description: 'Contact / book-a-call page for a business coach with form and quick answers.',
+  category: 'business',
+  sort_order: 53,
+  pageType: 'contact',
+  puck_data: {
+    root: { props: {} },
+    content: [
+      header([
+        { label: 'Home', href: '/' },
+        { label: 'Courses', href: '/courses' },
+        { label: 'FAQ', href: '#faq' },
+      ]),
+      c('HeroBlock', {
+        title: 'Book Your Free Strategy Call',
+        subtitle: 'Tell us about your business and goals. We will map a clear next step on a no-pressure call — whether or not we work together.',
+        primaryCtaLabel: '', primaryCtaHref: '', secondaryCtaLabel: '', secondaryCtaHref: '',
+        backgroundImage: '', alignment: 'center', overlayOpacity: 55, minHeight: '320px',
+      }),
+      c('ContactForm', {
+        title: 'Apply for a Call',
+        subtitle: 'Share where you are and where you want to go. We will be in touch within one business day.',
+        email: 'hello@momentum.coach',
+        showPhone: true, showMessage: true,
+      }),
+      c('FaqAccordion', {
+        title: 'Before You Book',
+        subtitle: '',
+        items: [
+          { question: 'Is the call really free?', answer: 'Yes. The strategy call is free and genuinely useful — you will leave with a clear next step even if we never work together.' },
+          { question: 'Will this be a sales pitch?', answer: 'No hard pitch. We focus on your goals. If coaching is a fit, we will mention it; if not, we will point you to the right resource.' },
+          { question: 'What should I prepare?', answer: 'Just come ready to talk about your business, your biggest challenge right now, and what success would look like for you.' },
+        ],
+      }),
+      footer(),
+    ],
+    zones: {},
+  },
+}
+
+export const businessCoachingTemplates: PuckTemplate[] = [
+  homeTemplate,
+  aboutTemplate,
+  faqTemplate,
+  contactTemplate,
+]

--- a/lib/puck/templates/design-school.ts
+++ b/lib/puck/templates/design-school.ts
@@ -1,0 +1,319 @@
+import { c, type PuckTemplate } from './_shared'
+
+// ─── Design / Creative School ────────────────────────────────────────────────
+// Multi-page pack for design schools and creative course creators (UX/UI,
+// graphic design, illustration, motion). Pages: Home, About, FAQ, Contact.
+
+const LOGO = '🎨 Canvas'
+const FOOTER_COLUMNS = [
+  { title: 'Learn', links: [{ label: 'All Courses', href: '/courses' }, { label: 'Learning Paths', href: '#paths' }, { label: 'Pricing', href: '/pricing' }] },
+  { title: 'Studio', links: [{ label: 'About', href: '#about' }, { label: 'Student Work', href: '#work' }, { label: 'Contact', href: '#contact' }] },
+  { title: 'Legal', links: [{ label: 'Terms', href: '/terms' }, { label: 'Privacy', href: '/privacy' }] },
+]
+
+function header(navLinks: { label: string; href: string }[]) {
+  return c('Header', {
+    logo: '', logoText: LOGO, navLinks,
+    ctaLabel: 'Start Creating', ctaHref: '/courses',
+    showLogin: true, sticky: true, transparent: false,
+  })
+}
+
+function footer() {
+  return c('Footer', {
+    description: 'Learn design by making real work. Project-based courses in UX/UI, graphic design, illustration, and motion.',
+    columns: FOOTER_COLUMNS,
+    socialLinks: [{ platform: 'Instagram', url: '#' }, { platform: 'Dribbble', url: '#' }, { platform: 'Behance', url: '#' }],
+    copyright: '© 2026 Canvas Design School. All rights reserved.',
+  })
+}
+
+const homeTemplate: PuckTemplate = {
+  name: 'Design School — Home',
+  description: 'Landing page for design schools and creative course creators (UX/UI, graphic, illustration).',
+  category: 'design',
+  sort_order: 60,
+  pageType: 'home',
+  puck_data: {
+    root: { props: {} },
+    content: [
+      header([
+        { label: 'Courses', href: '/courses' },
+        { label: 'Paths', href: '#paths' },
+        { label: 'Pricing', href: '#pricing' },
+        { label: 'About', href: '#about' },
+        { label: 'FAQ', href: '#faq' },
+      ]),
+      c('HeroBlock', {
+        title: 'Design Work You’ll Be Proud to Show',
+        subtitle: 'Project-based courses in UX/UI, graphic design, illustration, and motion. Build a real portfolio while you learn the craft.',
+        primaryCtaLabel: 'Start Creating',
+        primaryCtaHref: '/courses',
+        secondaryCtaLabel: 'Explore Paths',
+        secondaryCtaHref: '#paths',
+        backgroundImage: '', alignment: 'center', overlayOpacity: 55, minHeight: '520px',
+      }),
+      c('StatsCounter', {
+        items: [
+          { value: '14,000', label: 'Designers Trained', prefix: '', suffix: '+' },
+          { value: '120', label: 'Hands-On Projects', prefix: '', suffix: '+' },
+          { value: '40', label: 'Industry Mentors', prefix: '', suffix: '+' },
+          { value: '4.9', label: 'Student Rating', prefix: '', suffix: '/5' },
+        ],
+        alignment: 'center',
+      }),
+      c('FeaturesGrid', {
+        title: 'Why Design With Us',
+        subtitle: 'Everything you need to build skills and a standout portfolio.',
+        items: [
+          { icon: '🖌️', title: 'Learn by Making', description: 'Every course is built around real projects. You finish with portfolio pieces, not just notes.' },
+          { icon: '🔍', title: 'Mentor Critiques', description: 'Submit your work and get detailed feedback from practicing designers.' },
+          { icon: '🧰', title: 'Industry Tools', description: 'Master Figma, the Adobe suite, and the workflows real studios use every day.' },
+          { icon: '🗺️', title: 'Clear Learning Paths', description: 'Follow guided paths from fundamentals to job-ready specialization.' },
+          { icon: '💼', title: 'Portfolio & Career', description: 'Build a portfolio that gets noticed, with guidance on landing your first design role.' },
+          { icon: '👥', title: 'Creative Community', description: 'Share work, get inspired, and grow alongside thousands of fellow designers.' },
+        ],
+        columns: '3',
+      }),
+      c('FeaturesGrid', {
+        title: 'Choose Your Path',
+        subtitle: 'Specialize in the craft that excites you most.',
+        items: [
+          { icon: '📱', title: 'UX/UI Design', description: 'Research, wireframes, prototypes, and polished interfaces in Figma.' },
+          { icon: '🎨', title: 'Graphic Design', description: 'Branding, layout, typography, and visual systems that communicate.' },
+          { icon: '✏️', title: 'Illustration', description: 'Digital drawing, character design, and a signature visual style.' },
+          { icon: '🎬', title: 'Motion Design', description: 'Animation, transitions, and motion graphics that bring work to life.' },
+        ],
+        columns: '4',
+      }),
+      c('CourseGrid', {
+        title: 'Popular Courses',
+        subtitle: 'Start with our most popular courses, chosen by thousands of designers.',
+        maxItems: 6, columns: '3', showPrice: true, showDescription: true,
+      }),
+      c('PricingTable', {
+        title: 'Simple Pricing',
+        subtitle: 'Buy a course or unlock everything. Cancel anytime.',
+        items: [
+          { name: 'Single Course', price: '$59', period: 'one-time', description: 'Buy any course', features: 'Lifetime access to one course\nProject files & assets\nMentor critique\nCertificate\nCommunity access', highlighted: false, ctaLabel: 'Browse Courses', ctaHref: '/courses' },
+          { name: 'All-Access', price: '$29', period: '/month', description: 'Unlock the full library', features: 'All courses included\nNew courses monthly\nMonthly portfolio reviews\nAll learning paths\nPriority support', highlighted: true, ctaLabel: 'Get All-Access', ctaHref: '#' },
+          { name: 'Mentorship', price: '$129', period: '/month', description: 'Guided 1-on-1 support', features: 'Everything in All-Access\nBiweekly 1-on-1 mentor calls\nPersonal portfolio plan\nCareer & interview prep\nDirect messaging', highlighted: false, ctaLabel: 'Apply Now', ctaHref: '#contact' },
+        ],
+      }),
+      c('TestimonialGrid', {
+        title: 'From Our Students',
+        subtitle: 'Designers who built portfolios and careers here.',
+        items: [
+          { name: 'Elena V.', role: 'UX Designer at a startup', quote: 'I came in with zero design background. The project-based courses gave me a portfolio that landed my first UX role in five months.', rating: 5 },
+          { name: 'Kwame A.', role: 'Freelance Illustrator', quote: 'The mentor critiques pushed my work to a level I did not think I could reach. I am now taking paid client commissions.', rating: 5 },
+          { name: 'Yuki T.', role: 'Brand Designer', quote: 'Clear paths, real projects, honest feedback. I finally have a portfolio I am genuinely proud to show.', rating: 5 },
+        ],
+      }),
+      c('FaqAccordion', {
+        title: 'Common Questions',
+        subtitle: '',
+        items: [
+          { question: 'Do I need design experience?', answer: 'No. Our beginner courses start with the fundamentals — no prior experience or art degree required.' },
+          { question: 'What software do I need?', answer: 'Mostly Figma (free) and the Adobe Creative Suite for some courses. Each course lists exactly what you need, with free alternatives where possible.' },
+          { question: 'Will I build a portfolio?', answer: 'Yes. Every course is project-based, so you finish with real, portfolio-ready work you can show to clients or employers.' },
+          { question: 'Do I get feedback on my work?', answer: 'Yes. You can submit projects for mentor critiques, and All-Access and Mentorship members get regular portfolio reviews.' },
+        ],
+      }),
+      c('CtaBlock', {
+        title: 'Start Building Your Portfolio Today',
+        subtitle: 'Join 14,000+ designers learning the craft by making real work.',
+        primaryCtaLabel: 'Start Creating',
+        primaryCtaHref: '/courses',
+        secondaryCtaLabel: 'View Pricing',
+        secondaryCtaHref: '#pricing',
+        style: 'gradient',
+      }),
+      footer(),
+    ],
+    zones: {},
+  },
+}
+
+const aboutTemplate: PuckTemplate = {
+  name: 'Design School — About',
+  description: 'About page for a design school: mission, teaching approach, and mentors.',
+  category: 'design',
+  sort_order: 61,
+  pageType: 'about',
+  puck_data: {
+    root: { props: {} },
+    content: [
+      header([
+        { label: 'Home', href: '/' },
+        { label: 'Courses', href: '/courses' },
+        { label: 'FAQ', href: '#faq' },
+        { label: 'Contact', href: '#contact' },
+      ]),
+      c('HeroBlock', {
+        title: 'We Teach Design the Way It’s Actually Practiced',
+        subtitle: 'Not theory dumps and isolated exercises — real briefs, real critiques, and a real portfolio. The way you learn to design is by designing.',
+        primaryCtaLabel: '', primaryCtaHref: '', secondaryCtaLabel: '', secondaryCtaHref: '',
+        backgroundImage: '', alignment: 'center', overlayOpacity: 55, minHeight: '400px',
+      }),
+      c('TextBlock', {
+        content: 'Canvas was founded by designers who were tired of seeing talented people stall out in tutorials that never added up to anything. You can watch a hundred videos and still freeze when faced with a blank artboard.\n\nSo we built a school around doing. Every course is a real project with a real brief. You design, you get critiqued by working professionals, and you walk away with portfolio pieces — not just a completion badge. Since 2019 we have helped 14,000+ designers across 40 countries build the skills and the portfolios that launch creative careers.',
+        alignment: 'center', color: '', maxWidth: '768px', fontSize: '1.125rem',
+      }),
+      c('StatsCounter', {
+        items: [
+          { value: '14,000', label: 'Designers Trained', prefix: '', suffix: '+' },
+          { value: '40', label: 'Countries', prefix: '', suffix: '+' },
+          { value: '120', label: 'Real Projects', prefix: '', suffix: '+' },
+          { value: '2019', label: 'Founded', prefix: '', suffix: '' },
+        ],
+        alignment: 'center',
+      }),
+      c('FeaturesGrid', {
+        title: 'How We Teach',
+        subtitle: 'The principles behind every course.',
+        items: [
+          { icon: '🧱', title: 'Real Briefs', description: 'You work on projects modeled on actual client and product work — not toy exercises.' },
+          { icon: '🗣️', title: 'Honest Critique', description: 'Practicing designers review your work and tell you what will make it better.' },
+          { icon: '🎯', title: 'Craft & Process', description: 'We teach the why behind the what, so your decisions hold up in any project.' },
+          { icon: '🚀', title: 'Career-Ready', description: 'From portfolio to interview prep, we help you turn skills into a design career.' },
+        ],
+        columns: '2',
+      }),
+      c('TeamGrid', {
+        title: 'Meet Your Mentors',
+        subtitle: 'Working designers who love to teach.',
+        members: [
+          { name: 'Priya Nair', role: 'Founder & UX Lead', bio: 'Former product designer at a major tech company. 12 years shipping real products.', avatar: '' },
+          { name: 'Tomás Herrera', role: 'Graphic Design Mentor', bio: 'Brand and identity designer with an award-winning studio background.', avatar: '' },
+          { name: 'Hana Kim', role: 'Illustration Mentor', bio: 'Freelance illustrator whose work has appeared in major publications.', avatar: '' },
+          { name: 'Felix Bauer', role: 'Motion Mentor', bio: 'Motion designer for studios and brands, specializing in UI animation.', avatar: '' },
+        ],
+      }),
+      c('CtaBlock', {
+        title: 'Come Make Something Great',
+        subtitle: 'Start a project-based course and build a portfolio you’re proud of.',
+        primaryCtaLabel: 'Start Creating',
+        primaryCtaHref: '/courses',
+        secondaryCtaLabel: 'Contact Us',
+        secondaryCtaHref: '#contact',
+        style: 'gradient',
+      }),
+      footer(),
+    ],
+    zones: {},
+  },
+}
+
+const faqTemplate: PuckTemplate = {
+  name: 'Design School — FAQ',
+  description: 'FAQ page for a design school covering courses, tools, portfolio, and pricing.',
+  category: 'design',
+  sort_order: 62,
+  pageType: 'faq',
+  puck_data: {
+    root: { props: {} },
+    content: [
+      header([
+        { label: 'Home', href: '/' },
+        { label: 'Courses', href: '/courses' },
+        { label: 'Pricing', href: '/pricing' },
+        { label: 'Contact', href: '#contact' },
+      ]),
+      c('HeroBlock', {
+        title: 'Frequently Asked Questions',
+        subtitle: 'Everything you need to know about courses, tools, and building your portfolio.',
+        primaryCtaLabel: '', primaryCtaHref: '', secondaryCtaLabel: '', secondaryCtaHref: '',
+        backgroundImage: '', alignment: 'center', overlayOpacity: 55, minHeight: '300px',
+      }),
+      c('FaqAccordion', {
+        title: 'Getting Started',
+        subtitle: '',
+        items: [
+          { question: 'Do I need prior design experience?', answer: 'Not at all. Our beginner courses start from the fundamentals. No art degree or prior experience required — just curiosity and a willingness to make things.' },
+          { question: 'What software and tools do I need?', answer: 'Mostly Figma (free) for UX/UI and the Adobe Creative Suite for graphic and motion courses. Each course lists exactly what is needed, with free alternatives where possible.' },
+          { question: 'What can I specialize in?', answer: 'We offer learning paths in UX/UI design, graphic design, illustration, and motion design. You can focus on one or explore several.' },
+          { question: 'How are courses structured?', answer: 'Each course is project-based: short lessons followed by hands-on work, building toward a finished, portfolio-ready piece.' },
+        ],
+      }),
+      c('FaqAccordion', {
+        title: 'Portfolio & Feedback',
+        subtitle: '',
+        items: [
+          { question: 'Will I actually build a portfolio?', answer: 'Yes. Because every course is built around a real project, you finish with polished work you can show to clients or employers.' },
+          { question: 'How do critiques work?', answer: 'You submit your project and a practicing designer reviews it with specific, actionable feedback. All-Access and Mentorship members get recurring portfolio reviews.' },
+          { question: 'Do you help with getting a job?', answer: 'We provide portfolio guidance, resume and case-study help, and interview prep. Mentorship members get personalized career support.' },
+          { question: 'Can I share my work with the community?', answer: 'Absolutely. Our community is a place to post work, get inspired, exchange feedback, and grow alongside other designers.' },
+        ],
+      }),
+      c('FaqAccordion', {
+        title: 'Pricing & Plans',
+        subtitle: '',
+        items: [
+          { question: 'How much does it cost?', answer: 'Individual courses start at $59 (one-time). All-Access is $29/month for the full library, and Mentorship with 1-on-1 calls is $129/month.' },
+          { question: 'Is there a free trial?', answer: 'Several courses include free preview lessons so you can experience our teaching style before committing.' },
+          { question: 'Can I cancel anytime?', answer: 'Yes. Subscriptions have no contract — cancel with one click and keep access until your billing period ends.' },
+          { question: 'Do you offer refunds?', answer: 'We offer a 30-day money-back guarantee on all purchases. If it is not the right fit, contact us for a full refund.' },
+        ],
+      }),
+      c('CtaBlock', {
+        title: 'Still Have Questions?',
+        subtitle: 'Our team is happy to help you choose the right path and plan.',
+        primaryCtaLabel: 'Contact Us',
+        primaryCtaHref: '#contact',
+        secondaryCtaLabel: 'Browse Courses',
+        secondaryCtaHref: '/courses',
+        style: 'bordered',
+      }),
+      footer(),
+    ],
+    zones: {},
+  },
+}
+
+const contactTemplate: PuckTemplate = {
+  name: 'Design School — Contact',
+  description: 'Contact page for a design school with form and quick answers.',
+  category: 'design',
+  sort_order: 63,
+  pageType: 'contact',
+  puck_data: {
+    root: { props: {} },
+    content: [
+      header([
+        { label: 'Home', href: '/' },
+        { label: 'Courses', href: '/courses' },
+        { label: 'FAQ', href: '#faq' },
+      ]),
+      c('HeroBlock', {
+        title: 'Get in Touch',
+        subtitle: 'Questions about courses, mentorship, or your portfolio? We would love to help you start creating.',
+        primaryCtaLabel: '', primaryCtaHref: '', secondaryCtaLabel: '', secondaryCtaHref: '',
+        backgroundImage: '', alignment: 'center', overlayOpacity: 55, minHeight: '300px',
+      }),
+      c('ContactForm', {
+        title: 'Send Us a Message',
+        subtitle: 'Tell us what you want to design and your experience level — we will recommend the right path.',
+        email: 'hello@canvas.design',
+        showPhone: false, showMessage: true,
+      }),
+      c('FaqAccordion', {
+        title: 'Quick Answers',
+        subtitle: '',
+        items: [
+          { question: 'How do I get started?', answer: 'Browse the course catalog, pick a project that excites you, and enroll. You will be designing within your first lesson.' },
+          { question: 'Can I get 1-on-1 mentorship?', answer: 'Yes. Our Mentorship plan includes biweekly 1-on-1 calls, a personal portfolio plan, and career support.' },
+          { question: 'Do you work with teams or studios?', answer: 'We do. Reach out for team plans with group pricing and progress tracking for agencies and in-house design teams.' },
+        ],
+      }),
+      footer(),
+    ],
+    zones: {},
+  },
+}
+
+export const designSchoolTemplates: PuckTemplate[] = [
+  homeTemplate,
+  aboutTemplate,
+  faqTemplate,
+  contactTemplate,
+]

--- a/lib/puck/templates/fitness-studio.ts
+++ b/lib/puck/templates/fitness-studio.ts
@@ -1,0 +1,318 @@
+import { c, type PuckTemplate } from './_shared'
+
+// ─── Fitness / Wellness Studio ───────────────────────────────────────────────
+// Multi-page pack for fitness coaches, yoga studios, and online wellness
+// programs. Pages: Home, About, FAQ, Contact.
+
+const LOGO = '💪 FitFlow'
+const FOOTER_COLUMNS = [
+  { title: 'Train', links: [{ label: 'All Programs', href: '/courses' }, { label: 'Pricing', href: '/pricing' }, { label: 'Free Class', href: '#' }] },
+  { title: 'Studio', links: [{ label: 'About', href: '#about' }, { label: 'Our Coaches', href: '#about' }, { label: 'Contact', href: '#contact' }] },
+  { title: 'Legal', links: [{ label: 'Terms', href: '/terms' }, { label: 'Privacy', href: '/privacy' }] },
+]
+
+function header(navLinks: { label: string; href: string }[]) {
+  return c('Header', {
+    logo: '', logoText: LOGO, navLinks,
+    ctaLabel: 'Start Free Week', ctaHref: '/courses',
+    showLogin: true, sticky: true, transparent: false,
+  })
+}
+
+function footer() {
+  return c('Footer', {
+    description: 'Move better, feel stronger. On-demand and live workouts for every body and every level.',
+    columns: FOOTER_COLUMNS,
+    socialLinks: [{ platform: 'Instagram', url: '#' }, { platform: 'TikTok', url: '#' }, { platform: 'YouTube', url: '#' }],
+    copyright: '© 2026 FitFlow. All rights reserved.',
+  })
+}
+
+const homeTemplate: PuckTemplate = {
+  name: 'Fitness Studio — Home',
+  description: 'Landing page for fitness coaches, yoga studios, and online workout programs.',
+  category: 'fitness',
+  sort_order: 30,
+  pageType: 'home',
+  puck_data: {
+    root: { props: {} },
+    content: [
+      header([
+        { label: 'Programs', href: '/courses' },
+        { label: 'How It Works', href: '#features' },
+        { label: 'Pricing', href: '#pricing' },
+        { label: 'About', href: '#about' },
+        { label: 'FAQ', href: '#faq' },
+      ]),
+      c('HeroBlock', {
+        title: 'Stronger Every Day. On Your Schedule.',
+        subtitle: 'Live and on-demand workouts led by expert coaches. Strength, yoga, HIIT, and mobility — all in one place, for every level.',
+        primaryCtaLabel: 'Start Your Free Week',
+        primaryCtaHref: '/courses',
+        secondaryCtaLabel: 'See Programs',
+        secondaryCtaHref: '#programs',
+        backgroundImage: '', alignment: 'center', overlayOpacity: 60, minHeight: '520px',
+      }),
+      c('StatsCounter', {
+        items: [
+          { value: '25,000', label: 'Members', prefix: '', suffix: '+' },
+          { value: '600', label: 'Workouts', prefix: '', suffix: '+' },
+          { value: '15', label: 'Expert Coaches', prefix: '', suffix: '' },
+          { value: '4.9', label: 'App Rating', prefix: '', suffix: '/5' },
+        ],
+        alignment: 'center',
+      }),
+      c('FeaturesGrid', {
+        title: 'Why Train With Us',
+        subtitle: 'Everything you need to build a habit that actually sticks.',
+        items: [
+          { icon: '🏋️', title: 'Programs for Every Level', description: 'From total beginner to advanced athlete. Follow a plan built for where you are today.' },
+          { icon: '📅', title: 'Train Anytime', description: 'On-demand library plus daily live classes. Workout at 6am or 10pm — your call.' },
+          { icon: '🧘', title: 'Mind & Body', description: 'Strength, HIIT, yoga, mobility, and recovery. Balance intensity with rest.' },
+          { icon: '👟', title: 'No Equipment Needed', description: 'Most workouts need nothing but you and a mat. Upgrade with weights when ready.' },
+          { icon: '📊', title: 'Track Your Progress', description: 'Log workouts, watch streaks grow, and celebrate every milestone.' },
+          { icon: '🤝', title: 'Coaches in Your Corner', description: 'Form tips, modifications, and motivation from real coaches who care.' },
+        ],
+        columns: '3',
+      }),
+      c('FeaturesGrid', {
+        title: 'Find Your Program',
+        subtitle: 'Pick a path that matches your goals — or mix them all.',
+        items: [
+          { icon: '🔥', title: 'Fat Burn & HIIT', description: 'Short, intense sessions that torch calories and boost energy in 20–30 minutes.' },
+          { icon: '💪', title: 'Strength & Tone', description: 'Progressive strength programs to build lean muscle and full-body power.' },
+          { icon: '🌿', title: 'Yoga & Flexibility', description: 'Flow, stretch, and breathe. Improve mobility and melt away stress.' },
+        ],
+        columns: '3',
+      }),
+      c('CourseGrid', {
+        title: 'Popular Programs',
+        subtitle: 'Start with our most popular programs, loved by thousands of members.',
+        maxItems: 6, columns: '3', showPrice: true, showDescription: true,
+      }),
+      c('PricingTable', {
+        title: 'Membership Plans',
+        subtitle: 'Train as much as you want. Cancel anytime.',
+        items: [
+          { name: 'Monthly', price: '$19', period: '/month', description: 'Full access, no commitment', features: 'All on-demand workouts\nDaily live classes\nProgress tracking\nWorkout calendar\nCancel anytime', highlighted: false, ctaLabel: 'Start Monthly', ctaHref: '/courses' },
+          { name: 'Annual', price: '$149', period: '/year', description: 'Best value — save 35%', features: 'Everything in Monthly\nPersonalized programs\nNutrition guides\n1 monthly coach check-in\nMember community', highlighted: true, ctaLabel: 'Go Annual', ctaHref: '#' },
+          { name: 'Coaching', price: '$79', period: '/month', description: 'Personalized 1-on-1', features: 'Everything in Annual\nCustom training plan\nWeekly coach check-ins\nForm reviews\nDirect messaging', highlighted: false, ctaLabel: 'Get Coaching', ctaHref: '#contact' },
+        ],
+      }),
+      c('TestimonialGrid', {
+        title: 'Real Results, Real People',
+        subtitle: 'See what members are achieving from home.',
+        items: [
+          { name: 'Jasmine R.', role: 'Lost 18 lbs', quote: 'The 25-minute workouts fit around my kids and my job. I have never been this consistent — or this strong.', rating: 5 },
+          { name: 'Tom B.', role: 'Built strength', quote: 'I was intimidated by the gym. Training at home with real coaching changed everything. Down two belt sizes.', rating: 5 },
+          { name: 'Priya S.', role: 'Found her flow', quote: 'The yoga and mobility classes fixed my back pain and my stress levels. I look forward to every session.', rating: 5 },
+        ],
+      }),
+      c('FaqAccordion', {
+        title: 'Common Questions',
+        subtitle: '',
+        items: [
+          { question: 'I am a total beginner. Is this for me?', answer: 'Definitely. Every program has a beginner track with modifications, and coaches guide you through proper form every step of the way.' },
+          { question: 'Do I need equipment?', answer: 'No. Most workouts use just your bodyweight and a mat. Some strength programs offer optional dumbbell variations.' },
+          { question: 'How long are the workouts?', answer: 'Anywhere from 10 to 45 minutes. Filter by time, intensity, and type to find exactly what fits your day.' },
+          { question: 'Can I cancel anytime?', answer: 'Yes. There are no lock-in contracts. Cancel with one click and keep access until the end of your billing period.' },
+        ],
+      }),
+      c('CtaBlock', {
+        title: 'Your First Week Is On Us',
+        subtitle: 'Join 25,000+ members getting stronger from home. No equipment, no excuses, no risk.',
+        primaryCtaLabel: 'Start Free Week',
+        primaryCtaHref: '/courses',
+        secondaryCtaLabel: 'View Pricing',
+        secondaryCtaHref: '#pricing',
+        style: 'gradient',
+      }),
+      footer(),
+    ],
+    zones: {},
+  },
+}
+
+const aboutTemplate: PuckTemplate = {
+  name: 'Fitness Studio — About',
+  description: 'About page for a fitness studio: mission, philosophy, and coaches.',
+  category: 'fitness',
+  sort_order: 31,
+  pageType: 'about',
+  puck_data: {
+    root: { props: {} },
+    content: [
+      header([
+        { label: 'Home', href: '/' },
+        { label: 'Programs', href: '/courses' },
+        { label: 'FAQ', href: '#faq' },
+        { label: 'Contact', href: '#contact' },
+      ]),
+      c('HeroBlock', {
+        title: 'Fitness That Fits Real Life',
+        subtitle: 'We started FitFlow because getting healthy should not require a gym membership, a personal trainer budget, or perfect free time. Just press play.',
+        primaryCtaLabel: '', primaryCtaHref: '', secondaryCtaLabel: '', secondaryCtaHref: '',
+        backgroundImage: '', alignment: 'center', overlayOpacity: 55, minHeight: '400px',
+      }),
+      c('TextBlock', {
+        content: 'FitFlow began in a living room. Our founder, a former group-fitness instructor, watched talented coaches and motivated people kept apart by schedules, distance, and cost. So we brought the studio home.\n\nToday, 25,000+ members train with us from over 50 countries — before work, after the kids are asleep, on the road, anywhere. Our philosophy is simple: consistency beats intensity, every body is welcome, and progress is personal. We are not about punishing workouts or impossible standards. We are about showing up, feeling good, and getting a little stronger every day.',
+        alignment: 'center', color: '', maxWidth: '768px', fontSize: '1.125rem',
+      }),
+      c('StatsCounter', {
+        items: [
+          { value: '25,000', label: 'Members', prefix: '', suffix: '+' },
+          { value: '50', label: 'Countries', prefix: '', suffix: '+' },
+          { value: '1.2M', label: 'Workouts Completed', prefix: '', suffix: '' },
+          { value: '2020', label: 'Founded', prefix: '', suffix: '' },
+        ],
+        alignment: 'center',
+      }),
+      c('FeaturesGrid', {
+        title: 'What We Stand For',
+        subtitle: 'The values behind every workout we make.',
+        items: [
+          { icon: '❤️', title: 'Every Body Welcome', description: 'All ages, sizes, and fitness levels. We meet you where you are — no judgment, ever.' },
+          { icon: '🔁', title: 'Consistency Over Intensity', description: 'Sustainable habits beat burnout. We help you build a routine you can actually keep.' },
+          { icon: '🧠', title: 'Mind & Body', description: 'True wellness includes recovery, rest, and mental health — not just sweat.' },
+          { icon: '🎓', title: 'Coaches You Trust', description: 'Every coach is certified and trained to teach safe, effective movement for all levels.' },
+        ],
+        columns: '2',
+      }),
+      c('TeamGrid', {
+        title: 'Meet Your Coaches',
+        subtitle: 'Certified, encouraging, and genuinely in your corner.',
+        members: [
+          { name: 'Maya Torres', role: 'Founder & Head Coach', bio: 'Former group-fitness instructor with 12 years of experience and a passion for accessible fitness.', avatar: '' },
+          { name: 'Andre Smith', role: 'Strength Coach', bio: 'NASM-certified. Specializes in progressive strength training for all levels.', avatar: '' },
+          { name: 'Lena Park', role: 'Yoga & Mobility', bio: 'RYT-500 yoga teacher focused on flexibility, breath, and recovery.', avatar: '' },
+          { name: 'Carlos Vega', role: 'HIIT & Conditioning', bio: 'High-energy coach who makes tough workouts feel fun and achievable.', avatar: '' },
+        ],
+      }),
+      c('CtaBlock', {
+        title: 'Train With Us This Week',
+        subtitle: 'Your free week is waiting. Press play and feel the difference.',
+        primaryCtaLabel: 'Start Free Week',
+        primaryCtaHref: '/courses',
+        secondaryCtaLabel: 'Contact Us',
+        secondaryCtaHref: '#contact',
+        style: 'gradient',
+      }),
+      footer(),
+    ],
+    zones: {},
+  },
+}
+
+const faqTemplate: PuckTemplate = {
+  name: 'Fitness Studio — FAQ',
+  description: 'FAQ page for a fitness studio covering programs, equipment, pricing, and membership.',
+  category: 'fitness',
+  sort_order: 32,
+  pageType: 'faq',
+  puck_data: {
+    root: { props: {} },
+    content: [
+      header([
+        { label: 'Home', href: '/' },
+        { label: 'Programs', href: '/courses' },
+        { label: 'Pricing', href: '/pricing' },
+        { label: 'Contact', href: '#contact' },
+      ]),
+      c('HeroBlock', {
+        title: 'Frequently Asked Questions',
+        subtitle: 'Everything you need to know before your first workout.',
+        primaryCtaLabel: '', primaryCtaHref: '', secondaryCtaLabel: '', secondaryCtaHref: '',
+        backgroundImage: '', alignment: 'center', overlayOpacity: 55, minHeight: '300px',
+      }),
+      c('FaqAccordion', {
+        title: 'Getting Started',
+        subtitle: '',
+        items: [
+          { question: 'Is this suitable for beginners?', answer: 'Yes. Every program includes a beginner track with modifications, and our coaches walk you through proper form so you feel confident from day one.' },
+          { question: 'What equipment do I need?', answer: 'For most workouts, just a mat and a bit of floor space. Some strength programs offer optional dumbbell or resistance-band variations.' },
+          { question: 'How much space do I need?', answer: 'About the size of a yoga mat. All workouts are designed to fit small apartments and hotel rooms.' },
+          { question: 'Do I get a personalized plan?', answer: 'Annual and Coaching members get personalized programs based on your goals, fitness level, and available time.' },
+        ],
+      }),
+      c('FaqAccordion', {
+        title: 'Workouts & Schedule',
+        subtitle: '',
+        items: [
+          { question: 'Are classes live or on-demand?', answer: 'Both. We have a large on-demand library plus daily live classes you can join in real time with a coach.' },
+          { question: 'How long are the workouts?', answer: 'From quick 10-minute sessions to full 45-minute classes. Filter by duration, intensity, and type to match your day.' },
+          { question: 'What types of workouts are there?', answer: 'Strength, HIIT, yoga, mobility, low-impact, and recovery. There is something for every goal and energy level.' },
+          { question: 'Can I work out if I am injured?', answer: 'We offer low-impact and recovery programs, but always consult your doctor first. Coaches can suggest modifications for common limitations.' },
+        ],
+      }),
+      c('FaqAccordion', {
+        title: 'Membership & Billing',
+        subtitle: '',
+        items: [
+          { question: 'How much does membership cost?', answer: 'Monthly is $19, Annual is $149 (save 35%), and 1-on-1 Coaching is $79/month. All plans include full access to the workout library.' },
+          { question: 'Is there a free trial?', answer: 'Yes — your first week is completely free. Explore every program and class before you pay anything.' },
+          { question: 'Can I cancel anytime?', answer: 'Absolutely. No contracts, no cancellation fees. Cancel with one click and keep access until your billing period ends.' },
+          { question: 'Do you offer refunds?', answer: 'We offer a 14-day money-back guarantee on paid plans. If FitFlow is not for you, contact us for a full refund.' },
+        ],
+      }),
+      c('CtaBlock', {
+        title: 'Still Have Questions?',
+        subtitle: 'Reach out — our team is happy to help you get started.',
+        primaryCtaLabel: 'Contact Us',
+        primaryCtaHref: '#contact',
+        secondaryCtaLabel: 'Browse Programs',
+        secondaryCtaHref: '/courses',
+        style: 'bordered',
+      }),
+      footer(),
+    ],
+    zones: {},
+  },
+}
+
+const contactTemplate: PuckTemplate = {
+  name: 'Fitness Studio — Contact',
+  description: 'Contact page for a fitness studio with form and quick answers.',
+  category: 'fitness',
+  sort_order: 33,
+  pageType: 'contact',
+  puck_data: {
+    root: { props: {} },
+    content: [
+      header([
+        { label: 'Home', href: '/' },
+        { label: 'Programs', href: '/courses' },
+        { label: 'FAQ', href: '#faq' },
+      ]),
+      c('HeroBlock', {
+        title: 'Get in Touch',
+        subtitle: 'Questions about programs, coaching, or membership? We are here to help you start strong.',
+        primaryCtaLabel: '', primaryCtaHref: '', secondaryCtaLabel: '', secondaryCtaHref: '',
+        backgroundImage: '', alignment: 'center', overlayOpacity: 55, minHeight: '300px',
+      }),
+      c('ContactForm', {
+        title: 'Send Us a Message',
+        subtitle: 'Tell us your goals and we will recommend the right program for you.',
+        email: 'hello@fitflow.com',
+        showPhone: false, showMessage: true,
+      }),
+      c('FaqAccordion', {
+        title: 'Quick Answers',
+        subtitle: '',
+        items: [
+          { question: 'How do I start my free week?', answer: 'Click "Start Free Week" on any page and create your account. You will get full access for 7 days — no payment required upfront.' },
+          { question: 'Can I get 1-on-1 coaching?', answer: 'Yes. Our Coaching plan pairs you with a dedicated coach for custom plans, weekly check-ins, and form reviews.' },
+          { question: 'Do you offer corporate wellness?', answer: 'We do. Reach out for team plans with group pricing, challenges, and wellness reporting for your company.' },
+        ],
+      }),
+      footer(),
+    ],
+    zones: {},
+  },
+}
+
+export const fitnessStudioTemplates: PuckTemplate[] = [
+  homeTemplate,
+  aboutTemplate,
+  faqTemplate,
+  contactTemplate,
+]

--- a/lib/puck/templates/index.ts
+++ b/lib/puck/templates/index.ts
@@ -1,47 +1,14 @@
-import type { Data } from '@measured/puck'
-import { sectionSpacingDefaults } from '../utils/section-spacing'
+import { c, deepCloneWithFreshIds, type PuckTemplate } from './_shared'
+import { languageSchoolTemplates } from './language-school'
+import { fitnessStudioTemplates } from './fitness-studio'
+import { musicAcademyTemplates } from './music-academy'
+import { businessCoachingTemplates } from './business-coaching'
+import { designSchoolTemplates } from './design-school'
 
-export interface PuckTemplate {
-  name: string
-  description: string
-  category: string
-  puck_data: Data
-  sort_order: number
-  pageType: string
-}
-
-// Counter to generate unique-per-template IDs at module level.
-// Fresh IDs are generated when templates are applied via deepCloneWithFreshIds().
-// LMS component types that use section spacing
-const SPACED_COMPONENTS = new Set([
-  'FeaturesGrid', 'CourseGrid', 'TestimonialGrid', 'CtaBlock',
-  'PricingTable', 'FaqAccordion', 'StatsCounter', 'ContactForm',
-  'LogoCloud', 'Banner', 'TeamGrid', 'ImageGallery', 'SocialProof',
-])
-
-let idCounter = 0
-function c(type: string, props: Record<string, unknown>, id?: string) {
-  const spacing = SPACED_COMPONENTS.has(type) ? sectionSpacingDefaults : {}
-  return { type, props: { id: id || `${type}-tpl-${++idCounter}`, ...spacing, ...props } }
-}
-
-/** Deep-clone a template's puck_data and assign fresh random IDs to all components */
-export function deepCloneWithFreshIds(data: Data): Data {
-  const cloned = JSON.parse(JSON.stringify(data)) as Data
-  for (const item of cloned.content) {
-    if (item.props?.id) {
-      item.props.id = `${item.type}-${Math.random().toString(36).slice(2, 10)}`
-    }
-  }
-  for (const zoneItems of Object.values(cloned.zones || {})) {
-    for (const item of zoneItems as Array<{ type: string; props: Record<string, unknown> }>) {
-      if (item.props?.id) {
-        item.props.id = `${item.type}-${Math.random().toString(36).slice(2, 10)}`
-      }
-    }
-  }
-  return cloned
-}
+// Re-export shared helpers so existing importers (`@/lib/puck/templates`)
+// keep working unchanged.
+export { deepCloneWithFreshIds }
+export type { PuckTemplate }
 
 // ─── Blank Template ──────────────────────────────────────────────────────────
 
@@ -1136,4 +1103,10 @@ export const PUCK_TEMPLATES: PuckTemplate[] = [
   codeSchoolFaqTemplate,
   codeSchoolContactTemplate,
   codeSchoolCatalogTemplate,
+  // Vertical packs (Home / About / FAQ / Contact each)
+  ...languageSchoolTemplates,
+  ...fitnessStudioTemplates,
+  ...musicAcademyTemplates,
+  ...businessCoachingTemplates,
+  ...designSchoolTemplates,
 ]

--- a/lib/puck/templates/language-school.ts
+++ b/lib/puck/templates/language-school.ts
@@ -1,0 +1,318 @@
+import { c, type PuckTemplate } from './_shared'
+
+// ─── Language School ─────────────────────────────────────────────────────────
+// Multi-page pack for language academies (English, Spanish, French…). LATAM-
+// and English-market friendly. Pages: Home, About, FAQ, Contact.
+
+const LOGO = '🗣️ LinguaSchool'
+const FOOTER_COLUMNS = [
+  { title: 'Learn', links: [{ label: 'All Courses', href: '/courses' }, { label: 'Pricing', href: '/pricing' }, { label: 'Placement Test', href: '#' }] },
+  { title: 'School', links: [{ label: 'About', href: '#about' }, { label: 'Our Teachers', href: '#about' }, { label: 'Contact', href: '#contact' }] },
+  { title: 'Legal', links: [{ label: 'Terms', href: '/terms' }, { label: 'Privacy', href: '/privacy' }] },
+]
+
+function header(navLinks: { label: string; href: string }[]) {
+  return c('Header', {
+    logo: '', logoText: LOGO, navLinks,
+    ctaLabel: 'Start Free Trial', ctaHref: '/courses',
+    showLogin: true, sticky: true, transparent: false,
+  })
+}
+
+function footer() {
+  return c('Footer', {
+    description: 'Speak a new language with confidence. Live classes, native teachers, real conversation practice.',
+    columns: FOOTER_COLUMNS,
+    socialLinks: [{ platform: 'Instagram', url: '#' }, { platform: 'YouTube', url: '#' }, { platform: 'Facebook', url: '#' }],
+    copyright: '© 2026 LinguaSchool. All rights reserved.',
+  })
+}
+
+const homeTemplate: PuckTemplate = {
+  name: 'Language School — Home',
+  description: 'Landing page for language academies: levels, native teachers, conversation practice, and pricing.',
+  category: 'language-school',
+  sort_order: 20,
+  pageType: 'home',
+  puck_data: {
+    root: { props: {} },
+    content: [
+      header([
+        { label: 'Courses', href: '/courses' },
+        { label: 'Levels', href: '#levels' },
+        { label: 'Pricing', href: '#pricing' },
+        { label: 'About', href: '#about' },
+        { label: 'FAQ', href: '#faq' },
+      ]),
+      c('HeroBlock', {
+        title: 'Speak a New Language. Sooner Than You Think.',
+        subtitle: 'Live classes with native teachers, conversation practice from day one, and a path tailored to your level — from absolute beginner to fluent.',
+        primaryCtaLabel: 'Take Free Placement Test',
+        primaryCtaHref: '/courses',
+        secondaryCtaLabel: 'See Pricing',
+        secondaryCtaHref: '#pricing',
+        backgroundImage: '', alignment: 'center', overlayOpacity: 55, minHeight: '500px',
+      }),
+      c('StatsCounter', {
+        items: [
+          { value: '8,000', label: 'Active Students', prefix: '', suffix: '+' },
+          { value: '6', label: 'Languages', prefix: '', suffix: '' },
+          { value: '120', label: 'Native Teachers', prefix: '', suffix: '+' },
+          { value: '4.9', label: 'Average Rating', prefix: '', suffix: '/5' },
+        ],
+        alignment: 'center',
+      }),
+      c('FeaturesGrid', {
+        title: 'A Better Way to Learn a Language',
+        subtitle: 'Everything you need to go from your first words to real conversations.',
+        items: [
+          { icon: '🌍', title: 'Native Teachers', description: 'Learn pronunciation, slang, and culture from teachers who grew up speaking the language.' },
+          { icon: '💬', title: 'Conversation First', description: 'Speak from your very first class. We focus on real communication, not just grammar drills.' },
+          { icon: '📈', title: 'CEFR Levels', description: 'Structured A1–C2 path aligned to international standards. Always know exactly where you stand.' },
+          { icon: '🕐', title: 'Flexible Schedule', description: 'Morning, evening, and weekend classes. Learn on a schedule that fits your life.' },
+          { icon: '👥', title: 'Small Groups', description: 'Maximum 6 students per class so everyone gets to speak and get feedback.' },
+          { icon: '🏆', title: 'Official Certificates', description: 'Earn verifiable certificates at each level to prove your progress to employers and schools.' },
+        ],
+        columns: '3',
+      }),
+      c('FeaturesGrid', {
+        title: 'Find Your Level',
+        subtitle: 'Whether you are starting from zero or polishing fluency, there is a path for you.',
+        items: [
+          { icon: '🌱', title: 'Beginner (A1–A2)', description: 'Build a foundation: greetings, everyday vocabulary, and your first conversations.' },
+          { icon: '🌿', title: 'Intermediate (B1–B2)', description: 'Express opinions, handle travel and work situations, and understand native speakers.' },
+          { icon: '🌳', title: 'Advanced (C1–C2)', description: 'Master nuance, idioms, and professional fluency. Speak with confidence in any setting.' },
+        ],
+        columns: '3',
+      }),
+      c('CourseGrid', {
+        title: 'Popular Courses',
+        subtitle: 'Start with our most popular language courses, chosen by thousands of learners.',
+        maxItems: 6, columns: '3', showPrice: true, showDescription: true,
+      }),
+      c('PricingTable', {
+        title: 'Simple, Flexible Pricing',
+        subtitle: 'Pay as you go or save with a membership. Cancel anytime.',
+        items: [
+          { name: 'Group Classes', price: '$59', period: '/month', description: 'Learn with a small group', features: '4 live group classes per week\nNative teacher\nCourse materials included\nLevel certificate\nCommunity access', highlighted: false, ctaLabel: 'Join a Group', ctaHref: '/courses' },
+          { name: 'Unlimited', price: '$99', period: '/month', description: 'Our most popular plan', features: 'Unlimited group classes\n2 private lessons per month\nConversation clubs\nAI pronunciation feedback\nPriority scheduling', highlighted: true, ctaLabel: 'Start Unlimited', ctaHref: '#' },
+          { name: 'Private 1-on-1', price: '$29', period: '/lesson', description: 'Fully personalized', features: 'One-on-one with a native teacher\nCustom lesson plan\nFlexible scheduling\nFocus on your goals\nRecorded lessons', highlighted: false, ctaLabel: 'Book a Lesson', ctaHref: '#contact' },
+        ],
+      }),
+      c('TestimonialGrid', {
+        title: 'Loved by Learners Worldwide',
+        subtitle: 'Real stories from students who found their voice in a new language.',
+        items: [
+          { name: 'Camila T.', role: 'Learned English', quote: 'After six months I went from silent in meetings to leading them in English. The conversation focus made all the difference.', rating: 5 },
+          { name: 'Hiroshi N.', role: 'Learned Spanish', quote: 'The native teachers and small groups meant I actually spoke every class. I passed my B2 exam on the first try.', rating: 5 },
+          { name: 'Sophie L.', role: 'Learned French', quote: 'Flexible evening classes fit around my job perfectly. I am finally having real conversations on my trips to Paris.', rating: 5 },
+        ],
+      }),
+      c('FaqAccordion', {
+        title: 'Common Questions',
+        subtitle: '',
+        items: [
+          { question: 'I am a complete beginner. Can I still join?', answer: 'Absolutely. Our A1 courses assume zero prior knowledge. We start with the very basics and build up at a comfortable pace.' },
+          { question: 'How do you decide my level?', answer: 'Take our free online placement test. It takes about 15 minutes and recommends the right course for your current level.' },
+          { question: 'Are classes live or recorded?', answer: 'Classes are live with a native teacher so you get real conversation and instant feedback. Private lessons can also be recorded for review.' },
+          { question: 'What if I miss a class?', answer: 'No problem. You can join another group at the same level that week, and unlimited members get access to recorded conversation clubs.' },
+        ],
+      }),
+      c('CtaBlock', {
+        title: 'Your First Conversation Is One Click Away',
+        subtitle: 'Take the free placement test and book a trial class today — no credit card required.',
+        primaryCtaLabel: 'Start Free Trial',
+        primaryCtaHref: '/courses',
+        secondaryCtaLabel: 'View Pricing',
+        secondaryCtaHref: '#pricing',
+        style: 'gradient',
+      }),
+      footer(),
+    ],
+    zones: {},
+  },
+}
+
+const aboutTemplate: PuckTemplate = {
+  name: 'Language School — About',
+  description: 'About page for a language academy: mission, teaching method, and teachers.',
+  category: 'language-school',
+  sort_order: 21,
+  pageType: 'about',
+  puck_data: {
+    root: { props: {} },
+    content: [
+      header([
+        { label: 'Home', href: '/' },
+        { label: 'Courses', href: '/courses' },
+        { label: 'FAQ', href: '#faq' },
+        { label: 'Contact', href: '#contact' },
+      ]),
+      c('HeroBlock', {
+        title: 'We Believe Everyone Can Become Fluent',
+        subtitle: 'No memorizing endless grammar tables. Just real conversation, patient teachers, and a method built around how people actually learn to speak.',
+        primaryCtaLabel: '', primaryCtaHref: '', secondaryCtaLabel: '', secondaryCtaHref: '',
+        backgroundImage: '', alignment: 'center', overlayOpacity: 50, minHeight: '400px',
+      }),
+      c('TextBlock', {
+        content: 'LinguaSchool started with a simple frustration: people study a language for years and still freeze when it is time to speak. We knew there had to be a better way.\n\nSo we built a school around conversation. Every class is led by a native teacher, every group is small enough that you speak constantly, and every level follows the international CEFR standard so your progress is real and measurable. Today we help over 8,000 students across the world find the confidence to speak — at work, while traveling, and with the people they love.',
+        alignment: 'center', color: '', maxWidth: '768px', fontSize: '1.125rem',
+      }),
+      c('StatsCounter', {
+        items: [
+          { value: '8,000', label: 'Students Worldwide', prefix: '', suffix: '+' },
+          { value: '6', label: 'Languages Taught', prefix: '', suffix: '' },
+          { value: '50', label: 'Countries', prefix: '', suffix: '+' },
+          { value: '2017', label: 'Founded', prefix: '', suffix: '' },
+        ],
+        alignment: 'center',
+      }),
+      c('FeaturesGrid', {
+        title: 'Our Teaching Method',
+        subtitle: 'Four principles behind every class we teach.',
+        items: [
+          { icon: '💬', title: 'Speak From Day One', description: 'You start using the language immediately. We build confidence through practice, not perfection.' },
+          { icon: '🎧', title: 'Immersive & Native', description: 'Classes are taught in the target language by native speakers, so your ear adapts naturally.' },
+          { icon: '🧩', title: 'Real-Life Context', description: 'Learn vocabulary and grammar through scenarios you will actually use — ordering, traveling, working.' },
+          { icon: '📊', title: 'Measurable Progress', description: 'Every level maps to CEFR standards, so you always know exactly how far you have come.' },
+        ],
+        columns: '2',
+      }),
+      c('TeamGrid', {
+        title: 'Meet Our Teachers',
+        subtitle: 'Native speakers and certified language educators who love what they do.',
+        members: [
+          { name: 'Emma Wilson', role: 'Head of English', bio: 'CELTA-certified, 10+ years teaching English to professionals across Latin America.', avatar: '' },
+          { name: 'Diego Martínez', role: 'Head of Spanish', bio: 'Native from Madrid. Specializes in conversational fluency and exam preparation.', avatar: '' },
+          { name: 'Claire Dubois', role: 'Head of French', bio: 'Paris-born teacher passionate about culture-driven language learning.', avatar: '' },
+          { name: 'Marco Rossi', role: 'Curriculum Lead', bio: 'Applied linguist who designs our CEFR-aligned learning paths.', avatar: '' },
+        ],
+      }),
+      c('CtaBlock', {
+        title: 'Come Learn With Us',
+        subtitle: 'Take the free placement test and meet your future teacher.',
+        primaryCtaLabel: 'Start Free Trial',
+        primaryCtaHref: '/courses',
+        secondaryCtaLabel: 'Contact Us',
+        secondaryCtaHref: '#contact',
+        style: 'gradient',
+      }),
+      footer(),
+    ],
+    zones: {},
+  },
+}
+
+const faqTemplate: PuckTemplate = {
+  name: 'Language School — FAQ',
+  description: 'FAQ page for a language academy covering levels, classes, pricing, and certificates.',
+  category: 'language-school',
+  sort_order: 22,
+  pageType: 'faq',
+  puck_data: {
+    root: { props: {} },
+    content: [
+      header([
+        { label: 'Home', href: '/' },
+        { label: 'Courses', href: '/courses' },
+        { label: 'Pricing', href: '/pricing' },
+        { label: 'Contact', href: '#contact' },
+      ]),
+      c('HeroBlock', {
+        title: 'Frequently Asked Questions',
+        subtitle: 'Everything you need to know about classes, levels, pricing, and certificates.',
+        primaryCtaLabel: '', primaryCtaHref: '', secondaryCtaLabel: '', secondaryCtaHref: '',
+        backgroundImage: '', alignment: 'center', overlayOpacity: 50, minHeight: '300px',
+      }),
+      c('FaqAccordion', {
+        title: 'Getting Started',
+        subtitle: '',
+        items: [
+          { question: 'Do I need any prior knowledge?', answer: 'Not at all. Our A1 beginner courses assume zero knowledge. You will learn your first words and phrases in the very first class.' },
+          { question: 'How do I know which level to join?', answer: 'Take our free 15-minute online placement test. It evaluates your reading, listening, and grammar and recommends the perfect starting course.' },
+          { question: 'Which languages do you offer?', answer: 'We currently teach English, Spanish, French, Italian, German, and Portuguese, with new languages added regularly.' },
+          { question: 'Can I switch languages later?', answer: 'Yes. Your membership lets you start a new language anytime — many students learn two at once.' },
+        ],
+      }),
+      c('FaqAccordion', {
+        title: 'Classes & Schedule',
+        subtitle: '',
+        items: [
+          { question: 'Are classes live or self-paced?', answer: 'All group and private classes are live with a native teacher. We also offer self-paced practice materials and recorded conversation clubs.' },
+          { question: 'How big are the groups?', answer: 'Group classes are capped at 6 students so everyone gets plenty of speaking time and personal feedback.' },
+          { question: 'What times are classes available?', answer: 'We run classes across multiple time zones — mornings, evenings, and weekends — so you can always find a slot that fits.' },
+          { question: 'What happens if I miss a class?', answer: 'You can join another group at your level the same week, and unlimited members get access to recorded sessions and conversation clubs.' },
+        ],
+      }),
+      c('FaqAccordion', {
+        title: 'Pricing & Certificates',
+        subtitle: '',
+        items: [
+          { question: 'How much does it cost?', answer: 'Group memberships start at $59/month. Our most popular Unlimited plan is $99/month, and private 1-on-1 lessons are $29 each.' },
+          { question: 'Is there a free trial?', answer: 'Yes. You can take the placement test and book a free trial class before committing to any plan — no credit card required.' },
+          { question: 'Do I get a certificate?', answer: 'Yes. You earn a verifiable digital certificate at the end of each CEFR level (A1 through C2) that you can share on LinkedIn or your resume.' },
+          { question: 'Can I get a refund?', answer: 'We offer a 14-day money-back guarantee on all memberships. If it is not the right fit, contact us for a full refund.' },
+        ],
+      }),
+      c('CtaBlock', {
+        title: 'Still Have Questions?',
+        subtitle: 'Our team is happy to help you choose the right plan and level.',
+        primaryCtaLabel: 'Contact Us',
+        primaryCtaHref: '#contact',
+        secondaryCtaLabel: 'Browse Courses',
+        secondaryCtaHref: '/courses',
+        style: 'bordered',
+      }),
+      footer(),
+    ],
+    zones: {},
+  },
+}
+
+const contactTemplate: PuckTemplate = {
+  name: 'Language School — Contact',
+  description: 'Contact page for a language academy with form and quick answers.',
+  category: 'language-school',
+  sort_order: 23,
+  pageType: 'contact',
+  puck_data: {
+    root: { props: {} },
+    content: [
+      header([
+        { label: 'Home', href: '/' },
+        { label: 'Courses', href: '/courses' },
+        { label: 'FAQ', href: '#faq' },
+      ]),
+      c('HeroBlock', {
+        title: 'Get in Touch',
+        subtitle: 'Questions about levels, scheduling, or private lessons? We would love to help you start speaking.',
+        primaryCtaLabel: '', primaryCtaHref: '', secondaryCtaLabel: '', secondaryCtaHref: '',
+        backgroundImage: '', alignment: 'center', overlayOpacity: 50, minHeight: '300px',
+      }),
+      c('ContactForm', {
+        title: 'Send Us a Message',
+        subtitle: 'Tell us which language you want to learn and your goals — we will recommend the right path.',
+        email: 'hello@linguaschool.com',
+        showPhone: true, showMessage: true,
+      }),
+      c('FaqAccordion', {
+        title: 'Quick Answers',
+        subtitle: '',
+        items: [
+          { question: 'How do I book a free trial class?', answer: 'Take the placement test from the Courses page, then pick a trial slot at your recommended level. We will confirm by email.' },
+          { question: 'Can I take private lessons only?', answer: 'Yes. Private 1-on-1 lessons are available for every language and level, fully scheduled around your availability.' },
+          { question: 'Do you offer classes for companies?', answer: 'We do. Reach out for corporate language training with custom schedules, progress reports, and group pricing.' },
+        ],
+      }),
+      footer(),
+    ],
+    zones: {},
+  },
+}
+
+export const languageSchoolTemplates: PuckTemplate[] = [
+  homeTemplate,
+  aboutTemplate,
+  faqTemplate,
+  contactTemplate,
+]

--- a/lib/puck/templates/music-academy.ts
+++ b/lib/puck/templates/music-academy.ts
@@ -1,0 +1,319 @@
+import { c, type PuckTemplate } from './_shared'
+
+// ─── Music Academy ───────────────────────────────────────────────────────────
+// Multi-page pack for music schools and online instrument/vocal teachers.
+// Pages: Home, About, FAQ, Contact.
+
+const LOGO = '🎵 Crescendo'
+const FOOTER_COLUMNS = [
+  { title: 'Learn', links: [{ label: 'All Courses', href: '/courses' }, { label: 'Instruments', href: '#instruments' }, { label: 'Pricing', href: '/pricing' }] },
+  { title: 'Academy', links: [{ label: 'About', href: '#about' }, { label: 'Our Teachers', href: '#about' }, { label: 'Contact', href: '#contact' }] },
+  { title: 'Legal', links: [{ label: 'Terms', href: '/terms' }, { label: 'Privacy', href: '/privacy' }] },
+]
+
+function header(navLinks: { label: string; href: string }[]) {
+  return c('Header', {
+    logo: '', logoText: LOGO, navLinks,
+    ctaLabel: 'Book Free Lesson', ctaHref: '/courses',
+    showLogin: true, sticky: true, transparent: false,
+  })
+}
+
+function footer() {
+  return c('Footer', {
+    description: 'Learn to play the music you love. Step-by-step courses and live lessons for every instrument and level.',
+    columns: FOOTER_COLUMNS,
+    socialLinks: [{ platform: 'YouTube', url: '#' }, { platform: 'Instagram', url: '#' }, { platform: 'Spotify', url: '#' }],
+    copyright: '© 2026 Crescendo Music Academy. All rights reserved.',
+  })
+}
+
+const homeTemplate: PuckTemplate = {
+  name: 'Music Academy — Home',
+  description: 'Landing page for music schools and online instrument or vocal teachers.',
+  category: 'music',
+  sort_order: 40,
+  pageType: 'home',
+  puck_data: {
+    root: { props: {} },
+    content: [
+      header([
+        { label: 'Courses', href: '/courses' },
+        { label: 'Instruments', href: '#instruments' },
+        { label: 'Pricing', href: '#pricing' },
+        { label: 'About', href: '#about' },
+        { label: 'FAQ', href: '#faq' },
+      ]),
+      c('HeroBlock', {
+        title: 'Play the Music You Love',
+        subtitle: 'Step-by-step courses and live lessons for guitar, piano, voice, and more. Go from your first note to your first song — faster than you think.',
+        primaryCtaLabel: 'Book a Free Lesson',
+        primaryCtaHref: '/courses',
+        secondaryCtaLabel: 'Explore Instruments',
+        secondaryCtaHref: '#instruments',
+        backgroundImage: '', alignment: 'center', overlayOpacity: 60, minHeight: '520px',
+      }),
+      c('StatsCounter', {
+        items: [
+          { value: '18,000', label: 'Students', prefix: '', suffix: '+' },
+          { value: '10', label: 'Instruments', prefix: '', suffix: '+' },
+          { value: '90', label: 'Pro Teachers', prefix: '', suffix: '+' },
+          { value: '4.9', label: 'Student Rating', prefix: '', suffix: '/5' },
+        ],
+        alignment: 'center',
+      }),
+      c('FeaturesGrid', {
+        title: 'Why Learn With Us',
+        subtitle: 'Everything you need to make real musical progress.',
+        items: [
+          { icon: '🎸', title: 'Learn by Playing', description: 'Play real songs from your first lesson. We teach through music you actually want to play.' },
+          { icon: '🎹', title: 'Step-by-Step Path', description: 'Clear lesson sequences take you from absolute beginner to confident musician.' },
+          { icon: '🎤', title: 'Live Feedback', description: 'Book live lessons with pro teachers who correct your technique and answer questions.' },
+          { icon: '🎧', title: 'Play Along', description: 'Practice with backing tracks, slow-downs, and interactive sheet music.' },
+          { icon: '⏱️', title: 'Learn at Your Pace', description: 'Self-paced courses you can replay anytime, on any device.' },
+          { icon: '🏆', title: 'Track Your Growth', description: 'Hit milestones, earn certificates, and watch your skills build week by week.' },
+        ],
+        columns: '3',
+      }),
+      c('FeaturesGrid', {
+        title: 'Choose Your Instrument',
+        subtitle: 'Pick where you want to start — or learn several.',
+        items: [
+          { icon: '🎸', title: 'Guitar', description: 'Acoustic and electric. Chords, riffs, fingerstyle, and full songs.' },
+          { icon: '🎹', title: 'Piano & Keys', description: 'Read music, play by ear, and master classical to modern pop.' },
+          { icon: '🎤', title: 'Voice', description: 'Build range, control, and confidence with proven vocal technique.' },
+          { icon: '🥁', title: 'Drums', description: 'Groove, timing, and fills across rock, funk, and beyond.' },
+        ],
+        columns: '4',
+      }),
+      c('CourseGrid', {
+        title: 'Popular Courses',
+        subtitle: 'Start with our most popular courses, chosen by thousands of students.',
+        maxItems: 6, columns: '3', showPrice: true, showDescription: true,
+      }),
+      c('PricingTable', {
+        title: 'Plans for Every Musician',
+        subtitle: 'Self-paced or live lessons. Cancel anytime.',
+        items: [
+          { name: 'Self-Paced', price: '$15', period: '/month', description: 'Learn on your own time', features: 'All course library\nPlay-along tracks\nInteractive sheet music\nProgress tracking\nCertificates', highlighted: false, ctaLabel: 'Start Learning', ctaHref: '/courses' },
+          { name: 'Premium', price: '$39', period: '/month', description: 'Courses + live lessons', features: 'Everything in Self-Paced\n2 live lessons per month\nPersonalized practice plan\nTechnique feedback\nPriority support', highlighted: true, ctaLabel: 'Go Premium', ctaHref: '#' },
+          { name: 'Private', price: '$35', period: '/lesson', description: 'One-on-one coaching', features: 'Private lessons with a pro\nTailored to your goals\nFlexible scheduling\nRecorded sessions\nAny instrument or level', highlighted: false, ctaLabel: 'Book a Lesson', ctaHref: '#contact' },
+        ],
+      }),
+      c('TestimonialGrid', {
+        title: 'From Our Students',
+        subtitle: 'Real progress from real musicians.',
+        items: [
+          { name: 'Olivia M.', role: 'Guitar student', quote: 'I always thought I was tone deaf. Three months later I am playing full songs at family gatherings. The play-along approach just works.', rating: 5 },
+          { name: 'Raj P.', role: 'Piano student', quote: 'The step-by-step path kept me from giving up. Live feedback fixed bad habits I did not even know I had.', rating: 5 },
+          { name: 'Grace K.', role: 'Voice student', quote: 'My range and confidence have grown so much. I finally sang in front of people — and loved it.', rating: 5 },
+        ],
+      }),
+      c('FaqAccordion', {
+        title: 'Common Questions',
+        subtitle: '',
+        items: [
+          { question: 'I have never played before. Can I start here?', answer: 'Yes! Our beginner courses assume zero experience. You will learn how to hold the instrument, read along, and play your first notes right away.' },
+          { question: 'Do I need my own instrument?', answer: 'Yes, you will need access to your instrument to practice. We offer buying guides for affordable starter options.' },
+          { question: 'How quickly will I learn a song?', answer: 'Most beginners play a recognizable song within their first two weeks of regular practice.' },
+          { question: 'Are live lessons available for my instrument?', answer: 'We offer live lessons for guitar, piano, voice, drums, bass, ukulele, and more. Check the course page for availability.' },
+        ],
+      }),
+      c('CtaBlock', {
+        title: 'Your First Song Is Waiting',
+        subtitle: 'Book a free lesson and start playing the music you love today.',
+        primaryCtaLabel: 'Book Free Lesson',
+        primaryCtaHref: '/courses',
+        secondaryCtaLabel: 'View Pricing',
+        secondaryCtaHref: '#pricing',
+        style: 'gradient',
+      }),
+      footer(),
+    ],
+    zones: {},
+  },
+}
+
+const aboutTemplate: PuckTemplate = {
+  name: 'Music Academy — About',
+  description: 'About page for a music academy: mission, approach, and teachers.',
+  category: 'music',
+  sort_order: 41,
+  pageType: 'about',
+  puck_data: {
+    root: { props: {} },
+    content: [
+      header([
+        { label: 'Home', href: '/' },
+        { label: 'Courses', href: '/courses' },
+        { label: 'FAQ', href: '#faq' },
+        { label: 'Contact', href: '#contact' },
+      ]),
+      c('HeroBlock', {
+        title: 'Music Belongs to Everyone',
+        subtitle: 'We built Crescendo because learning an instrument should be joyful, not intimidating — and you should be playing real music from the very first lesson.',
+        primaryCtaLabel: '', primaryCtaHref: '', secondaryCtaLabel: '', secondaryCtaHref: '',
+        backgroundImage: '', alignment: 'center', overlayOpacity: 55, minHeight: '400px',
+      }),
+      c('TextBlock', {
+        content: 'Too many people quit an instrument in the first month — buried in boring exercises before they ever play a song they love. We knew there was a better way.\n\nCrescendo teaches through real music. Every course is built around songs, every lesson gives you something you can actually play, and every student can book live feedback from a professional teacher. Since 2018 we have helped over 18,000 students pick up guitars, sit at pianos, and find their voice. Whether you are seven or seventy, a total beginner or returning after years away, there is a place for you here.',
+        alignment: 'center', color: '', maxWidth: '768px', fontSize: '1.125rem',
+      }),
+      c('StatsCounter', {
+        items: [
+          { value: '18,000', label: 'Students', prefix: '', suffix: '+' },
+          { value: '10', label: 'Instruments', prefix: '', suffix: '+' },
+          { value: '45', label: 'Countries', prefix: '', suffix: '+' },
+          { value: '2018', label: 'Founded', prefix: '', suffix: '' },
+        ],
+        alignment: 'center',
+      }),
+      c('FeaturesGrid', {
+        title: 'Our Approach',
+        subtitle: 'What makes learning with us different.',
+        items: [
+          { icon: '🎶', title: 'Songs First', description: 'You learn theory and technique through real music — not endless scales in isolation.' },
+          { icon: '🧑‍🏫', title: 'Pro Teachers', description: 'Every live lesson is with a working, performing musician who knows how to teach.' },
+          { icon: '🪜', title: 'Clear Progression', description: 'Structured paths mean you always know your next step and never feel lost.' },
+          { icon: '🎉', title: 'Joyful Practice', description: 'We make practice something you look forward to, with play-alongs and quick wins.' },
+        ],
+        columns: '2',
+      }),
+      c('TeamGrid', {
+        title: 'Meet Your Teachers',
+        subtitle: 'Performing musicians who love to teach.',
+        members: [
+          { name: 'Nina Alvarez', role: 'Founder & Guitar', bio: 'Touring guitarist turned educator with 15 years of teaching experience.', avatar: '' },
+          { name: 'David Okafor', role: 'Piano & Theory', bio: 'Conservatory-trained pianist who makes music theory finally make sense.', avatar: '' },
+          { name: 'Mia Sørensen', role: 'Voice', bio: 'Professional vocalist specializing in technique, range, and stage confidence.', avatar: '' },
+          { name: 'Leo Bianchi', role: 'Drums & Rhythm', bio: 'Session drummer who has played hundreds of shows across every genre.', avatar: '' },
+        ],
+      }),
+      c('CtaBlock', {
+        title: 'Start Making Music Today',
+        subtitle: 'Book a free lesson and discover how good it feels to play.',
+        primaryCtaLabel: 'Book Free Lesson',
+        primaryCtaHref: '/courses',
+        secondaryCtaLabel: 'Contact Us',
+        secondaryCtaHref: '#contact',
+        style: 'gradient',
+      }),
+      footer(),
+    ],
+    zones: {},
+  },
+}
+
+const faqTemplate: PuckTemplate = {
+  name: 'Music Academy — FAQ',
+  description: 'FAQ page for a music academy covering instruments, lessons, pricing, and equipment.',
+  category: 'music',
+  sort_order: 42,
+  pageType: 'faq',
+  puck_data: {
+    root: { props: {} },
+    content: [
+      header([
+        { label: 'Home', href: '/' },
+        { label: 'Courses', href: '/courses' },
+        { label: 'Pricing', href: '/pricing' },
+        { label: 'Contact', href: '#contact' },
+      ]),
+      c('HeroBlock', {
+        title: 'Frequently Asked Questions',
+        subtitle: 'Everything you need to know about lessons, instruments, and pricing.',
+        primaryCtaLabel: '', primaryCtaHref: '', secondaryCtaLabel: '', secondaryCtaHref: '',
+        backgroundImage: '', alignment: 'center', overlayOpacity: 55, minHeight: '300px',
+      }),
+      c('FaqAccordion', {
+        title: 'Getting Started',
+        subtitle: '',
+        items: [
+          { question: 'Do I need any musical experience?', answer: 'None at all. Our beginner courses start from the very basics — how to hold your instrument, read along, and play your first notes.' },
+          { question: 'Which instruments can I learn?', answer: 'Guitar, piano, voice, drums, bass, ukulele, violin, and more. New instruments and courses are added regularly.' },
+          { question: 'Do I need my own instrument?', answer: 'Yes — you will need access to your instrument to practice. We provide buying guides for affordable, quality starter options.' },
+          { question: 'How long until I can play a song?', answer: 'Most beginners play a recognizable song within two weeks of regular practice. Quick wins keep you motivated from the start.' },
+        ],
+      }),
+      c('FaqAccordion', {
+        title: 'Lessons & Practice',
+        subtitle: '',
+        items: [
+          { question: 'Are lessons live or self-paced?', answer: 'Both. Self-paced courses are available 24/7, and Premium and Private members can book live lessons with professional teachers.' },
+          { question: 'How do live lessons work?', answer: 'You book a time slot, join a video call with your teacher, and get real-time feedback on your playing and technique. Sessions can be recorded for review.' },
+          { question: 'How much should I practice?', answer: 'Even 15–20 minutes a day makes a big difference. Our practice plans help you build a consistent, enjoyable routine.' },
+          { question: 'Can I learn more than one instrument?', answer: 'Yes! Your membership gives you access to courses across all instruments, so you can explore as many as you like.' },
+        ],
+      }),
+      c('FaqAccordion', {
+        title: 'Pricing & Plans',
+        subtitle: '',
+        items: [
+          { question: 'How much does it cost?', answer: 'Self-Paced is $15/month, Premium (courses + live lessons) is $39/month, and Private 1-on-1 lessons are $35 each.' },
+          { question: 'Is there a free lesson?', answer: 'Yes. You can book a free introductory lesson to experience our teaching style before choosing a plan.' },
+          { question: 'Can I cancel anytime?', answer: 'Absolutely. There are no contracts. Cancel with one click and keep access until your billing period ends.' },
+          { question: 'Do you offer family or group plans?', answer: 'We do. Reach out for family memberships and discounts for music schools or community groups.' },
+        ],
+      }),
+      c('CtaBlock', {
+        title: 'Still Have Questions?',
+        subtitle: 'Our team is happy to help you find the right instrument and plan.',
+        primaryCtaLabel: 'Contact Us',
+        primaryCtaHref: '#contact',
+        secondaryCtaLabel: 'Browse Courses',
+        secondaryCtaHref: '/courses',
+        style: 'bordered',
+      }),
+      footer(),
+    ],
+    zones: {},
+  },
+}
+
+const contactTemplate: PuckTemplate = {
+  name: 'Music Academy — Contact',
+  description: 'Contact page for a music academy with form and quick answers.',
+  category: 'music',
+  sort_order: 43,
+  pageType: 'contact',
+  puck_data: {
+    root: { props: {} },
+    content: [
+      header([
+        { label: 'Home', href: '/' },
+        { label: 'Courses', href: '/courses' },
+        { label: 'FAQ', href: '#faq' },
+      ]),
+      c('HeroBlock', {
+        title: 'Get in Touch',
+        subtitle: 'Questions about instruments, live lessons, or plans? We would love to help you start playing.',
+        primaryCtaLabel: '', primaryCtaHref: '', secondaryCtaLabel: '', secondaryCtaHref: '',
+        backgroundImage: '', alignment: 'center', overlayOpacity: 55, minHeight: '300px',
+      }),
+      c('ContactForm', {
+        title: 'Send Us a Message',
+        subtitle: 'Tell us what you want to play and your experience level — we will point you to the perfect course.',
+        email: 'hello@crescendo.com',
+        showPhone: false, showMessage: true,
+      }),
+      c('FaqAccordion', {
+        title: 'Quick Answers',
+        subtitle: '',
+        items: [
+          { question: 'How do I book my free lesson?', answer: 'Click "Book Free Lesson" on any page, pick your instrument, and choose an available time. We will confirm by email.' },
+          { question: 'Can I take private lessons only?', answer: 'Yes. Private 1-on-1 lessons are available for every instrument and level, scheduled around your availability.' },
+          { question: 'Do you teach children?', answer: 'We do. Many of our courses and teachers specialize in young learners, with parent-friendly progress updates.' },
+        ],
+      }),
+      footer(),
+    ],
+    zones: {},
+  },
+}
+
+export const musicAcademyTemplates: PuckTemplate[] = [
+  homeTemplate,
+  aboutTemplate,
+  faqTemplate,
+  contactTemplate,
+]


### PR DESCRIPTION
## What

Adds **5 ready-made vertical template packs** to the Puck landing-page builder so a new school can pick its niche and launch a full multi-page site in one click. Extends the existing generic *Academy* + *Code School* sets toward true zero-effort onboarding.

**20 new templates** — each pack ships Home / About / FAQ / Contact:

| Pack | Category | Focus |
|------|----------|-------|
| 🗣️ Language School | `language-school` | CEFR levels, native teachers, conversation-first |
| 💪 Fitness Studio | `fitness` | Programs, live + on-demand, memberships |
| 🎵 Music Academy | `music` | Instruments, live lessons, play-along learning |
| 🚀 Business Coaching | `business` | Client acquisition, group + 1-on-1 coaching |
| 🎨 Design School | `design` | UX/UI · graphic · illustration · portfolio |

## How it works

- Each page targets the correct Puck `pageType` (`home`/`about`/`faq`/`contact`) so it surfaces under the right step in the existing `TemplatePicker` flow.
- Each pack has a distinct `category` with a matching badge color added to the picker.
- `CourseGrid` blocks pull the tenant's **real published catalog** server-side (existing dynamic-data path) — placeholders only for testimonials/team/pricing copy.
- All content is plain copy (no i18n keys) — consistent with the existing templates.

## Refactor

Extracted the shared `c()` content builder + `deepCloneWithFreshIds` into `lib/puck/templates/_shared.ts` so each vertical lives in its own file without an import cycle. `index.ts` re-exports both, so existing importers of `@/lib/puck/templates` are unchanged.

## Verification

- `npx tsc --noEmit` — clean
- `npm run build` — passes, middleware compiled
- New templates appear in `PUCK_TEMPLATES` and flow through the picker → create → Puck editor → publish path with no code changes to the editor.

## Notes

Visual QA (picker screenshots per vertical) available on request — left out here since this is template data that renders through the already-shipped editor/render pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)