### PR TITLE
feat(payments): provider-agnostic billing — native subscriptions + unified webhooks (#280 phases 1-3)

### DIFF
--- a/app/api/payments/webhook/[provider]/route.ts
+++ b/app/api/payments/webhook/[provider]/route.ts
@@ -1,0 +1,155 @@
+/**
+ * Unified, provider-agnostic webhook endpoint.
+ *
+ * Pipeline (issue #280, Phase 3):
+ *   raw body → provider.verifyWebhook → persist to webhook_events (idempotent)
+ *            → provider.normalizeWebhookEvent → dispatchBillingEvent → 200
+ *
+ * This is the path NEW providers (Lemon Squeezy, MercadoPago, Solana, …) use.
+ * The legacy Stripe Connect endpoint at /api/stripe/webhook stays canonical for
+ * Stripe (it also owns the transactions state machine, payouts and emails) and
+ * shares the same dispatchBillingEvent for subscription lifecycle.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+import { getPaymentProvider } from '@/lib/payments'
+import type { PaymentProvider } from '@/lib/payments/types'
+import { dispatchBillingEvent } from '@/lib/payments/webhook-dispatch'
+
+export const runtime = 'nodejs'
+
+// Providers exposed on this endpoint. getPaymentProvider() still gates on
+// configured credentials; providers without verify/normalize return 501.
+// `manual` is intentionally excluded: it has no signed webhooks, so exposing a
+// route for it would be an unauthenticated mutation surface.
+const SUPPORTED: PaymentProvider[] = ['stripe', 'paypal']
+
+function getSupabaseAdmin() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (!url || !serviceKey) {
+    throw new Error('Supabase environment variables not set')
+  }
+  return createClient(url, serviceKey)
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ provider: string }> }
+) {
+  const { provider } = await params
+
+  if (!SUPPORTED.includes(provider as PaymentProvider)) {
+    return NextResponse.json({ error: `Unknown provider: ${provider}` }, { status: 404 })
+  }
+
+  const rawBody = await req.text()
+  const headers: Record<string, string> = {}
+  req.headers.forEach((value, key) => {
+    headers[key] = value
+  })
+
+  // Instantiate provider (throws if credentials are not configured).
+  let p
+  try {
+    p = getPaymentProvider(provider as PaymentProvider)
+  } catch (err) {
+    console.error(`[webhook/${provider}] provider not configured:`, err)
+    return NextResponse.json({ error: 'Provider not configured' }, { status: 503 })
+  }
+
+  if (!p.verifyWebhook || !p.normalizeWebhookEvent) {
+    return NextResponse.json(
+      { error: `Provider ${provider} does not support unified webhooks yet` },
+      { status: 501 }
+    )
+  }
+
+  // 1. Verify signature on the RAW body.
+  const verified = await p.verifyWebhook(rawBody, headers)
+  if (!verified) {
+    console.error(`[webhook/${provider}] signature verification failed`)
+    return NextResponse.json({ error: 'Invalid signature' }, { status: 400 })
+  }
+
+  // 2. Normalize. null = an event type we do not model — ack so the provider
+  //    stops retrying.
+  const event = await p.normalizeWebhookEvent(rawBody)
+  if (!event) {
+    return NextResponse.json({ received: true, ignored: true })
+  }
+
+  // Idempotency requires a stable, provider-unique event id. A synthesized key
+  // (e.g. by type+sub) would collapse two legitimate same-type events — two
+  // renewals on the same subscription — into one and silently drop the second.
+  // Adapters MUST supply providerEventId; reject (no retry) if absent.
+  const providerEventId = event.providerEventId
+  if (!providerEventId) {
+    console.error(`[webhook/${provider}] normalized event missing providerEventId — cannot dedupe`)
+    return NextResponse.json({ error: 'Event missing provider event id' }, { status: 422 })
+  }
+
+  const admin = getSupabaseAdmin()
+
+  // 3. Idempotency: skip if this event was already processed.
+  const { data: existing } = await admin
+    .from('webhook_events')
+    .select('id, processed_at')
+    .eq('provider', provider)
+    .eq('provider_event_id', providerEventId)
+    .maybeSingle()
+
+  if (existing?.processed_at) {
+    return NextResponse.json({ received: true, duplicate: true })
+  }
+
+  let rowId = existing?.id as string | undefined
+  if (!rowId) {
+    const { data: inserted, error: insertErr } = await admin
+      .from('webhook_events')
+      .insert({
+        provider,
+        provider_event_id: providerEventId,
+        event_type: event.type,
+        payload: event.raw as Record<string, unknown>,
+      })
+      .select('id')
+      .single()
+
+    if (insertErr) {
+      // 23505 = unique violation: a concurrent delivery beat us to it.
+      if ((insertErr as { code?: string }).code === '23505') {
+        return NextResponse.json({ received: true, duplicate: true })
+      }
+      console.error(`[webhook/${provider}] failed to persist event:`, insertErr)
+      return NextResponse.json({ error: 'Failed to persist event' }, { status: 500 })
+    }
+    rowId = inserted.id
+  }
+
+  // 4. Dispatch. On failure, record the error and 500 so the provider retries.
+  try {
+    await dispatchBillingEvent(event, { provider, admin })
+  } catch (err) {
+    console.error(`[webhook/${provider}] dispatch failed:`, err)
+    await admin
+      .from('webhook_events')
+      .update({ error: err instanceof Error ? err.message : String(err) })
+      .eq('id', rowId)
+    return NextResponse.json({ error: 'Dispatch failed' }, { status: 500 })
+  }
+
+  // 5. Mark processed. If this write fails the event will be redelivered and
+  //    re-dispatched; the dispatcher is idempotent (status writes converge,
+  //    period end comes from the event, not now()), so log rather than fail.
+  const { error: markErr } = await admin
+    .from('webhook_events')
+    .update({ processed_at: new Date().toISOString() })
+    .eq('id', rowId)
+  if (markErr) {
+    console.error(`[webhook/${provider}] failed to mark event ${providerEventId} processed:`, markErr)
+  }
+
+  return NextResponse.json({ received: true })
+}

--- a/app/api/stripe/create-payment-intent/route.ts
+++ b/app/api/stripe/create-payment-intent/route.ts
@@ -3,6 +3,7 @@ import { getStripe } from '@/lib/stripe'
 import { createClient } from '@/lib/supabase/server'
 import { getCurrentTenantId } from '@/lib/supabase/tenant'
 import { toCents } from '@/lib/currency'
+import { getPaymentProvider } from '@/lib/payments'
 
 export async function POST(req: NextRequest) {
   try {
@@ -67,11 +68,13 @@ export async function POST(req: NextRequest) {
     let amount: number
     let itemName: string
     let currency = 'usd'
+    let planProviderPriceId: string | null = null
+    let planPaymentProvider = 'stripe'
 
     if (planId) {
       const { data: plan, error } = await supabase
         .from('plans')
-        .select('price, plan_name, currency')
+        .select('price, plan_name, currency, provider_price_id, payment_provider')
         .eq('plan_id', planId)
         .eq('tenant_id', tenantId)
         .single()
@@ -82,6 +85,8 @@ export async function POST(req: NextRequest) {
       currency = plan.currency || 'usd'
       amount = toCents(Number(plan.price), currency)
       itemName = plan.plan_name
+      planProviderPriceId = plan.provider_price_id
+      planPaymentProvider = plan.payment_provider || 'stripe'
     } else {
       const { data: product, error } = await supabase
         .from('products')
@@ -128,6 +133,57 @@ export async function POST(req: NextRequest) {
     if (txError || !transaction) {
       console.error('Transaction creation error:', txError)
       return NextResponse.json({ error: 'Failed to create transaction' }, { status: 500 })
+    }
+
+    // Native subscription path (#280 Phase 2): a Stripe plan with a recurring
+    // price becomes a real Stripe Subscription, so provider_subscription_id is
+    // stored at creation and renewals/cancels are webhook-driven. Legacy/manual
+    // plans (no recurring provider_price_id) fall through to the one-time
+    // PaymentIntent path below, unchanged.
+    if (planId && planPaymentProvider === 'stripe' && planProviderPriceId) {
+      try {
+        const provider = getPaymentProvider('stripe')
+        const session = await provider.createCheckoutSession!({
+          mode: 'subscription',
+          providerPriceId: planProviderPriceId,
+          amount,
+          currency,
+          reference: transaction.transaction_id.toString(),
+          providerCustomerId: stripeCustomerId,
+          destinationAccount: tenant.stripe_account_id,
+          applicationFeePercent: platformPercentage,
+          metadata: {
+            transactionId: transaction.transaction_id.toString(),
+            userId: user.id,
+            tenantId,
+            planId: planId.toString(),
+          },
+        })
+
+        // Persist the Stripe subscription id; the handle_new_subscription trigger
+        // copies it onto the subscriptions row when the first invoice succeeds.
+        await supabase
+          .from('transactions')
+          .update({ provider_subscription_id: session.providerRef })
+          .eq('transaction_id', transaction.transaction_id)
+
+        if (!session.clientSecret) {
+          return NextResponse.json({ error: 'Failed to initialize subscription payment' }, { status: 500 })
+        }
+
+        return NextResponse.json({
+          clientSecret: session.clientSecret,
+          transactionId: transaction.transaction_id,
+        })
+      } catch (subErr) {
+        console.error('Subscription creation error:', subErr)
+        // Roll the pending transaction back so the unique index doesn't block a retry.
+        await supabase
+          .from('transactions')
+          .update({ status: 'failed' })
+          .eq('transaction_id', transaction.transaction_id)
+        return NextResponse.json({ error: 'Failed to create subscription' }, { status: 500 })
+      }
     }
 
     // Create Stripe PaymentIntent with Connect (revenue split)

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -17,6 +17,23 @@ function getSupabaseAdmin() {
 }
 
 /**
+ * Extract the subscription id + metadata from an Invoice across Stripe API
+ * versions. On 2026-02-25.clover the subscription moved under
+ * `invoice.parent.subscription_details`; older versions used `invoice.subscription`.
+ */
+function getInvoiceSubscription(invoice: Stripe.Invoice): {
+  id: string | null
+  metadata: Record<string, string>
+} {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const inv = invoice as any
+  const details = inv.parent?.subscription_details
+  const sub = details?.subscription ?? inv.subscription
+  const id = (typeof sub === 'string' ? sub : sub?.id) ?? null
+  return { id, metadata: details?.metadata ?? {} }
+}
+
+/**
  * Resolve tenant_id from a Stripe Connect account ID.
  * Returns null for direct (non-Connect) events.
  */
@@ -327,7 +344,7 @@ export async function POST(req: NextRequest) {
     // Stripe's retry window until a customer.subscription.deleted arrives.
     case 'invoice.payment_failed': {
       const invoice = event.data.object as Stripe.Invoice
-      const stripeSubId = (invoice as any).subscription as string | null
+      const { id: stripeSubId } = getInvoiceSubscription(invoice)
 
       await dispatchBillingEvent(
         {
@@ -338,6 +355,72 @@ export async function POST(req: NextRequest) {
         },
         { provider: 'stripe', admin: getSupabaseAdmin() }
       )
+      break
+    }
+
+    // Native subscriptions (#280 Phase 2). The first invoice's PaymentIntent is
+    // created by Stripe and carries NO transactionId metadata, so it cannot be
+    // activated via payment_intent.succeeded — this invoice event is the signal.
+    case 'invoice.payment_succeeded': {
+      const invoice = event.data.object as Stripe.Invoice
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const billingReason = (invoice as any).billing_reason as string | undefined
+      const { id: stripeSubId, metadata: subMeta } = getInvoiceSubscription(invoice)
+
+      if (!stripeSubId) break
+
+      if (billingReason === 'subscription_create') {
+        // First payment. Match the pending transaction by the transactionId we
+        // put in the subscription metadata at checkout (robust to the route's
+        // RLS provider_subscription_id write racing this webhook), falling back
+        // to the stored provider_subscription_id. Then flip → successful AND set
+        // provider_subscription_id authoritatively (admin client) in one update,
+        // so handle_new_subscription always reads the real sub id. Status-guarded
+        // for idempotency.
+        const txnIdMeta = subMeta.transactionId ? parseInt(subMeta.transactionId, 10) : null
+
+        let lookup = getSupabaseAdmin()
+          .from('transactions')
+          .select('transaction_id')
+          .eq('status', 'pending')
+        lookup = txnIdMeta
+          ? lookup.eq('transaction_id', txnIdMeta)
+          : lookup.eq('provider_subscription_id', stripeSubId).eq('payment_provider', 'stripe')
+        const { data: tx } = await lookup.maybeSingle()
+
+        if (tx) {
+          await getSupabaseAdmin()
+            .from('transactions')
+            .update({
+              status: 'successful',
+              provider_subscription_id: stripeSubId,
+              payment_provider: 'stripe',
+            })
+            .eq('transaction_id', tx.transaction_id)
+            .eq('status', 'pending')
+          console.log(`Activated subscription transaction ${tx.transaction_id} (Stripe sub ${stripeSubId})`)
+        } else {
+          console.warn(`No pending transaction for subscription_create (Stripe sub ${stripeSubId}, txn meta ${subMeta.transactionId ?? 'none'})`)
+        }
+      } else if (billingReason === 'subscription_cycle') {
+        // Renewal: extend the access window (end_date + entitlements) via the
+        // shared dispatcher → extend_subscription_period RPC. Idempotent: the
+        // period end comes from the invoice, not now().
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const inv = invoice as any
+        const periodEndUnix = inv.lines?.data?.[0]?.period?.end ?? inv.period_end
+        await dispatchBillingEvent(
+          {
+            type: 'subscription.renewed',
+            providerEventId: event.id,
+            providerSubscriptionId: stripeSubId,
+            periodEnd: periodEndUnix ? new Date(periodEndUnix * 1000) : undefined,
+            raw: event,
+          },
+          { provider: 'stripe', admin: getSupabaseAdmin() }
+        )
+        console.log(`Processed subscription renewal for Stripe sub ${stripeSubId}`)
+      }
       break
     }
 

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -4,6 +4,7 @@ import { createClient } from '@supabase/supabase-js'
 import Stripe from 'stripe'
 import { sendEmail } from '@/lib/email/send'
 import { enrollmentConfirmedTemplate } from '@/lib/email/templates/enrollment-confirmed'
+import { dispatchBillingEvent } from '@/lib/payments/webhook-dispatch'
 
 // Lazy initialize Supabase admin client
 function getSupabaseAdmin() {
@@ -287,71 +288,56 @@ export async function POST(req: NextRequest) {
       const stripeSub = event.data.object as Stripe.Subscription
       const stripeSubId = stripeSub.id
 
-      // Find our subscription row by matching the provider subscription ID
-      // stored at creation (provider-agnostic column; scoped to Stripe).
-      const { data: sub } = await getSupabaseAdmin()
-        .from('subscriptions')
-        .select('subscription_id, user_id, plan_id, tenant_id')
-        .eq('provider_subscription_id', stripeSubId)
-        .eq('payment_provider', 'stripe')
-        .maybeSingle()
+      // Shared dispatcher: matches by (provider_subscription_id, 'stripe') and
+      // sets status → expired (DB trigger disables linked enrollments).
+      await dispatchBillingEvent(
+        {
+          type: 'subscription.expired',
+          providerEventId: event.id,
+          providerSubscriptionId: stripeSubId,
+          raw: event,
+        },
+        { provider: 'stripe', admin: getSupabaseAdmin() }
+      )
 
-      if (sub) {
+      // Fallback for legacy rows created before provider_subscription_id was
+      // stored: match by tenant + metadata. The status='active' filter means
+      // this is a no-op when the dispatcher already matched the row above.
+      const tenantMeta = stripeSub.metadata?.tenant_id || tenantId
+      const userId = stripeSub.metadata?.user_id
+      if (tenantMeta && userId) {
         await getSupabaseAdmin()
           .from('subscriptions')
           .update({
             subscription_status: 'expired',
             ended_at: new Date().toISOString(),
           })
-          .eq('subscription_id', sub.subscription_id)
-
-        console.log(`Subscription ${sub.subscription_id} expired (Stripe sub ${stripeSubId})`)
-      } else {
-        // Fallback: match by tenant + metadata if stripe_subscription_id not stored
-        const tenantMeta = stripeSub.metadata?.tenant_id || tenantId
-        if (tenantMeta) {
-          const userId = stripeSub.metadata?.user_id
-          if (userId) {
-            await getSupabaseAdmin()
-              .from('subscriptions')
-              .update({
-                subscription_status: 'expired',
-                ended_at: new Date().toISOString(),
-              })
-              .eq('user_id', userId)
-              .eq('tenant_id', tenantMeta)
-              .eq('subscription_status', 'active')
-
-            console.log(`Expired active subscriptions for user ${userId} tenant ${tenantMeta}`)
-          }
-        }
+          .eq('user_id', userId)
+          .eq('tenant_id', tenantMeta)
+          .eq('subscription_status', 'active')
       }
+
+      console.log(`Processed subscription.deleted (Stripe sub ${stripeSubId})`)
       break
     }
 
     // Fired when a recurring payment fails (before subscription is deleted).
-    // Mark subscription as past_due — access continues during Stripe's retry window.
+    // The subscription_status enum has no 'past_due' value, so the shared
+    // dispatcher logs this rather than writing it — access continues during
+    // Stripe's retry window until a customer.subscription.deleted arrives.
     case 'invoice.payment_failed': {
       const invoice = event.data.object as Stripe.Invoice
       const stripeSubId = (invoice as any).subscription as string | null
 
-      if (stripeSubId) {
-        const { data: sub } = await getSupabaseAdmin()
-          .from('subscriptions')
-          .select('subscription_id')
-          .eq('provider_subscription_id', stripeSubId)
-          .eq('payment_provider', 'stripe')
-          .maybeSingle()
-
-        if (sub) {
-          await getSupabaseAdmin()
-            .from('subscriptions')
-            .update({ subscription_status: 'past_due' as any })
-            .eq('subscription_id', sub.subscription_id)
-
-          console.log(`Subscription ${sub.subscription_id} marked past_due`)
-        }
-      }
+      await dispatchBillingEvent(
+        {
+          type: 'subscription.past_due',
+          providerEventId: event.id,
+          providerSubscriptionId: stripeSubId ?? undefined,
+          raw: event,
+        },
+        { provider: 'stripe', admin: getSupabaseAdmin() }
+      )
       break
     }
 

--- a/docs/PROVIDER_AGNOSTIC_PAYMENTS_SPIKE.md
+++ b/docs/PROVIDER_AGNOSTIC_PAYMENTS_SPIKE.md
@@ -1,0 +1,399 @@
+# Spike: Provider-Agnostic Payments & Subscriptions
+
+> **Status:** Design spike (no live code paths changed). Companion to issue #280 and PR #330.
+> **Author:** generated 2026-06-15.
+> **Reference stubs:** `lib/payments/spike/` (proposed contract + Lemon Squeezy + Solana adapters).
+
+## TL;DR
+
+We are **not** trying to support every payment processor ourselves. We are designing a
+**thin, well-documented contract** so that:
+
+1. A school admin can pick *which* provider a plan/product is sold through (Stripe, PayPal,
+   Lemon Squeezy, MercadoPago, crypto, cash/bank transfer…), per product.
+2. Adding a brand-new provider is a **single adapter file + one webhook normalizer + one
+   factory line** — a contained PR that a contributor (or a future us) can submit without
+   rewriting the checkout, the subscription model, or the entitlement logic.
+3. The **subscription/entitlement model works identically** whether the provider pushes
+   renewal events (Stripe/Lemon Squeezy/Paddle/MercadoPago) or requires us to manage the
+   billing period ourselves (cash, bank transfer, most crypto).
+
+The key architectural move is **decoupling entitlements from billing**: our database is the
+source of truth for "can this user access this course right now," and providers only feed
+*events* into that model. This is already 80% true in the codebase — products are fully
+abstracted, and PR #330 extended the abstraction to the plan/subscription *lookup & cancel*
+layer. This spike defines the rest: a **checkout-session abstraction**, a **unified webhook
+ingestion layer**, **provider capability flags**, and a **self-managed billing-period** path
+for providers without native recurring billing.
+
+---
+
+## 1. Goals & non-goals
+
+### Goals
+- One interface (`IBillingProvider`) that any provider implements. No `import Stripe` outside
+  `stripe-provider.ts`.
+- Per-product / per-plan provider selection (already exists for products; extend confidence to plans).
+- A subscription lifecycle that is **identical across providers** at the DB/entitlement level.
+- A **contributor on-ramp**: documented "how to add a provider" with a checklist and two worked
+  reference stubs (Lemon Squeezy = native recurring + Merchant-of-Record; Solana = one-time +
+  self-managed period).
+- LATAM-first: make local methods (MercadoPago, PIX/OXXO/Boleto, bank transfer, crypto) first-class.
+
+### Non-goals (for this spike)
+- Building production integrations for every provider. We ship **stubs + the contract**; the
+  community/we fill them in later.
+- A payment-orchestration *router* (auto-failover between providers, smart routing by BIN/geo).
+  That's a possible future layer (see §11) but out of scope.
+- Changing platform/tenant billing (`platform_subscriptions`, Stripe Connect). That is a separate
+  Stripe-Billing concern and stays as-is.
+
+---
+
+## 2. Current state (what's already agnostic vs coupled)
+
+The product payment system is a good template; plans/subscriptions are mid-migration.
+
+| Concern | File | State |
+|---|---|---|
+| Provider factory | `lib/payments/index.ts` | ✅ `getPaymentProvider()` switch; `binance` throws, `paypal` is a stub |
+| `IPaymentProvider` contract | `lib/payments/types.ts` | ✅ products/prices; ⚠️ subscriptions are *optional* methods only; ❌ no checkout-session / customer / webhook / refund concepts |
+| Stripe adapter | `lib/payments/stripe-provider.ts` | ✅ full products/prices + subscription create/cancel/get |
+| Manual adapter | `lib/payments/manual-provider.ts` | ✅ DB-only no-ops (correct for offline) |
+| PayPal adapter | `lib/payments/paypal-provider.ts` | ⚠️ placeholder — every method `console.log` + TODO |
+| Product CRUD | `app/actions/admin/products.ts` | ✅ fully via `getPaymentProvider()` + `provider_product_id/price_id` |
+| Plan CRUD | `app/actions/admin/plans.ts` | ✅ refactored onto the provider pattern (PR #330) |
+| Subscription cancel | `app/actions/admin/subscriptions.ts` | ✅ provider-aware (PR #330) |
+| Stripe webhook | `app/api/stripe/webhook/route.ts` | ⚠️ lookup fixed to `provider_subscription_id` (PR #330), but still a **Stripe-only file**; routes by Stripe event strings |
+| Manual / offline | `app/actions/payment-requests.ts` | ✅ provider-agnostic for products *and* plans |
+| Checkout (student) | `app/[locale]/(public)/checkout/*` | ⚠️ card tab = Stripe-ish + `mock_test`; offline tab = payment request. No generic "provider checkout session" |
+| Enrollment / access | `enroll_user` / `handle_new_subscription` RPC + `entitlements` | ✅ single path for all providers (transaction insert → trigger → RPC) |
+
+### The real coupling points still left
+
+1. **No checkout-session abstraction.** A student "subscribing" today just inserts a
+   `transactions` row with `status='successful'`, and a DB trigger calls
+   `handle_new_subscription`. There is **no call to any provider's "start a subscription"** —
+   `provider_subscription_id` is never populated by the create flow, so renewal webhooks have
+   nothing to match (PR #330 fixed the *lookup*, but nothing *writes* the id yet). This is the
+   single biggest gap.
+2. **`profiles.stripe_customer_id`** is a Stripe-named column read by `subscriptions.ts` and the
+   webhook. Should be provider-scoped.
+3. **The webhook file is Stripe-shaped.** Event routing, signature verification, and DB writes
+   all live in one Stripe-specific handler. There is no per-provider signature verification or
+   event normalization.
+4. **Refunds are Stripe-only** (`charge.refunded`). No abstract refund concept.
+5. **Subscription expiry cron** treats everything as time-based; it doesn't know that
+   push-renewal providers should *not* be expired by cron (only by their webhook).
+
+---
+
+## 3. Research summary (what others do)
+
+Full notes with source URLs in §12. Condensed conclusions:
+
+### 3.1 The pattern everyone converges on
+- **Adapter/strategy per provider** behind one interface + a **factory** that selects by config.
+  (Exactly what the codebase already does for products.)
+- **Decouple entitlements from billing.** Three layers: *entitlements* (what the user can access
+  now) ← *billing rules* (when/how to charge) ← *payment rail* (the provider moving money). The
+  app only ever queries entitlements. This is the load-bearing idea for supporting providers with
+  wildly different capabilities.
+- Open-source prior art: **Hyperswitch** (payment orchestration, 300+ PSPs, self-hostable),
+  **Lago** (open-source billing + entitlements). We don't need to adopt these, but they validate
+  the layering.
+
+### 3.2 Provider landscape relevant to a LATAM LMS
+
+| Provider | Recurring model | LATAM fit | Tax / MoR | Notes |
+|---|---|---|---|---|
+| **Stripe** | Native subscriptions + webhooks | Weak in several LATAM countries; high intl-card declines | No (you handle tax) | Already integrated |
+| **Lemon Squeezy** | Native subscriptions + webhooks | Card + PayPal only (no local methods) | ✅ **Merchant of Record** (handles VAT/IVA globally) | Simplest API; Stripe-owned since 2024. **Our reference "easy win".** |
+| **Paddle** | Native, richer (proration/dunning/pause) | Card + Alipay; no PIX/OXXO | ✅ MoR | Heavier API; best if we outgrow LS |
+| **MercadoPago** | Native via **Preapproval API** (card only) | ⭐ Dominant LATAM processor, best local card acceptance | No | PIX/OXXO are **one-time only** via preapproval |
+| **Rebill** | Native, LATAM-specialized | ⭐ PIX, Boleto, OXXO, SPEI, PSE, Nequi, Yape, MP | No | Purpose-built LATAM recurring; ~20% higher acceptance claim |
+| **PayPal** | Native (Billing Plans API) | OK | No | Adapter is a stub today |
+| **Solana Pay** | **None** (one-time only) | Borderless | n/a | QR/URL spec; confirm on-chain via `getSignaturesForAddress`. **Our reference "self-managed period" example.** |
+| **Helio / Solana native subs** | Email-reminder renewal *or* on-chain auto-pull (native program) | Borderless, USDC | n/a | Real crypto recurring; higher integration complexity |
+| **Cash / bank transfer** | **None** (admin-managed) | ⭐ Universal | n/a | Already works via `payment_requests` |
+
+### 3.3 The capability spectrum (this drives the design)
+
+Providers fall into three buckets. The contract must serve all three with the *same*
+subscription model:
+
+1. **Push-renewal** (Stripe, Lemon Squeezy, Paddle, MercadoPago-card, PayPal): the provider
+   charges on a schedule and **sends a webhook** on each renewal/failure/cancellation. We update
+   `current_period_end` from the event. **Never expire these via cron.**
+2. **Self-managed period** (cash, bank transfer, OXXO/Boleto, basic crypto/Solana Pay): there is
+   no external recurring engine. **We** set `current_period_end` when payment is confirmed and a
+   **cron job expires** the row when the period lapses. Renewal = a new payment.
+3. **Hybrid crypto** (Helio / Solana native subscriptions): can be either — treat as push-renewal
+   if the provider emits renewal webhooks, otherwise as self-managed.
+
+---
+
+## 4. Proposed contract: `IBillingProvider`
+
+> Lives (as a spike) in `lib/payments/spike/billing-contract.ts`. The intent is to **grow the
+> existing `IPaymentProvider`** into this, not replace it wholesale — all new methods are additive
+> and capability-gated, so existing providers keep working.
+
+Three additions to today's product/price/subscription interface:
+
+### 4.1 Capability flags
+A static descriptor so the app can branch *without* `if (provider === 'stripe')` checks:
+
+```ts
+interface ProviderCapabilities {
+  supportsNativeSubscriptions: boolean   // provider charges on a schedule itself
+  emitsRenewalWebhooks: boolean          // we get told about renewals → don't cron-expire
+  supportsHostedCheckout: boolean        // provider gives us a redirect URL
+  supportsRefunds: boolean
+  isMerchantOfRecord: boolean            // provider handles tax (LS/Paddle)
+  selfManagedPeriod: boolean             // WE extend the period on confirmed payment
+}
+```
+
+### 4.2 Checkout sessions (the missing creation path)
+Unify "send the student somewhere to pay" across hosted-redirect (LS, MercadoPago, PayPal),
+client-confirmed (Stripe PaymentIntent), QR/URL (Solana Pay), and offline (payment request):
+
+```ts
+interface CheckoutSession {
+  kind: 'redirect' | 'client_secret' | 'qr' | 'offline'
+  url?: string            // redirect / QR target
+  clientSecret?: string   // Stripe-style client confirmation
+  reference: string       // our internal correlation id (→ transaction/payment_request)
+  providerRef?: string    // provider's session/intent id
+  expiresAt?: Date
+}
+
+createCheckoutSession(params: CreateCheckoutParams): Promise<CheckoutSession>
+```
+
+### 4.3 Customer + webhook normalization + refunds
+```ts
+// optional — providers that need a stored customer (Stripe/MP card-on-file)
+ensureCustomer?(params: EnsureCustomerParams): Promise<{ providerCustomerId: string }>
+
+// turn a raw provider webhook into our internal event vocabulary
+verifyWebhook(rawBody: string, headers: Record<string,string>): Promise<boolean>
+normalizeWebhookEvent(rawBody: string): Promise<NormalizedBillingEvent | null>
+
+// optional
+refund?(params: RefundParams): Promise<void>
+```
+
+Where the **internal event vocabulary** is provider-independent:
+
+```ts
+type BillingEventType =
+  | 'payment.succeeded' | 'payment.failed'
+  | 'subscription.activated' | 'subscription.renewed'
+  | 'subscription.past_due' | 'subscription.canceled' | 'subscription.expired'
+  | 'refund.succeeded'
+
+interface NormalizedBillingEvent {
+  type: BillingEventType
+  providerSubscriptionId?: string
+  providerPaymentId?: string
+  reference?: string          // our correlation id from metadata
+  periodEnd?: Date
+  raw: unknown                // keep the original for audit
+}
+```
+
+This is the crux: **every provider's webhook collapses into the same handful of events**, and a
+single internal handler updates `subscriptions` / `transactions` / `entitlements`.
+
+---
+
+## 5. Unified webhook ingestion layer
+
+Replace the Stripe-only route with a per-provider route that shares one pipeline:
+
+```
+POST /api/payments/webhook/[provider]
+  1. read RAW body (needed for HMAC)
+  2. provider = getBillingProvider(params.provider)
+  3. if (!await provider.verifyWebhook(raw, headers)) → 400
+  4. persist raw event → webhook_events (idempotency key = (provider, provider_event_id))
+  5. 200 OK immediately
+  6. event = await provider.normalizeWebhookEvent(raw)
+  7. dispatch(event) → ONE internal handler updates subscriptions/entitlements
+```
+
+- **Per-provider signature schemes** stay inside each adapter's `verifyWebhook` (Stripe
+  `Stripe-Signature`, Lemon Squeezy `X-Signature`, MercadoPago `x-signature`, Solana = on-chain
+  RPC confirmation, not HMAC).
+- **Idempotency** via a new `webhook_events` table with a unique `(provider, provider_event_id)`
+  and a `processed_at` guard. Critical because crypto/manual confirmation may be polled and
+  retried.
+- The existing `/api/stripe/webhook` route can **delegate** to this for a transition period
+  (keep Stripe's URL alive, call the shared dispatcher).
+
+---
+
+## 6. Subscription lifecycle (identical across providers)
+
+State machine on `subscriptions.subscription_status` regardless of provider:
+
+```
+              ┌──────────── renew ok ─────────────┐
+              ▼                                    │
+ (start) → active → past_due ──retry ok──→ active  │
+              │  │        └──give up──→ canceled    
+              │  └── cancel(at period end) ─────────┐
+              │                                      ▼
+              └── cancel(immediate) ───────────► canceled
+   self-managed only:  active ──period lapses (cron)──► expired
+```
+
+| Event source | Who advances the state |
+|---|---|
+| Push-renewal providers | their webhook → `normalizeWebhookEvent` → dispatcher |
+| Self-managed (cash/crypto) | payment confirmation extends `current_period_end`; **daily cron** flips lapsed rows to `expired` |
+
+The cron must be capability-aware:
+
+```sql
+UPDATE subscriptions s
+SET subscription_status = 'expired'
+FROM plans p
+WHERE s.plan_id = p.plan_id
+  AND s.subscription_status = 'active'
+  AND s.current_period_end < now()
+  AND <provider for s is selfManagedPeriod>;   -- never expire push-renewal subs
+```
+
+Access checks never touch a provider — they read entitlements:
+`status='active' AND current_period_end > now()` joined through `plan_courses`.
+
+---
+
+## 7. Data model changes needed
+
+Building on the PR #330 migration (`payment_provider`, `provider_subscription_id`,
+`provider_product_id/price_id` already added):
+
+1. **Rename `profiles.stripe_customer_id` → `provider_customer_id`** *(plus optionally a
+   `payment_provider` companion, or a small `provider_customers(user_id, provider, customer_id)`
+   table since one user may have a customer id per provider)*. Recommended: the join table — a user
+   can legitimately have a Stripe *and* a MercadoPago customer id.
+2. **New `webhook_events` table** for idempotent ingestion + audit:
+   `(id, provider, provider_event_id UNIQUE, event_type, payload jsonb, received_at, processed_at)`.
+3. **`subscriptions.current_period_start`** (if missing) for cleaner reporting; `current_period_end`
+   already exists.
+4. **Extend the `payment_provider` CHECK / union** to include new slugs as adapters land
+   (`lemonsqueezy`, `mercadopago`, `solana`, …). Today's union is
+   `'stripe' | 'paypal' | 'binance' | 'manual'` in `lib/payments/types.ts`.
+
+No destructive changes; all additive/rename-with-guard like the existing migration.
+
+---
+
+## 8. How to add a provider (contributor guide)
+
+This is the payoff. Adding "Foo Pay" should be ~one PR:
+
+1. **Adapter** — `lib/payments/foo-provider.ts` implementing `IBillingProvider`
+   (declare `capabilities`; implement `createCheckoutSession`, `verifyWebhook`,
+   `normalizeWebhookEvent`; products/prices/subscriptions as the provider supports — others can be
+   no-ops if e.g. it's offline-like).
+2. **Factory line** — add `case 'foo':` to `getPaymentProvider()` in `lib/payments/index.ts`,
+   reading its env vars.
+3. **Union/CHECK** — add `'foo'` to the `PaymentProvider` type and the DB `payment_provider`
+   CHECK constraint (one-line migration).
+4. **Env** — document keys in `.env.example`.
+5. **UI** — the provider already appears in the plan/product form selector once it's in the union;
+   add a label/icon.
+6. **Webhook** — nothing new to wire: `/api/payments/webhook/foo` is generic; the adapter's
+   `verifyWebhook` + `normalizeWebhookEvent` do the work.
+7. **Tests** — a normalization unit test (sample webhook payload → expected
+   `NormalizedBillingEvent`) is the highest-value test and needs no live credentials.
+
+**Checklist for the PR template:**
+- [ ] `capabilities` accurately set (esp. `emitsRenewalWebhooks` / `selfManagedPeriod`)
+- [ ] `createCheckoutSession` returns the right `kind`
+- [ ] `verifyWebhook` uses the **raw** body
+- [ ] `normalizeWebhookEvent` maps every lifecycle event the provider sends
+- [ ] No `import`/types leak the provider SDK outside the adapter
+- [ ] Manual/offline fallbacks behave (no crash if optional methods absent)
+
+---
+
+## 9. Phased roadmap
+
+| Phase | Scope | Risk |
+|---|---|---|
+| **0 — done** | PR #330: migration, webhook lookup fix, plan CRUD on provider pattern | merged-pending |
+| **1 — contract** | Land `IBillingProvider` (additive to `IPaymentProvider`): capabilities + checkout-session + webhook-normalize + refund signatures. Stub adapters compile. No behavior change. | low |
+| **2 — checkout session** | Wire `createCheckoutSession` into the student checkout so a real `provider_subscription_id` gets stored at creation (closes the §2.1 gap). Start with Stripe (already has `createSubscription`). | medium |
+| **3 — webhook layer** | Add `webhook_events` table + `/api/payments/webhook/[provider]` + dispatcher; have the existing Stripe route delegate to it. | medium |
+| **4 — first new provider** | Implement **Lemon Squeezy** end-to-end (MoR, native subs) as the proof the abstraction holds. | medium |
+| **5 — LATAM** | **MercadoPago** (card recurring) and/or **Rebill** (local methods); **Solana Pay** one-time + self-managed period; capability-aware expiry cron. | higher |
+| **6 — customers** | `provider_customers` join table; rename `stripe_customer_id`. | low/med |
+
+Phases 1, 3, and the stub adapters are safe to do now without touching money flows.
+
+---
+
+## 10. Risks & open questions
+
+- **Customer identity per provider.** Stripe/MP need a stored customer for card-on-file recurring;
+  LS/Solana don't. The `provider_customers` join table resolves this but adds a write to checkout.
+- **MoR vs Connect revenue split.** Lemon Squeezy/Paddle are Merchant-of-Record — *they* are the
+  seller and remit to the school differently than Stripe Connect's `application_fee_amount`. Our
+  `revenue_splits` model assumes Connect. MoR providers may need a different payout reconciliation
+  (open question — likely out of scope, schools using MoR get paid by the MoR, not by us).
+- **Crypto refunds are effectively manual.** `supportsRefunds=false` for Solana Pay; admin issues
+  an on-chain refund out of band.
+- **MercadoPago PIX/OXXO are one-time only** — they can't back a native subscription; they map to
+  the **self-managed period** path (generate a new charge each cycle).
+- **Per-tenant provider credentials.** Today keys are global env vars. True multi-tenant means each
+  school brings its own Stripe/MP/LS keys → a `tenant_payment_credentials` table (encrypted). Big,
+  separate effort; the contract doesn't block it but the factory would read tenant creds instead of
+  env.
+
+---
+
+## 11. Optional future: orchestration layer
+
+Once 2+ providers exist, a thin router could pick a provider by tenant config, buyer geo, or
+failover (retry MercadoPago if a Stripe card declines). Hyperswitch is the open-source reference.
+**Explicitly out of scope** — listed so the contract above stays compatible with it (it already is:
+a router just calls `getBillingProvider()` with a chosen slug).
+
+---
+
+## 12. Sources
+
+Architecture / orchestration:
+- Adapter pattern for payment gateways — https://endgrate.com/blog/adapter-pattern-use-cases-payment-gateway-integration
+- Abstract monetization engine (entitlements vs billing) — https://www.webdigestpro.com/architecting-an-abstract-monetization-engine-a-technical-guide-to-high-integrity-saas-billing/
+- Hyperswitch (open-source orchestration) — https://hyperswitch.io/
+- Lago (open-source billing + entitlements) — https://getlago.com/blog/lago-entitlements
+- Recurring-payment system design — https://www.geeksforgeeks.org/system-design/system-design-pattern-for-recurring-payments/
+
+Merchant-of-Record:
+- Lemon Squeezy vs Paddle 2026 — https://thesoftwarescout.com/lemon-squeezy-vs-paddle-2026-best-payment-platform-for-saas-developers/
+- Lemon Squeezy webhooks — https://docs.lemonsqueezy.com/help/webhooks/webhook-requests
+- LS vs Polar vs Paddle MoR 2026 — https://www.buildmvpfast.com/blog/lemon-squeezy-vs-polar-paddle-merchant-of-record-2026
+
+Crypto:
+- Solana Pay spec — https://docs.solanapay.com/spec
+- Solana native subscriptions & allowances — https://solana.com/news/subscriptions-and-allowances
+- Helio subscriptions — https://www.hel.io/blog/introducing-helio-subscriptions
+- NOWPayments recurring API — https://nowpayments.io/blog/recurring-payments-api
+- Recurring crypto platforms 2026 — https://eco.com/support/en/articles/15232579-best-recurring-crypto-payment-platforms-2026-stablecoin-subscription-billing-compared
+
+LATAM:
+- Rebill (LATAM subscriptions) — https://www.rebill.com/en/solutions/saas-subscription-payments-latin-america
+- MercadoPago subscriptions (preapproval) — https://www.mercadopago.com.co/developers/en/docs/subscriptions/integration-configuration/subscription-associated-plan
+- MercadoPago subscription webhooks — https://www.mercadopago.com.co/developers/en/docs/subscriptions/additional-content/your-integrations/notifications/webhooks
+- LATAM recurring landscape (PIX/Boleto/OXXO) — https://www.ppro.com/insights/subscriptions-and-recurring-payments-the-latam-revolution/
+
+Webhooks:
+- Webhook processing at scale (idempotency/signatures/queues) — https://dev.to/whoffagents/webhook-processing-at-scale-idempotency-signature-verification-and-async-queues-45b3
+- Webhook reliability 2026 — https://www.digitalapplied.com/blog/webhook-reliability-idempotency-retries-engineering-reference-2026

--- a/lib/payments/manual-provider.ts
+++ b/lib/payments/manual-provider.ts
@@ -14,10 +14,21 @@ import {
   UpdatePriceParams,
   CreateSubscriptionParams,
   ProviderSubscription,
+  ProviderCapabilities,
 } from './types'
 
 export class ManualPaymentProvider implements IPaymentProvider {
   readonly provider: PaymentProvider = 'manual'
+  // Offline/manual: no external engine. WE own the billing period; an admin
+  // confirms each payment and a cron expires lapsed rows. No webhooks/refunds.
+  readonly capabilities: ProviderCapabilities = {
+    supportsNativeSubscriptions: false,
+    emitsRenewalWebhooks: false,
+    supportsHostedCheckout: false,
+    supportsRefunds: false,
+    isMerchantOfRecord: false,
+    selfManagedPeriod: true,
+  }
 
   convertAmount(amount: number, fromUnit: 'base' | 'major'): number {
     // Manual payments use major units (no conversion needed)

--- a/lib/payments/paypal-provider.ts
+++ b/lib/payments/paypal-provider.ts
@@ -15,10 +15,21 @@ import {
   CreatePriceParams,
   UpdateProductParams,
   UpdatePriceParams,
+  ProviderCapabilities,
 } from './types'
 
 export class PayPalPaymentProvider implements IPaymentProvider {
   readonly provider: PaymentProvider = 'paypal'
+  // PayPal: hosted checkout redirect, native Billing Plans (recurring) +
+  // webhooks, programmatic refunds. Not a Merchant of Record.
+  readonly capabilities: ProviderCapabilities = {
+    supportsNativeSubscriptions: true,
+    emitsRenewalWebhooks: true,
+    supportsHostedCheckout: true,
+    supportsRefunds: true,
+    isMerchantOfRecord: false,
+    selfManagedPeriod: false,
+  }
   private clientId: string
   private clientSecret: string
 

--- a/lib/payments/spike/README.md
+++ b/lib/payments/spike/README.md
@@ -1,0 +1,44 @@
+# `lib/payments/spike/` — provider-agnostic billing (design spike)
+
+> **These files are not wired into any live payment flow.** They are the design
+> target for issue #280. Read the full write-up first:
+> [`docs/PROVIDER_AGNOSTIC_PAYMENTS_SPIKE.md`](../../../docs/PROVIDER_AGNOSTIC_PAYMENTS_SPIKE.md).
+
+## What's here
+
+| File | Purpose |
+|---|---|
+| `billing-contract.ts` | Proposed `IBillingProvider` — the contract every provider implements. Adds **capabilities**, **checkout sessions**, **customers**, **webhook normalization**, and **refunds** on top of today's `IPaymentProvider`. |
+| `lemonsqueezy-provider.ts` | Reference stub #1 — a **push-renewal, Merchant-of-Record** provider (native subscriptions, hosted redirect checkout, HMAC webhooks). |
+| `solana-provider.ts` | Reference stub #2 — a **self-managed-period** crypto provider (one-time Solana Pay, QR checkout, on-chain confirmation, cron-driven expiry). |
+
+These two stubs were chosen because they sit at opposite ends of the capability
+spectrum. If one contract serves both, it serves the providers in between
+(PayPal, MercadoPago, Paddle, cash/bank transfer, Helio).
+
+## Why these two prove the design
+
+| | Lemon Squeezy | Solana Pay |
+|---|---|---|
+| Native recurring? | ✅ provider charges on schedule | ❌ one-time only |
+| Renewal webhooks? | ✅ → never cron-expire | ❌ → we own the period, cron expires |
+| Checkout kind | `redirect` (hosted URL) | `qr` (Solana Pay URL) |
+| Tax | ✅ Merchant of Record | n/a |
+| Refunds | programmatic | manual / out of band |
+
+The app branches on `provider.capabilities.*`, **never** on `provider === '...'`.
+
+## Adding a real provider (the payoff)
+
+A new provider should be ~one PR. See §8 of the spike doc for the full checklist; in short:
+
+1. Add `lib/payments/<name>-provider.ts` implementing `IBillingProvider`.
+2. Add a `case` to `getPaymentProvider()` in `lib/payments/index.ts` (reads its env vars).
+3. Add the slug to the `PaymentProvider` union (`lib/payments/types.ts`) and the DB
+   `payment_provider` CHECK (one-line migration).
+4. Document env keys in `.env.example`.
+5. Add a normalization unit test (sample webhook payload → expected `NormalizedBillingEvent`) —
+   highest value, needs no live credentials.
+
+Nothing about the webhook route, the subscription state machine, or the entitlement
+checks needs to change — that's the whole point.

--- a/lib/payments/spike/billing-contract.ts
+++ b/lib/payments/spike/billing-contract.ts
@@ -1,87 +1,49 @@
 /**
- * Payment Provider Types
- * Defines interfaces for multiple payment providers (Stripe, PayPal, Binance, etc.)
+ * SPIKE — Proposed provider-agnostic billing contract.
+ *
+ * This file is NOT wired into any live code path. It is the design target for
+ * issue #280 / the provider-agnostic payments spike (see
+ * docs/PROVIDER_AGNOSTIC_PAYMENTS_SPIKE.md).
+ *
+ * Intent: GROW the existing `IPaymentProvider` (lib/payments/types.ts) into this
+ * `IBillingProvider` over time. Everything here is ADDITIVE and capability-gated:
+ *   - products / prices / subscriptions are reused from the existing types
+ *   - new concepts (capabilities, checkout sessions, customers, webhook
+ *     normalization, refunds) are added so providers with very different
+ *     abilities (Stripe vs Lemon Squeezy vs Solana Pay vs cash) all fit one API.
+ *
+ * Nothing imports this yet. The two reference stubs in this folder implement it
+ * to prove the shape compiles and that "add a provider" is a contained change.
  */
 
-export type PaymentProvider = 'stripe' | 'paypal' | 'binance' | 'manual'
-
-export type Currency = 'usd' | 'eur' | 'btc' | 'eth' | 'usdt'
-
-export type PaymentType = 'one_time' | 'subscription'
-
-export interface PaymentProduct {
-  id: string
-  name: string
-  description: string
-  amount: number
-  currency: Currency
-  metadata?: Record<string, string>
-}
-
-export interface PaymentPrice {
-  id: string
-  productId: string
-  amount: number
-  currency: Currency
-  type: PaymentType
-  interval?: 'month' | 'year'
-  metadata?: Record<string, string>
-}
-
-export interface CreateProductParams {
-  name: string
-  description: string
-  images?: string[]
-  metadata?: Record<string, string>
-}
-
-export interface CreatePriceParams {
-  productId: string
-  amount: number // Amount in smallest currency unit (cents, satoshis, etc.)
-  currency: Currency
-  type: PaymentType
-  interval?: 'month' | 'year'
-  intervalCount?: number
-  metadata?: Record<string, string>
-}
-
-export interface UpdateProductParams {
-  name?: string
-  description?: string
-  images?: string[]
-  active?: boolean
-  metadata?: Record<string, string>
-}
-
-export interface UpdatePriceParams {
-  active?: boolean
-  metadata?: Record<string, string>
-}
-
-export interface CreateSubscriptionParams {
-  providerPriceId: string
-  providerCustomerId: string
-  metadata?: Record<string, string>
-}
-
-export interface ProviderSubscription {
-  id: string
-  status: 'active' | 'canceled' | 'past_due'
-  currentPeriodEnd: Date
-  cancelAtPeriodEnd: boolean
-}
-
-// ---------------------------------------------------------------------------
-// Provider-agnostic billing additions (issue #280 / provider-agnostic spike).
-// All ADDITIVE: new concepts so providers with different abilities (Stripe vs
-// Lemon Squeezy vs Solana Pay vs cash) all fit one API. The app branches on
-// capabilities, NEVER on provider identity. See docs/PROVIDER_AGNOSTIC_PAYMENTS_SPIKE.md
-// ---------------------------------------------------------------------------
+import type {
+  CreatePriceParams,
+  CreateProductParams,
+  CreateSubscriptionParams,
+  PaymentPrice,
+  PaymentProduct,
+  ProviderSubscription,
+  UpdatePriceParams,
+  UpdateProductParams,
+} from '../types'
 
 /**
- * Static descriptor of what a provider can do. Lets the app branch on ability,
- * never on provider identity.
+ * Slugs proposed for new adapters. The production union lives in
+ * `lib/payments/types.ts` as `PaymentProvider`; new slugs get added there (and
+ * to the DB `payment_provider` CHECK) when an adapter actually lands.
  */
+export type BillingProviderSlug =
+  | 'stripe'
+  | 'paypal'
+  | 'manual'
+  | 'lemonsqueezy'
+  | 'mercadopago'
+  | 'solana'
+
+// ---------------------------------------------------------------------------
+// 1. Capabilities — lets the app branch on ability, never on provider identity.
+// ---------------------------------------------------------------------------
+
 export interface ProviderCapabilities {
   /** Provider charges on a recurring schedule itself (Stripe/LS/Paddle/MP-card). */
   supportsNativeSubscriptions: boolean
@@ -102,7 +64,10 @@ export interface ProviderCapabilities {
   selfManagedPeriod: boolean
 }
 
-/** Params for starting a payment (the missing "start a payment" abstraction). */
+// ---------------------------------------------------------------------------
+// 2. Checkout session — the missing "start a payment" abstraction.
+// ---------------------------------------------------------------------------
+
 export interface CreateCheckoutParams {
   /** One-time product purchase or a recurring plan subscription. */
   mode: 'one_time' | 'subscription'
@@ -137,7 +102,10 @@ export interface CheckoutSession {
   expiresAt?: Date
 }
 
-/** Params for ensuring a stored customer (card-on-file providers only). */
+// ---------------------------------------------------------------------------
+// 3. Customers (optional — only providers needing card-on-file recurring).
+// ---------------------------------------------------------------------------
+
 export interface EnsureCustomerParams {
   userId: string
   email: string
@@ -145,7 +113,10 @@ export interface EnsureCustomerParams {
   metadata?: Record<string, string>
 }
 
-/** Every provider webhook collapses to ONE internal vocabulary. */
+// ---------------------------------------------------------------------------
+// 4. Webhook normalization — every provider event collapses to ONE vocabulary.
+// ---------------------------------------------------------------------------
+
 export type BillingEventType =
   | 'payment.succeeded'
   | 'payment.failed'
@@ -158,8 +129,6 @@ export type BillingEventType =
 
 export interface NormalizedBillingEvent {
   type: BillingEventType
-  /** Provider's own unique event id — the idempotency key for webhook_events. */
-  providerEventId?: string
   providerSubscriptionId?: string
   providerPaymentId?: string
   /** Our correlation id, recovered from provider metadata. */
@@ -170,73 +139,54 @@ export interface NormalizedBillingEvent {
   raw: unknown
 }
 
+// ---------------------------------------------------------------------------
+// 5. Refunds (optional).
+// ---------------------------------------------------------------------------
+
 export interface RefundParams {
   providerPaymentId: string
   amount?: number // omit for full refund
   reason?: string
 }
 
-export interface PaymentProviderConfig {
-  provider: PaymentProvider
-  apiKey: string
-  webhookSecret?: string
-  environment?: 'test' | 'production'
-  additionalConfig?: Record<string, any>
-}
+// ---------------------------------------------------------------------------
+// The contract every provider implements.
+// ---------------------------------------------------------------------------
 
-/**
- * Base interface that all payment providers must implement
- */
-export interface IPaymentProvider {
-  readonly provider: PaymentProvider
-
-  /**
-   * What this provider can do. The app branches on these flags, never on
-   * `provider` identity. Required so every provider declares its abilities.
-   */
+export interface IBillingProvider {
+  readonly provider: BillingProviderSlug
   readonly capabilities: ProviderCapabilities
 
-  // Product operations
+  // --- Catalog (same as today's IPaymentProvider) ---
   createProduct(params: CreateProductParams): Promise<PaymentProduct>
   updateProduct(productId: string, params: UpdateProductParams): Promise<PaymentProduct>
   getProduct(productId: string): Promise<PaymentProduct>
   archiveProduct(productId: string): Promise<void>
   restoreProduct(productId: string): Promise<void>
 
-  // Price operations
   createPrice(params: CreatePriceParams): Promise<PaymentPrice>
   updatePrice(priceId: string, params: UpdatePriceParams): Promise<PaymentPrice>
   getPrice(priceId: string): Promise<PaymentPrice>
   archivePrice(priceId: string): Promise<void>
 
-  // Subscription operations (optional — providers without recurring billing,
-  // e.g. manual/offline, implement these as no-ops)
+  // --- Checkout (NEW — the creation path that stores provider_subscription_id) ---
+  createCheckoutSession(params: CreateCheckoutParams): Promise<CheckoutSession>
+
+  // --- Subscriptions (optional; no-ops for self-managed providers) ---
   createSubscription?(params: CreateSubscriptionParams): Promise<ProviderSubscription>
   cancelSubscription?(providerSubId: string, immediate: boolean): Promise<void>
   getSubscription?(providerSubId: string): Promise<ProviderSubscription>
 
-  // Checkout (optional — the creation path that stores provider_subscription_id;
-  // providers wire this in Phase 2). Capability-gated by supportsHostedCheckout
-  // / native subscription support.
-  createCheckoutSession?(params: CreateCheckoutParams): Promise<CheckoutSession>
-
-  // Customers (optional — only providers needing card-on-file recurring).
+  // --- Customers (optional) ---
   ensureCustomer?(params: EnsureCustomerParams): Promise<{ providerCustomerId: string }>
 
-  // Webhooks (optional — per-provider verify + normalize; wired in Phase 3).
-  verifyWebhook?(rawBody: string, headers: Record<string, string>): Promise<boolean>
-  normalizeWebhookEvent?(rawBody: string): Promise<NormalizedBillingEvent | null>
+  // --- Webhooks (NEW — per-provider verify + normalize) ---
+  verifyWebhook(rawBody: string, headers: Record<string, string>): Promise<boolean>
+  normalizeWebhookEvent(rawBody: string): Promise<NormalizedBillingEvent | null>
 
-  // Refunds (optional — capability-gated by supportsRefunds).
+  // --- Refunds (optional) ---
   refund?(params: RefundParams): Promise<void>
 
-  // Utility
+  // --- Utility (same as today) ---
   convertAmount(amount: number, fromUnit: 'base' | 'major'): number
 }
-
-/**
- * Result type for operations
- */
-export type PaymentResult<T = unknown> =
-  | { success: true; data: T }
-  | { success: false; error: string }

--- a/lib/payments/spike/lemonsqueezy-provider.ts
+++ b/lib/payments/spike/lemonsqueezy-provider.ts
@@ -1,0 +1,142 @@
+/**
+ * SPIKE STUB — Lemon Squeezy adapter (reference example #1).
+ *
+ * NOT wired into any live flow. Demonstrates a PUSH-RENEWAL,
+ * MERCHANT-OF-RECORD provider: Lemon Squeezy is the legal seller, handles global
+ * tax (incl. LATAM VAT/IVA), charges subscriptions on a schedule, and notifies us
+ * via webhooks. So:
+ *   - capabilities.emitsRenewalWebhooks = true  → never cron-expire its subs
+ *   - capabilities.isMerchantOfRecord   = true  → tax handled for us
+ *   - checkout.kind = 'redirect'                → hosted checkout URL
+ *
+ * Real implementation would use the Lemon Squeezy REST API (JSON:API):
+ *   - createCheckoutSession → POST /v1/checkouts
+ *   - subscriptions         → GET/DELETE /v1/subscriptions/{id}
+ *   - webhook verify        → HMAC-SHA256 of the RAW body with the signing secret,
+ *                             compared to the `X-Signature` header
+ * Docs: https://docs.lemonsqueezy.com/api  ·  webhooks: https://docs.lemonsqueezy.com/help/webhooks
+ *
+ * To make this real (per docs/PROVIDER_AGNOSTIC_PAYMENTS_SPIKE.md §8):
+ *   1. fill these methods using the LS API
+ *   2. add 'lemonsqueezy' to PaymentProvider union + DB CHECK
+ *   3. add a `case 'lemonsqueezy'` to getPaymentProvider() reading LEMONSQUEEZY_API_KEY
+ *   4. add LEMONSQUEEZY_API_KEY / LEMONSQUEEZY_STORE_ID / LEMONSQUEEZY_WEBHOOK_SECRET to .env.example
+ */
+
+import type {
+  CreatePriceParams,
+  CreateProductParams,
+  CreateSubscriptionParams,
+  PaymentPrice,
+  PaymentProduct,
+  ProviderSubscription,
+  UpdatePriceParams,
+  UpdateProductParams,
+} from '../types'
+import type {
+  CheckoutSession,
+  CreateCheckoutParams,
+  IBillingProvider,
+  NormalizedBillingEvent,
+  ProviderCapabilities,
+  RefundParams,
+} from './billing-contract'
+
+const todo = (method: string): never => {
+  throw new Error(`[spike] LemonSqueezyProvider.${method} not implemented yet`)
+}
+
+export class LemonSqueezyProvider implements IBillingProvider {
+  readonly provider = 'lemonsqueezy' as const
+
+  readonly capabilities: ProviderCapabilities = {
+    supportsNativeSubscriptions: true,
+    emitsRenewalWebhooks: true,
+    supportsHostedCheckout: true,
+    supportsRefunds: true,
+    isMerchantOfRecord: true,
+    selfManagedPeriod: false,
+  }
+
+  // LS stores amounts in cents, like Stripe.
+  convertAmount(amount: number, fromUnit: 'base' | 'major'): number {
+    return fromUnit === 'major' ? Math.round(amount * 100) : amount
+  }
+
+  // --- Catalog: in LS these map to "products" and "variants". ---
+  async createProduct(_params: CreateProductParams): Promise<PaymentProduct> {
+    return todo('createProduct')
+  }
+  async updateProduct(_id: string, _params: UpdateProductParams): Promise<PaymentProduct> {
+    return todo('updateProduct')
+  }
+  async getProduct(_id: string): Promise<PaymentProduct> {
+    return todo('getProduct')
+  }
+  async archiveProduct(_id: string): Promise<void> {
+    return todo('archiveProduct')
+  }
+  async restoreProduct(_id: string): Promise<void> {
+    return todo('restoreProduct')
+  }
+  async createPrice(_params: CreatePriceParams): Promise<PaymentPrice> {
+    return todo('createPrice')
+  }
+  async updatePrice(_id: string, _params: UpdatePriceParams): Promise<PaymentPrice> {
+    return todo('updatePrice')
+  }
+  async getPrice(_id: string): Promise<PaymentPrice> {
+    return todo('getPrice')
+  }
+  async archivePrice(_id: string): Promise<void> {
+    return todo('archivePrice')
+  }
+
+  // --- Checkout: LS returns a hosted checkout URL → kind 'redirect'. ---
+  async createCheckoutSession(_params: CreateCheckoutParams): Promise<CheckoutSession> {
+    // Real: POST /v1/checkouts with custom_data: { reference } so it round-trips
+    // on the webhook, then return { kind: 'redirect', url: data.attributes.url }.
+    return todo('createCheckoutSession')
+  }
+
+  // --- Subscriptions: managed by LS; we mostly read/cancel. ---
+  async cancelSubscription(_providerSubId: string, _immediate: boolean): Promise<void> {
+    // Real: DELETE /v1/subscriptions/{id} (cancels at period end) or PATCH cancelled.
+    return todo('cancelSubscription')
+  }
+  async getSubscription(_providerSubId: string): Promise<ProviderSubscription> {
+    return todo('getSubscription')
+  }
+  // createSubscription intentionally omitted: with LS the subscription is created
+  // by the hosted checkout, not by a separate API call. The webhook
+  // `subscription_created` tells us the provider_subscription_id to store.
+  async createSubscription(_params: CreateSubscriptionParams): Promise<ProviderSubscription> {
+    return todo('createSubscription')
+  }
+
+  // --- Webhooks: HMAC-SHA256 of RAW body vs X-Signature header. ---
+  async verifyWebhook(_rawBody: string, _headers: Record<string, string>): Promise<boolean> {
+    // Real:
+    //   const sig = headers['x-signature']
+    //   const digest = createHmac('sha256', process.env.LEMONSQUEEZY_WEBHOOK_SECRET!)
+    //                    .update(rawBody).digest('hex')
+    //   return timingSafeEqual(Buffer.from(sig), Buffer.from(digest))
+    return todo('verifyWebhook')
+  }
+
+  async normalizeWebhookEvent(_rawBody: string): Promise<NormalizedBillingEvent | null> {
+    // Real mapping (meta.event_name → our vocabulary):
+    //   subscription_created   → 'subscription.activated'
+    //   subscription_updated   → 'subscription.renewed' (if active) / 'subscription.past_due'
+    //   subscription_payment_failed → 'subscription.past_due'
+    //   subscription_cancelled → 'subscription.canceled'
+    //   subscription_expired   → 'subscription.expired'
+    // reference recovered from meta.custom_data.reference; periodEnd from
+    // data.attributes.renews_at.
+    return todo('normalizeWebhookEvent')
+  }
+
+  async refund(_params: RefundParams): Promise<void> {
+    return todo('refund')
+  }
+}

--- a/lib/payments/spike/solana-provider.ts
+++ b/lib/payments/spike/solana-provider.ts
@@ -1,0 +1,159 @@
+/**
+ * SPIKE STUB — Solana Pay adapter (reference example #2).
+ *
+ * NOT wired into any live flow. Demonstrates a SELF-MANAGED-PERIOD provider:
+ * Solana Pay (the spec) has NO native recurring billing — it does one-time
+ * transfers via a payment-request URL / QR code, confirmed ON-CHAIN. So:
+ *   - capabilities.supportsNativeSubscriptions = false
+ *   - capabilities.emitsRenewalWebhooks        = false → WE own the period; a
+ *     daily cron expires lapsed subscriptions, and a "renewal" is just a new
+ *     one-time payment that extends current_period_end.
+ *   - capabilities.selfManagedPeriod           = true
+ *   - checkout.kind = 'qr'  (render the solana: URL as a QR code)
+ *
+ * There is no HMAC webhook. "Confirmation" is polling the chain for our unique
+ * `reference` key: getSignaturesForAddress(reference) — once a signature appears
+ * and the transfer matches recipient+amount+mint, the payment is confirmed.
+ *
+ * For TRUE crypto recurring (auto-pull), a separate adapter would wrap Helio or
+ * the Solana native subscription program; that one WOULD set
+ * supportsNativeSubscriptions=true and emit renewal events. Kept separate so the
+ * simple one-time path stays simple.
+ *
+ * Spec: https://docs.solanapay.com/spec  ·  Native subs: https://solana.com/news/subscriptions-and-allowances
+ *
+ * To make this real (per docs/PROVIDER_AGNOSTIC_PAYMENTS_SPIKE.md §8):
+ *   1. build the solana: transfer-request URL in createCheckoutSession (recipient,
+ *      amount, spl-token=USDC mint, reference, label, memo)
+ *   2. add a confirmation poller (or a /verify endpoint) that calls
+ *      getSignaturesForAddress(reference) and, on match, inserts the successful
+ *      transaction (→ handle_new_subscription) and sets current_period_end
+ *   3. add 'solana' to PaymentProvider union + DB CHECK + factory + .env
+ *      (SOLANA_RPC_URL, SOLANA_RECIPIENT, SOLANA_USDC_MINT)
+ */
+
+import type {
+  CreatePriceParams,
+  CreateProductParams,
+  PaymentPrice,
+  PaymentProduct,
+  UpdatePriceParams,
+  UpdateProductParams,
+} from '../types'
+import type {
+  CheckoutSession,
+  CreateCheckoutParams,
+  IBillingProvider,
+  NormalizedBillingEvent,
+  ProviderCapabilities,
+} from './billing-contract'
+
+const todo = (method: string): never => {
+  throw new Error(`[spike] SolanaProvider.${method} not implemented yet`)
+}
+
+export class SolanaProvider implements IBillingProvider {
+  readonly provider = 'solana' as const
+
+  readonly capabilities: ProviderCapabilities = {
+    supportsNativeSubscriptions: false,
+    emitsRenewalWebhooks: false,
+    supportsHostedCheckout: false,
+    supportsRefunds: false, // on-chain refunds are manual, out of band
+    isMerchantOfRecord: false,
+    selfManagedPeriod: true,
+  }
+
+  // Solana Pay amounts are decimal token units (e.g. 9.99 USDC), not cents.
+  // We keep "major" units and let the URL builder format decimals.
+  convertAmount(amount: number, _fromUnit: 'base' | 'major'): number {
+    return amount
+  }
+
+  // --- Catalog: there is no remote catalog; products/prices live only in our DB
+  //     (same approach as the manual provider). Return local placeholder ids. ---
+  async createProduct(params: CreateProductParams): Promise<PaymentProduct> {
+    return {
+      id: `solana_prod_${params.name.toLowerCase().replace(/\s+/g, '_')}`,
+      name: params.name,
+      description: params.description,
+      amount: 0,
+      currency: 'usdt',
+      metadata: params.metadata,
+    }
+  }
+  async updateProduct(id: string, params: UpdateProductParams): Promise<PaymentProduct> {
+    return {
+      id,
+      name: params.name ?? '',
+      description: params.description ?? '',
+      amount: 0,
+      currency: 'usdt',
+      metadata: params.metadata,
+    }
+  }
+  async getProduct(id: string): Promise<PaymentProduct> {
+    return { id, name: 'Solana Product', description: '', amount: 0, currency: 'usdt' }
+  }
+  async archiveProduct(_id: string): Promise<void> {
+    /* DB-only */
+  }
+  async restoreProduct(_id: string): Promise<void> {
+    /* DB-only */
+  }
+  async createPrice(params: CreatePriceParams): Promise<PaymentPrice> {
+    return {
+      id: `solana_price_${params.productId}`,
+      productId: params.productId,
+      amount: params.amount,
+      currency: params.currency,
+      type: params.type,
+      interval: params.interval,
+      metadata: params.metadata,
+    }
+  }
+  async updatePrice(id: string, params: UpdatePriceParams): Promise<PaymentPrice> {
+    return { id, productId: '', amount: 0, currency: 'usdt', type: 'one_time', metadata: params.metadata }
+  }
+  async getPrice(id: string): Promise<PaymentPrice> {
+    return { id, productId: '', amount: 0, currency: 'usdt', type: 'one_time' }
+  }
+  async archivePrice(_id: string): Promise<void> {
+    /* DB-only */
+  }
+
+  // --- Checkout: build a Solana Pay transfer-request URL, render as QR. ---
+  async createCheckoutSession(_params: CreateCheckoutParams): Promise<CheckoutSession> {
+    // Real:
+    //   const reference = Keypair.generate().publicKey  // unique on-chain marker
+    //   const url = encodeURL({ recipient, amount, splToken: USDC_MINT,
+    //                           reference, label, message })
+    //   persist reference against our internal `params.reference`
+    //   return { kind: 'qr', url: url.toString(), reference: params.reference,
+    //            providerRef: reference.toBase58() }
+    return todo('createCheckoutSession')
+  }
+
+  // No native subscription engine: createSubscription/cancelSubscription are
+  // intentionally absent. The DB row is the source of truth; "cancel" just stops
+  // future renewals (the period is never auto-charged), and the capability-aware
+  // cron flips the row to 'expired' when current_period_end lapses.
+
+  // --- "Webhook": Solana has no signed callback. Confirmation is on-chain. ---
+  async verifyWebhook(_rawBody: string, _headers: Record<string, string>): Promise<boolean> {
+    // No HMAC. Authenticity comes from the chain: only a real on-chain transfer
+    // carrying our `reference` can confirm payment. The generic webhook route
+    // does not apply to Solana — confirmation flows through a poller/verify
+    // endpoint instead (see normalizeWebhookEvent note).
+    return false
+  }
+
+  async normalizeWebhookEvent(_rawBody: string): Promise<NormalizedBillingEvent | null> {
+    // Not driven by inbound webhooks. Instead a confirmation poller calls
+    // getSignaturesForAddress(reference); on a matching, finalized transfer it
+    // synthesizes { type: 'payment.succeeded', reference, providerPaymentId: sig }
+    // and feeds the same internal dispatcher. Returning null here signals "this
+    // provider is not webhook-driven."
+    return null
+  }
+}

--- a/lib/payments/stripe-provider.ts
+++ b/lib/payments/stripe-provider.ts
@@ -14,11 +14,24 @@ import {
   UpdatePriceParams,
   CreateSubscriptionParams,
   ProviderSubscription,
+  ProviderCapabilities,
+  NormalizedBillingEvent,
   Currency,
 } from './types'
 
 export class StripePaymentProvider implements IPaymentProvider {
   readonly provider: PaymentProvider = 'stripe'
+  // Stripe Connect: native recurring billing + renewal webhooks. We use
+  // PaymentIntent/Elements (client_secret), not hosted Checkout, so
+  // supportsHostedCheckout is false. Not a Merchant of Record.
+  readonly capabilities: ProviderCapabilities = {
+    supportsNativeSubscriptions: true,
+    emitsRenewalWebhooks: true,
+    supportsHostedCheckout: false,
+    supportsRefunds: true,
+    isMerchantOfRecord: false,
+    selfManagedPeriod: false,
+  }
   private stripe: Stripe
 
   constructor(apiKey: string) {
@@ -264,6 +277,111 @@ export class StripePaymentProvider implements IPaymentProvider {
       return this.mapSubscription(stripeSub)
     } catch (error) {
       throw new Error(`Stripe getSubscription failed: ${error instanceof Error ? error.message : 'Unknown error'}`)
+    }
+  }
+
+  /**
+   * Verify a Stripe webhook signature against STRIPE_WEBHOOK_SECRET (the Connect
+   * student-payments endpoint secret). Used by the unified webhook route.
+   */
+  async verifyWebhook(rawBody: string, headers: Record<string, string>): Promise<boolean> {
+    const secret = process.env.STRIPE_WEBHOOK_SECRET
+    if (!secret) return false
+    const signature = headers['stripe-signature'] ?? headers['Stripe-Signature']
+    if (!signature) return false
+    try {
+      this.stripe.webhooks.constructEvent(rawBody, signature, secret)
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  /**
+   * Collapse a Stripe event into our internal billing vocabulary. Called AFTER
+   * verifyWebhook, so a plain JSON parse of the (already trusted) body is safe.
+   * Returns null for event types the unified layer does not model.
+   */
+  async normalizeWebhookEvent(rawBody: string): Promise<NormalizedBillingEvent | null> {
+    let event: Stripe.Event
+    try {
+      event = JSON.parse(rawBody) as Stripe.Event
+    } catch {
+      return null
+    }
+
+    const obj = (event.data?.object ?? {}) as any
+    const eventId = event.id
+    const toDate = (unix?: number) => (unix ? new Date(unix * 1000) : undefined)
+
+    switch (event.type) {
+      case 'customer.subscription.deleted':
+        return {
+          type: 'subscription.expired',
+          providerEventId: eventId,
+          providerSubscriptionId: obj.id,
+          periodEnd: toDate(obj.current_period_end),
+          raw: event,
+        }
+      case 'customer.subscription.created':
+      case 'customer.subscription.updated': {
+        if (obj.status === 'active' || obj.status === 'trialing') {
+          return {
+            type: 'subscription.activated',
+            providerEventId: eventId,
+            providerSubscriptionId: obj.id,
+            periodEnd: toDate(obj.current_period_end),
+            raw: event,
+          }
+        }
+        if (obj.status === 'past_due') {
+          return { type: 'subscription.past_due', providerEventId: eventId, providerSubscriptionId: obj.id, raw: event }
+        }
+        if (obj.status === 'canceled') {
+          return { type: 'subscription.canceled', providerEventId: eventId, providerSubscriptionId: obj.id, raw: event }
+        }
+        return null
+      }
+      case 'invoice.payment_succeeded':
+        return {
+          type: 'subscription.renewed',
+          providerEventId: eventId,
+          providerSubscriptionId: obj.subscription ?? undefined,
+          periodEnd: toDate(obj.lines?.data?.[0]?.period?.end),
+          raw: event,
+        }
+      case 'invoice.payment_failed':
+        return {
+          type: 'subscription.past_due',
+          providerEventId: eventId,
+          providerSubscriptionId: obj.subscription ?? undefined,
+          raw: event,
+        }
+      case 'charge.refunded':
+        return {
+          type: 'refund.succeeded',
+          providerEventId: eventId,
+          providerPaymentId: obj.payment_intent ?? undefined,
+          raw: event,
+        }
+      case 'payment_intent.succeeded':
+        return {
+          type: 'payment.succeeded',
+          providerEventId: eventId,
+          providerPaymentId: obj.id,
+          reference: obj.metadata?.transactionId,
+          raw: event,
+        }
+      case 'payment_intent.payment_failed':
+        return {
+          type: 'payment.failed',
+          providerEventId: eventId,
+          providerPaymentId: obj.id,
+          reference: obj.metadata?.transactionId,
+          raw: event,
+        }
+      default:
+        return null
     }
   }
 

--- a/lib/payments/stripe-provider.ts
+++ b/lib/payments/stripe-provider.ts
@@ -16,6 +16,8 @@ import {
   ProviderSubscription,
   ProviderCapabilities,
   NormalizedBillingEvent,
+  CreateCheckoutParams,
+  CheckoutSession,
   Currency,
 } from './types'
 
@@ -281,6 +283,86 @@ export class StripePaymentProvider implements IPaymentProvider {
   }
 
   /**
+   * Start a payment. The missing "creation" path that stores a real
+   * provider_subscription_id (issue #280, Phase 2).
+   *
+   * - mode 'subscription' → creates a Stripe Subscription on the recurring
+   *   price with `payment_behavior: 'default_incomplete'`, so the first
+   *   invoice's PaymentIntent is confirmed client-side. Connect destination
+   *   charges + `application_fee_percent` keep the existing revenue split.
+   *   `providerRef` is the Subscription id — store it at creation so renewal /
+   *   cancel webhooks can match the row.
+   * - mode 'one_time' → a PaymentIntent (kept for parity / future product use).
+   *
+   * Both return `kind: 'client_secret'`; the existing Stripe Elements
+   * confirmation on the client works unchanged for either.
+   */
+  async createCheckoutSession(params: CreateCheckoutParams): Promise<CheckoutSession> {
+    try {
+      if (params.mode === 'subscription') {
+        if (!params.providerCustomerId) {
+          throw new Error('providerCustomerId is required for a Stripe subscription')
+        }
+        const subParams: Record<string, unknown> = {
+          customer: params.providerCustomerId,
+          items: [{ price: params.providerPriceId }],
+          payment_behavior: 'default_incomplete',
+          payment_settings: { save_default_payment_method: 'on_subscription' },
+          expand: ['latest_invoice.payment_intent'],
+          metadata: { reference: params.reference, ...(params.metadata || {}) },
+        }
+        if (params.applicationFeePercent && params.applicationFeePercent > 0) {
+          subParams.application_fee_percent = params.applicationFeePercent
+        }
+        if (params.destinationAccount) {
+          subParams.transfer_data = { destination: params.destinationAccount }
+        }
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const sub = await this.stripe.subscriptions.create(subParams as any)
+        // latest_invoice / payment_intent are expanded; cast across API-version types.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const invoice = (sub as any).latest_invoice as Stripe.Invoice | undefined
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const paymentIntent = (invoice as any)?.payment_intent as Stripe.PaymentIntent | undefined
+
+        return {
+          kind: 'client_secret',
+          clientSecret: paymentIntent?.client_secret ?? undefined,
+          reference: params.reference,
+          providerRef: sub.id,
+        }
+      }
+
+      // one_time
+      const piParams: Record<string, unknown> = {
+        amount: params.amount,
+        currency: params.currency,
+        automatic_payment_methods: { enabled: true },
+        metadata: { reference: params.reference, ...(params.metadata || {}) },
+      }
+      if (params.providerCustomerId) piParams.customer = params.providerCustomerId
+      if (params.destinationAccount) {
+        piParams.transfer_data = { destination: params.destinationAccount }
+      }
+      if (params.applicationFeePercent && params.applicationFeePercent > 0) {
+        piParams.application_fee_amount = Math.round((params.amount * params.applicationFeePercent) / 100)
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pi = await this.stripe.paymentIntents.create(piParams as any)
+      return {
+        kind: 'client_secret',
+        clientSecret: pi.client_secret ?? undefined,
+        reference: params.reference,
+        providerRef: pi.id,
+      }
+    } catch (error) {
+      throw new Error(`Stripe createCheckoutSession failed: ${error instanceof Error ? error.message : 'Unknown error'}`)
+    }
+  }
+
+  /**
    * Verify a Stripe webhook signature against STRIPE_WEBHOOK_SECRET (the Connect
    * student-payments endpoint secret). Used by the unified webhook route.
    */
@@ -310,9 +392,19 @@ export class StripePaymentProvider implements IPaymentProvider {
       return null
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const obj = (event.data?.object ?? {}) as any
     const eventId = event.id
     const toDate = (unix?: number) => (unix ? new Date(unix * 1000) : undefined)
+    // API 2026-02-25.clover: current_period_end moved off the Subscription onto
+    // its items; the Invoice's subscription moved under parent.subscription_details.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const subPeriodEnd = (s: any) => toDate(s?.items?.data?.[0]?.current_period_end)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const invoiceSubId = (inv: any): string | undefined => {
+      const sub = inv?.parent?.subscription_details?.subscription ?? inv?.subscription
+      return (typeof sub === 'string' ? sub : sub?.id) ?? undefined
+    }
 
     switch (event.type) {
       case 'customer.subscription.deleted':
@@ -320,7 +412,7 @@ export class StripePaymentProvider implements IPaymentProvider {
           type: 'subscription.expired',
           providerEventId: eventId,
           providerSubscriptionId: obj.id,
-          periodEnd: toDate(obj.current_period_end),
+          periodEnd: subPeriodEnd(obj),
           raw: event,
         }
       case 'customer.subscription.created':
@@ -330,7 +422,7 @@ export class StripePaymentProvider implements IPaymentProvider {
             type: 'subscription.activated',
             providerEventId: eventId,
             providerSubscriptionId: obj.id,
-            periodEnd: toDate(obj.current_period_end),
+            periodEnd: subPeriodEnd(obj),
             raw: event,
           }
         }
@@ -346,15 +438,15 @@ export class StripePaymentProvider implements IPaymentProvider {
         return {
           type: 'subscription.renewed',
           providerEventId: eventId,
-          providerSubscriptionId: obj.subscription ?? undefined,
-          periodEnd: toDate(obj.lines?.data?.[0]?.period?.end),
+          providerSubscriptionId: invoiceSubId(obj),
+          periodEnd: toDate(obj.lines?.data?.[0]?.period?.end ?? obj.period_end),
           raw: event,
         }
       case 'invoice.payment_failed':
         return {
           type: 'subscription.past_due',
           providerEventId: eventId,
-          providerSubscriptionId: obj.subscription ?? undefined,
+          providerSubscriptionId: invoiceSubId(obj),
           raw: event,
         }
       case 'charge.refunded':
@@ -397,10 +489,13 @@ export class StripePaymentProvider implements IPaymentProvider {
           ? 'past_due'
           : 'canceled'
 
+    // API 2026-02-25.clover: current_period_end lives on the subscription item.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const periodEndUnix = (stripeSub as any).items?.data?.[0]?.current_period_end ?? 0
     return {
       id: stripeSub.id,
       status,
-      currentPeriodEnd: new Date(((stripeSub as any).current_period_end ?? 0) * 1000),
+      currentPeriodEnd: new Date(periodEndUnix * 1000),
       cancelAtPeriodEnd: stripeSub.cancel_at_period_end,
     }
   }

--- a/lib/payments/stripe-provider.ts
+++ b/lib/payments/stripe-provider.ts
@@ -308,7 +308,9 @@ export class StripePaymentProvider implements IPaymentProvider {
           items: [{ price: params.providerPriceId }],
           payment_behavior: 'default_incomplete',
           payment_settings: { save_default_payment_method: 'on_subscription' },
-          expand: ['latest_invoice.payment_intent'],
+          // API 2026-02-25.clover: the first-invoice client secret is exposed via
+          // confirmation_secret (Invoice.payment_intent was removed).
+          expand: ['latest_invoice.confirmation_secret'],
           metadata: { reference: params.reference, ...(params.metadata || {}) },
         }
         if (params.applicationFeePercent && params.applicationFeePercent > 0) {
@@ -320,15 +322,17 @@ export class StripePaymentProvider implements IPaymentProvider {
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const sub = await this.stripe.subscriptions.create(subParams as any)
-        // latest_invoice / payment_intent are expanded; cast across API-version types.
+        // latest_invoice is expanded; cast across API-version type differences.
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const invoice = (sub as any).latest_invoice as Stripe.Invoice | undefined
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const paymentIntent = (invoice as any)?.payment_intent as Stripe.PaymentIntent | undefined
+        const invoice = (sub as any).latest_invoice as any
+        const clientSecret =
+          invoice?.confirmation_secret?.client_secret ??
+          invoice?.payment_intent?.client_secret ?? // fallback for older API versions
+          undefined
 
         return {
           kind: 'client_secret',
-          clientSecret: paymentIntent?.client_secret ?? undefined,
+          clientSecret,
           reference: params.reference,
           providerRef: sub.id,
         }

--- a/lib/payments/types.ts
+++ b/lib/payments/types.ts
@@ -113,8 +113,20 @@ export interface CreateCheckoutParams {
   currency: string
   /** Our internal correlation id — must round-trip back on the webhook. */
   reference: string
-  /** Optional stored customer (Stripe/MP card-on-file). */
+  /** Optional stored customer (Stripe/MP card-on-file). Required for native subs. */
   providerCustomerId?: string
+  /**
+   * Marketplace split: route funds to this connected account
+   * (Stripe Connect `transfer_data.destination`). Omit for non-marketplace
+   * providers / Merchant-of-Record.
+   */
+  destinationAccount?: string
+  /**
+   * Platform fee as a percent of each charge (Stripe Connect
+   * `application_fee_percent` for subscriptions; converted to a fixed
+   * `application_fee_amount` for one-time charges). 0–100.
+   */
+  applicationFeePercent?: number
   successUrl?: string
   cancelUrl?: string
   metadata?: Record<string, string>

--- a/lib/payments/webhook-dispatch.ts
+++ b/lib/payments/webhook-dispatch.ts
@@ -1,0 +1,82 @@
+/**
+ * Shared billing-event dispatcher.
+ *
+ * Single source of truth for applying a NormalizedBillingEvent to our
+ * subscription state. BOTH the unified `/api/payments/webhook/[provider]` route
+ * (new providers) and the legacy `/api/stripe/webhook` route call this, so the
+ * subscription lifecycle logic lives in ONE place.
+ *
+ * Subscriptions are matched by (provider_subscription_id, payment_provider).
+ * Writing `subscription_status` fires the DB trigger
+ * `handle_subscription_status_change`, which disables linked enrollments on
+ * canceled/expired and re-enables them on a return to active.
+ *
+ * IMPORTANT: the `subscription_status` enum is
+ * ('active','canceled','expired','renewed') — there is NO 'past_due'. past_due
+ * events are logged only (access continues during the provider's retry window)
+ * rather than written to an invalid enum value.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type { NormalizedBillingEvent } from './types'
+
+export interface DispatchContext {
+  /** Provider slug — used as the payment_provider match key. */
+  provider: string
+  /** Service-role Supabase client (bypasses RLS). */
+  admin: SupabaseClient
+}
+
+export async function dispatchBillingEvent(
+  event: NormalizedBillingEvent,
+  { provider, admin }: DispatchContext
+): Promise<void> {
+  const subId = event.providerSubscriptionId
+
+  switch (event.type) {
+    case 'subscription.activated':
+    case 'subscription.renewed': {
+      if (!subId) break
+      // Set 'active' (not 'renewed') so the enrollment-reactivation branch of
+      // handle_subscription_status_change fires on a return from expired.
+      const patch: Record<string, unknown> = { subscription_status: 'active' }
+      if (event.periodEnd) patch.current_period_end = event.periodEnd.toISOString()
+      const { error } = await admin
+        .from('subscriptions')
+        .update(patch)
+        .eq('provider_subscription_id', subId)
+        .eq('payment_provider', provider)
+      if (error) throw new Error(`dispatch ${event.type} failed: ${error.message}`)
+      break
+    }
+
+    case 'subscription.canceled':
+    case 'subscription.expired': {
+      if (!subId) break
+      const status = event.type === 'subscription.canceled' ? 'canceled' : 'expired'
+      const { error } = await admin
+        .from('subscriptions')
+        .update({ subscription_status: status, ended_at: new Date().toISOString() })
+        .eq('provider_subscription_id', subId)
+        .eq('payment_provider', provider)
+      if (error) throw new Error(`dispatch ${event.type} failed: ${error.message}`)
+      break
+    }
+
+    case 'subscription.past_due':
+      // No 'past_due' enum value; log only. Access continues during the
+      // provider's retry window — a later canceled/expired event ends it.
+      console.log(`[webhook] past_due for ${provider} sub ${subId ?? 'unknown'} — no status change`)
+      break
+
+    case 'payment.succeeded':
+    case 'payment.failed':
+    case 'refund.succeeded':
+      // Transaction-level events stay with provider-specific routes (e.g. the
+      // Stripe Connect route's payment_intent / charge.refunded handlers, which
+      // own the transactions state machine, emails and entitlement revocation).
+      // Logged here so the unified path is explicit about what it does NOT own.
+      console.log(`[webhook] ${event.type} for ${provider} — no-op in shared dispatcher`)
+      break
+  }
+}

--- a/lib/payments/webhook-dispatch.ts
+++ b/lib/payments/webhook-dispatch.ts
@@ -34,8 +34,7 @@ export async function dispatchBillingEvent(
   const subId = event.providerSubscriptionId
 
   switch (event.type) {
-    case 'subscription.activated':
-    case 'subscription.renewed': {
+    case 'subscription.activated': {
       if (!subId) break
       // Set 'active' (not 'renewed') so the enrollment-reactivation branch of
       // handle_subscription_status_change fires on a return from expired.
@@ -46,6 +45,25 @@ export async function dispatchBillingEvent(
         .update(patch)
         .eq('provider_subscription_id', subId)
         .eq('payment_provider', provider)
+      if (error) throw new Error(`dispatch ${event.type} failed: ${error.message}`)
+      break
+    }
+
+    case 'subscription.renewed': {
+      if (!subId) break
+      // A renewal must EXTEND the access window — not just touch a status. The
+      // partial unique index transactions_unique_plan blocks fabricating a new
+      // successful transaction, so extend the subscription + its entitlements
+      // atomically via the RPC (end_date, current_period_end, expires_at).
+      if (!event.periodEnd) {
+        console.warn(`[webhook] renewed for ${provider} sub ${subId} without periodEnd — cannot extend access`)
+        break
+      }
+      const { error } = await admin.rpc('extend_subscription_period', {
+        _provider_subscription_id: subId,
+        _provider: provider,
+        _new_period_end: event.periodEnd.toISOString(),
+      })
       if (error) throw new Error(`dispatch ${event.type} failed: ${error.message}`)
       break
     }

--- a/supabase/migrations/20260615130000_webhook_events.sql
+++ b/supabase/migrations/20260615130000_webhook_events.sql
@@ -1,0 +1,44 @@
+-- Unified webhook ingestion log: idempotency + audit for ALL payment providers.
+--
+-- Part of the provider-agnostic payments work (issue #280, Phase 3). Every
+-- inbound provider webhook is recorded here BEFORE processing, keyed by
+-- (provider, provider_event_id). A row whose processed_at is set has already
+-- been handled, so redelivered events are no-ops. The raw payload is kept for
+-- audit / replay.
+--
+-- The unified route app/api/payments/webhook/[provider] writes here via the
+-- service-role admin client (bypasses RLS). RLS is enabled with NO policies so
+-- no tenant/anon role can read provider payloads.
+
+CREATE TABLE IF NOT EXISTS public.webhook_events (
+  id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  provider          text NOT NULL,
+  provider_event_id text NOT NULL,
+  event_type        text,
+  payload           jsonb NOT NULL DEFAULT '{}'::jsonb,
+  received_at       timestamptz NOT NULL DEFAULT now(),
+  processed_at      timestamptz,
+  error             text,
+  CONSTRAINT webhook_events_provider_event_unique UNIQUE (provider, provider_event_id)
+);
+
+-- Fast scan for un-processed / failed events (replay, monitoring).
+CREATE INDEX IF NOT EXISTS idx_webhook_events_unprocessed
+  ON public.webhook_events (received_at)
+  WHERE processed_at IS NULL;
+
+-- Service-role only: enable RLS, define no policies.
+ALTER TABLE public.webhook_events ENABLE ROW LEVEL SECURITY;
+
+-- Harden the subscription webhook-lookup key. The previous migration
+-- (20260615120000) added a NON-unique index on subscriptions.provider_subscription_id.
+-- The shared dispatcher updates by (provider_subscription_id, payment_provider),
+-- so that pair MUST be unique — otherwise one provider event could mutate
+-- several subscription rows. Provider subscription ids are unique per provider,
+-- so this constraint is always satisfiable. (Cross-tenant isolation relies on
+-- each provider account belonging to one tenant; per-tenant provider credentials
+-- remain a separate, larger effort — see the spike doc.)
+DROP INDEX IF EXISTS public.idx_subscriptions_provider_subscription_id;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_subscriptions_provider_sub_unique
+  ON public.subscriptions (provider_subscription_id, payment_provider)
+  WHERE provider_subscription_id IS NOT NULL;

--- a/supabase/migrations/20260615140000_phase2_native_subscriptions.sql
+++ b/supabase/migrations/20260615140000_phase2_native_subscriptions.sql
@@ -1,0 +1,131 @@
+-- Phase 2 of provider-agnostic payments (issue #280): native Stripe
+-- subscriptions. Plan checkout now creates a real Stripe Subscription and must
+-- persist its id onto our subscription row at creation, so renewal / cancel
+-- webhooks can match it.
+--
+-- 1. Carry the provider + provider subscription id on the transaction so the
+--    creation trigger can copy them onto the subscriptions row.
+-- 2. handle_new_subscription: copy those fields + align current_period_end with
+--    the access window (end_date).
+-- 3. extend_subscription_period: the renewal path. A Stripe `invoice.payment_
+--    succeeded` (billing_reason = subscription_cycle) can't be modelled as a new
+--    transaction (the transactions_unique_plan partial index forbids a second
+--    successful row per (user, plan)), so renewals extend the subscription and
+--    its entitlements directly.
+
+-- 1. transactions: provider columns (idempotent; column may already exist in
+--    cloud as drift — the student checkout already writes payment_provider).
+ALTER TABLE public.transactions
+  ADD COLUMN IF NOT EXISTS payment_provider         TEXT,
+  ADD COLUMN IF NOT EXISTS provider_subscription_id TEXT;
+
+-- 2. handle_new_subscription — same body as 20260530150000 (grant access only,
+--    no auto-enroll) plus: copy payment_provider / provider_subscription_id from
+--    the transaction, and set current_period_end = end_date.
+CREATE OR REPLACE FUNCTION public.handle_new_subscription(
+  _user_id uuid,
+  _plan_id integer,
+  _transaction_id integer,
+  _start_date timestamp with time zone DEFAULT now()
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+    _duration INTERVAL;
+    _end_date TIMESTAMP WITH TIME ZONE;
+    _existing_end TIMESTAMP WITH TIME ZONE;
+    _tenant_id UUID;
+    _subscription_id INTEGER;
+    _provider TEXT;
+    _provider_sub_id TEXT;
+    _rec RECORD;
+BEGIN
+    SELECT make_interval(days => p.duration_in_days), p.tenant_id INTO _duration, _tenant_id
+    FROM plans p WHERE p.plan_id = _plan_id;
+    IF _tenant_id IS NULL THEN
+        RAISE EXCEPTION 'Plan % not found', _plan_id;
+    END IF;
+
+    -- Provider info recorded on the transaction at checkout (native sub id).
+    SELECT t.payment_provider, t.provider_subscription_id
+      INTO _provider, _provider_sub_id
+    FROM transactions t WHERE t.transaction_id = _transaction_id;
+
+    SELECT end_date INTO _existing_end FROM subscriptions WHERE user_id = _user_id AND plan_id = _plan_id;
+    _end_date := GREATEST(COALESCE(_existing_end, _start_date), _start_date) + _duration;
+
+    INSERT INTO subscriptions (
+        user_id, plan_id, start_date, end_date, current_period_end, transaction_id,
+        subscription_status, tenant_id, payment_provider, provider_subscription_id
+    )
+    VALUES (
+        _user_id, _plan_id, _start_date, _end_date, _end_date, _transaction_id,
+        'active', _tenant_id, COALESCE(_provider, 'manual'), _provider_sub_id
+    )
+    ON CONFLICT (user_id, plan_id) DO UPDATE SET
+        end_date = EXCLUDED.end_date,
+        current_period_end = EXCLUDED.current_period_end,
+        transaction_id = EXCLUDED.transaction_id,
+        subscription_status = 'active',
+        tenant_id = EXCLUDED.tenant_id,
+        ended_at = NULL,
+        -- COALESCE so a manual/legacy transaction with NULL provider info never
+        -- wipes an existing native subscription id.
+        payment_provider = COALESCE(EXCLUDED.payment_provider, subscriptions.payment_provider),
+        provider_subscription_id = COALESCE(EXCLUDED.provider_subscription_id, subscriptions.provider_subscription_id)
+    RETURNING subscription_id INTO _subscription_id;
+
+    -- Grant access only. Enrollment is the student's explicit choice (self-enroll
+    -- via /browse), NOT auto-created here.
+    FOR _rec IN SELECT pc.course_id FROM plan_courses pc WHERE pc.plan_id = _plan_id
+    LOOP
+        INSERT INTO entitlements (user_id, course_id, tenant_id, source_type, source_id, status, expires_at)
+        VALUES (_user_id, _rec.course_id, _tenant_id, 'subscription', _subscription_id, 'active', _end_date)
+        ON CONFLICT (user_id, course_id, source_type, source_id) DO UPDATE SET
+            status = 'active', expires_at = EXCLUDED.expires_at, revoked_at = NULL, tenant_id = EXCLUDED.tenant_id;
+    END LOOP;
+END;
+$function$;
+
+-- 3. extend_subscription_period — renewal path (webhook-driven).
+CREATE OR REPLACE FUNCTION public.extend_subscription_period(
+  _provider_subscription_id text,
+  _provider text,
+  _new_period_end timestamp with time zone
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+    _subscription_id INTEGER;
+BEGIN
+    IF _new_period_end IS NULL THEN
+        RAISE NOTICE 'extend_subscription_period: null period end for % %', _provider, _provider_subscription_id;
+        RETURN;
+    END IF;
+
+    UPDATE subscriptions
+       SET end_date = _new_period_end,
+           current_period_end = _new_period_end,
+           subscription_status = 'active',
+           ended_at = NULL
+     WHERE provider_subscription_id = _provider_subscription_id
+       AND payment_provider = _provider
+    RETURNING subscription_id INTO _subscription_id;
+
+    IF _subscription_id IS NULL THEN
+        RAISE NOTICE 'extend_subscription_period: no subscription for % %', _provider, _provider_subscription_id;
+        RETURN;
+    END IF;
+
+    -- Extend the access window on this subscription's entitlements.
+    UPDATE entitlements
+       SET expires_at = _new_period_end, status = 'active', revoked_at = NULL
+     WHERE source_type = 'subscription' AND source_id = _subscription_id;
+END;
+$function$;


### PR DESCRIPTION
Provider-agnostic payments — phases 1–3 of #280 (supersedes #331, which auto-closed when #330's base branch was deleted on merge).

## Phase 1 — billing contract (additive)
`IPaymentProvider` grows toward `IBillingProvider`: `ProviderCapabilities`, `CreateCheckoutParams`/`CheckoutSession`, `NormalizedBillingEvent`, `EnsureCustomerParams`, `RefundParams`; required `capabilities` + optional checkout/customer/webhook/refund methods. Stripe/manual/paypal declare capabilities.

## Phase 2 — native Stripe subscriptions (closes the central gap)
Plan checkout creates a real Stripe Subscription (`default_incomplete`, Connect `application_fee_percent` + `transfer_data.destination`) and stores `provider_subscription_id` on the pending tx. `invoice.payment_succeeded` drives the lifecycle: `subscription_create` flips the tx → trigger builds the sub row; `subscription_cycle` extends access via `extend_subscription_period`. Migration `20260615140000`.

## Phase 3 — unified webhook layer
`webhook_events` (idempotency + audit, migration `20260615130000`) + `/api/payments/webhook/[provider]` + shared dispatcher; Stripe `verifyWebhook`/`normalizeWebhookEvent`; legacy route delegates subscription cases.

## Verified locally (Stripe CLI test mode)
DB lifecycle (SQL harness), `createCheckoutSession` vs live test API, and full E2E (`stripe listen` → webhook → `subscriptions` row + entitlement). Live test caught + fixed a clover API bug: first-invoice client secret is on `invoice.confirmation_secret` (`Invoice.payment_intent` removed).

## ⚠️ Deploy ordering
Depends on migrations `20260615130000` + `20260615140000` (this PR) and `20260615120000` (#330). **Push all three to cloud before deploying** or payments break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
