### PR TITLE
fix: add recharts peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,6 +76,7 @@
         "react": "19.2.4",
         "react-confetti": "^6.4.0",
         "react-dom": "19.2.4",
+        "react-is": "^19.2.4",
         "react-markdown": "^10.1.0",
         "recharts": "^3.8.0",
         "rehype-autolink-headings": "^7.1.0",
@@ -19884,8 +19885,7 @@
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
       "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "react": "19.2.4",
     "react-confetti": "^6.4.0",
     "react-dom": "19.2.4",
+    "react-is": "^19.2.4",
     "react-markdown": "^10.1.0",
     "recharts": "^3.8.0",
     "rehype-autolink-headings": "^7.1.0",


### PR DESCRIPTION
This pull request introduces a minor update to the project's dependencies by adding a new package.

- Dependency update:
  * Added `react-is` version `^19.2.4` to the dependencies in `package.json`.