### PR TITLE
fix(mcp): bind 0.0.0.0 in Docker image

### DIFF
--- a/mcp-server/.env.example
+++ b/mcp-server/.env.example
@@ -35,3 +35,6 @@ SUPABASE_SERVICE_ROLE_KEY=
 # server's INTERNAL address, e.g. http://127.0.0.1:3001.)
 MCP_SERVER_URL=http://localhost:3000
 # PORT=3000
+# Bind address — mcp-use defaults to "localhost", which is loopback-only.
+# In Docker/production set 0.0.0.0 (the Dockerfile already does).
+# HOST=0.0.0.0

--- a/mcp-server/Dockerfile
+++ b/mcp-server/Dockerfile
@@ -27,6 +27,9 @@ EXPOSE 3000
 
 ENV NODE_ENV=production
 ENV PORT=3000
+# mcp-use binds "localhost" by default — unreachable from outside the
+# container. HOST is read by MCPServer.listen().
+ENV HOST=0.0.0.0
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
   CMD node -e "require('http').get('http://localhost:3000/.well-known/oauth-protected-resource', (r) => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"


### PR DESCRIPTION
mcp-use's \`listen()\` binds \`localhost\` unless the \`HOST\` env is set, making the container unreachable from other services (the Next.js proxy got ECONNREFUSED across the Docker network). Bake \`HOST=0.0.0.0\` into the runner stage and document it in \`.env.example\`.

Already applied as a runtime env override on the Dokploy service (verified live: prod \`POST /api/mcp\` now returns 401 with the correct \`WWW-Authenticate\`); this makes the image correct by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)