### PR TITLE
feat(api): Bearer-token auth + JWT tenant resolution for chat routes (mobile app backend)

### DIFF
--- a/app/[locale]/dashboard/student/browse/page.tsx
+++ b/app/[locale]/dashboard/student/browse/page.tsx
@@ -9,6 +9,12 @@ import Link from 'next/link'
 import { IconAlertCircle, IconSparkles, IconTrophy, IconSearch } from '@tabler/icons-react'
 import {getCurrentTenantId, getCurrentUserId } from '@/lib/supabase/tenant'
 import { fetchAccessibleCourseIds } from '@/lib/services/course-access'
+import {
+  getPublishedCourses,
+  getCourseCategories,
+  getActiveSubscriptions,
+  getPlanCourses,
+} from '@lms/core'
 
 export default async function BrowseCoursesPage({
   searchParams,
@@ -28,50 +34,14 @@ export default async function BrowseCoursesPage({
     redirect('/auth/login')
   }
 
-  // Build course query with filters
-  let query = supabase
-    .from('courses')
-    .select(`
-      course_id,
-      title,
-      description,
-      thumbnail_url,
-      tags,
-      category_id
-    `)
-    .eq('tenant_id', tenantId)
-    .eq('status', 'published')
-    .order('title', { ascending: true })
-
-  // Apply search filter
-  if (sanitizedSearch) {
-    query = query.or(`title.ilike.%${sanitizedSearch}%,description.ilike.%${sanitizedSearch}%`)
-  }
-
-  // Apply category filter
-  if (category) {
-    query = query.eq('category_id', category)
-  }
-
-  // Parallelize 4 independent queries
+  // Parallelize 4 independent queries — shared query logic from @lms/core
   const [{ data: subscriptions }, { data: categories }, { data: courses }, accessibleCourseIds] = await Promise.all([
-    supabase.from('subscriptions').select(`
-      subscription_id,
-      subscription_status,
-      end_date,
-      plan:plans!subscriptions_plan_id_fkey (
-        plan_id,
-        plan_name,
-        price
-      )
-    `)
-      .eq('user_id', userId).eq('tenant_id', tenantId)
-      .eq('subscription_status', 'active')
-      .gte('end_date', new Date().toISOString())
-      .order('end_date', { ascending: false }),
-    supabase.from('course_categories').select('id, name')
-      .eq('tenant_id', tenantId).order('name'),
-    query,
+    getActiveSubscriptions(supabase, userId, tenantId),
+    getCourseCategories(supabase, tenantId),
+    getPublishedCourses(supabase, tenantId, {
+      search: sanitizedSearch || undefined,
+      categoryId: category ? Number(category) : undefined,
+    }),
     // "Already enrolled" set — entitlements model (any active access source).
     fetchAccessibleCourseIds(supabase, userId),
   ])
@@ -83,10 +53,7 @@ export default async function BrowseCoursesPage({
   if (activeSubscription) {
     const planId = (activeSubscription.plan as any)?.plan_id
     if (planId) {
-      const { data: planCourses } = await supabase
-        .from('plan_courses')
-        .select('course_id')
-        .eq('plan_id', planId)
+      const { data: planCourses } = await getPlanCourses(supabase, planId)
 
       if (planCourses && planCourses.length > 0) {
         allowedCourseIds = new Set(planCourses.map(pc => pc.course_id))

--- a/app/[locale]/dashboard/student/courses/[courseId]/exercises/[exerciseId]/page.tsx
+++ b/app/[locale]/dashboard/student/courses/[courseId]/exercises/[exerciseId]/page.tsx
@@ -247,7 +247,6 @@ export default async function ExercisePage({ params }: PageProps) {
                         exerciseId={exercise.id}
                         isExerciseCompleted={isExerciseCompleted}
                         userCode={lastSubmission?.submission_code}
-                        tenantId={tenantId}
                     />
 
                     {otherExercises && otherExercises.length > 0 && (

--- a/app/[locale]/dashboard/student/courses/[courseId]/lessons/[lessonId]/page.tsx
+++ b/app/[locale]/dashboard/student/courses/[courseId]/lessons/[lessonId]/page.tsx
@@ -371,7 +371,7 @@ export default async function LessonPage({ params }: PageProps) {
 
             {/* Comments Section */}
             <section className="border-t pt-10">
-              <LessonComments lessonId={lesson.id} userId={userId} tenantId={tenantId} initialComments={initialComments} />
+              <LessonComments lessonId={lesson.id} userId={userId} initialComments={initialComments} />
             </section>
           </div>
         </div>

--- a/app/[locale]/dashboard/student/courses/page.tsx
+++ b/app/[locale]/dashboard/student/courses/page.tsx
@@ -9,6 +9,13 @@ import Link from 'next/link'
 import {getCurrentTenantId, getCurrentUserId } from '@/lib/supabase/tenant'
 import { fetchCourseAccessMap } from '@/lib/services/course-access'
 import type { CourseAccess } from '@/lib/services/enrollment-service'
+import {
+  getCoursesByIds,
+  getLessonsByCourseIds,
+  getExamsByCourseIds,
+  getLessonCompletions,
+  getExamSubmissions,
+} from '@lms/core'
 
 const NO_ACCESS: CourseAccess = {
   hasAccess: false,
@@ -62,16 +69,11 @@ export default async function MyCoursesPage({ searchParams }: PageProps) {
       { data: lessonCompletions },
       { data: examSubmissions },
     ] = await Promise.all([
-      supabase.from('courses').select('course_id, title, description, thumbnail_url, status')
-        .in('course_id', courseIds).eq('tenant_id', tenantId),
-      supabase.from('lessons').select('id, title, sequence, course_id')
-        .in('course_id', courseIds).eq('tenant_id', tenantId),
-      supabase.from('exams').select('exam_id, title, sequence, course_id')
-        .in('course_id', courseIds).eq('tenant_id', tenantId),
-      supabase.from('lesson_completions').select('lesson_id, completed_at')
-        .eq('user_id', userId),
-      supabase.from('exam_submissions').select('submission_id, exam_id, submission_date, score')
-        .eq('student_id', userId).eq('tenant_id', tenantId),
+      getCoursesByIds(supabase, courseIds, tenantId),
+      getLessonsByCourseIds(supabase, courseIds, tenantId),
+      getExamsByCourseIds(supabase, courseIds, tenantId),
+      getLessonCompletions(supabase, userId),
+      getExamSubmissions(supabase, userId, tenantId),
     ])
 
     // Build lookup maps

--- a/app/[locale]/dashboard/student/page.tsx
+++ b/app/[locale]/dashboard/student/page.tsx
@@ -13,6 +13,7 @@ import { MiniLeaderboard } from '@/components/gamification/mini-leaderboard'
 import { getCurrentTenantId, getSessionUser } from '@/lib/supabase/tenant'
 import { OnboardingChecklist } from '@/components/shared/onboarding-checklist'
 import { StudentDashboardTour } from '@/components/tours/student-dashboard-tour'
+import { getLessonCompletions } from '@lms/core'
 
 async function getData(userId: string, tenantId: string) {
   const supabase = createAdminClient()
@@ -44,10 +45,7 @@ async function getData(userId: string, tenantId: string) {
       .order('submission_date', { ascending: false })
       .limit(5),
 
-    supabase
-      .from('lesson_completions')
-      .select('lesson_id')
-      .eq('user_id', userId),
+    getLessonCompletions(supabase, userId),
 
     supabase
       .from('exams')

--- a/app/api/chat/aristotle/restart/route.ts
+++ b/app/api/chat/aristotle/restart/route.ts
@@ -1,13 +1,10 @@
-import { createClient } from '@/lib/supabase/server'
-import { getCurrentTenantId } from '@/lib/supabase/tenant'
+import { getApiAuthContext } from '@/lib/supabase/api-auth'
 import { generateSessionSummary } from '@/lib/ai/aristotle-summary'
 
 export async function POST(req: Request) {
-    const supabase = await createClient()
-    const tenantId = await getCurrentTenantId()
-    const { data: { user } } = await supabase.auth.getUser()
-
-    if (!user) return new Response('Unauthorized', { status: 401 })
+    const auth = await getApiAuthContext(req)
+    if (!auth) return new Response('Unauthorized', { status: 401 })
+    const { supabase, user, tenantId } = auth
 
     const { courseId } = await req.json()
     if (!courseId) return new Response('Course ID is required', { status: 400 })

--- a/app/api/chat/aristotle/route.ts
+++ b/app/api/chat/aristotle/route.ts
@@ -1,5 +1,4 @@
-import { createClient } from '@/lib/supabase/server'
-import { getCurrentTenantId } from '@/lib/supabase/tenant'
+import { getApiAuthContext } from '@/lib/supabase/api-auth'
 import { AI_CONFIG, AI_MODELS } from '@/lib/ai/config'
 import { buildAristotlePrompt } from '@/lib/ai/aristotle-prompt'
 import { convertToModelMessages, stepCountIs, streamText } from 'ai'
@@ -10,11 +9,9 @@ export const maxDuration = 120
 const SESSION_IDLE_MINUTES = 30
 
 export async function POST(req: Request) {
-    const supabase = await createClient()
-    const tenantId = await getCurrentTenantId()
-    const { data: { user } } = await supabase.auth.getUser()
-
-    if (!user) return new Response('Unauthorized', { status: 401 })
+    const auth = await getApiAuthContext(req)
+    if (!auth) return new Response('Unauthorized', { status: 401 })
+    const { supabase, user, tenantId } = auth
 
     const body = await req.json()
     const { messages, courseId, contextPage } = body

--- a/app/api/chat/exercises/student/restart/route.ts
+++ b/app/api/chat/exercises/student/restart/route.ts
@@ -1,16 +1,13 @@
-import { createClient } from '@/lib/supabase/server'
-import { getCurrentTenantId } from '@/lib/supabase/tenant'
+import { getApiAuthContext } from '@/lib/supabase/api-auth'
 import { NextResponse } from 'next/server'
 
 export async function POST(req: Request) {
     try {
-        const supabase = await createClient()
-        const tenantId = await getCurrentTenantId()
-        const { data: { user } } = await supabase.auth.getUser()
-
-        if (!user) {
+        const auth = await getApiAuthContext(req)
+        if (!auth) {
             return new NextResponse('Unauthorized', { status: 401 })
         }
+        const { supabase, user, tenantId } = auth
 
         const { exerciseId } = await req.json()
 

--- a/app/api/chat/exercises/student/route.ts
+++ b/app/api/chat/exercises/student/route.ts
@@ -1,5 +1,4 @@
-import { createClient } from '@/lib/supabase/server'
-import { getCurrentTenantId } from '@/lib/supabase/tenant'
+import { getApiAuthContext } from '@/lib/supabase/api-auth'
 import { AI_CONFIG, AI_MODELS } from '@/lib/ai/config'
 import { PROMPTS } from '@/lib/ai/prompts'
 import { createAITools } from '@/lib/ai/tools'
@@ -8,11 +7,9 @@ import { convertToModelMessages, stepCountIs, streamText } from 'ai'
 export const maxDuration = 120
 
 export async function POST(req: Request) {
-    const supabase = await createClient()
-    const tenantId = await getCurrentTenantId()
-    const { data: { user } } = await supabase.auth.getUser()
-
-    if (!user) return new Response('Unauthorized', { status: 401 })
+    const auth = await getApiAuthContext(req)
+    if (!auth) return new Response('Unauthorized', { status: 401 })
+    const { supabase, user, tenantId } = auth
 
     const { messages, exerciseId } = await req.json()
     if (!exerciseId) return new Response('Exercise ID is required', { status: 400 })
@@ -29,13 +26,21 @@ export async function POST(req: Request) {
     // 2. Save user message
     const lastUserMessage = messages[messages.length - 1]
     if (lastUserMessage?.role === 'user') {
-        // exercise_messages has NO tenant_id column — sending it silently fails the insert.
-        await supabase.from('exercise_messages').insert({
-            exercise_id: exerciseId,
-            user_id: user.id,
-            role: 'user',
-            message: lastUserMessage.content,
-        })
+        // AI SDK v6 messages carry text in `parts`, not `content`
+        const messageText = lastUserMessage.parts
+            ?.filter((part: any) => part.type === 'text')
+            .map((part: any) => part.text)
+            .join(' ') || lastUserMessage.content || ''
+
+        if (messageText) {
+            // exercise_messages has NO tenant_id column — sending it silently fails the insert.
+            await supabase.from('exercise_messages').insert({
+                exercise_id: exerciseId,
+                user_id: user.id,
+                role: 'user',
+                message: messageText,
+            })
+        }
     }
 
     // 3. Stream Response

--- a/app/api/chat/exercises/student/route.ts
+++ b/app/api/chat/exercises/student/route.ts
@@ -29,12 +29,12 @@ export async function POST(req: Request) {
     // 2. Save user message
     const lastUserMessage = messages[messages.length - 1]
     if (lastUserMessage?.role === 'user') {
+        // exercise_messages has NO tenant_id column — sending it silently fails the insert.
         await supabase.from('exercise_messages').insert({
             exercise_id: exerciseId,
             user_id: user.id,
             role: 'user',
             message: lastUserMessage.content,
-            tenant_id: tenantId,
         })
     }
 
@@ -51,7 +51,6 @@ export async function POST(req: Request) {
                 user_id: user.id,
                 role: 'assistant',
                 message: event.text,
-                tenant_id: tenantId,
             })
         },
         stopWhen: stepCountIs(AI_CONFIG.maxSteps),

--- a/app/api/chat/lesson-task/restart/route.ts
+++ b/app/api/chat/lesson-task/restart/route.ts
@@ -1,16 +1,13 @@
-import { createClient } from '@/lib/supabase/server'
-import { getCurrentTenantId } from '@/lib/supabase/tenant'
+import { getApiAuthContext } from '@/lib/supabase/api-auth'
 import { NextResponse } from 'next/server'
 
 export async function POST(req: Request) {
     try {
-        const supabase = await createClient()
-        const tenantId = await getCurrentTenantId()
-        const { data: { user } } = await supabase.auth.getUser()
-
-        if (!user) {
+        const auth = await getApiAuthContext(req)
+        if (!auth) {
             return new NextResponse('Unauthorized', { status: 401 })
         }
+        const { supabase, user, tenantId } = auth
 
         const { lessonId } = await req.json()
 

--- a/app/api/chat/lesson-task/route.ts
+++ b/app/api/chat/lesson-task/route.ts
@@ -1,5 +1,4 @@
-import { createClient } from '@/lib/supabase/server'
-import { getCurrentTenantId } from '@/lib/supabase/tenant'
+import { getApiAuthContext } from '@/lib/supabase/api-auth'
 import { AI_CONFIG, AI_MODELS } from '@/lib/ai/config'
 import { PROMPTS } from '@/lib/ai/prompts'
 import { createAITools } from '@/lib/ai/tools'
@@ -8,11 +7,9 @@ import { convertToModelMessages, stepCountIs, streamText } from 'ai'
 export const maxDuration = 120
 
 export async function POST(req: Request) {
-    const supabase = await createClient()
-    const tenantId = await getCurrentTenantId()
-    const { data: { user } } = await supabase.auth.getUser()
-
-    if (!user) return new Response('Unauthorized', { status: 401 })
+    const auth = await getApiAuthContext(req)
+    if (!auth) return new Response('Unauthorized', { status: 401 })
+    const { supabase, user, tenantId } = auth
 
     const body = await req.json()
     console.log('Received request body:', JSON.stringify(body, null, 2))

--- a/app/api/chat/lesson-task/route.ts
+++ b/app/api/chat/lesson-task/route.ts
@@ -44,12 +44,12 @@ export async function POST(req: Request) {
             .join(' ') || lastMessage.content || ''
             
         if (messageText) {
+            // lessons_ai_task_messages has NO tenant_id column — sending it silently fails the insert.
             await supabase.from('lessons_ai_task_messages').insert({
                 lesson_id: lessonId,
                 user_id: user.id,
                 sender: 'user',
                 message: messageText,
-                tenant_id: tenantId,
             })
         }
     }
@@ -62,12 +62,12 @@ export async function POST(req: Request) {
         tools: createAITools(supabase, { lessonId, userId: user.id, courseId: lesson.course_id, tenantId }),
         experimental_telemetry: { isEnabled: true, functionId: 'lesson-tutor', metadata: { lessonId: String(lessonId), userId: user.id, tenantId } },
         onFinish: async (event) => {
+            // lessons_ai_task_messages has NO tenant_id column — sending it silently fails the insert.
             const messageData: any = {
                 lesson_id: lessonId,
                 user_id: user.id,
                 sender: 'assistant',
                 message: event.text,
-                tenant_id: tenantId,
             };
             
             // Only add tool_invocations if the column exists (check schema)

--- a/app/api/exercises/artifact/evaluate/route.ts
+++ b/app/api/exercises/artifact/evaluate/route.ts
@@ -145,6 +145,7 @@ Evaluate the student's submission based on the evaluation criteria above. Respon
 
     // 11. Record completion if passed
     if (passed) {
+      // exercise_completions has NO tenant_id column — sending it 400s the insert.
       await adminClient
         .from('exercise_completions')
         .insert({
@@ -152,7 +153,6 @@ Evaluate the student's submission based on the evaluation criteria above. Respon
           user_id: user.id,
           completed_by: user.id,
           score: evaluation.score,
-          tenant_id: tenantId,
         })
         .select('id')
         .single()

--- a/app/api/exercises/media/analyze/route.ts
+++ b/app/api/exercises/media/analyze/route.ts
@@ -141,12 +141,12 @@ export async function POST(req: Request) {
 
     // 12. Record exercise completion only if score meets passing threshold
     if (passed) {
+      // exercise_completions has NO tenant_id column — sending it 400s the insert.
       await adminClient.from('exercise_completions').insert({
         exercise_id: submission.exercise_id,
         user_id: user.id,
         completed_by: user.id,
         score: evaluation.score,
-        tenant_id: tenantId,
       }).select('id').single()
       // unique index (exercise_id, user_id) prevents duplicates
     }

--- a/components/exercises/code-challenge-wrapper.tsx
+++ b/components/exercises/code-challenge-wrapper.tsx
@@ -21,7 +21,6 @@ interface CodeChallengeWrapperProps {
     exerciseId: number;
     isExerciseCompleted: boolean;
     userCode?: string;
-    tenantId: string;
 }
 
 const SubmitButton = ({ onComplete }: { onComplete: () => void }) => {
@@ -59,7 +58,6 @@ export default function CodeChallengeWrapper({
     exerciseId,
     isExerciseCompleted: initialCompleted,
     userCode,
-    tenantId,
 }: CodeChallengeWrapperProps) {
     const [isCompleted, setIsCompleted] = useState(initialCompleted);
     const tGamification = useTranslations("components.gamification");
@@ -70,12 +68,13 @@ export default function CodeChallengeWrapper({
         const { data: { session } } = await supabase.auth.getSession();
         const user = session?.user;
         if (user) {
+            // exercise_completions has NO tenant_id column — isolation is via
+            // RLS through exercise_id. Sending tenant_id 400s the insert.
             await supabase.from('exercise_completions').insert({
                 exercise_id: exerciseId,
                 user_id: user.id,
                 completed_by: user.id,
                 score: 100,
-                tenant_id: tenantId,
             });
             toast.success(tGamification("xpAwarded.exercise_completion"));
         }

--- a/components/student/browse-course-card.tsx
+++ b/components/student/browse-course-card.tsx
@@ -18,9 +18,9 @@ interface BrowseCourseCardProps {
   course: {
     course_id: number
     title: string
-    description?: string
-    thumbnail_url?: string
-    tags?: string | string[]
+    description?: string | null
+    thumbnail_url?: string | null
+    tags?: string | string[] | null
   }
   enrollmentStatus: EnrollmentStatus
 }

--- a/components/student/lesson-comments.tsx
+++ b/components/student/lesson-comments.tsx
@@ -42,11 +42,10 @@ interface Comment {
 interface LessonCommentsProps {
   lessonId: number
   userId: string
-  tenantId: string
   initialComments?: Comment[]
 }
 
-export function LessonComments({ lessonId, userId, tenantId, initialComments = [] }: LessonCommentsProps) {
+export function LessonComments({ lessonId, userId, initialComments = [] }: LessonCommentsProps) {
   const [comments, setComments] = useState<Comment[]>(initialComments)
   const [newComment, setNewComment] = useState('')
   const [submitting, setSubmitting] = useState(false)
@@ -155,12 +154,13 @@ export function LessonComments({ lessonId, userId, tenantId, initialComments = [
 
     setSubmitting(true)
     try {
+      // lesson_comments has NO tenant_id column — isolation rides on the
+      // lesson FK + RLS (insert policy: auth.uid() = user_id). Never add it.
       const { error } = await supabase.from('lesson_comments').insert({
         lesson_id: lessonId,
         user_id: userId,
         content: content.trim(),
         parent_comment_id: parentId,
-        tenant_id: tenantId,
       })
 
       if (error) throw error

--- a/lib/ai/tools.ts
+++ b/lib/ai/tools.ts
@@ -56,10 +56,10 @@ export const createAITools = (supabase: SupabaseClient, context: { exerciseId?: 
                 .single();
 
             if (!existing) {
+                // lesson_completions has NO tenant_id column — sending it fails the insert.
                 const { error: insertError } = await supabase.from('lesson_completions').insert({
                     user_id: context.userId,
                     lesson_id: context.lessonId,
-                    tenant_id: context.tenantId,
                 });
 
                 if (insertError) {

--- a/lib/ai/tools.ts
+++ b/lib/ai/tools.ts
@@ -14,12 +14,12 @@ export const createAITools = (supabase: SupabaseClient, context: { exerciseId?: 
             if (!context.exerciseId) throw new Error('Exercise ID is required');
 
             // Upsert completion (ON CONFLICT do nothing)
+            // exercise_completions has NO tenant_id column — sending it 400s the insert.
             await supabase.from('exercise_completions').insert({
                 exercise_id: context.exerciseId,
                 user_id: context.userId,
                 completed_by: context.userId,
                 score: score,
-                tenant_id: context.tenantId,
             }).select('id').single();
 
             // Insert unified evaluation for text-based exercises

--- a/lib/supabase/api-auth.ts
+++ b/lib/supabase/api-auth.ts
@@ -1,0 +1,105 @@
+import { createClient as createBearerClient, type SupabaseClient, type User } from '@supabase/supabase-js'
+import { cookies } from 'next/headers'
+import { createClient } from '@/lib/supabase/server'
+import { getCurrentTenantId } from '@/lib/supabase/tenant'
+
+const DEFAULT_TENANT_ID = '00000000-0000-0000-0000-000000000001'
+
+export interface ApiAuthContext {
+    supabase: SupabaseClient
+    user: User
+    tenantId: string
+}
+
+/**
+ * Resolve auth for API routes that serve both the web app and the mobile app.
+ *
+ * - Web requests carry sb-* session cookies (and a subdomain-derived
+ *   x-tenant-id header set by proxy.ts) — handled exactly as before via
+ *   the cookie-based server client.
+ * - Mobile requests carry `Authorization: Bearer <supabase access_token>`
+ *   and no cookies/subdomain — handled by building an RLS-scoped client
+ *   from the token and resolving the tenant from the verified JWT claim.
+ *
+ * Returns null when the request is unauthenticated (routes respond 401).
+ */
+export async function getApiAuthContext(req: Request): Promise<ApiAuthContext | null> {
+    const bearerToken = (req.headers.get('authorization') ?? '').match(/^Bearer\s+(.+)$/i)?.[1]
+    const cookieStore = await cookies()
+    const hasSessionCookies = cookieStore.getAll().some((c) => c.name.startsWith('sb-'))
+
+    // Cookie path takes precedence — the web never sends a Bearer header to
+    // these routes, and a browser session must keep working unchanged.
+    if (!bearerToken || hasSessionCookies) {
+        const supabase = await createClient()
+        const tenantId = await getCurrentTenantId()
+        const { data: { user } } = await supabase.auth.getUser()
+        if (!user) return null
+        return { supabase, user, tenantId }
+    }
+
+    return getBearerContext(bearerToken)
+}
+
+async function getBearerContext(token: string): Promise<ApiAuthContext | null> {
+    const url = process.env.NEXT_PUBLIC_SUPABASE_URL!
+    const anonKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_OR_ANON_KEY!
+
+    const authClient = createBearerClient(url, anonKey, {
+        global: { headers: { Authorization: `Bearer ${token}` } },
+        auth: { persistSession: false, autoRefreshToken: false },
+    })
+
+    // Server-side verification — the claims below are only trusted because
+    // this call validated the token's signature and expiry.
+    const { data, error } = await authClient.auth.getUser(token)
+    if (error || !data?.user) return null
+    const user = data.user
+
+    const claimTenantId = decodeJwtPayload(token)?.tenant_id
+    const tenantId =
+        (typeof claimTenantId === 'string' && claimTenantId) ||
+        (await resolveTenantFromMembership(authClient, user.id)) ||
+        DEFAULT_TENANT_ID
+
+    // Forward x-tenant-id like the web client does, so get_tenant_id()'s
+    // header fallback stays consistent for tokens without a tenant_id claim.
+    const supabase = createBearerClient(url, anonKey, {
+        global: {
+            headers: {
+                Authorization: `Bearer ${token}`,
+                'x-tenant-id': tenantId,
+            },
+        },
+        auth: { persistSession: false, autoRefreshToken: false },
+    })
+
+    return { supabase, user, tenantId }
+}
+
+/**
+ * Tokens issued before a user's app_metadata.tenant_id was set carry no
+ * tenant_id claim. Fall back to the user's single active membership —
+ * tenant_users is the authoritative source. Ambiguous (0 or 2+) → null.
+ */
+async function resolveTenantFromMembership(
+    supabase: SupabaseClient,
+    userId: string
+): Promise<string | null> {
+    const { data } = await supabase
+        .from('tenant_users')
+        .select('tenant_id')
+        .eq('user_id', userId)
+        .eq('status', 'active')
+        .limit(2)
+    if (data?.length === 1) return data[0].tenant_id
+    return null
+}
+
+function decodeJwtPayload(token: string): Record<string, unknown> | null {
+    try {
+        return JSON.parse(Buffer.from(token.split('.')[1], 'base64url').toString('utf8'))
+    } catch {
+        return null
+    }
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -6,6 +6,7 @@ const withNextIntl = createNextIntlPlugin('./i18n.ts');
 
 const nextConfig: NextConfig = {
   output: 'standalone',
+  transpilePackages: ['@lms/core'],
   async rewrites() {
     return {
       beforeFiles: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,15 @@
 {
-  "name": "next-app",
+  "name": "lms-front",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "next-app",
+      "name": "lms-front",
       "version": "0.1.0",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@ai-sdk/google": "^3.0.43",
         "@ai-sdk/openai": "^3.0.41",
@@ -2875,6 +2878,10 @@
       "dependencies": {
         "@lezer/common": "^1.0.0"
       }
+    },
+    "node_modules/@lms/core": {
+      "resolved": "packages/core",
+      "link": true
     },
     "node_modules/@marijn/find-cluster-break": {
       "version": "1.0.2",
@@ -21533,6 +21540,13 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "packages/core": {
+      "name": "@lms/core",
+      "version": "0.1.0",
+      "peerDependencies": {
+        "@supabase/supabase-js": "^2.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,10 @@
 {
-  "name": "next-app",
+  "name": "lms-front",
   "version": "0.1.0",
   "private": true,
+  "workspaces": [
+    "packages/*"
+  ],
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@lms/core",
+  "version": "0.1.0",
+  "private": true,
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "peerDependencies": {
+    "@supabase/supabase-js": "^2.0.0"
+  }
+}

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -1,0 +1,21 @@
+/**
+ * Structural Supabase client surface — intentionally NOT `import { SupabaseClient }`.
+ *
+ * Web (lms-front) and mobile (lms-app) are separate repos, each with its own
+ * `@supabase/supabase-js` install. `SupabaseClient` carries nominal/branded members,
+ * so the two installs' types are not assignable to each other — passing the app's
+ * client to a fn typed against lms-front's copy fails (TS2345). Typing the param
+ * structurally (just the `.from`/`.rpc` we call) decouples core from either copy's
+ * brand, so any supabase-js client satisfies it. Return types are declared explicitly
+ * on each query fn, so call sites still get fully-typed `data`.
+ */
+export interface DbClient {
+  from(table: string): any
+  rpc(fn: string, args?: Record<string, unknown>): any
+}
+
+/** Shape of an awaited supabase query — `{ data, error }`. */
+export type DbResult<T> = PromiseLike<{
+  data: T | null
+  error: { message: string } | null
+}>

--- a/packages/core/src/constants/index.ts
+++ b/packages/core/src/constants/index.ts
@@ -1,0 +1,47 @@
+export const TRANSACTION_STATUS = {
+  PENDING: 'pending',
+  SUCCESSFUL: 'successful',
+  FAILED: 'failed',
+  ARCHIVED: 'archived',
+  CANCELED: 'canceled',
+  REFUNDED: 'refunded',
+} as const
+
+export type TransactionStatus = typeof TRANSACTION_STATUS[keyof typeof TRANSACTION_STATUS]
+
+export const ENROLLMENT_STATUS = {
+  ACTIVE: 'active',
+  DISABLED: 'disabled',
+} as const
+
+export type EnrollmentStatus = typeof ENROLLMENT_STATUS[keyof typeof ENROLLMENT_STATUS]
+
+export const COURSE_STATUS = {
+  PUBLISHED: 'published',
+  DRAFT: 'draft',
+  ARCHIVED: 'archived',
+} as const
+
+export type CourseStatus = typeof COURSE_STATUS[keyof typeof COURSE_STATUS]
+
+export const TENANT_ROLE = {
+  STUDENT: 'student',
+  TEACHER: 'teacher',
+  ADMIN: 'admin',
+} as const
+
+export type TenantRole = typeof TENANT_ROLE[keyof typeof TENANT_ROLE]
+
+export const SUBSCRIPTION_STATUS = {
+  ACTIVE: 'active',
+  EXPIRED: 'expired',
+  CANCELED: 'canceled',
+} as const
+
+export type SubscriptionStatus = typeof SUBSCRIPTION_STATUS[keyof typeof SUBSCRIPTION_STATUS]
+
+export const DEFAULT_PASSING_SCORE = 70
+
+export function computeCoinBalance(totalXp: number, totalCoinsSpent: number): number {
+  return Math.floor(totalXp / 10) - totalCoinsSpent
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,0 +1,6 @@
+export * from './types'
+export * from './constants'
+export * from './client'
+export * from './queries/courses'
+export * from './queries/lessons'
+export * from './queries/exams'

--- a/packages/core/src/queries/courses.ts
+++ b/packages/core/src/queries/courses.ts
@@ -1,0 +1,171 @@
+import type { DbClient, DbResult } from '../client'
+import type { EnrolledCourse } from '../types'
+
+export interface PublishedCourse {
+  course_id: number
+  title: string
+  description: string | null
+  thumbnail_url: string | null
+  tags: string[] | null
+  category_id: number | null
+}
+
+export interface CourseCategory {
+  id: number
+  name: string
+}
+
+export interface CourseForList {
+  course_id: number
+  title: string
+  description: string | null
+  thumbnail_url: string | null
+  status: string
+}
+
+export interface EnrollmentRow {
+  enrollment_id: number
+  course_id: number
+  enrollment_date: string
+  status: string
+}
+
+export interface ActiveSubscription {
+  subscription_id: number
+  subscription_status: string
+  end_date: string
+  plan: {
+    plan_id: number
+    plan_name: string
+    price: number
+  } | null
+}
+
+/**
+ * Published courses visible in the catalog. Caller sanitizes `search` before passing
+ * (strip %, _, \\ to prevent ilike injection).
+ */
+export function getPublishedCourses(
+  supabase: DbClient,
+  tenantId: string,
+  opts?: { search?: string; categoryId?: number }
+): DbResult<PublishedCourse[]> {
+  let query = supabase
+    .from('courses')
+    .select('course_id, title, description, thumbnail_url, tags, category_id')
+    .eq('tenant_id', tenantId)
+    .eq('status', 'published')
+    .order('title', { ascending: true })
+
+  if (opts?.search) {
+    const safe = opts.search.replace(/[%_\\]/g, '')
+    if (safe) {
+      query = query.or(`title.ilike.%${safe}%,description.ilike.%${safe}%`)
+    }
+  }
+
+  if (opts?.categoryId != null) {
+    query = query.eq('category_id', opts.categoryId)
+  }
+
+  return query
+}
+
+export function getCourseCategories(
+  supabase: DbClient,
+  tenantId: string
+): DbResult<CourseCategory[]> {
+  return supabase
+    .from('course_categories')
+    .select('id, name')
+    .eq('tenant_id', tenantId)
+    .order('name')
+}
+
+export function getEnrolledCourses(
+  supabase: DbClient,
+  userId: string,
+  tenantId: string
+): DbResult<EnrollmentRow[]> {
+  return supabase
+    .from('enrollments')
+    .select('enrollment_id, course_id, enrollment_date, status')
+    .eq('user_id', userId)
+    .eq('tenant_id', tenantId)
+    .order('enrollment_date', { ascending: false })
+}
+
+/**
+ * Enrolled courses with nested lessons + this user's completions, for progress %.
+ * The trailing `course.lessons.lesson_completions.user_id` filter scopes the embedded
+ * completions to THIS user (PostgREST embedded filter) — without it every user's
+ * completions leak into the count. Returns shape = EnrolledCourse[].
+ */
+export function getEnrolledCoursesWithProgress(
+  supabase: DbClient,
+  userId: string,
+  tenantId: string
+): DbResult<EnrolledCourse[]> {
+  return supabase
+    .from('enrollments')
+    .select(`
+      enrollment_id,
+      course:courses (
+        course_id,
+        title,
+        description,
+        thumbnail_url,
+        lessons (id, title, lesson_completions (user_id))
+      )
+    `)
+    .eq('user_id', userId)
+    .eq('tenant_id', tenantId)
+    .eq('status', 'active')
+    .eq('course.lessons.lesson_completions.user_id', userId)
+}
+
+export function getCoursesByIds(
+  supabase: DbClient,
+  courseIds: number[],
+  tenantId: string
+): DbResult<CourseForList[]> {
+  return supabase
+    .from('courses')
+    .select('course_id, title, description, thumbnail_url, status')
+    .in('course_id', courseIds)
+    .eq('tenant_id', tenantId)
+}
+
+export function getActiveSubscriptions(
+  supabase: DbClient,
+  userId: string,
+  tenantId: string
+): DbResult<ActiveSubscription[]> {
+  return supabase
+    .from('subscriptions')
+    .select(`
+      subscription_id,
+      subscription_status,
+      end_date,
+      plan:plans!subscriptions_plan_id_fkey (
+        plan_id,
+        plan_name,
+        price
+      )
+    `)
+    .eq('user_id', userId)
+    .eq('tenant_id', tenantId)
+    .eq('subscription_status', 'active')
+    .gte('end_date', new Date().toISOString())
+    .order('end_date', { ascending: false })
+}
+
+export function getPlanCourses(
+  supabase: DbClient,
+  planId: number
+): DbResult<{ course_id: number }[]> {
+  return supabase
+    .from('plan_courses')
+    .select('course_id')
+    .eq('plan_id', planId)
+}

--- a/packages/core/src/queries/exams.ts
+++ b/packages/core/src/queries/exams.ts
@@ -1,0 +1,82 @@
+import type { DbClient, DbResult } from '../client'
+
+export interface ExamListItem {
+  exam_id: number
+  title: string
+  sequence: number | null
+  course_id: number
+}
+
+export interface ExamSubmissionRow {
+  submission_id: number
+  exam_id: number
+  score: number | null
+  submission_date: string
+}
+
+export interface ExamAnswerInsert {
+  submission_id: number
+  question_id: number
+  answer_text: string
+}
+
+/** Exams across many courses (enrolled-courses progress grid). */
+export function getExamsByCourseIds(
+  supabase: DbClient,
+  courseIds: number[],
+  tenantId: string
+): DbResult<ExamListItem[]> {
+  return supabase
+    .from('exams')
+    .select('exam_id, title, sequence, course_id')
+    .in('course_id', courseIds)
+    .eq('tenant_id', tenantId)
+}
+
+/**
+ * This student's exam submissions. `exam_submissions` keys on `student_id`
+ * (NOT `user_id`) and the date column is `submission_date` (NOT
+ * `submitted_at`). It DOES carry `tenant_id`.
+ */
+export function getExamSubmissions(
+  supabase: DbClient,
+  studentId: string,
+  tenantId: string
+): DbResult<ExamSubmissionRow[]> {
+  return supabase
+    .from('exam_submissions')
+    .select('submission_id, exam_id, score, submission_date')
+    .eq('student_id', studentId)
+    .eq('tenant_id', tenantId)
+}
+
+/**
+ * Create an exam submission and return its id. `exam_submissions` HAS
+ * `tenant_id`; pass it. Scores/answers are written separately by the grading
+ * step — this only opens the submission row.
+ */
+export function createExamSubmission(
+  supabase: DbClient,
+  examId: number,
+  studentId: string,
+  tenantId: string
+): DbResult<{ submission_id: number }> {
+  return supabase
+    .from('exam_submissions')
+    .insert({ exam_id: examId, student_id: studentId, tenant_id: tenantId })
+    .select('submission_id')
+    .single()
+}
+
+/**
+ * Bulk-insert a submission's answers. `exam_answers` has NO `tenant_id`
+ * (isolation rides on the parent submission via RLS) — never add a tenant
+ * filter/column here. Store `answer_text` only; `is_correct` / scores are
+ * owned by the grading step.
+ */
+export function insertExamAnswers(
+  supabase: DbClient,
+  rows: ExamAnswerInsert[]
+): DbResult<unknown> {
+  return supabase.from('exam_answers').insert(rows)
+}

--- a/packages/core/src/queries/lessons.ts
+++ b/packages/core/src/queries/lessons.ts
@@ -1,0 +1,72 @@
+import type { DbClient, DbResult } from '../client'
+
+export interface LessonListItem {
+  id: number
+  title: string
+  sequence: number | null
+  course_id: number
+}
+
+export interface LessonCompletionRow {
+  lesson_id: number
+  completed_at: string | null
+  user_id: string
+}
+
+/**
+ * This user's lesson completions. `lesson_completions` has NO `tenant_id`
+ * column and keys on `user_id` (NOT `student_id`) — scope by user only.
+ * Used both for the progress-% rollup and the "already completed" set.
+ */
+export function getLessonCompletions(
+  supabase: DbClient,
+  userId: string
+): DbResult<LessonCompletionRow[]> {
+  return supabase
+    .from('lesson_completions')
+    .select('lesson_id, completed_at, user_id')
+    .eq('user_id', userId)
+}
+
+/** Published lessons of one course, ordered for sequential display. */
+export function getPublishedLessonsByCourse(
+  supabase: DbClient,
+  courseId: number,
+  tenantId: string
+): DbResult<LessonListItem[]> {
+  return supabase
+    .from('lessons')
+    .select('id, title, sequence, course_id')
+    .eq('course_id', courseId)
+    .eq('status', 'published')
+    .eq('tenant_id', tenantId)
+    .order('sequence', { ascending: true })
+}
+
+/** Lessons across many courses (e.g. the enrolled-courses progress grid). */
+export function getLessonsByCourseIds(
+  supabase: DbClient,
+  courseIds: number[],
+  tenantId: string
+): DbResult<LessonListItem[]> {
+  return supabase
+    .from('lessons')
+    .select('id, title, sequence, course_id')
+    .in('course_id', courseIds)
+    .eq('tenant_id', tenantId)
+}
+
+/**
+ * Mark a lesson complete for this user. `lesson_completions` has NO
+ * `tenant_id` — insert `user_id` + `lesson_id` only; `completed_at` defaults
+ * server-side. Caller decides idempotency (upsert / pre-check).
+ */
+export function markLessonComplete(
+  supabase: DbClient,
+  lessonId: number,
+  userId: string
+): DbResult<unknown> {
+  return supabase
+    .from('lesson_completions')
+    .insert({ lesson_id: lessonId, user_id: userId })
+}

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -1,0 +1,229 @@
+/**
+ * Row shapes for the subset of the lms-front schema the student app reads.
+ * Mirrors the web app's query patterns — see docs/BACKEND.md for gotchas
+ * (PK naming, missing tenant_id columns, etc.).
+ */
+
+export interface Tenant {
+  id: string;
+  slug: string;
+  name: string;
+  domain: string | null;
+  logo_url: string | null;
+  primary_color: string;
+  secondary_color: string;
+  plan: string;
+  status: string;
+}
+
+export interface Course {
+  course_id: number;
+  title: string;
+  description: string | null;
+  thumbnail_url: string | null;
+}
+
+export interface Lesson {
+  id: number;
+  title: string;
+  sequence: number | null;
+  content: string | null;
+  video_url: string | null;
+  embed_code: string | null;
+  course_id: number;
+}
+
+export interface LessonCompletion {
+  lesson_id: number;
+  user_id: string;
+}
+
+/** Shape returned by the enrolled-courses query on the dashboard. */
+export interface EnrolledCourse {
+  enrollment_id: number;
+  course: (Course & {
+    lessons: { id: number; title: string; lesson_completions: { user_id: string }[] }[];
+  }) | null;
+}
+
+// ── Exams ────────────────────────────────────────────────────────────────
+// Gotchas: `exams` has `sequence` for ordering; child tables
+// (exam_questions, question_options, exam_answers) have NO tenant_id.
+
+export type QuestionType = 'true_false' | 'multiple_choice' | 'free_text';
+
+export interface QuestionOption {
+  option_id: number;
+  question_id: number;
+  option_text: string;
+  is_correct: boolean;
+}
+
+export interface ExamQuestion {
+  question_id: number;
+  exam_id: number;
+  question_text: string;
+  question_type: QuestionType;
+  question_options: QuestionOption[];
+}
+
+export interface ExamAnswer {
+  answer_id: number;
+  question_id: number;
+  answer_text: string | null;
+  is_correct: boolean | null;
+  feedback: string | null;
+}
+
+/** Written by the save_exam_feedback RPC (AI grading) or teacher review. */
+export interface ExamQuestionScore {
+  question_id: number;
+  points_earned: number | null;
+  points_possible: number | null;
+  is_correct: boolean | null;
+  ai_feedback: string | null;
+  ai_confidence: number | null;
+  teacher_notes: string | null;
+  is_overridden: boolean | null;
+}
+
+export interface ExamSubmission {
+  submission_id: number;
+  student_id: string;
+  submission_date: string;
+  score: number | null;
+  review_status: 'pending' | 'ai_reviewed' | 'pending_teacher_review' | 'teacher_reviewed';
+  /** jsonb set by save_exam_feedback: { overall_feedback, question_feedback, graded_at } */
+  ai_data: { overall_feedback?: string; summary?: string } | null;
+  exam_answers: ExamAnswer[];
+  exam_scores: { score_id: number; score: number | null }[];
+  exam_question_scores: ExamQuestionScore[];
+}
+
+export interface ExamSummary {
+  exam_id: number;
+  title: string;
+  description: string | null;
+  duration: number | null;
+  sequence: number | null;
+  exam_submissions: Pick<ExamSubmission, 'submission_id' | 'score' | 'review_status'>[];
+}
+
+// ── Exercises ────────────────────────────────────────────────────────────
+// Gotchas: `exercises.id` PK; exercise_completions and exercise_messages
+// have NO tenant_id — never insert or filter it on those tables.
+
+export type ExerciseType =
+  | 'quiz'
+  | 'coding_challenge'
+  | 'essay'
+  | 'multiple_choice'
+  | 'true_false'
+  | 'fill_in_the_blank'
+  | 'discussion'
+  | 'audio_evaluation'
+  | 'video_evaluation'
+  | 'artifact'
+  | 'real_time_conversation';
+
+/** jsonb — fields depend on exercise_type (artifact / audio / video). */
+export interface ExerciseConfig {
+  artifact_type?: string;
+  artifact_html?: string;
+  passing_score?: number;
+  max_daily_attempts?: number;
+  topic_prompt?: string;
+  min_duration_seconds?: number;
+  max_duration_seconds?: number;
+}
+
+export interface ExerciseSummary {
+  id: number;
+  title: string;
+  description: string | null;
+  exercise_type: ExerciseType | string;
+  difficulty_level: string | null;
+  exercise_completions: { id: number; score?: number | null; completed_at?: string | null }[];
+}
+
+export interface ExerciseDetail extends ExerciseSummary {
+  course_id: number;
+  instructions: string;
+  time_limit: number | null;
+  active_file: string | null;
+  exercise_config: ExerciseConfig | null;
+  exercise_messages: ExerciseMessage[];
+}
+
+/** Starter files for coding_challenge. NO tenant_id column. */
+export interface ExerciseFile {
+  file_path: string;
+  content: string;
+}
+
+/** Saved student code (coding_challenge). NO tenant_id column. */
+export interface CodeSubmission {
+  id: number;
+  submission_code: string;
+  created_at: string;
+}
+
+/** Audio/video evaluation attempts. This table HAS tenant_id. */
+export interface MediaSubmission {
+  id: number;
+  media_type: string | null;
+  duration_seconds: number | null;
+  status: string | null;
+  ai_evaluation: Record<string, unknown> | null;
+  score: number | null;
+  created_at: string;
+}
+
+export interface ExerciseMessage {
+  id: number;
+  message: string;
+  role: 'user' | 'assistant' | 'system' | 'function' | 'data' | 'tool';
+  created_at: string;
+}
+
+// ── Lessons (detail screen) ──────────────────────────────────────────────
+// Gotchas: lessons_ai_task_messages and lesson_comments have NO tenant_id;
+// lesson_resources HAS tenant_id.
+
+export interface AiTask {
+  id: number;
+  task_instructions: string | null;
+}
+
+/** Chat history for the lesson AI tutor. `sender` is the role column. */
+export interface AiTaskMessage {
+  id: number;
+  message: string | null;
+  sender: 'user' | 'assistant';
+  created_at: string;
+}
+
+export type ReactionType = 'like' | 'dislike' | 'boring' | 'funny';
+
+export interface CommentReaction {
+  comment_id: number;
+  user_id: string;
+  reaction_type: ReactionType;
+}
+
+export interface LessonComment {
+  id: number;
+  user_id: string;
+  parent_comment_id: number | null;
+  content: string;
+  created_at: string;
+  profiles: { id: string; full_name: string | null; avatar_url: string | null } | null;
+  comment_reactions: CommentReaction[];
+}
+
+export interface LessonResource {
+  id: number;
+  file_name: string;
+  file_size: number | null;
+  mime_type: string | null;
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "declaration": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"]
+}

--- a/supabase/migrations/20260611120000_fix_xp_trigger_lesson_id.sql
+++ b/supabase/migrations/20260611120000_fix_xp_trigger_lesson_id.sql
@@ -1,0 +1,79 @@
+-- =============================================================================
+-- Fix XP trigger functions: lessons PK is `id`, not `lesson_id`
+-- =============================================================================
+-- Three SECURITY DEFINER trigger functions joined `lessons l` on `l.lesson_id`,
+-- which does not exist (the lessons primary key is `id`). The bad reference
+-- raised `42703 column l.lesson_id does not exist` inside the trigger, which
+-- rolled back the host INSERT:
+--   * handle_comment_posted_xp     -> every lesson_comments insert failed
+--   * handle_exercise_completion_xp -> every exercise_completions insert failed
+--   * handle_lesson_completion_xp  -> only the NULL-tenant fallback path (latent)
+--
+-- Fix = `l.lesson_id` -> `l.id`. Bodies are otherwise unchanged.
+-- Source of the bug: 20260217030000_tenant_scope_gamification.sql.
+
+-- Trigger: lesson_completions -> award XP
+CREATE OR REPLACE FUNCTION handle_lesson_completion_xp()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant_id UUID;
+BEGIN
+  -- lesson_completions has tenant_id directly
+  v_tenant_id := NEW.tenant_id;
+
+  IF v_tenant_id IS NULL THEN
+    -- Fallback: look up from lessons -> courses
+    SELECT c.tenant_id INTO v_tenant_id
+    FROM lessons l
+    JOIN courses c ON c.course_id = l.course_id
+    WHERE l.id = NEW.lesson_id;
+  END IF;
+
+  PERFORM award_xp(NEW.user_id, 'lesson_completion', 100, NEW.lesson_id::text, 'lesson', v_tenant_id);
+  RETURN NEW;
+END;
+$$;
+
+-- Trigger: exercise_completions -> award XP
+CREATE OR REPLACE FUNCTION handle_exercise_completion_xp()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant_id UUID;
+BEGIN
+  -- Look up tenant from exercises -> lessons -> courses
+  SELECT c.tenant_id INTO v_tenant_id
+  FROM exercises e
+  JOIN lessons l ON l.id = e.lesson_id
+  JOIN courses c ON c.course_id = l.course_id
+  WHERE e.id = NEW.exercise_id;
+
+  PERFORM award_xp(NEW.user_id, 'exercise_completion', 50, NEW.exercise_id::text, 'exercise', v_tenant_id);
+  RETURN NEW;
+END;
+$$;
+
+-- Trigger: lesson_comments -> award XP
+CREATE OR REPLACE FUNCTION handle_comment_posted_xp()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_tenant_id UUID;
+BEGIN
+  -- Look up tenant from lessons -> courses
+  SELECT c.tenant_id INTO v_tenant_id
+  FROM lessons l
+  JOIN courses c ON c.course_id = l.course_id
+  WHERE l.id = NEW.lesson_id;
+
+  PERFORM award_xp(NEW.user_id, 'comment_posted', 10, NEW.id::text, 'comment', v_tenant_id);
+  RETURN NEW;
+END;
+$$;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -544,6 +544,38 @@ VALUES
   (2001, 2002)   -- Code Academy Pro Monthly → Data Analysis with Pandas
 ON CONFLICT DO NOTHING;
 
+-- ---------------------------------------------------------------------------
+-- 15b. ALICE'S SUBSCRIPTION (Code Academy Pro Monthly)
+-- Gives alice@student.com an active subscription to plan 2001 so she can
+-- self-enroll into covered courses (2001/2002) via /browse and exercise the
+-- exam-taking + exercise-completion flows.
+--
+-- We only insert the backing transaction: the `after_transaction_insert`
+-- trigger (trigger_manage_transactions) fires handle_new_subscription() on a
+-- successful plan transaction, which creates the 'active' subscription
+-- (end_date = now + plan.duration_in_days = 30d) and grants entitlements for
+-- every plan_courses row (courses 2001 + 2002). Enrollment is NOT auto-created
+-- by design — alice self-enrolls via /browse (which calls
+-- self_enroll_subscription_course()). Do NOT also insert the subscription
+-- here: that collides with subscriptions_user_id_plan_id_key.
+-- ---------------------------------------------------------------------------
+INSERT INTO transactions (transaction_id, user_id, plan_id, amount, status, currency, tenant_id)
+OVERRIDING SYSTEM VALUE
+VALUES
+(
+  2001,
+  'a1000000-0000-0000-0000-000000000004',  -- alice@student.com
+  2001,                                     -- Code Academy Pro Monthly
+  19.00,
+  'successful',
+  'usd',
+  '00000000-0000-0000-0000-000000000002'    -- Code Academy Pro tenant
+)
+ON CONFLICT (transaction_id) DO NOTHING;
+
+SELECT setval('transactions_transaction_id_seq', 10000, false);
+SELECT setval('subscriptions_subscription_id_seq', 10000, false);
+
 
 -- ---------------------------------------------------------------------------
 -- 16. GAMIFICATION LEVELS & ACHIEVEMENTS  (renumbered from 15)


### PR DESCRIPTION
## What

Teaches the 6 chat API routes (`lesson-task`, `aristotle`, `exercises/student` + their `/restart` siblings) to accept `Authorization: Bearer <supabase access_token>` so the mobile app (lms-app) can use them as its production chat backend — **Path A** of the chat-backend plan.

**Stacked on #322** (needs `@lms/core` + the phantom-`tenant_id` chat fixes from that branch; lms-app's `file:../lms-front/packages/core` dependency also requires it). Merge #322 first.

## How

New `lib/supabase/api-auth.ts` → `getApiAuthContext(req)`:

- **`sb-*` session cookies present (web):** exact same path as before — cookie server client + `getCurrentTenantId()` (subdomain header) + `getUser()`. Behavior unchanged.
- **Bearer token, no cookies (mobile):** supabase-js client from anon key + the token (RLS-scoped to that user), verified server-side via `auth.getUser(token)` *before* any claim is trusted. Tenant = verified JWT `tenant_id` claim → fallback single active `tenant_users` membership → default tenant. Resolved tenant forwarded as `x-tenant-id` so `get_tenant_id()`'s header fallback stays consistent for claim-less tokens.

Each route swaps its three-line auth preamble for the helper; route bodies untouched.

Also fixes a real persistence bug found while testing: the exercise coach saved `lastUserMessage.content`, but AI SDK v6 clients (web + app) send text in `parts` → `message` was `undefined` → the fire-and-forget insert silently violated NOT NULL and **coach chat history was never saved**. Now extracts text from `parts` like lesson-task does.

## Security

- No service-role anywhere; Bearer client = anon key + user JWT, same RLS context as the cookie client.
- Claims only read after `getUser(token)` signature/expiry validation.
- Adversarial review (cross-tenant, bypass, privilege widening, cookie regression, header injection, parts extraction): all vectors safe.

## Verified locally

- `alice@student.com` (Code Academy) + `student@e2etest.com` (Default School) Bearer tokens: all 3 chat routes stream 200; rows persist in `lessons_ai_task_messages` / `exercise_messages` / `aristotle_messages`; aristotle session created with correct `tenant_id`.
- Cross-tenant lesson access → 404 **both directions**; missing/garbage token → 401.
- Restart route deletes only the caller's rows (200, count 0 after).
- Web regression via real browser: cookie login, role routing, lesson page, and cookie-authenticated tutor chat on `code-academy.lvh.me` all unchanged (POST `/api/chat/lesson-task` 200, zero console errors).
- `tsc` + `npm run build` green.

Companion lms-app commit `7751747` repoints the app's lesson/exercise chat at these routes (with local dev fallback). Asistente tab deferred — aristotle needs a `courseId` the generic tab doesn't have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)