### PR TITLE
fix(mcp): node:22-alpine Docker base — Realtime needs native WebSocket

### DIFF
--- a/mcp-server/Dockerfile
+++ b/mcp-server/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:20-alpine AS builder
+# Node >=22 required: supabase-js Realtime needs native WebSocket at runtime
+FROM node:22-alpine AS builder
 
 WORKDIR /app
 
@@ -13,7 +14,7 @@ COPY public ./public
 # during widget/type-registry generation). A dummy value is fine for the build.
 RUN SUPABASE_URL=http://localhost:54321 SUPABASE_ANON_KEY=build npm run build
 
-FROM node:20-alpine AS runner
+FROM node:22-alpine AS runner
 
 WORKDIR /app
 

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -147,7 +147,7 @@ max_indexes = 5
 enabled = true
 # The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
 # in emails.
-site_url = "http://127.0.0.1:3000"
+site_url = "http://localhost:3005"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
 additional_redirect_urls = ["https://127.0.0.1:3000"]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
@@ -345,8 +345,8 @@ enabled = false
 [auth.oauth_server]
 # Enable OAuth server functionality
 enabled = true
-# Path for OAuth consent flow UI (LMS MCP server hosts it at /auth/consent)
-authorization_url_path = "/auth/consent"
+# Path for OAuth consent flow UI (Next.js app hosts it at /oauth/consent)
+authorization_url_path = "/oauth/consent"
 # Allow dynamic client registration
 allow_dynamic_registration = true
 


### PR DESCRIPTION
Prod MCP tool calls fail with `Node.js 20 detected without native WebSocket support` (supabase-js Realtime requires Node ≥22 or the `ws` package). Bumps the MCP server image to `node:22-alpine` (verified: native `WebSocket` present; image builds locally).

Also aligns local Supabase `config.toml` with the shipped OAuth design: `authorization_url_path=/oauth/consent`, `site_url` on the Next dev port 3005 — local Claude Code OAuth E2E (DCR → consent → token → 75 tools) passes with this config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)