### PR TITLE
fix(security): server-action write guards + status-guarded webhook/cron flips

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,7 +66,7 @@ MCP_PROXY_SECRET=                                  # Optional — shared secret 
 MCP_SERVER_URL=http://localhost:3001               # Has-Default — URL of the MCP server
 
 # ─── CRON ─────────────────────────────────────────────────────────────────────
-CRON_SECRET=                                       # Optional — protects cron endpoints (/api/cron/*)
+CRON_SECRET=                                       # Required — protects cron endpoints (/api/cron/*); unset = all cron requests rejected
 
 # ─── INVOICING ────────────────────────────────────────────────────────────────
 COMPANY_NAME=                                      # Optional — appears on generated invoices

--- a/app/actions/join-school.ts
+++ b/app/actions/join-school.ts
@@ -82,10 +82,14 @@ export async function joinCurrentSchool() {
     if (invitation) {
       assignedRole = invitation.role as 'student' | 'teacher'
       // Mark invitation as accepted
-      await adminClient
+      const { error: invitationError } = await adminClient
         .from('tenant_invitations')
         .update({ status: 'accepted', accepted_at: new Date().toISOString() })
         .eq('id', invitation.id)
+      // Non-blocking: invitation bookkeeping failure shouldn't stop the join.
+      if (invitationError) {
+        console.error('Failed to mark invitation as accepted:', invitationError)
+      }
     }
   }
 
@@ -106,17 +110,28 @@ export async function joinCurrentSchool() {
   }
 
   // Create gamification profile for this tenant (ignore if already exists)
-  await adminClient
+  const { error: gamificationError } = await adminClient
     .from('gamification_profiles')
     .upsert(
       { user_id: user.id, tenant_id: tenantId, total_xp: 0, level: 1 },
       { onConflict: 'user_id,tenant_id', ignoreDuplicates: true }
     )
+  // Non-blocking: a missing gamification profile is recoverable and shouldn't
+  // block the user from joining the school.
+  if (gamificationError) {
+    console.error('Failed to create gamification profile:', gamificationError)
+  }
 
-  // Set app_metadata.tenant_id so the JWT hook includes it in claims
-  await adminClient.auth.admin.updateUserById(user.id, {
+  // Set app_metadata.tenant_id so the JWT hook includes it in claims. This is
+  // critical: if it fails, the user "joins" but their JWT never gets the tenant
+  // claim, breaking tenant resolution on the next request — so fail loudly.
+  const { error: metaError } = await adminClient.auth.admin.updateUserById(user.id, {
     app_metadata: { tenant_id: tenantId },
   })
+  if (metaError) {
+    console.error('Failed to set tenant_id app_metadata:', metaError)
+    return { success: false, error: 'Failed to finalize school membership. Please try again.' }
+  }
 
   // Update user's preferred tenant
   await supabase.auth.updateUser({

--- a/app/actions/mcp-tokens.ts
+++ b/app/actions/mcp-tokens.ts
@@ -81,13 +81,19 @@ export async function revokeMcpToken(tokenId: number) {
   }
 
   const supabase = await createClient()
+  const userId = await getCurrentUserId()
+  if (!userId) throw new Error('Not authenticated')
 
-  const { error } = await supabase
+  const { data: updated, error } = await supabase
     .from('mcp_api_tokens')
     .update({ is_active: false })
     .eq('id', tokenId)
+    .eq('user_id', userId)
+    .select('id')
+    .maybeSingle()
 
   if (error) throw new Error(error.message)
+  if (!updated) throw new Error('Token not found')
 
   revalidatePath('/dashboard/admin/api-tokens')
   revalidatePath('/dashboard/teacher/api-tokens')
@@ -100,13 +106,19 @@ export async function deleteMcpToken(tokenId: number) {
   }
 
   const supabase = await createClient()
+  const userId = await getCurrentUserId()
+  if (!userId) throw new Error('Not authenticated')
 
-  const { error } = await supabase
+  const { data: deleted, error } = await supabase
     .from('mcp_api_tokens')
     .delete()
     .eq('id', tokenId)
+    .eq('user_id', userId)
+    .select('id')
+    .maybeSingle()
 
   if (error) throw new Error(error.message)
+  if (!deleted) throw new Error('Token not found')
 
   revalidatePath('/dashboard/admin/api-tokens')
   revalidatePath('/dashboard/teacher/api-tokens')

--- a/app/api/cron/expire-subscriptions/route.ts
+++ b/app/api/cron/expire-subscriptions/route.ts
@@ -18,8 +18,9 @@ function getSupabaseAdmin() {
  * Secured by CRON_SECRET env var (set the same value in Vercel dashboard).
  */
 export async function GET(req: NextRequest) {
-  const secret = req.headers.get('authorization')?.replace('Bearer ', '')
-  if (process.env.CRON_SECRET && secret !== process.env.CRON_SECRET) {
+  const cronSecret = process.env.CRON_SECRET
+  const provided = req.headers.get('authorization')?.replace('Bearer ', '')
+  if (!cronSecret || provided !== cronSecret) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -111,15 +111,24 @@ export async function POST(req: NextRequest) {
           break
         }
 
-        const { error } = await getSupabaseAdmin()
+        const { data: flipped, error } = await getSupabaseAdmin()
           .from('transactions')
           .update({ status: 'successful' })
           .eq('transaction_id', parseInt(transactionId))
           .eq('status', 'pending')
+          .select('transaction_id')
+          .maybeSingle()
 
         if (error) {
           console.error('Failed to update transaction:', error)
           return NextResponse.json({ error: 'Failed to update transaction' }, { status: 500 })
+        }
+
+        if (!flipped) {
+          // Concurrent delivery already flipped this transaction — do not re-send
+          // the enrollment email or re-run side effects. The first delivery owns them.
+          console.log(`Transaction ${transactionId} already flipped by a concurrent delivery — skipping side effects`)
+          break
         }
 
         // Send enrollment confirmation email


### PR DESCRIPTION
Advisor hardening batch — **non-Solana** security/correctness fixes (split out of the original stacked branch for clean review).

## Changes
- **004** — `join-school` checks write errors; MCP token writes scoped to owner (`app/actions/join-school.ts`, `app/actions/mcp-tokens.ts`)
- **001 (master half)** — `expire-subscriptions` cron fails closed when `CRON_SECRET` unset (`.env.example`, `app/api/cron/expire-subscriptions/route.ts`). The Solana-pull cron half ships on #334.
- **003 (master half)** — Stripe webhook status-guarded flip (`select().maybeSingle()`) so concurrent deliveries don't re-run side effects (`app/api/stripe/webhook/route.ts`). The solana/verify half ships on #334.

## Notes
- Does **not** touch `package.json`/lock — no merge-order constraint with the other advisor PRs.
- Local-verified against the original stacked build (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)