### PR TITLE
feat(nav): trim sidebar into collapsible groups across all roles

### DIFF
--- a/app/[locale]/dashboard/admin/api-tokens/page.tsx
+++ b/app/[locale]/dashboard/admin/api-tokens/page.tsx
@@ -20,23 +20,17 @@ export default async function AdminApiTokensPage() {
     ? `https://${tenant.slug}.${platformDomain}/api/mcp/cli`
     : `https://${platformDomain}/api/mcp/cli`
 
-  const t = await getTranslations('dashboard.admin.apiTokens')
-
   return (
     <div className="min-h-screen bg-background" data-testid="api-tokens-page">
       {/* Header */}
       <header className="border-b bg-card">
         <div className="mx-auto max-w-7xl px-4 py-5 sm:px-6 lg:px-8">
-          <div className="mb-4">
-            <AdminBreadcrumb
-              items={[
-                { label: tBreadcrumbs('admin'), href: '/dashboard/admin' },
-                { label: tBreadcrumbs('apiTokens') },
-              ]}
-            />
-          </div>
-          <h1 className="text-2xl font-bold tracking-tight">{t('title')}</h1>
-          <p className="mt-0.5 text-sm text-muted-foreground">{t('description')}</p>
+          <AdminBreadcrumb
+            items={[
+              { label: tBreadcrumbs('admin'), href: '/dashboard/admin' },
+              { label: tBreadcrumbs('apiTokens') },
+            ]}
+          />
         </div>
       </header>
 

--- a/app/[locale]/dashboard/admin/appearance/page.tsx
+++ b/app/[locale]/dashboard/admin/appearance/page.tsx
@@ -31,7 +31,7 @@ export default async function AppearancePage() {
             <AdminBreadcrumb
               items={[
                 { label: tBreadcrumbs('admin'), href: '/dashboard/admin' },
-                { label: tBreadcrumbs('settings'), href: '/dashboard/admin/settings' },
+                { label: tBreadcrumbs('website'), href: '/dashboard/admin/landing-page' },
                 { label: tBreadcrumbs('appearance') },
               ]}
             />

--- a/app/[locale]/dashboard/teacher/page.tsx
+++ b/app/[locale]/dashboard/teacher/page.tsx
@@ -24,6 +24,12 @@ import {getCurrentTenantId, getCurrentUserId } from '@/lib/supabase/tenant'
 import { OnboardingChecklist } from '@/components/shared/onboarding-checklist'
 import { TeacherDashboardTour } from '@/components/tours/teacher-dashboard-tour'
 
+interface EnrollmentActivity {
+  enrollment_date: string
+  profiles: { id: string; full_name: string | null; avatar_url: string | null } | null
+  courses: { title: string | null } | null
+}
+
 export default async function TeacherDashboard() {
   const supabase = createAdminClient()
   const t = await getTranslations('dashboard.teacher')
@@ -95,7 +101,8 @@ export default async function TeacherDashboard() {
       .single()
   ])
 
-  const recentEnrollments = enrollmentsRes.data || []
+  // PostgREST returns objects for these to-one embeds; the untyped client infers arrays
+  const recentEnrollments = (enrollmentsRes.data || []) as unknown as EnrollmentActivity[]
   const totalEnrollmentsList = allEnrollmentsRes.data || []
   const allSubmissions = submissionsRes.data || []
   const profile = profileRes.data
@@ -129,7 +136,7 @@ export default async function TeacherDashboard() {
               {t('promptTemplates')}
             </Button>
           </Link>
-          <Link href="/dashboard/teacher/courses/new">
+          <Link href="/dashboard/teacher/courses/new" data-tour="sidebar-create-course">
             <Button size="sm" className="gap-2">
               <IconPlus className="h-3.5 w-3.5" />
               {t('createCourse')}
@@ -360,7 +367,7 @@ export default async function TeacherDashboard() {
           <CardContent>
             <div className="space-y-5">
               {recentEnrollments.length > 0 ? (
-                recentEnrollments.map((activity: any, idx) => (
+                recentEnrollments.map((activity, idx) => (
                   <div key={idx} className="flex items-start gap-3">
                     <div className="relative">
                       <div className="h-9 w-9 rounded-full bg-primary/10 flex items-center justify-center overflow-hidden text-xs font-semibold text-primary">

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -7,27 +7,18 @@ import { useTranslations } from "next-intl"
 import {
     IconBook,
     IconBookmark,
-    IconCalendar,
-    IconCertificate,
     IconChartBar,
+    IconChevronRight,
     IconCoins,
-    IconCreditCard,
-    IconCrown,
     IconCurrencyDollar,
     IconDashboard,
-    IconFileInvoice,
     IconKey,
     IconLayout,
     IconLogout,
     IconMessages,
-    IconPalette,
-    IconPlus,
     IconReceipt,
     IconSearch,
     IconSettings,
-    IconShoppingCart,
-    IconTrendingUp,
-    IconTrophy,
     IconUsers,
 } from "@tabler/icons-react"
 
@@ -37,31 +28,48 @@ import {
     SidebarFooter,
     SidebarGroup,
     SidebarGroupContent,
-    SidebarGroupLabel,
     SidebarHeader,
     SidebarMenu,
+    SidebarMenuAction,
     SidebarMenuButton,
     SidebarMenuItem,
+    SidebarMenuSub,
+    SidebarMenuSubButton,
+    SidebarMenuSubItem,
     SidebarRail,
 } from "@/components/ui/sidebar"
+import {
+    Collapsible,
+    CollapsibleContent,
+    CollapsibleTrigger,
+} from "@/components/ui/collapsible"
 import { useTenant } from "@/components/tenant/tenant-provider"
 import { useLogout } from "@/hooks/use-logout"
 import Image from "next/image"
+
+interface NavSubItem {
+    title: string
+    href: string
+    tourId?: string
+}
 
 interface NavItem {
     title: string
     href: string
     icon: React.ComponentType<{ className?: string }>
     tourId?: string
-}
-
-interface NavGroup {
-    label: string
-    items: NavItem[]
+    items?: NavSubItem[]
 }
 
 interface AppSidebarProps extends React.ComponentProps<typeof Sidebar> {
     userRole: 'student' | 'teacher' | 'admin' | null
+}
+
+// On hard loads the browser URL carries the locale prefix (/en, /es) while nav
+// hrefs are locale-less; client-side navigations are already locale-less.
+// (i18n.ts can't be imported here — it pulls in next-intl/server.)
+function stripLocale(pathname: string): string {
+    return pathname.replace(/^\/(en|es)(?=\/|$)/, '') || '/'
 }
 
 function isNavActive(href: string, pathname: string): boolean {
@@ -73,29 +81,65 @@ function isNavActive(href: string, pathname: string): boolean {
     return false
 }
 
-function NavSection({ group }: { group: NavGroup }) {
-    const pathname = usePathname()
+function NavEntry({ item }: { item: NavItem }) {
+    const pathname = stripLocale(usePathname())
+    const active = isNavActive(item.href, pathname)
+    const tourProps = item.tourId ? { 'data-tour': item.tourId } : {}
+
+    if (!item.items?.length) {
+        return (
+            <SidebarMenuItem {...tourProps}>
+                <SidebarMenuButton
+                    render={<Link href={item.href} />}
+                    isActive={active}
+                    tooltip={item.title}
+                >
+                    <item.icon />
+                    <span>{item.title}</span>
+                </SidebarMenuButton>
+            </SidebarMenuItem>
+        )
+    }
+
+    const childActive = item.items.some((sub) => isNavActive(sub.href, pathname))
 
     return (
-        <SidebarGroup>
-            <SidebarGroupLabel>{group.label}</SidebarGroupLabel>
-            <SidebarGroupContent>
-                <SidebarMenu>
-                    {group.items.map((item) => (
-                        <SidebarMenuItem key={item.href} {...(item.tourId ? { 'data-tour': item.tourId } : {})}>
-                            <SidebarMenuButton
-                                render={<Link href={item.href} />}
-                                isActive={isNavActive(item.href, pathname)}
-                                tooltip={item.title}
+        <Collapsible
+            defaultOpen={active || childActive}
+            render={<SidebarMenuItem {...tourProps} />}
+        >
+            <SidebarMenuButton
+                render={<Link href={item.href} />}
+                isActive={active}
+                tooltip={item.title}
+            >
+                <item.icon />
+                <span>{item.title}</span>
+            </SidebarMenuButton>
+            <CollapsibleTrigger
+                render={<SidebarMenuAction className="data-[panel-open]:rotate-90" />}
+            >
+                <IconChevronRight />
+                <span className="sr-only">{item.title}</span>
+            </CollapsibleTrigger>
+            <CollapsibleContent>
+                <SidebarMenuSub>
+                    {item.items.map((sub) => (
+                        <SidebarMenuSubItem
+                            key={sub.href}
+                            {...(sub.tourId ? { 'data-tour': sub.tourId } : {})}
+                        >
+                            <SidebarMenuSubButton
+                                render={<Link href={sub.href} />}
+                                isActive={isNavActive(sub.href, pathname)}
                             >
-                                <item.icon />
-                                <span>{item.title}</span>
-                            </SidebarMenuButton>
-                        </SidebarMenuItem>
+                                <span>{sub.title}</span>
+                            </SidebarMenuSubButton>
+                        </SidebarMenuSubItem>
                     ))}
-                </SidebarMenu>
-            </SidebarGroupContent>
-        </SidebarGroup>
+                </SidebarMenuSub>
+            </CollapsibleContent>
+        </Collapsible>
     )
 }
 
@@ -108,103 +152,88 @@ export function AppSidebar({ userRole, ...props }: AppSidebarProps) {
     const logoUrl = tenant?.logo_url
     const initials = schoolName.slice(0, 2).toUpperCase()
 
-    const navGroups = React.useMemo((): NavGroup[] => {
+    const navItems = React.useMemo((): NavItem[] => {
         if (!userRole) return []
 
-        const groups: Record<string, NavGroup[]> = {
+        const items: Record<string, NavItem[]> = {
             admin: [
+                { title: t('dashboard'), href: "/dashboard/admin", icon: IconDashboard },
                 {
-                    label: t('main'),
+                    title: t('courses'), href: "/dashboard/admin/courses", icon: IconBook,
                     items: [
-                        { title: t('dashboard'), href: "/dashboard/admin", icon: IconDashboard },
+                        { title: t('myCourses'), href: "/dashboard/teacher/courses", tourId: 'sidebar-courses' },
+                        { title: t('enrollments'), href: "/dashboard/admin/enrollments" },
                     ],
                 },
                 {
-                    label: t('management'),
+                    title: t('people'), href: "/dashboard/admin/users", icon: IconUsers,
                     items: [
-                        { title: t('users'), href: "/dashboard/admin/users", icon: IconUsers },
-                        { title: t('community'), href: "/dashboard/admin/community", icon: IconMessages },
-                        { title: t('allCourses'), href: "/dashboard/admin/courses", icon: IconBook },
-                        { title: t('myCourses'), href: "/dashboard/teacher/courses", icon: IconBook, tourId: 'sidebar-courses' },
-                        { title: t('createCourse'), href: "/dashboard/teacher/courses/new", icon: IconPlus, tourId: 'sidebar-create-course' },
-                        { title: t('enrollments'), href: "/dashboard/admin/enrollments", icon: IconCertificate },
-                        { title: t('analytics'), href: "/dashboard/admin/analytics", icon: IconChartBar },
-                        { title: t('billing'), href: "/dashboard/admin/billing", icon: IconCreditCard },
-                        { title: t('pages'), href: "/dashboard/admin/landing-page", icon: IconLayout },
-                        { title: t('appearance'), href: "/dashboard/admin/appearance", icon: IconPalette },
-                        { title: t('settings'), href: "/dashboard/admin/settings", icon: IconSettings, tourId: 'sidebar-settings' },
-                        { title: t('apiTokens'), href: "/dashboard/admin/api-tokens", icon: IconKey },
+                        { title: t('community'), href: "/dashboard/admin/community" },
                     ],
                 },
                 {
-                    label: t('monetization'),
+                    title: t('monetization'), href: "/dashboard/admin/monetization", icon: IconCurrencyDollar,
                     items: [
-                        { title: t('monetizationOverview'), href: "/dashboard/admin/monetization", icon: IconCurrencyDollar },
-                        { title: t('products'), href: "/dashboard/admin/products", icon: IconShoppingCart },
-                        { title: t('plans'), href: "/dashboard/admin/plans", icon: IconCalendar },
-                        { title: t('revenue'), href: "/dashboard/admin/revenue", icon: IconTrendingUp },
-                        { title: t('payouts'), href: "/dashboard/admin/payouts", icon: IconCoins },
-                        { title: t('transactions'), href: "/dashboard/admin/transactions", icon: IconReceipt },
-                        { title: t('invoices'), href: "/dashboard/admin/invoices", icon: IconFileInvoice },
-                        { title: t('subscriptions'), href: "/dashboard/admin/subscriptions", icon: IconCrown },
-                        { title: t('paymentRequests'), href: "/dashboard/admin/payment-requests", icon: IconFileInvoice },
+                        { title: t('products'), href: "/dashboard/admin/products" },
+                        { title: t('plans'), href: "/dashboard/admin/plans" },
+                        { title: t('subscriptions'), href: "/dashboard/admin/subscriptions" },
+                        { title: t('transactions'), href: "/dashboard/admin/transactions" },
+                        { title: t('paymentRequests'), href: "/dashboard/admin/payment-requests" },
+                        { title: t('revenue'), href: "/dashboard/admin/revenue" },
+                        { title: t('payouts'), href: "/dashboard/admin/payouts" },
+                        { title: t('invoices'), href: "/dashboard/admin/invoices" },
+                    ],
+                },
+                { title: t('analytics'), href: "/dashboard/admin/analytics", icon: IconChartBar },
+                {
+                    title: t('website'), href: "/dashboard/admin/landing-page", icon: IconLayout,
+                    items: [
+                        { title: t('appearance'), href: "/dashboard/admin/appearance" },
+                    ],
+                },
+                {
+                    title: t('settings'), href: "/dashboard/admin/settings", icon: IconSettings, tourId: 'sidebar-settings',
+                    items: [
+                        { title: t('billing'), href: "/dashboard/admin/billing" },
+                        { title: t('apiTokens'), href: "/dashboard/admin/api-tokens" },
                     ],
                 },
             ],
             teacher: [
-                {
-                    label: t('main'),
-                    items: [
-                        { title: t('dashboard'), href: "/dashboard/teacher", icon: IconDashboard },
-                        { title: t('community'), href: "/dashboard/teacher/community", icon: IconMessages },
-                    ],
-                },
-                {
-                    label: t('contentManagement'),
-                    items: [
-                        { title: t('myCourses'), href: "/dashboard/teacher/courses", icon: IconBook, tourId: 'sidebar-courses' },
-                        { title: t('createCourse'), href: "/dashboard/teacher/courses/new", icon: IconPlus, tourId: 'sidebar-create-course' },
-                        { title: t('apiTokens'), href: "/dashboard/teacher/api-tokens", icon: IconKey },
-                    ],
-                },
-                {
-                    label: t('business'),
-                    items: [
-                        { title: t('revenue'), href: "/dashboard/teacher/revenue", icon: IconCurrencyDollar },
-                    ],
-                },
+                { title: t('dashboard'), href: "/dashboard/teacher", icon: IconDashboard },
+                { title: t('myCourses'), href: "/dashboard/teacher/courses", icon: IconBook, tourId: 'sidebar-courses' },
+                { title: t('community'), href: "/dashboard/teacher/community", icon: IconMessages },
+                { title: t('revenue'), href: "/dashboard/teacher/revenue", icon: IconCurrencyDollar },
+                { title: t('apiTokens'), href: "/dashboard/teacher/api-tokens", icon: IconKey },
             ],
             student: [
+                { title: t('dashboard'), href: "/dashboard/student", icon: IconDashboard },
                 {
-                    label: t('main'),
+                    title: t('myCourses'), href: "/dashboard/student/courses", icon: IconBookmark,
                     items: [
-                        { title: t('dashboard'), href: "/dashboard/student", icon: IconDashboard },
-                        { title: t('myCourses'), href: "/dashboard/student/courses", icon: IconBookmark },
-                        { title: t('community'), href: "/dashboard/student/community", icon: IconMessages },
+                        { title: t('completed'), href: "/dashboard/student/courses?status=completed" },
+                        { title: t('myCertificates'), href: "/dashboard/student/certificates" },
+                        { title: t('progressReport'), href: "/dashboard/student/progress", tourId: 'sidebar-progress' },
                     ],
                 },
                 {
-                    label: t('discover'),
+                    title: t('browseCourses'), href: "/dashboard/student/browse", icon: IconSearch, tourId: 'sidebar-browse',
                     items: [
-                        { title: t('browseCourses'), href: "/dashboard/student/browse", icon: IconSearch, tourId: 'sidebar-browse' },
-                        { title: t('courseCatalog'), href: "/courses", icon: IconBook },
+                        { title: t('courseCatalog'), href: "/courses" },
                     ],
                 },
+                { title: t('community'), href: "/dashboard/student/community", icon: IconMessages },
                 {
-                    label: t('resources'),
+                    title: t('myBilling'), href: "/dashboard/student/billing", icon: IconReceipt,
                     items: [
-                        { title: t('myBilling'), href: "/dashboard/student/billing", icon: IconReceipt },
-                        { title: t('myPayments'), href: "/dashboard/student/payments", icon: IconCreditCard },
-                        { title: t('myCertificates'), href: "/dashboard/student/certificates", icon: IconCertificate },
-                        { title: t('progressReport'), href: "/dashboard/student/progress", icon: IconChartBar, tourId: 'sidebar-progress' },
-                        { title: t('completed'), href: "/dashboard/student/courses?status=completed", icon: IconTrophy },
-                        { title: t('pointStore'), href: "/dashboard/student/store", icon: IconCoins },
+                        { title: t('myPayments'), href: "/dashboard/student/payments" },
                     ],
                 },
+                { title: t('pointStore'), href: "/dashboard/student/store", icon: IconCoins },
             ],
         }
 
-        return groups[userRole] || []
+        return items[userRole] || []
     }, [userRole, t])
 
     return (
@@ -236,9 +265,15 @@ export function AppSidebar({ userRole, ...props }: AppSidebarProps) {
             </SidebarHeader>
 
             <SidebarContent>
-                {navGroups.map((group) => (
-                    <NavSection key={group.label} group={group} />
-                ))}
+                <SidebarGroup>
+                    <SidebarGroupContent>
+                        <SidebarMenu>
+                            {navItems.map((item) => (
+                                <NavEntry key={item.href} item={item} />
+                            ))}
+                        </SidebarMenu>
+                    </SidebarGroupContent>
+                </SidebarGroup>
             </SidebarContent>
 
             <SidebarFooter>

--- a/messages/en.json
+++ b/messages/en.json
@@ -1391,7 +1391,8 @@
         "tenants": "Tenants",
         "apiTokens": "API Tokens",
         "monetization": "Monetization",
-        "appearance": "Appearance"
+        "appearance": "Appearance",
+        "website": "Website"
       },
       "appearance": {
         "title": "Appearance",
@@ -3136,6 +3137,9 @@
     "analytics": "Analytics",
     "monetization": "Monetization",
     "monetizationOverview": "Overview",
+    "courses": "Courses",
+    "people": "People",
+    "website": "Website",
     "products": "Products",
     "plans": "Plans",
     "subscriptions": "Subscriptions",

--- a/messages/es.json
+++ b/messages/es.json
@@ -1391,7 +1391,8 @@
         "tenants": "Inquilinos",
         "apiTokens": "Tokens de API",
         "monetization": "Monetización",
-        "appearance": "Apariencia"
+        "appearance": "Apariencia",
+        "website": "Sitio Web"
       },
       "appearance": {
         "title": "Apariencia",
@@ -2981,6 +2982,9 @@
     "analytics": "Analíticas",
     "monetization": "Monetización",
     "monetizationOverview": "Resumen",
+    "courses": "Cursos",
+    "people": "Personas",
+    "website": "Sitio Web",
     "products": "Productos",
     "plans": "Planes",
     "subscriptions": "Suscripciones",


### PR DESCRIPTION
## Summary

The admin sidebar had grown to 22 flat items across 3 labeled sections, making it hard to scan and understand. This PR restructures navigation for all three roles around collapsible groups (shadcn `SidebarMenuSub` + base-ui `Collapsible` — primitives already in the repo, previously unused).

**Admin: 22 flat items → 7 top-level entries**

| Top-level | Sub-items |
|---|---|
| Dashboard | — |
| Courses | My Courses, Enrollments |
| People | Community |
| Monetization | Products, Plans, Subscriptions, Transactions, Payment Requests, Revenue, Payouts, Invoices |
| Analytics | — |
| Website | Appearance |
| Settings | Billing, API Tokens |

- Parent rows are real links (Courses → All Courses page, People → Users, Website → Pages, etc.), so icon-collapsed mode stays fully navigable; the chevron (`SidebarMenuAction`) toggles the sub-menu
- Groups containing the active route auto-expand on load
- Section labels (Main/Management/Monetization) removed
- **Teacher:** 5 flat items; **Student:** 9 → 6 top-level (progress/certificates under My Courses, payments under Billing)
- "Create Course" removed from nav (sidebar shows destinations, not actions) — its onboarding-tour anchor moved to the Create Course button in the teacher dashboard header

## Bug fixes included

- **Active state / auto-expand dead on hard page loads:** `usePathname()` returns the locale-prefixed path (`/en/...`) on full loads while nav hrefs are locale-less, so highlighting silently failed (pre-existing in the old sidebar too). Locale prefix is now stripped before matching.
- **Duplicated header on admin API Tokens page** — wrapper page and shared `ApiTokensPage` component both rendered title + description; wrapper copy removed.
- **Appearance breadcrumb** said `Settings >` while the sidebar nests it under Website — now `Admin > Website > Appearance`.
- Replaced a pre-existing `any` in the teacher dashboard activity feed (blocked the pre-commit hook).

## Testing

- `tsc --noEmit` and ESLint clean on changed files
- Browser QA (Playwright) on local stack: admin and student sidebars verified — structure, expand/collapse, sub-item navigation + active styling, auto-expand on hard loads, no hydration/console errors
- E2E specs unaffected: no test navigates via removed sidebar labels (login.spec.ts targets the header button, smoke tests navigate by URL)
- i18n: en + es keys added (`sidebar.courses/people/website`, `breadcrumbs.website`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)