### PR TITLE
fix(deploy): restore prod Docker build (@lms/core workspace link + @solana/subscriptions pin)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY package.json package-lock.json ./
+# Workspace package manifests must exist at install time so npm links
+# @lms/core into node_modules (source-only package via transpilePackages).
+COPY packages/core/package.json ./packages/core/package.json
 # Remove the lockfile so npm freshly resolves platform-specific optional
 # native binaries (lightningcss/Tailwind v4) for this Linux image — npm has a
 # long-standing bug that skips optional native deps when a lockfile is present.

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "@solana/kit-plugin-signer": "^0.10.0",
         "@solana/pay": "^0.2.6",
         "@solana/spl-token": "^0.4.14",
-        "@solana/subscriptions": "^0.4.0-rc.1",
+        "@solana/subscriptions": "0.4.0-rc.1",
         "@solana/web3.js": "^1.98.4",
         "@streamdown/cjk": "^1.0.2",
         "@streamdown/code": "^1.1.0",
@@ -15893,20 +15893,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/jayson/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
       }
     },
     "node_modules/jest-worker": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "@solana/kit-plugin-signer": "^0.10.0",
         "@solana/pay": "^0.2.6",
         "@solana/spl-token": "^0.4.14",
-        "@solana/subscriptions": "0.4.0-rc.1",
+        "@solana/subscriptions": "^0.4.0-rc.1",
         "@solana/web3.js": "^1.98.4",
         "@streamdown/cjk": "^1.0.2",
         "@streamdown/code": "^1.1.0",
@@ -15893,6 +15893,20 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jayson/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
       }
     },
     "node_modules/jest-worker": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@solana/kit-plugin-signer": "^0.10.0",
     "@solana/pay": "^0.2.6",
     "@solana/spl-token": "^0.4.14",
-    "@solana/subscriptions": "^0.4.0-rc.1",
+    "@solana/subscriptions": "0.4.0-rc.1",
     "@solana/web3.js": "^1.98.4",
     "@streamdown/cjk": "^1.0.2",
     "@streamdown/code": "^1.1.0",


### PR DESCRIPTION
## Problem

**Every production deploy has failed since July 4** (deploy.yml history is solid red). Two stacked causes, both only reproducible inside the Docker build:

1. `Module not found: Can't resolve '@lms/core'` — the `deps` stage copies only the root `package.json`, so npm workspaces never links `packages/core` into `node_modules`. Local dev never sees this (full checkout present).
2. After fixing (1): `Type error: Property 'eventAuthority' is missing … in SubscribeInput` at `lib/payments/solana-subscriptions.ts:306`. The Dockerfile deletes the lockfile before `npm install` (optional-native-deps workaround), so `^0.4.0-rc.1` floated to `@solana/subscriptions@0.4.0-rc.2`, which added a required account to the subscribe instruction. Local `tsc` passes because the lockfile pins `rc.1`.

## Fix

- `Dockerfile`: copy `packages/core/package.json` into the deps stage so the workspace links (source-only package consumed via `transpilePackages`).
- `package.json`: pin `@solana/subscriptions` to exact `0.4.0-rc.1` — survives the lockfile deletion. (Upgrading to `rc.2` properly means threading `eventAuthority` through the subscribe/init flows — separate change.)
- `package-lock.json`: regenerated for the exact spec.

## Verification

Full local `docker build` with production build args: deps install → Turbopack compile → **type check passes** → standalone output, exit 0. (`npx tsc --noEmit` clean locally as well.)

## Impact

Unblocks the whole deploy pipeline — prod is currently weeks stale, including today's MCP connector OAuth work (#369, #375) which this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)