### PR TITLE
fix(oauth): consent page shows tenant role, not global role

### DIFF
--- a/app/[locale]/oauth/consent/page.tsx
+++ b/app/[locale]/oauth/consent/page.tsx
@@ -42,8 +42,9 @@ export default async function OAuthConsentPage({
 
   // All roles may connect — the MCP server's tool policy scopes what each
   // role can do (students get only self-scoped learning tools; RLS enforces
-  // tenant isolation on every query).
-  const userRole = roleData?.role || "student"
+  // tenant isolation on every query). Global role is only a fallback for the
+  // headline — the role that matters is the one in the connected tenant.
+  const globalRole = roleData?.role || "student"
 
   // The tenant_id claim in the minted token decides which school's data the
   // connected client sees. Load the user's active memberships so multi-school
@@ -132,7 +133,7 @@ export default async function OAuthConsentPage({
 
         <div className="mb-4 rounded-md border border-yellow-500/20 bg-yellow-500/10 p-3">
           <p className="text-xs text-yellow-700 dark:text-yellow-300">
-            Signed in as <strong>{user.email}</strong> ({userRole})
+            Signed in as <strong>{user.email}</strong> ({currentTenant?.role ?? globalRole})
             {currentTenant && memberships.length === 1 && (
               <> — connecting to <strong>{currentTenant.name}</strong></>
             )}.


### PR DESCRIPTION
The consent headline displayed the global `user_roles` role ("(student)") even when the user's role in the tenant being connected is admin/teacher. Now shows the current tenant membership's role, falling back to the global role only when no membership matches.

Verified live on the local OAuth flow: owner@e2etest.com (global student, tenant admin) now renders "(admin)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)