### PR TITLE
feat(oauth): school picker on MCP consent — pin tenant claim per connection

### DIFF
--- a/app/[locale]/oauth/consent/consent-form.tsx
+++ b/app/[locale]/oauth/consent/consent-form.tsx
@@ -1,19 +1,36 @@
 "use client"
 
 import { useState } from "react"
-import { useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+
+export interface TenantMembership {
+  tenantId: string
+  name: string
+  role: string
+}
 
 interface ConsentFormProps {
   authorizationId: string
+  memberships: TenantMembership[]
+  defaultTenantId?: string
 }
 
-export function ConsentForm({ authorizationId }: ConsentFormProps) {
-  const router = useRouter()
+export function ConsentForm({ authorizationId, memberships, defaultTenantId }: ConsentFormProps) {
   const [loading, setLoading] = useState<"approve" | "deny" | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [tenantId, setTenantId] = useState<string | undefined>(defaultTenantId)
 
   async function handleDecision(decision: "approve" | "deny") {
     setLoading(decision)
+    setError(null)
 
     try {
       const res = await fetch("/api/oauth/decision", {
@@ -22,6 +39,8 @@ export function ConsentForm({ authorizationId }: ConsentFormProps) {
         body: JSON.stringify({
           authorization_id: authorizationId,
           decision,
+          // Which school this connection is for — the minted token's tenant claim.
+          ...(decision === "approve" && tenantId ? { tenant_id: tenantId } : {}),
         }),
       })
 
@@ -29,33 +48,62 @@ export function ConsentForm({ authorizationId }: ConsentFormProps) {
 
       if (data.redirect_to) {
         window.location.href = data.redirect_to
-      } else if (data.error) {
-        alert(data.error)
+      } else {
+        setError(data.error || "Something went wrong. Please try again.")
         setLoading(null)
       }
     } catch {
-      alert("An error occurred. Please try again.")
+      setError("An error occurred. Please try again.")
       setLoading(null)
     }
   }
 
   return (
-    <div className="flex gap-3">
-      <Button
-        variant="outline"
-        className="flex-1"
-        disabled={loading !== null}
-        onClick={() => handleDecision("deny")}
-      >
-        {loading === "deny" ? "Denying..." : "Deny"}
-      </Button>
-      <Button
-        className="flex-1"
-        disabled={loading !== null}
-        onClick={() => handleDecision("approve")}
-      >
-        {loading === "approve" ? "Approving..." : "Approve"}
-      </Button>
+    <div className="space-y-4">
+      {memberships.length > 1 && (
+        <div className="space-y-2">
+          <Label htmlFor="consent-tenant">Connect to school</Label>
+          <Select value={tenantId} onValueChange={(v) => v && setTenantId(v)}>
+            <SelectTrigger id="consent-tenant" className="w-full">
+              <SelectValue placeholder="Choose a school" />
+            </SelectTrigger>
+            <SelectContent>
+              {memberships.map((m) => (
+                <SelectItem key={m.tenantId} value={m.tenantId}>
+                  {m.name} ({m.role})
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <p className="text-xs text-muted-foreground">
+            The application will only see this school&apos;s data.
+          </p>
+        </div>
+      )}
+
+      <div className="flex gap-3">
+        <Button
+          variant="outline"
+          className="flex-1"
+          disabled={loading !== null}
+          onClick={() => handleDecision("deny")}
+        >
+          {loading === "deny" ? "Denying..." : "Deny"}
+        </Button>
+        <Button
+          className="flex-1"
+          disabled={loading !== null || (memberships.length > 1 && !tenantId)}
+          onClick={() => handleDecision("approve")}
+        >
+          {loading === "approve" ? "Approving..." : "Approve"}
+        </Button>
+      </div>
+
+      {error && (
+        <p className="text-sm text-destructive" role="alert">
+          {error}
+        </p>
+      )}
     </div>
   )
 }

--- a/app/[locale]/oauth/consent/page.tsx
+++ b/app/[locale]/oauth/consent/page.tsx
@@ -1,6 +1,7 @@
 import { createClient } from "@/lib/supabase/server"
+import { createAdminClient } from "@/lib/supabase/admin"
 import { redirect } from "next/navigation"
-import { ConsentForm } from "./consent-form"
+import { ConsentForm, type TenantMembership } from "./consent-form"
 
 export default async function OAuthConsentPage({
   searchParams,
@@ -43,6 +44,30 @@ export default async function OAuthConsentPage({
   // role can do (students get only self-scoped learning tools; RLS enforces
   // tenant isolation on every query).
   const userRole = roleData?.role || "student"
+
+  // The tenant_id claim in the minted token decides which school's data the
+  // connected client sees. Load the user's active memberships so multi-school
+  // users can pick which school this connection is for. Admin client: tenant
+  // names must resolve regardless of the caller's current tenant claim.
+  const adminClient = createAdminClient()
+  const { data: membershipRows } = await adminClient
+    .from("tenant_users")
+    .select("tenant_id, role, tenants(name)")
+    .eq("user_id", user.id)
+    .eq("status", "active")
+
+  const memberships: TenantMembership[] = (membershipRows ?? []).map((row) => ({
+    tenantId: row.tenant_id as string,
+    role: (row.role as string) ?? "student",
+    name:
+      ((row.tenants as { name?: string } | null)?.name as string) ??
+      "Unknown school",
+  }))
+
+  const currentTenantId =
+    (user.app_metadata?.tenant_id as string | undefined) ??
+    memberships[0]?.tenantId
+  const currentTenant = memberships.find((m) => m.tenantId === currentTenantId)
 
   // Get authorization details from Supabase OAuth server
   const { data: authDetails, error } = await supabase.auth.oauth.getAuthorizationDetails(
@@ -107,13 +132,20 @@ export default async function OAuthConsentPage({
 
         <div className="mb-4 rounded-md border border-yellow-500/20 bg-yellow-500/10 p-3">
           <p className="text-xs text-yellow-700 dark:text-yellow-300">
-            Signed in as <strong>{user.email}</strong> ({userRole}).
+            Signed in as <strong>{user.email}</strong> ({userRole})
+            {currentTenant && memberships.length === 1 && (
+              <> — connecting to <strong>{currentTenant.name}</strong></>
+            )}.
             This will let the application access your LMS data — teachers and
             admins get course management, students get their own learning tools.
           </p>
         </div>
 
-        <ConsentForm authorizationId={authorization_id} />
+        <ConsentForm
+          authorizationId={authorization_id}
+          memberships={memberships}
+          defaultTenantId={currentTenantId}
+        />
       </div>
     </div>
   )

--- a/app/api/oauth/decision/route.ts
+++ b/app/api/oauth/decision/route.ts
@@ -1,9 +1,10 @@
 import { createClient } from "@/lib/supabase/server"
+import { createAdminClient } from "@/lib/supabase/admin"
 import { NextResponse } from "next/server"
 
 export async function POST(request: Request) {
   const body = await request.json()
-  const { authorization_id, decision } = body
+  const { authorization_id, decision, tenant_id } = body
 
   if (!authorization_id || !decision) {
     return NextResponse.json(
@@ -31,6 +32,43 @@ export async function POST(request: Request) {
 
   // All roles may connect — the MCP server's tool policy scopes what each
   // role can do; RLS enforces tenant isolation on every query.
+
+  // Pin the tenant BEFORE approving: the token minted at the code exchange
+  // carries app_metadata.tenant_id as its tenant claim, which decides which
+  // school's rows RLS exposes to the connected client. Only accept tenants
+  // the user is an active member of (same pattern as join-school.ts).
+  if (decision === "approve" && tenant_id) {
+    const adminClient = createAdminClient()
+
+    const { data: membership } = await adminClient
+      .from("tenant_users")
+      .select("tenant_id")
+      .eq("user_id", user.id)
+      .eq("tenant_id", tenant_id)
+      .eq("status", "active")
+      .maybeSingle()
+
+    if (!membership) {
+      return NextResponse.json(
+        { error: "You are not an active member of the selected school." },
+        { status: 403 }
+      )
+    }
+
+    if (user.app_metadata?.tenant_id !== tenant_id) {
+      const { error: metaError } = await adminClient.auth.admin.updateUserById(user.id, {
+        app_metadata: { tenant_id },
+      })
+      if (metaError) {
+        return NextResponse.json(
+          { error: "Failed to set the school for this connection. Please try again." },
+          { status: 500 }
+        )
+      }
+      // Keep the app's preferred-tenant in sync (mirrors join-school.ts).
+      await supabase.auth.updateUser({ data: { preferred_tenant_id: tenant_id } })
+    }
+  }
 
   try {
     const oauthAuth = supabase.auth.oauth


### PR DESCRIPTION
## Why

The `tenant_id` claim minted into the OAuth token at consent decides which school's data RLS exposes to a connected MCP client (Claude custom connector). Users belonging to multiple schools got whatever tenant their account last preferred — safely isolated, but potentially the wrong school, with no way to choose.

## What

- **Consent page** (`/oauth/consent`): loads the user's active `tenant_users` memberships and shows which school the connection targets. Single-school users (the common case) see "connecting to **X**"; multi-school users get a school picker.
- **`/api/oauth/decision`**: accepts `tenant_id` on approve. Validates the user is an **active member** of that tenant (403 otherwise), then pins `app_metadata.tenant_id` via `auth.admin.updateUserById` **before** `approveAuthorization`, so the token minted at the code exchange carries the chosen school. Mirrors the established `join-school.ts` pattern, including `preferred_tenant_id` sync.
- No `tenant_id` sent (single/zero-membership, legacy clients) → identical behavior to before.

Isolation model unchanged: tenant comes from the signed JWT claim, enforced by RLS in Postgres (`get_tenant_id()` reads claim first, header never trusted for authenticated requests).

## Verification

- `npx tsc --noEmit` clean.
- Live browser test (local, logged in as `owner@e2etest.com`): login `redirectTo` returns to consent with `authorization_id` preserved; consent page renders with the membership query executing; decision route: wrong tenant → **403** "not an active member", valid tenant → passes membership and fails only on the fake authorization id (**400**, proving validation ordering), no `tenant_id` → legacy path unchanged; unauthenticated → **401**.

Known/accepted semantics: pinning updates the user's preferred tenant globally (same as switching schools in the web app); a later tenant switch flips existing MCP connections on their next token refresh. True per-connection pinning would require per-client claims, which Supabase doesn't support — tracked as the future membership-based-RLS option if cross-school agent access is ever needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)