### PR TITLE
feat(mcp): widget markdown rendering + full Tailwind conversion (17/17)

### DIFF
--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -16,7 +16,9 @@
         "nanoid": "^5.1.6",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "react-markdown": "^10.1.0",
         "react-router": "^7.13.0",
+        "remark-gfm": "^4.0.1",
         "tailwindcss": "^4.2.0",
         "zod": "^4.3.6"
       },
@@ -893,6 +895,33 @@
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
         "tailwindcss": "^4.0.10"
+      }
+    },
+    "node_modules/@openai/apps-sdk-ui/node_modules/react-markdown": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-9.1.0.tgz",
+      "integrity": "sha512-xaijuJB0kzGiUdG7nc2MOMDUDBWPyGAjZtUrow9XxUeua8IqeP+VlIfAZ3bphpcLTnSZXz6z9jcVC/TCwbfgdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
       }
     },
     "node_modules/@opentelemetry/api": {
@@ -7646,9 +7675,9 @@
       }
     },
     "node_modules/react-markdown": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-9.1.0.tgz",
-      "integrity": "sha512-xaijuJB0kzGiUdG7nc2MOMDUDBWPyGAjZtUrow9XxUeua8IqeP+VlIfAZ3bphpcLTnSZXz6z9jcVC/TCwbfgdw==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -34,7 +34,9 @@
     "nanoid": "^5.1.6",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "react-markdown": "^10.1.0",
     "react-router": "^7.13.0",
+    "remark-gfm": "^4.0.1",
     "tailwindcss": "^4.2.0",
     "zod": "^4.3.6"
   },

--- a/mcp-server/resources/artifact-sandbox/widget.tsx
+++ b/mcp-server/resources/artifact-sandbox/widget.tsx
@@ -47,18 +47,14 @@ type Tab = "preview" | "html" | "evaluation";
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
-function difficultyPill(
-  level: string,
-  theme: "light" | "dark"
-): { bg: string; text: string } {
-  const dark = theme === "dark";
+function difficultyPill(level: string): string {
   switch (level.toLowerCase()) {
     case "easy":
-      return { bg: dark ? "#14532d" : "#dcfce7", text: dark ? "#86efac" : "#166534" };
+      return "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300";
     case "hard":
-      return { bg: dark ? "#7f1d1d" : "#fee2e2", text: dark ? "#fca5a5" : "#991b1b" };
+      return "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-300";
     default: // medium
-      return { bg: dark ? "#422006" : "#fef3c7", text: dark ? "#fcd34d" : "#92400e" };
+      return "bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300";
   }
 }
 
@@ -98,51 +94,14 @@ export default function ArtifactSandbox() {
     "lms_update_artifact_exercise"
   );
 
-  const colors = {
-    bg: dark ? "#0f0f0f" : "#fafafa",
-    surface: dark ? "#1a1a1a" : "#ffffff",
-    border: dark ? "#2a2a2a" : "#e5e7eb",
-    text: dark ? "#f4f4f5" : "#111827",
-    textSecondary: dark ? "#a1a1aa" : "#6b7280",
-    textMuted: dark ? "#71717a" : "#9ca3af",
-    accent: dark ? "#a78bfa" : "#7c3aed",
-    accentBg: dark ? "#2e1065" : "#f5f3ff",
-    sectionBg: dark ? "#141414" : "#f9fafb",
-    codeBg: dark ? "#0a0a0a" : "#f6f8fa",
-    warnBg: dark ? "#3f2d0a" : "#fffbeb",
-    warnBorder: dark ? "#854d0e" : "#fde68a",
-    warnText: dark ? "#fcd34d" : "#92400e",
-    okBg: dark ? "#14532d" : "#dcfce7",
-    okText: dark ? "#86efac" : "#166534",
-    errBg: dark ? "#7f1d1d" : "#fee2e2",
-    errText: dark ? "#fca5a5" : "#991b1b",
-  };
-
   if (isPending) {
     return (
       <McpUseProvider autoSize>
-        <div
-          style={{
-            padding: 40,
-            textAlign: "center",
-            color: colors.textMuted,
-            backgroundColor: colors.bg,
-            fontFamily: "system-ui, sans-serif",
-          }}
-        >
-          <div
-            style={{
-              width: 36,
-              height: 36,
-              border: `3px solid ${colors.border}`,
-              borderTop: `3px solid ${colors.accent}`,
-              borderRadius: "50%",
-              margin: "0 auto 12px",
-              animation: "spin 0.8s linear infinite",
-            }}
-          />
-          <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
-          <p style={{ margin: 0, fontSize: 14 }}>Rendering artifact…</p>
+        <div className={dark ? "dark" : ""}>
+          <div className="bg-zinc-50 p-10 text-center font-sans text-zinc-400 dark:bg-zinc-950 dark:text-zinc-500">
+            <div className="mx-auto mb-3 size-9 animate-spin rounded-full border-[3px] border-zinc-200 border-t-violet-600 dark:border-zinc-800 dark:border-t-violet-400" />
+            <p className="m-0 text-sm">Rendering artifact…</p>
+          </div>
         </div>
       </McpUseProvider>
     );
@@ -151,7 +110,6 @@ export default function ArtifactSandbox() {
   const { exercise, artifact } = props;
   const currentHtml = html ?? artifact.html;
   const dirty = currentHtml !== artifact.html;
-  const pill = difficultyPill(exercise.difficulty, theme);
 
   const handleSave = () => {
     saveArtifact({ exercise_id: exercise.id, artifact_html: currentHtml });
@@ -160,17 +118,11 @@ export default function ArtifactSandbox() {
   const tabButton = (id: Tab, label: string) => (
     <button
       onClick={() => setTab(id)}
-      style={{
-        padding: "6px 14px",
-        borderRadius: 8,
-        border: "none",
-        backgroundColor: tab === id ? colors.accentBg : "transparent",
-        color: tab === id ? colors.accent : colors.textSecondary,
-        fontSize: 13,
-        fontWeight: tab === id ? 600 : 500,
-        cursor: "pointer",
-        transition: "all 0.15s",
-      }}
+      className={`cursor-pointer rounded-lg border-none px-3.5 py-1.5 text-[13px] transition-all duration-150 ${
+        tab === id
+          ? "bg-violet-50 font-semibold text-violet-600 dark:bg-violet-950 dark:text-violet-400"
+          : "bg-transparent font-medium text-zinc-500 dark:text-zinc-400"
+      }`}
     >
       {label}
     </button>
@@ -178,281 +130,133 @@ export default function ArtifactSandbox() {
 
   return (
     <McpUseProvider autoSize>
-      <div
-        style={{
-          fontFamily: "system-ui, -apple-system, sans-serif",
-          backgroundColor: colors.bg,
-          padding: 24,
-        }}
-      >
-        {/* Header */}
-        <div
-          style={{
-            display: "flex",
-            justifyContent: "space-between",
-            alignItems: "flex-start",
-            gap: 12,
-            marginBottom: 6,
-          }}
-        >
-          <h2
-            style={{
-              margin: 0,
-              fontSize: 19,
-              fontWeight: 700,
-              color: colors.text,
-              letterSpacing: "-0.01em",
-              lineHeight: 1.3,
-            }}
-          >
-            {artifactEmoji(artifact.type)} {exercise.title}
-          </h2>
-          <span
-            style={{
-              padding: "3px 10px",
-              borderRadius: 10,
-              fontSize: 12,
-              fontWeight: 600,
-              backgroundColor: pill.bg,
-              color: pill.text,
-              whiteSpace: "nowrap",
-              flexShrink: 0,
-            }}
-          >
-            {exercise.difficulty}
-          </span>
-        </div>
+      <div className={dark ? "dark" : ""}>
+        <div className="bg-zinc-50 p-6 font-sans dark:bg-zinc-950">
+          {/* Header */}
+          <div className="mb-1.5 flex items-start justify-between gap-3">
+            <h2 className="m-0 text-[19px] leading-[1.3] font-bold tracking-tight text-zinc-900 dark:text-zinc-100">
+              {artifactEmoji(artifact.type)} {exercise.title}
+            </h2>
+            <span
+              className={`shrink-0 rounded-[10px] px-2.5 py-[3px] text-xs font-semibold whitespace-nowrap ${difficultyPill(exercise.difficulty)}`}
+            >
+              {exercise.difficulty}
+            </span>
+          </div>
 
-        <div style={{ display: "flex", gap: 14, flexWrap: "wrap", marginBottom: 14 }}>
-          <span style={{ fontSize: 13, color: colors.textMuted }}>
-            {artifact.type.replace("_", " ")}
-          </span>
-          <span style={{ fontSize: 13, color: colors.textMuted }}>
-            🎯 Pass ≥ {artifact.passing_score}%
-          </span>
-        </div>
+          <div className="mb-3.5 flex flex-wrap gap-3.5">
+            <span className="text-[13px] text-zinc-400 dark:text-zinc-500">
+              {artifact.type.replace("_", " ")}
+            </span>
+            <span className="text-[13px] text-zinc-400 dark:text-zinc-500">
+              🎯 Pass ≥ {artifact.passing_score}%
+            </span>
+          </div>
 
-        {exercise.instructions && (
-          <p
-            style={{
-              margin: "0 0 16px",
-              fontSize: 14,
-              color: colors.textSecondary,
-              lineHeight: 1.6,
-            }}
-          >
-            {exercise.instructions}
-          </p>
-        )}
+          {exercise.instructions && (
+            <p className="mt-0 mb-4 text-sm leading-relaxed text-zinc-500 dark:text-zinc-400">
+              {exercise.instructions}
+            </p>
+          )}
 
-        {/* Tabs */}
-        <div
-          style={{
-            display: "flex",
-            gap: 4,
-            marginBottom: 12,
-            padding: 4,
-            borderRadius: 10,
-            backgroundColor: colors.sectionBg,
-            width: "fit-content",
-          }}
-        >
-          {tabButton("preview", "Preview")}
-          {tabButton("html", `HTML${dirty ? " •" : ""}`)}
-          {tabButton("evaluation", "Evaluation")}
-        </div>
+          {/* Tabs */}
+          <div className="mb-3 flex w-fit gap-1 rounded-[10px] bg-zinc-100 p-1 dark:bg-zinc-900">
+            {tabButton("preview", "Preview")}
+            {tabButton("html", `HTML${dirty ? " •" : ""}`)}
+            {tabButton("evaluation", "Evaluation")}
+          </div>
 
-        {/* Preview */}
-        {tab === "preview" && (
-          <div
-            style={{
-              border: `1px solid ${colors.border}`,
-              borderRadius: 12,
-              overflow: "hidden",
-              backgroundColor: "#ffffff",
-            }}
-          >
-            {currentHtml ? (
-              // sandbox WITHOUT allow-same-origin: the artifact can run scripts
-              // but cannot reach the parent — exactly how students run it.
-              <iframe
-                title="Artifact preview"
-                srcDoc={currentHtml}
-                sandbox="allow-scripts allow-forms"
-                style={{ width: "100%", height: 460, border: "none", display: "block" }}
+          {/* Preview */}
+          {tab === "preview" && (
+            <div className="overflow-hidden rounded-xl border border-zinc-200 bg-white dark:border-zinc-800">
+              {currentHtml ? (
+                // sandbox WITHOUT allow-same-origin: the artifact can run scripts
+                // but cannot reach the parent — exactly how students run it.
+                <iframe
+                  title="Artifact preview"
+                  srcDoc={currentHtml}
+                  sandbox="allow-scripts allow-forms"
+                  className="block h-[460px] w-full border-none"
+                />
+              ) : (
+                <div className="p-10 text-center text-[13px] text-zinc-400 dark:text-zinc-500">
+                  No HTML content to preview.
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* HTML editor */}
+          {tab === "html" && (
+            <div>
+              <textarea
+                value={currentHtml}
+                onChange={(e) => setHtml(e.target.value)}
+                spellCheck={false}
+                className="box-border h-[360px] w-full resize-y rounded-xl border border-zinc-200 bg-zinc-50 p-3 font-mono text-[12.5px] leading-normal text-zinc-900 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-100"
               />
-            ) : (
-              <div
-                style={{
-                  padding: 40,
-                  textAlign: "center",
-                  fontSize: 13,
-                  color: colors.textMuted,
-                }}
-              >
-                No HTML content to preview.
-              </div>
-            )}
-          </div>
-        )}
-
-        {/* HTML editor */}
-        {tab === "html" && (
-          <div>
-            <textarea
-              value={currentHtml}
-              onChange={(e) => setHtml(e.target.value)}
-              spellCheck={false}
-              style={{
-                width: "100%",
-                height: 360,
-                boxSizing: "border-box",
-                padding: 12,
-                borderRadius: 12,
-                border: `1px solid ${colors.border}`,
-                backgroundColor: colors.codeBg,
-                color: colors.text,
-                fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
-                fontSize: 12.5,
-                lineHeight: 1.5,
-                resize: "vertical",
-              }}
-            />
-            <div
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: 12,
-                marginTop: 10,
-              }}
-            >
-              <button
-                onClick={handleSave}
-                disabled={saving || !dirty}
-                style={{
-                  padding: "8px 18px",
-                  borderRadius: 8,
-                  border: "none",
-                  backgroundColor: dirty ? colors.accent : colors.border,
-                  color: dirty ? "#ffffff" : colors.textMuted,
-                  fontSize: 13,
-                  fontWeight: 600,
-                  cursor: saving || !dirty ? "not-allowed" : "pointer",
-                  opacity: saving ? 0.7 : 1,
-                  transition: "all 0.15s",
-                }}
-              >
-                {saving ? "Saving…" : dirty ? "Save changes" : "Saved"}
-              </button>
-              {dirty && (
+              <div className="mt-2.5 flex items-center gap-3">
                 <button
-                  onClick={() => setHtml(null)}
-                  disabled={saving}
-                  style={{
-                    padding: "8px 14px",
-                    borderRadius: 8,
-                    border: `1px solid ${colors.border}`,
-                    backgroundColor: "transparent",
-                    color: colors.textSecondary,
-                    fontSize: 13,
-                    fontWeight: 500,
-                    cursor: "pointer",
-                  }}
+                  onClick={handleSave}
+                  disabled={saving || !dirty}
+                  className={`rounded-lg border-none px-[18px] py-2 text-[13px] font-semibold transition-all duration-150 ${
+                    dirty
+                      ? "cursor-pointer bg-violet-600 text-white dark:bg-violet-400 dark:text-zinc-950"
+                      : "cursor-not-allowed bg-zinc-200 text-zinc-400 dark:bg-zinc-800 dark:text-zinc-500"
+                  } ${saving ? "cursor-not-allowed opacity-70" : ""}`}
                 >
-                  Revert
+                  {saving ? "Saving…" : dirty ? "Save changes" : "Saved"}
                 </button>
-              )}
-              {saved && !dirty && (
-                <span style={{ fontSize: 13, color: colors.okText }}>✓ Saved</span>
-              )}
-              {saveFailed && (
-                <span style={{ fontSize: 13, color: colors.errText }}>
-                  {saveError instanceof Error ? saveError.message : "Save failed"}
-                </span>
+                {dirty && (
+                  <button
+                    onClick={() => setHtml(null)}
+                    disabled={saving}
+                    className="cursor-pointer rounded-lg border border-zinc-200 bg-transparent px-3.5 py-2 text-[13px] font-medium text-zinc-500 dark:border-zinc-800 dark:text-zinc-400"
+                  >
+                    Revert
+                  </button>
+                )}
+                {saved && !dirty && (
+                  <span className="text-[13px] text-green-600 dark:text-green-400">
+                    ✓ Saved
+                  </span>
+                )}
+                {saveFailed && (
+                  <span className="text-[13px] text-red-600 dark:text-red-400">
+                    {saveError instanceof Error ? saveError.message : "Save failed"}
+                  </span>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Evaluation (server-side answer key) */}
+          {tab === "evaluation" && (
+            <div>
+              <div className="mb-3 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-[12.5px] font-medium text-amber-600 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-400">
+                🔒 Server-side only — students never receive this.
+              </div>
+
+              <h4 className="mt-0 mb-1.5 text-[13px] font-semibold text-zinc-900 dark:text-zinc-100">
+                Evaluation criteria
+              </h4>
+              <pre className="mt-0 mb-4 rounded-[10px] border border-zinc-200 bg-zinc-50 p-3 font-mono text-[12.5px] leading-relaxed break-words whitespace-pre-wrap text-zinc-500 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-400">
+                {artifact.evaluation_criteria || "(none set)"}
+              </pre>
+
+              {artifact.system_prompt && (
+                <>
+                  <h4 className="mt-0 mb-1.5 text-[13px] font-semibold text-zinc-900 dark:text-zinc-100">
+                    Evaluator system prompt
+                  </h4>
+                  <pre className="m-0 rounded-[10px] border border-zinc-200 bg-zinc-50 p-3 font-mono text-[12.5px] leading-relaxed break-words whitespace-pre-wrap text-zinc-500 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-400">
+                    {artifact.system_prompt}
+                  </pre>
+                </>
               )}
             </div>
-          </div>
-        )}
-
-        {/* Evaluation (server-side answer key) */}
-        {tab === "evaluation" && (
-          <div>
-            <div
-              style={{
-                padding: "8px 12px",
-                borderRadius: 8,
-                backgroundColor: colors.warnBg,
-                border: `1px solid ${colors.warnBorder}`,
-                color: colors.warnText,
-                fontSize: 12.5,
-                fontWeight: 500,
-                marginBottom: 12,
-              }}
-            >
-              🔒 Server-side only — students never receive this.
-            </div>
-
-            <h4
-              style={{
-                margin: "0 0 6px",
-                fontSize: 13,
-                fontWeight: 600,
-                color: colors.text,
-              }}
-            >
-              Evaluation criteria
-            </h4>
-            <pre
-              style={{
-                margin: "0 0 16px",
-                padding: 12,
-                borderRadius: 10,
-                backgroundColor: colors.codeBg,
-                border: `1px solid ${colors.border}`,
-                color: colors.textSecondary,
-                fontSize: 12.5,
-                lineHeight: 1.6,
-                whiteSpace: "pre-wrap",
-                wordBreak: "break-word",
-                fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
-              }}
-            >
-              {artifact.evaluation_criteria || "(none set)"}
-            </pre>
-
-            {artifact.system_prompt && (
-              <>
-                <h4
-                  style={{
-                    margin: "0 0 6px",
-                    fontSize: 13,
-                    fontWeight: 600,
-                    color: colors.text,
-                  }}
-                >
-                  Evaluator system prompt
-                </h4>
-                <pre
-                  style={{
-                    margin: 0,
-                    padding: 12,
-                    borderRadius: 10,
-                    backgroundColor: colors.codeBg,
-                    border: `1px solid ${colors.border}`,
-                    color: colors.textSecondary,
-                    fontSize: 12.5,
-                    lineHeight: 1.6,
-                    whiteSpace: "pre-wrap",
-                    wordBreak: "break-word",
-                    fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
-                  }}
-                >
-                  {artifact.system_prompt}
-                </pre>
-              </>
-            )}
-          </div>
-        )}
+          )}
+        </div>
       </div>
     </McpUseProvider>
   );

--- a/mcp-server/resources/course-catalog/widget.tsx
+++ b/mcp-server/resources/course-catalog/widget.tsx
@@ -68,48 +68,17 @@ export default function CourseCatalog() {
   // every card, so which card is pending/enrolled must be tracked separately.
   const [pendingIds, setPendingIds] = useState<Set<number>>(new Set());
   const [enrolledIds, setEnrolledIds] = useState<Set<number>>(new Set());
+  const [enrollError, setEnrollError] = useState<string | null>(null);
   const dark = theme === "dark";
-
-  const colors = {
-    bg: dark ? "#0f0f0f" : "#fafafa",
-    surface: dark ? "#1a1a1a" : "#ffffff",
-    border: dark ? "#2a2a2a" : "#e5e7eb",
-    text: dark ? "#f4f4f5" : "#111827",
-    textSecondary: dark ? "#a1a1aa" : "#6b7280",
-    textMuted: dark ? "#71717a" : "#9ca3af",
-    accent: dark ? "#a78bfa" : "#7c3aed",
-    accentBg: dark ? "#2e1065" : "#f5f3ff",
-    enrolled: dark ? "#4ade80" : "#16a34a",
-    enrolledBg: dark ? "#14532d" : "#dcfce7",
-    tagBg: dark ? "#27272a" : "#f4f4f5",
-    thumbBg: dark ? "#27272a" : "#f4f4f5",
-  };
 
   if (isPending) {
     return (
       <McpUseProvider autoSize>
-        <div
-          style={{
-            padding: 40,
-            textAlign: "center",
-            color: colors.textMuted,
-            backgroundColor: colors.bg,
-            fontFamily: "system-ui, sans-serif",
-          }}
-        >
-          <div
-            style={{
-              width: 36,
-              height: 36,
-              border: `3px solid ${colors.border}`,
-              borderTop: `3px solid ${colors.accent}`,
-              borderRadius: "50%",
-              margin: "0 auto 12px",
-              animation: "spin 0.8s linear infinite",
-            }}
-          />
-          <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
-          <p style={{ margin: 0, fontSize: 14 }}>Browsing catalog…</p>
+        <div className={dark ? "dark" : ""}>
+          <div className="bg-zinc-50 p-10 text-center font-sans text-zinc-400 dark:bg-zinc-950 dark:text-zinc-500">
+            <div className="mx-auto mb-3 size-9 animate-spin rounded-full border-[3px] border-zinc-200 border-t-violet-600 dark:border-zinc-800 dark:border-t-violet-400" />
+            <p className="m-0 text-sm">Browsing catalog…</p>
+          </div>
         </div>
       </McpUseProvider>
     );
@@ -119,6 +88,7 @@ export default function CourseCatalog() {
 
   const handleEnroll = (courseId: number, title: string) => {
     setPendingIds((prev) => new Set(prev).add(courseId));
+    setEnrollError(null);
     enrollInCourse(
       { course_id: courseId },
       {
@@ -128,6 +98,8 @@ export default function CourseCatalog() {
             `I just enrolled in ${title} — what should I start with?`
           );
         },
+        onError: () =>
+          setEnrollError(`Could not enroll in "${title}". Please try again.`),
         onSettled: () => {
           setPendingIds((prev) => {
             const next = new Set(prev);
@@ -141,214 +113,110 @@ export default function CourseCatalog() {
 
   return (
     <McpUseProvider autoSize>
-      <div
-        style={{
-          fontFamily: "system-ui, -apple-system, sans-serif",
-          backgroundColor: colors.bg,
-          padding: 24,
-          maxWidth: 820,
-          margin: "0 auto",
-        }}
-      >
-        <div
-          style={{
-            display: "flex",
-            alignItems: "baseline",
-            justifyContent: "space-between",
-            marginBottom: 18,
-            flexWrap: "wrap",
-            gap: 8,
-          }}
-        >
-          <h1
-            style={{
-              margin: 0,
-              fontSize: 22,
-              fontWeight: 700,
-              color: colors.text,
-              letterSpacing: "-0.02em",
-            }}
-          >
-            Course Catalog
-          </h1>
-          <span style={{ fontSize: 13, color: colors.textSecondary }}>
-            {total} published course{total === 1 ? "" : "s"}
-            {has_subscription ? " · subscription active" : ""}
-          </span>
-        </div>
-
-        {courses.length === 0 ? (
-          <div
-            style={{
-              backgroundColor: colors.surface,
-              border: `1px solid ${colors.border}`,
-              borderRadius: 12,
-              padding: 40,
-              textAlign: "center",
-            }}
-          >
-            <div style={{ fontSize: 32, marginBottom: 8 }}>📚</div>
-            <p style={{ margin: 0, color: colors.text, fontWeight: 600, fontSize: 15 }}>
-              No published courses found
-            </p>
+      <div className={dark ? "dark" : ""}>
+        <div className="mx-auto max-w-[820px] bg-zinc-50 p-6 font-sans dark:bg-zinc-950">
+          <div className="mb-4.5 flex flex-wrap items-baseline justify-between gap-2">
+            <h1 className="m-0 text-[22px] font-bold tracking-tight text-zinc-900 dark:text-zinc-100">
+              Course Catalog
+            </h1>
+            <span className="text-[13px] text-zinc-500 dark:text-zinc-400">
+              {total} published course{total === 1 ? "" : "s"}
+              {has_subscription ? " · subscription active" : ""}
+            </span>
           </div>
-        ) : (
-          <div
-            style={{
-              display: "grid",
-              gridTemplateColumns: "repeat(auto-fill, minmax(230px, 1fr))",
-              gap: 14,
-            }}
-          >
-            {courses.map((course) => {
-              const tags = normalizeTags(course.tags).slice(0, 3);
-              return (
-                <div
-                  key={course.id}
-                  style={{
-                    backgroundColor: colors.surface,
-                    border: `1px solid ${colors.border}`,
-                    borderRadius: 12,
-                    overflow: "hidden",
-                    display: "flex",
-                    flexDirection: "column",
-                  }}
-                >
-                  {/* Thumbnail */}
-                  <div
-                    style={{
-                      height: 96,
-                      backgroundColor: colors.thumbBg,
-                      backgroundImage: course.thumbnail_url
-                        ? `url(${course.thumbnail_url})`
-                        : undefined,
-                      backgroundSize: "cover",
-                      backgroundPosition: "center",
-                      display: "flex",
-                      alignItems: "center",
-                      justifyContent: "center",
-                      fontSize: 28,
-                    }}
-                  >
-                    {!course.thumbnail_url && "📖"}
-                  </div>
 
+          {enrollError && (
+            <div
+              className="mb-3 rounded-[10px] bg-red-50 px-[13px] py-[9px] text-[13px] text-red-700 dark:bg-red-950 dark:text-red-400"
+              role="alert"
+            >
+              {enrollError}
+            </div>
+          )}
+
+          {courses.length === 0 ? (
+            <div className="rounded-xl border border-zinc-200 bg-white p-10 text-center dark:border-zinc-800 dark:bg-zinc-900">
+              <div className="mb-2 text-[32px]">📚</div>
+              <p className="m-0 text-[15px] font-semibold text-zinc-900 dark:text-zinc-100">
+                No published courses found
+              </p>
+            </div>
+          ) : (
+            <div className="grid grid-cols-[repeat(auto-fill,minmax(230px,1fr))] gap-3.5">
+              {courses.map((course) => {
+                const tags = normalizeTags(course.tags).slice(0, 3);
+                return (
                   <div
-                    style={{
-                      padding: 14,
-                      display: "flex",
-                      flexDirection: "column",
-                      gap: 8,
-                      flex: 1,
-                    }}
+                    key={course.id}
+                    className="flex flex-col overflow-hidden rounded-xl border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900"
                   >
-                    <div>
-                      <div
-                        style={{
-                          fontSize: 14.5,
-                          fontWeight: 650,
-                          color: colors.text,
-                          lineHeight: 1.3,
-                        }}
-                      >
-                        {course.title}
+                    {/* Thumbnail */}
+                    <div
+                      className="flex h-24 items-center justify-center bg-zinc-100 bg-cover bg-center text-[28px] dark:bg-zinc-800"
+                      style={
+                        course.thumbnail_url
+                          ? { backgroundImage: `url(${course.thumbnail_url})` }
+                          : undefined
+                      }
+                    >
+                      {!course.thumbnail_url && "📖"}
+                    </div>
+
+                    <div className="flex flex-1 flex-col gap-2 p-3.5">
+                      <div>
+                        <div className="text-[14.5px] leading-[1.3] font-semibold text-zinc-900 dark:text-zinc-100">
+                          {course.title}
+                        </div>
+                        {course.description && (
+                          <div className="mt-1 line-clamp-2 text-xs leading-[1.45] text-zinc-400 dark:text-zinc-500">
+                            {course.description}
+                          </div>
+                        )}
                       </div>
-                      {course.description && (
-                        <div
-                          style={{
-                            fontSize: 12,
-                            color: colors.textMuted,
-                            marginTop: 4,
-                            lineHeight: 1.45,
-                            display: "-webkit-box",
-                            WebkitLineClamp: 2,
-                            WebkitBoxOrient: "vertical",
-                            overflow: "hidden",
-                          }}
-                        >
-                          {course.description}
+
+                      {tags.length > 0 && (
+                        <div className="flex flex-wrap gap-[5px]">
+                          {tags.map((tag) => (
+                            <span
+                              key={tag}
+                              className="rounded-lg bg-zinc-100 px-2 py-0.5 text-[10.5px] font-semibold text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400"
+                            >
+                              {tag}
+                            </span>
+                          ))}
                         </div>
                       )}
-                    </div>
 
-                    {tags.length > 0 && (
-                      <div style={{ display: "flex", gap: 5, flexWrap: "wrap" }}>
-                        {tags.map((tag) => (
-                          <span
-                            key={tag}
-                            style={{
-                              padding: "2px 8px",
-                              borderRadius: 8,
-                              fontSize: 10.5,
-                              fontWeight: 600,
-                              backgroundColor: colors.tagBg,
-                              color: colors.textSecondary,
-                            }}
-                          >
-                            {tag}
+                      <div className="mt-auto flex items-center justify-between gap-2">
+                        <span className="text-[11.5px] text-zinc-400 dark:text-zinc-500">
+                          {course.lesson_count} lesson
+                          {course.lesson_count === 1 ? "" : "s"}
+                        </span>
+                        {course.enrolled || enrolledIds.has(course.id) ? (
+                          <span className="rounded-full bg-green-100 px-[9px] py-[3px] text-[11px] font-bold text-green-600 dark:bg-green-900 dark:text-green-400">
+                            ✓ Enrolled
                           </span>
-                        ))}
+                        ) : course.covered_by_plan ? (
+                          <button
+                            onClick={() => handleEnroll(course.id, course.title)}
+                            disabled={pendingIds.has(course.id)}
+                            className="cursor-pointer rounded-full border-none bg-violet-600 px-2.5 py-[3px] text-[11px] font-bold text-white disabled:cursor-default disabled:opacity-60 dark:bg-violet-400"
+                          >
+                            {pendingIds.has(course.id) ? "Enrolling…" : "Enroll"}
+                          </button>
+                        ) : (
+                          <span className="text-[11px] text-zinc-400 dark:text-zinc-500">
+                            Not in plan
+                          </span>
+                        )}
                       </div>
-                    )}
-
-                    <div
-                      style={{
-                        marginTop: "auto",
-                        display: "flex",
-                        alignItems: "center",
-                        justifyContent: "space-between",
-                        gap: 8,
-                      }}
-                    >
-                      <span style={{ fontSize: 11.5, color: colors.textMuted }}>
-                        {course.lesson_count} lesson
-                        {course.lesson_count === 1 ? "" : "s"}
-                      </span>
-                      {course.enrolled || enrolledIds.has(course.id) ? (
-                        <span
-                          style={{
-                            padding: "3px 9px",
-                            borderRadius: 999,
-                            fontSize: 11,
-                            fontWeight: 700,
-                            backgroundColor: colors.enrolledBg,
-                            color: colors.enrolled,
-                          }}
-                        >
-                          ✓ Enrolled
-                        </span>
-                      ) : course.covered_by_plan ? (
-                        <button
-                          onClick={() => handleEnroll(course.id, course.title)}
-                          disabled={pendingIds.has(course.id)}
-                          style={{
-                            padding: "3px 10px",
-                            borderRadius: 999,
-                            fontSize: 11,
-                            fontWeight: 700,
-                            border: "none",
-                            backgroundColor: colors.accent,
-                            color: "#ffffff",
-                            cursor: pendingIds.has(course.id)
-                              ? "default"
-                              : "pointer",
-                            opacity: pendingIds.has(course.id) ? 0.6 : 1,
-                          }}
-                        >
-                          {pendingIds.has(course.id) ? "Enrolling…" : "Enroll"}
-                        </button>
-                      ) : (
-                        <span style={{ fontSize: 11, color: colors.textMuted }}>
-                          Not in plan
-                        </span>
-                      )}
                     </div>
                   </div>
-                </div>
-              );
-            })}
-          </div>
-        )}
+                );
+              })}
+            </div>
+          )}
+        </div>
       </div>
     </McpUseProvider>
   );

--- a/mcp-server/resources/course-dashboard/widget.tsx
+++ b/mcp-server/resources/course-dashboard/widget.tsx
@@ -53,32 +53,16 @@ function normalizeTags(tags: string[] | string | null): string[] {
   return tags.split(",").map((t) => t.trim()).filter(Boolean);
 }
 
-function statusColor(
-  status: string,
-  theme: "light" | "dark"
-): { bg: string; text: string } {
-  const dark = theme === "dark";
+function statusColor(status: string): string {
   switch (status.toLowerCase()) {
     case "published":
-      return {
-        bg: dark ? "#14532d" : "#dcfce7",
-        text: dark ? "#86efac" : "#166534",
-      };
+      return "bg-green-100 text-green-600 dark:bg-green-900 dark:text-green-400";
     case "draft":
-      return {
-        bg: dark ? "#3f3f46" : "#f4f4f5",
-        text: dark ? "#a1a1aa" : "#52525b",
-      };
+      return "bg-zinc-100 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400";
     case "archived":
-      return {
-        bg: dark ? "#1e1b4b" : "#ede9fe",
-        text: dark ? "#a5b4fc" : "#4338ca",
-      };
+      return "bg-violet-50 text-violet-600 dark:bg-violet-950 dark:text-violet-400";
     default:
-      return {
-        bg: dark ? "#422006" : "#fef3c7",
-        text: dark ? "#fcd34d" : "#92400e",
-      };
+      return "bg-amber-100 text-amber-600 dark:bg-amber-950 dark:text-amber-400";
   }
 }
 
@@ -91,45 +75,14 @@ export default function CourseDashboard() {
 
   const dark = theme === "dark";
 
-  const colors = {
-    bg: dark ? "#0f0f0f" : "#fafafa",
-    surface: dark ? "#1a1a1a" : "#ffffff",
-    border: dark ? "#2a2a2a" : "#e5e7eb",
-    text: dark ? "#f4f4f5" : "#111827",
-    textSecondary: dark ? "#a1a1aa" : "#6b7280",
-    textMuted: dark ? "#71717a" : "#9ca3af",
-    accent: dark ? "#a78bfa" : "#7c3aed",
-    accentBg: dark ? "#2e1065" : "#f5f3ff",
-    hover: dark ? "#27272a" : "#f9fafb",
-    tagBg: dark ? "#27272a" : "#f3f4f6",
-    tagText: dark ? "#d4d4d8" : "#374151",
-  };
-
   if (isPending) {
     return (
       <McpUseProvider autoSize>
-        <div
-          style={{
-            padding: 40,
-            textAlign: "center",
-            color: colors.textMuted,
-            backgroundColor: colors.bg,
-            fontFamily: "system-ui, sans-serif",
-          }}
-        >
-          <div
-            style={{
-              width: 36,
-              height: 36,
-              border: `3px solid ${colors.border}`,
-              borderTop: `3px solid ${colors.accent}`,
-              borderRadius: "50%",
-              margin: "0 auto 12px",
-              animation: "spin 0.8s linear infinite",
-            }}
-          />
-          <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
-          <p style={{ margin: 0, fontSize: 14 }}>Loading courses…</p>
+        <div className={dark ? "dark" : ""}>
+          <div className="bg-zinc-50 p-10 text-center font-sans text-zinc-400 dark:bg-zinc-950 dark:text-zinc-500">
+            <div className="mx-auto mb-3 size-9 animate-spin rounded-full border-[3px] border-zinc-200 border-t-violet-600 dark:border-zinc-800 dark:border-t-violet-400" />
+            <p className="m-0 text-sm">Loading courses…</p>
+          </div>
         </div>
       </McpUseProvider>
     );
@@ -146,228 +99,110 @@ export default function CourseDashboard() {
 
   return (
     <McpUseProvider autoSize>
-      <div
-        style={{
-          fontFamily: "system-ui, -apple-system, sans-serif",
-          backgroundColor: colors.bg,
-          padding: 24,
-          minHeight: 0,
-        }}
-      >
-        {/* Header */}
-        <div
-          style={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "space-between",
-            marginBottom: 20,
-            flexWrap: "wrap",
-            gap: 12,
-          }}
-        >
-          <div>
-            <h2
-              style={{
-                margin: 0,
-                fontSize: 20,
-                fontWeight: 600,
-                color: colors.text,
-                letterSpacing: "-0.01em",
-              }}
-            >
-              {labelForFilter} Courses
-            </h2>
-            <p
-              style={{
-                margin: "2px 0 0",
-                fontSize: 13,
-                color: colors.textSecondary,
-              }}
-            >
-              {props.total} course{props.total !== 1 ? "s" : ""} total
-            </p>
+      <div className={dark ? "dark" : ""}>
+        <div className="min-h-0 bg-zinc-50 p-6 font-sans dark:bg-zinc-950">
+          {/* Header */}
+          <div className="mb-5 flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <h2 className="m-0 text-xl font-semibold tracking-tight text-zinc-900 dark:text-zinc-100">
+                {labelForFilter} Courses
+              </h2>
+              <p className="mt-0.5 mb-0 text-[13px] text-zinc-500 dark:text-zinc-400">
+                {props.total} course{props.total !== 1 ? "s" : ""} total
+              </p>
+            </div>
+
+            {/* Status filter tabs */}
+            <div className="flex flex-wrap gap-1.5">
+              {allStatuses.map((s) => {
+                const active = s === activeFilter;
+                return (
+                  <button
+                    key={s}
+                    onClick={() => setActiveFilter(s)}
+                    className={`cursor-pointer rounded-full border px-3 py-[5px] text-xs transition-all duration-150 ${
+                      active
+                        ? "border-violet-600 bg-violet-50 font-semibold text-violet-600 dark:border-violet-400 dark:bg-violet-950 dark:text-violet-400"
+                        : "border-zinc-200 bg-transparent font-normal text-zinc-500 dark:border-zinc-800 dark:text-zinc-400"
+                    }`}
+                  >
+                    {s.charAt(0).toUpperCase() + s.slice(1)}
+                  </button>
+                );
+              })}
+            </div>
           </div>
 
-          {/* Status filter tabs */}
-          <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
-            {allStatuses.map((s) => {
-              const active = s === activeFilter;
+          {/* Empty state */}
+          {filtered.length === 0 && (
+            <div className="p-12 text-center text-zinc-400 dark:text-zinc-500">
+              <div className="mb-3 text-4xl">📚</div>
+              <p className="m-0 text-sm">No courses match this filter</p>
+            </div>
+          )}
+
+          {/* Card grid */}
+          <div className="grid grid-cols-[repeat(auto-fill,minmax(260px,1fr))] gap-4">
+            {filtered.map((course) => {
+              const tags = normalizeTags(course.tags);
               return (
-                <button
-                  key={s}
-                  onClick={() => setActiveFilter(s)}
-                  style={{
-                    padding: "5px 12px",
-                    borderRadius: 20,
-                    border: active
-                      ? `1px solid ${colors.accent}`
-                      : `1px solid ${colors.border}`,
-                    backgroundColor: active ? colors.accentBg : "transparent",
-                    color: active ? colors.accent : colors.textSecondary,
-                    fontSize: 12,
-                    fontWeight: active ? 600 : 400,
-                    cursor: "pointer",
-                    transition: "all 0.15s",
-                  }}
+                <div
+                  key={course.id}
+                  className="flex flex-col gap-2.5 rounded-xl border border-zinc-200 bg-white p-[18px] transition-shadow duration-150 dark:border-zinc-800 dark:bg-zinc-900"
                 >
-                  {s.charAt(0).toUpperCase() + s.slice(1)}
-                </button>
+                  {/* Title + status */}
+                  <div className="flex items-start justify-between gap-2">
+                    <h3 className="m-0 line-clamp-2 flex-1 text-[15px] leading-[1.3] font-semibold text-zinc-900 dark:text-zinc-100">
+                      {course.title}
+                    </h3>
+                    <span
+                      className={`shrink-0 rounded-[10px] px-2 py-0.5 text-[11px] font-semibold whitespace-nowrap ${statusColor(
+                        course.status
+                      )}`}
+                    >
+                      {course.status}
+                    </span>
+                  </div>
+
+                  {/* Description */}
+                  {course.description && (
+                    <p className="m-0 line-clamp-2 text-[13px] leading-normal text-zinc-500 dark:text-zinc-400">
+                      {course.description}
+                    </p>
+                  )}
+
+                  {/* Tags */}
+                  {tags.length > 0 && (
+                    <div className="flex flex-wrap gap-1">
+                      {tags.slice(0, 4).map((tag) => (
+                        <span
+                          key={tag}
+                          className="rounded-md bg-zinc-100 px-[7px] py-0.5 text-[11px] text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300"
+                        >
+                          {tag}
+                        </span>
+                      ))}
+                      {tags.length > 4 && (
+                        <span className="rounded-md bg-zinc-100 px-[7px] py-0.5 text-[11px] text-zinc-400 dark:bg-zinc-800 dark:text-zinc-500">
+                          +{tags.length - 4}
+                        </span>
+                      )}
+                    </div>
+                  )}
+
+                  {/* Stats */}
+                  <div className="mt-auto flex gap-3.5 border-t border-zinc-200 pt-2 dark:border-zinc-800">
+                    <span className="text-xs text-zinc-400 dark:text-zinc-500">
+                      📖 {course.lesson_count} lesson{course.lesson_count !== 1 ? "s" : ""}
+                    </span>
+                    <span className="text-xs text-zinc-400 dark:text-zinc-500">
+                      👥 {course.enrollment_count} enrolled
+                    </span>
+                  </div>
+                </div>
               );
             })}
           </div>
-        </div>
-
-        {/* Empty state */}
-        {filtered.length === 0 && (
-          <div
-            style={{
-              padding: 48,
-              textAlign: "center",
-              color: colors.textMuted,
-            }}
-          >
-            <div style={{ fontSize: 36, marginBottom: 12 }}>📚</div>
-            <p style={{ margin: 0, fontSize: 14 }}>No courses match this filter</p>
-          </div>
-        )}
-
-        {/* Card grid */}
-        <div
-          style={{
-            display: "grid",
-            gridTemplateColumns: "repeat(auto-fill, minmax(260px, 1fr))",
-            gap: 16,
-          }}
-        >
-          {filtered.map((course) => {
-            const pill = statusColor(course.status, theme);
-            const tags = normalizeTags(course.tags);
-            return (
-              <div
-                key={course.id}
-                style={{
-                  backgroundColor: colors.surface,
-                  border: `1px solid ${colors.border}`,
-                  borderRadius: 12,
-                  padding: 18,
-                  display: "flex",
-                  flexDirection: "column",
-                  gap: 10,
-                  transition: "box-shadow 0.15s",
-                }}
-              >
-                {/* Title + status */}
-                <div
-                  style={{
-                    display: "flex",
-                    justifyContent: "space-between",
-                    alignItems: "flex-start",
-                    gap: 8,
-                  }}
-                >
-                  <h3
-                    style={{
-                      margin: 0,
-                      fontSize: 15,
-                      fontWeight: 600,
-                      color: colors.text,
-                      lineHeight: 1.3,
-                      flex: 1,
-                      overflow: "hidden",
-                      display: "-webkit-box",
-                      WebkitLineClamp: 2,
-                      WebkitBoxOrient: "vertical",
-                    }}
-                  >
-                    {course.title}
-                  </h3>
-                  <span
-                    style={{
-                      padding: "2px 8px",
-                      borderRadius: 10,
-                      fontSize: 11,
-                      fontWeight: 600,
-                      backgroundColor: pill.bg,
-                      color: pill.text,
-                      whiteSpace: "nowrap",
-                      flexShrink: 0,
-                    }}
-                  >
-                    {course.status}
-                  </span>
-                </div>
-
-                {/* Description */}
-                {course.description && (
-                  <p
-                    style={{
-                      margin: 0,
-                      fontSize: 13,
-                      color: colors.textSecondary,
-                      lineHeight: 1.5,
-                      overflow: "hidden",
-                      display: "-webkit-box",
-                      WebkitLineClamp: 2,
-                      WebkitBoxOrient: "vertical",
-                    }}
-                  >
-                    {course.description}
-                  </p>
-                )}
-
-                {/* Tags */}
-                {tags.length > 0 && (
-                  <div style={{ display: "flex", flexWrap: "wrap", gap: 4 }}>
-                    {tags.slice(0, 4).map((tag) => (
-                      <span
-                        key={tag}
-                        style={{
-                          padding: "2px 7px",
-                          borderRadius: 6,
-                          fontSize: 11,
-                          backgroundColor: colors.tagBg,
-                          color: colors.tagText,
-                        }}
-                      >
-                        {tag}
-                      </span>
-                    ))}
-                    {tags.length > 4 && (
-                      <span
-                        style={{
-                          padding: "2px 7px",
-                          borderRadius: 6,
-                          fontSize: 11,
-                          backgroundColor: colors.tagBg,
-                          color: colors.textMuted,
-                        }}
-                      >
-                        +{tags.length - 4}
-                      </span>
-                    )}
-                  </div>
-                )}
-
-                {/* Stats */}
-                <div
-                  style={{
-                    display: "flex",
-                    gap: 14,
-                    paddingTop: 8,
-                    borderTop: `1px solid ${colors.border}`,
-                    marginTop: "auto",
-                  }}
-                >
-                  <span style={{ fontSize: 12, color: colors.textMuted }}>
-                    📖 {course.lesson_count} lesson{course.lesson_count !== 1 ? "s" : ""}
-                  </span>
-                  <span style={{ fontSize: 12, color: colors.textMuted }}>
-                    👥 {course.enrollment_count} enrolled
-                  </span>
-                </div>
-              </div>
-            );
-          })}
         </div>
       </div>
     </McpUseProvider>

--- a/mcp-server/resources/course-detail/widget.tsx
+++ b/mcp-server/resources/course-detail/widget.tsx
@@ -56,20 +56,16 @@ type Props = z.infer<typeof propsSchema>;
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
-function statusPill(
-  status: string,
-  theme: "light" | "dark"
-): { bg: string; text: string } {
-  const dark = theme === "dark";
+function statusPill(status: string): string {
   switch (status.toLowerCase()) {
     case "published":
-      return { bg: dark ? "#14532d" : "#dcfce7", text: dark ? "#86efac" : "#166534" };
+      return "bg-green-100 text-green-600 dark:bg-green-900 dark:text-green-400";
     case "draft":
-      return { bg: dark ? "#3f3f46" : "#f4f4f5", text: dark ? "#a1a1aa" : "#52525b" };
+      return "bg-zinc-100 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400";
     case "archived":
-      return { bg: dark ? "#1e1b4b" : "#ede9fe", text: dark ? "#a5b4fc" : "#4338ca" };
+      return "bg-violet-50 text-violet-600 dark:bg-violet-950 dark:text-violet-400";
     default:
-      return { bg: dark ? "#422006" : "#fef3c7", text: dark ? "#fcd34d" : "#92400e" };
+      return "bg-amber-100 text-amber-600 dark:bg-amber-950 dark:text-amber-400";
   }
 }
 
@@ -116,52 +112,20 @@ export default function CourseDetail() {
 
   const dark = theme === "dark";
 
-  const colors = {
-    bg: dark ? "#0f0f0f" : "#fafafa",
-    surface: dark ? "#1a1a1a" : "#ffffff",
-    border: dark ? "#2a2a2a" : "#e5e7eb",
-    text: dark ? "#f4f4f5" : "#111827",
-    textSecondary: dark ? "#a1a1aa" : "#6b7280",
-    textMuted: dark ? "#71717a" : "#9ca3af",
-    accent: dark ? "#a78bfa" : "#7c3aed",
-    accentBg: dark ? "#2e1065" : "#f5f3ff",
-    sectionBg: dark ? "#141414" : "#f9fafb",
-    statsBg: dark ? "#1c1c1c" : "#f0fdf4",
-    statsBorder: dark ? "#166534" : "#bbf7d0",
-  };
-
   if (isPending) {
     return (
       <McpUseProvider autoSize>
-        <div
-          style={{
-            padding: 40,
-            textAlign: "center",
-            color: colors.textMuted,
-            backgroundColor: colors.bg,
-            fontFamily: "system-ui, sans-serif",
-          }}
-        >
-          <div
-            style={{
-              width: 36,
-              height: 36,
-              border: `3px solid ${colors.border}`,
-              borderTop: `3px solid ${colors.accent}`,
-              borderRadius: "50%",
-              margin: "0 auto 12px",
-              animation: "spin 0.8s linear infinite",
-            }}
-          />
-          <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
-          <p style={{ margin: 0, fontSize: 14 }}>Loading course…</p>
+        <div className={dark ? "dark" : ""}>
+          <div className="bg-zinc-50 p-10 text-center font-sans text-zinc-400 dark:bg-zinc-950 dark:text-zinc-500">
+            <div className="mx-auto mb-3 size-9 animate-spin rounded-full border-[3px] border-zinc-200 border-t-violet-600 dark:border-zinc-800 dark:border-t-violet-400" />
+            <p className="m-0 text-sm">Loading course…</p>
+          </div>
         </div>
       </McpUseProvider>
     );
   }
 
   const { course, lessons, exams } = props;
-  const pill = statusPill(course.status, theme);
   const stats = parseCourseStats(statsData?.structuredContent);
 
   const handleLoadStats = () => {
@@ -171,328 +135,171 @@ export default function CourseDetail() {
 
   return (
     <McpUseProvider autoSize>
-      <div
-        style={{
-          fontFamily: "system-ui, -apple-system, sans-serif",
-          backgroundColor: colors.bg,
-          padding: 24,
-        }}
-      >
-        {/* Course header */}
-        <div
-          style={{
-            backgroundColor: colors.surface,
-            border: `1px solid ${colors.border}`,
-            borderRadius: 12,
-            padding: 20,
-            marginBottom: 16,
-          }}
-        >
-          <div
-            style={{
-              display: "flex",
-              justifyContent: "space-between",
-              alignItems: "flex-start",
-              gap: 12,
-              marginBottom: 8,
-            }}
-          >
-            <h2
-              style={{
-                margin: 0,
-                fontSize: 20,
-                fontWeight: 700,
-                color: colors.text,
-                letterSpacing: "-0.01em",
-                lineHeight: 1.3,
-              }}
-            >
-              {course.title}
-            </h2>
-            <span
-              style={{
-                padding: "3px 10px",
-                borderRadius: 10,
-                fontSize: 12,
-                fontWeight: 600,
-                backgroundColor: pill.bg,
-                color: pill.text,
-                whiteSpace: "nowrap",
-                flexShrink: 0,
-              }}
-            >
-              {course.status}
-            </span>
-          </div>
+      <div className={dark ? "dark" : ""}>
+        <div className="bg-zinc-50 p-6 font-sans dark:bg-zinc-950">
+          {/* Course header */}
+          <div className="mb-4 rounded-xl border border-zinc-200 bg-white p-5 dark:border-zinc-800 dark:bg-zinc-900">
+            <div className="mb-2 flex items-start justify-between gap-3">
+              <h2 className="m-0 text-xl leading-[1.3] font-bold tracking-tight text-zinc-900 dark:text-zinc-100">
+                {course.title}
+              </h2>
+              <span
+                className={`shrink-0 rounded-[10px] px-2.5 py-[3px] text-xs font-semibold whitespace-nowrap ${statusPill(
+                  course.status
+                )}`}
+              >
+                {course.status}
+              </span>
+            </div>
 
-          {course.description && (
-            <p
-              style={{
-                margin: "0 0 12px",
-                fontSize: 14,
-                color: colors.textSecondary,
-                lineHeight: 1.6,
-              }}
-            >
-              {course.description}
-            </p>
-          )}
+            {course.description && (
+              <p className="mt-0 mb-3 text-sm leading-relaxed text-zinc-500 dark:text-zinc-400">
+                {course.description}
+              </p>
+            )}
 
-          <div style={{ display: "flex", gap: 16, flexWrap: "wrap", marginBottom: 14 }}>
-            <span style={{ fontSize: 13, color: colors.textMuted }}>
-              👥 {course.enrollment_count} enrolled
-            </span>
-            <span style={{ fontSize: 13, color: colors.textMuted }}>
-              📅 Created {formatDate(course.created_at)}
-            </span>
-            {course.require_sequential_completion && (
-              <span style={{ fontSize: 13, color: colors.textMuted }}>🔒 Sequential</span>
+            <div className="mb-3.5 flex flex-wrap gap-4">
+              <span className="text-[13px] text-zinc-400 dark:text-zinc-500">
+                👥 {course.enrollment_count} enrolled
+              </span>
+              <span className="text-[13px] text-zinc-400 dark:text-zinc-500">
+                📅 Created {formatDate(course.created_at)}
+              </span>
+              {course.require_sequential_completion && (
+                <span className="text-[13px] text-zinc-400 dark:text-zinc-500">🔒 Sequential</span>
+              )}
+            </div>
+
+            {/* Load stats button */}
+            <button
+              onClick={handleLoadStats}
+              disabled={statsLoading}
+              className={`cursor-pointer rounded-lg border border-violet-600 px-4 py-[7px] text-[13px] font-medium text-violet-600 transition-all duration-150 disabled:cursor-not-allowed disabled:opacity-70 dark:border-violet-400 dark:text-violet-400 ${
+                statsVisible
+                  ? "bg-violet-50 dark:bg-violet-950"
+                  : "bg-transparent"
+              }`}
+            >
+              {statsLoading ? "Loading stats…" : "Load stats"}
+            </button>
+
+            {/* Stats row */}
+            {statsVisible && stats && (
+              <div className="mt-3.5 grid grid-cols-[repeat(auto-fill,minmax(120px,1fr))] gap-3 rounded-[10px] border border-green-200 bg-green-50 p-3.5 dark:border-green-900 dark:bg-green-950">
+                {[
+                  { label: "Active enrollments", value: stats.active_enrollments },
+                  { label: "Published lessons", value: stats.published_lessons },
+                  {
+                    label: "Completion rate",
+                    value:
+                      stats.lesson_completion_rate != null
+                        ? `${Math.round(stats.lesson_completion_rate)}%`
+                        : undefined,
+                  },
+                  { label: "Exams", value: stats.exam_count },
+                  { label: "Submissions", value: stats.submission_count },
+                  {
+                    label: "Avg score",
+                    value:
+                      stats.average_score != null
+                        ? `${Math.round(stats.average_score)}%`
+                        : undefined,
+                  },
+                ]
+                  .filter((s) => s.value !== undefined)
+                  .map(({ label, value }) => (
+                    <div key={label} className="text-center">
+                      <div className="text-lg font-bold text-green-600 dark:text-green-400">
+                        {value}
+                      </div>
+                      <div className="mt-0.5 text-[11px] text-zinc-400 dark:text-zinc-500">
+                        {label}
+                      </div>
+                    </div>
+                  ))}
+              </div>
             )}
           </div>
 
-          {/* Load stats button */}
-          <button
-            onClick={handleLoadStats}
-            disabled={statsLoading}
-            style={{
-              padding: "7px 16px",
-              borderRadius: 8,
-              border: `1px solid ${colors.accent}`,
-              backgroundColor: statsVisible ? colors.accentBg : "transparent",
-              color: colors.accent,
-              fontSize: 13,
-              fontWeight: 500,
-              cursor: statsLoading ? "not-allowed" : "pointer",
-              opacity: statsLoading ? 0.7 : 1,
-              transition: "all 0.15s",
-            }}
-          >
-            {statsLoading ? "Loading stats…" : "Load stats"}
-          </button>
+          {/* Lessons */}
+          <div className="mb-4 rounded-xl border border-zinc-200 bg-white p-[18px] dark:border-zinc-800 dark:bg-zinc-900">
+            <h3 className="mt-0 mb-3.5 text-[15px] font-semibold text-zinc-900 dark:text-zinc-100">
+              Lessons ({lessons.length})
+            </h3>
 
-          {/* Stats row */}
-          {statsVisible && stats && (
-            <div
-              style={{
-                marginTop: 14,
-                padding: 14,
-                borderRadius: 10,
-                backgroundColor: colors.statsBg,
-                border: `1px solid ${colors.statsBorder}`,
-                display: "grid",
-                gridTemplateColumns: "repeat(auto-fill, minmax(120px, 1fr))",
-                gap: 12,
-              }}
-            >
-              {[
-                { label: "Active enrollments", value: stats.active_enrollments },
-                { label: "Published lessons", value: stats.published_lessons },
-                {
-                  label: "Completion rate",
-                  value:
-                    stats.lesson_completion_rate != null
-                      ? `${Math.round(stats.lesson_completion_rate)}%`
-                      : undefined,
-                },
-                { label: "Exams", value: stats.exam_count },
-                { label: "Submissions", value: stats.submission_count },
-                {
-                  label: "Avg score",
-                  value:
-                    stats.average_score != null
-                      ? `${Math.round(stats.average_score)}%`
-                      : undefined,
-                },
-              ]
-                .filter((s) => s.value !== undefined)
-                .map(({ label, value }) => (
-                  <div key={label} style={{ textAlign: "center" }}>
-                    <div
-                      style={{
-                        fontSize: 18,
-                        fontWeight: 700,
-                        color: dark ? "#86efac" : "#15803d",
-                      }}
-                    >
-                      {value}
-                    </div>
-                    <div style={{ fontSize: 11, color: colors.textMuted, marginTop: 2 }}>
-                      {label}
-                    </div>
-                  </div>
-                ))}
-            </div>
-          )}
-        </div>
-
-        {/* Lessons */}
-        <div
-          style={{
-            backgroundColor: colors.surface,
-            border: `1px solid ${colors.border}`,
-            borderRadius: 12,
-            padding: 18,
-            marginBottom: 16,
-          }}
-        >
-          <h3
-            style={{
-              margin: "0 0 14px",
-              fontSize: 15,
-              fontWeight: 600,
-              color: colors.text,
-            }}
-          >
-            Lessons ({lessons.length})
-          </h3>
-
-          {lessons.length === 0 ? (
-            <p style={{ margin: 0, fontSize: 13, color: colors.textMuted }}>
-              No lessons yet.
-            </p>
-          ) : (
-            <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-              {lessons
-                .slice()
-                .sort((a, b) => a.sequence - b.sequence)
-                .map((lesson) => {
-                  const lp = statusPill(lesson.status, theme);
-                  return (
+            {lessons.length === 0 ? (
+              <p className="m-0 text-[13px] text-zinc-400 dark:text-zinc-500">
+                No lessons yet.
+              </p>
+            ) : (
+              <div className="flex flex-col gap-2">
+                {lessons
+                  .slice()
+                  .sort((a, b) => a.sequence - b.sequence)
+                  .map((lesson) => (
                     <div
                       key={lesson.id}
-                      style={{
-                        display: "flex",
-                        alignItems: "center",
-                        gap: 10,
-                        padding: "8px 10px",
-                        borderRadius: 8,
-                        backgroundColor: colors.sectionBg,
-                      }}
+                      className="flex items-center gap-2.5 rounded-lg bg-zinc-100 px-2.5 py-2 dark:bg-zinc-800"
                     >
-                      <span
-                        style={{
-                          minWidth: 24,
-                          height: 24,
-                          borderRadius: "50%",
-                          backgroundColor: colors.accentBg,
-                          color: colors.accent,
-                          fontSize: 11,
-                          fontWeight: 700,
-                          display: "flex",
-                          alignItems: "center",
-                          justifyContent: "center",
-                          flexShrink: 0,
-                        }}
-                      >
+                      <span className="flex h-6 min-w-6 shrink-0 items-center justify-center rounded-full bg-violet-50 text-[11px] font-bold text-violet-600 dark:bg-violet-950 dark:text-violet-400">
                         {lesson.sequence}
                       </span>
-                      <span
-                        style={{
-                          flex: 1,
-                          fontSize: 13,
-                          color: colors.text,
-                          fontWeight: 500,
-                        }}
-                      >
+                      <span className="flex-1 text-[13px] font-medium text-zinc-900 dark:text-zinc-100">
                         {lesson.title}
                       </span>
                       <span
-                        style={{
-                          padding: "2px 7px",
-                          borderRadius: 8,
-                          fontSize: 11,
-                          fontWeight: 600,
-                          backgroundColor: lp.bg,
-                          color: lp.text,
-                          flexShrink: 0,
-                        }}
+                        className={`shrink-0 rounded-lg px-[7px] py-0.5 text-[11px] font-semibold ${statusPill(
+                          lesson.status
+                        )}`}
                       >
                         {lesson.status}
                       </span>
                     </div>
-                  );
-                })}
-            </div>
-          )}
-        </div>
+                  ))}
+              </div>
+            )}
+          </div>
 
-        {/* Exams */}
-        <div
-          style={{
-            backgroundColor: colors.surface,
-            border: `1px solid ${colors.border}`,
-            borderRadius: 12,
-            padding: 18,
-          }}
-        >
-          <h3
-            style={{
-              margin: "0 0 14px",
-              fontSize: 15,
-              fontWeight: 600,
-              color: colors.text,
-            }}
-          >
-            Exams ({exams.length})
-          </h3>
+          {/* Exams */}
+          <div className="rounded-xl border border-zinc-200 bg-white p-[18px] dark:border-zinc-800 dark:bg-zinc-900">
+            <h3 className="mt-0 mb-3.5 text-[15px] font-semibold text-zinc-900 dark:text-zinc-100">
+              Exams ({exams.length})
+            </h3>
 
-          {exams.length === 0 ? (
-            <p style={{ margin: 0, fontSize: 13, color: colors.textMuted }}>
-              No exams yet.
-            </p>
-          ) : (
-            <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-              {exams.map((exam) => {
-                const ep = statusPill(exam.status, theme);
-                return (
+            {exams.length === 0 ? (
+              <p className="m-0 text-[13px] text-zinc-400 dark:text-zinc-500">
+                No exams yet.
+              </p>
+            ) : (
+              <div className="flex flex-col gap-2">
+                {exams.map((exam) => (
                   <div
                     key={exam.id}
-                    style={{
-                      display: "flex",
-                      alignItems: "center",
-                      gap: 10,
-                      padding: "8px 10px",
-                      borderRadius: 8,
-                      backgroundColor: colors.sectionBg,
-                      flexWrap: "wrap",
-                    }}
+                    className="flex flex-wrap items-center gap-2.5 rounded-lg bg-zinc-100 px-2.5 py-2 dark:bg-zinc-800"
                   >
-                    <span
-                      style={{
-                        flex: 1,
-                        fontSize: 13,
-                        color: colors.text,
-                        fontWeight: 500,
-                        minWidth: 100,
-                      }}
-                    >
+                    <span className="min-w-[100px] flex-1 text-[13px] font-medium text-zinc-900 dark:text-zinc-100">
                       {exam.title}
                     </span>
-                    <span style={{ fontSize: 12, color: colors.textMuted }}>
+                    <span className="text-xs text-zinc-400 dark:text-zinc-500">
                       ⏱ {exam.duration} min
                     </span>
                     {exam.date && (
-                      <span style={{ fontSize: 12, color: colors.textMuted }}>
+                      <span className="text-xs text-zinc-400 dark:text-zinc-500">
                         📅 {formatDate(exam.date)}
                       </span>
                     )}
                     <span
-                      style={{
-                        padding: "2px 7px",
-                        borderRadius: 8,
-                        fontSize: 11,
-                        fontWeight: 600,
-                        backgroundColor: ep.bg,
-                        color: ep.text,
-                      }}
+                      className={`rounded-lg px-[7px] py-0.5 text-[11px] font-semibold ${statusPill(
+                        exam.status
+                      )}`}
                     >
                       {exam.status}
                     </span>
                   </div>
-                );
-              })}
-            </div>
-          )}
+                ))}
+              </div>
+            )}
+          </div>
         </div>
       </div>
     </McpUseProvider>

--- a/mcp-server/resources/exam-readiness/widget.tsx
+++ b/mcp-server/resources/exam-readiness/widget.tsx
@@ -57,49 +57,40 @@ export const widgetMetadata: WidgetMetadata = {
 
 type Props = z.infer<typeof propsSchema>;
 
+// Fixed score buckets → Tailwind class strings (pass ≥80, warn ≥60, fail <60)
+const bandText = (v: number) =>
+  v >= 80
+    ? "text-green-600 dark:text-green-400"
+    : v >= 60
+      ? "text-amber-600 dark:text-amber-400"
+      : "text-red-600 dark:text-red-400";
+
+const bandFill = (v: number) =>
+  v >= 80
+    ? "bg-green-600 dark:bg-green-400"
+    : v >= 60
+      ? "bg-amber-600 dark:bg-amber-400"
+      : "bg-red-600 dark:bg-red-400";
+
+const bandDial = (v: number) =>
+  v >= 80
+    ? "border-green-600 bg-green-100 dark:border-green-400 dark:bg-green-900"
+    : v >= 60
+      ? "border-amber-600 bg-amber-100 dark:border-amber-400 dark:bg-amber-950"
+      : "border-red-600 bg-red-100 dark:border-red-400 dark:bg-red-950";
+
 export default function ExamReadiness() {
   const { props, isPending, sendFollowUpMessage } = useWidget<Props>();
   const theme = useWidgetTheme();
   const dark = theme === "dark";
-  const colors = {
-    bg: dark ? "#0f0f0f" : "#fafafa",
-    surface: dark ? "#1a1a1a" : "#ffffff",
-    border: dark ? "#2a2a2a" : "#e5e7eb",
-    text: dark ? "#f4f4f5" : "#111827",
-    textSecondary: dark ? "#a1a1aa" : "#6b7280",
-    textMuted: dark ? "#71717a" : "#9ca3af",
-    accent: dark ? "#a78bfa" : "#7c3aed",
-    pass: dark ? "#4ade80" : "#16a34a",
-    passBg: dark ? "#14532d" : "#dcfce7",
-    warn: dark ? "#fbbf24" : "#d97706",
-    warnBg: dark ? "#451a03" : "#fef3c7",
-    fail: dark ? "#f87171" : "#dc2626",
-    failBg: dark ? "#450a0a" : "#fee2e2",
-  };
 
   if (isPending) {
     return (
       <McpUseProvider autoSize>
-        <div
-          style={{
-            fontFamily: "system-ui, -apple-system, sans-serif",
-            padding: 40,
-            display: "flex",
-            justifyContent: "center",
-            backgroundColor: colors.bg,
-          }}
-        >
-          <div
-            style={{
-              width: 24,
-              height: 24,
-              border: `3px solid ${colors.border}`,
-              borderTopColor: colors.accent,
-              borderRadius: "50%",
-              animation: "spin 0.8s linear infinite",
-            }}
-          />
-          <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
+        <div className={dark ? "dark" : ""}>
+          <div className="flex justify-center bg-zinc-50 p-10 font-sans dark:bg-zinc-950">
+            <div className="size-6 animate-spin rounded-full border-[3px] border-zinc-200 border-t-violet-600 dark:border-zinc-800 dark:border-t-violet-400" />
+          </div>
         </div>
       </McpUseProvider>
     );
@@ -107,11 +98,6 @@ export default function ExamReadiness() {
 
   const { course_title, exam, readiness, components, formula, topics, lessons } =
     props;
-
-  const bandColor = (v: number) =>
-    v >= 80 ? colors.pass : v >= 60 ? colors.warn : colors.fail;
-  const bandBg = (v: number) =>
-    v >= 80 ? colors.passBg : v >= 60 ? colors.warnBg : colors.failBg;
 
   const examDate = exam?.exam_date
     ? new Date(exam.exam_date).toLocaleDateString(undefined, {
@@ -133,223 +119,123 @@ export default function ExamReadiness() {
 
   return (
     <McpUseProvider autoSize>
-      <div
-        style={{
-          fontFamily: "system-ui, -apple-system, sans-serif",
-          backgroundColor: colors.bg,
-          padding: 24,
-          maxWidth: 720,
-          margin: "0 auto",
-        }}
-      >
-        <div style={{ marginBottom: 16 }}>
-          <h2 style={{ margin: 0, fontSize: 18, fontWeight: 700, color: colors.text }}>
-            Exam readiness — {course_title}
-          </h2>
-          {exam && (
-            <p style={{ margin: "4px 0 0", fontSize: 13, color: colors.textSecondary }}>
-              {exam.title}
-              {examDate ? ` · ${examDate}` : ""}
-            </p>
-          )}
-        </div>
-
-        {readiness === null ? (
-          <div
-            style={{
-              backgroundColor: colors.surface,
-              border: `1px solid ${colors.border}`,
-              borderRadius: 12,
-              padding: 40,
-              textAlign: "center",
-            }}
-          >
-            <div style={{ fontSize: 32, marginBottom: 8 }}>🧭</div>
-            <p style={{ margin: 0, color: colors.text, fontWeight: 600, fontSize: 15 }}>
-              No signal yet
-            </p>
-            <p style={{ margin: "6px 0 0", color: colors.textMuted, fontSize: 13 }}>
-              Take a practice quiz to calibrate your readiness.
-            </p>
-            <button
-              onClick={() =>
-                sendFollowUpMessage(
-                  `Generate a diagnostic practice quiz for "${course_title}" with lms_practice_quiz so we can calibrate my exam readiness.`
-                )
-              }
-              style={{
-                marginTop: 16,
-                padding: "8px 16px",
-                fontSize: 13,
-                fontWeight: 600,
-                color: "#ffffff",
-                backgroundColor: colors.accent,
-                border: "none",
-                borderRadius: 8,
-                cursor: "pointer",
-              }}
-            >
-              Start a diagnostic quiz
-            </button>
+      <div className={dark ? "dark" : ""}>
+        <div className="mx-auto max-w-[720px] bg-zinc-50 p-6 font-sans dark:bg-zinc-950">
+          <div className="mb-4">
+            <h2 className="m-0 text-lg font-bold text-zinc-900 dark:text-zinc-100">
+              Exam readiness — {course_title}
+            </h2>
+            {exam && (
+              <p className="mt-1 mb-0 text-[13px] text-zinc-500 dark:text-zinc-400">
+                {exam.title}
+                {examDate ? ` · ${examDate}` : ""}
+              </p>
+            )}
           </div>
-        ) : (
-          <>
-            <div
-              style={{
-                backgroundColor: colors.surface,
-                border: `1px solid ${colors.border}`,
-                borderRadius: 12,
-                padding: 20,
-                display: "flex",
-                alignItems: "center",
-                gap: 20,
-                marginBottom: 16,
-                flexWrap: "wrap",
-              }}
-            >
-              <div
-                style={{
-                  width: 88,
-                  height: 88,
-                  borderRadius: "50%",
-                  border: `6px solid ${bandColor(readiness)}`,
-                  backgroundColor: bandBg(readiness),
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  flexShrink: 0,
-                }}
+
+          {readiness === null ? (
+            <div className="rounded-xl border border-zinc-200 bg-white p-10 text-center dark:border-zinc-800 dark:bg-zinc-900">
+              <div className="mb-2 text-3xl">🧭</div>
+              <p className="m-0 text-[15px] font-semibold text-zinc-900 dark:text-zinc-100">
+                No signal yet
+              </p>
+              <p className="mt-1.5 mb-0 text-[13px] text-zinc-400 dark:text-zinc-500">
+                Take a practice quiz to calibrate your readiness.
+              </p>
+              <button
+                onClick={() =>
+                  sendFollowUpMessage(
+                    `Generate a diagnostic practice quiz for "${course_title}" with lms_practice_quiz so we can calibrate my exam readiness.`
+                  )
+                }
+                className="mt-4 cursor-pointer rounded-lg border-none bg-violet-600 px-4 py-2 text-[13px] font-semibold text-white dark:bg-violet-400"
               >
-                <span style={{ fontSize: 26, fontWeight: 800, color: bandColor(readiness) }}>
-                  {readiness}
-                </span>
+                Start a diagnostic quiz
+              </button>
+            </div>
+          ) : (
+            <>
+              <div className="mb-4 flex flex-wrap items-center gap-5 rounded-xl border border-zinc-200 bg-white p-5 dark:border-zinc-800 dark:bg-zinc-900">
+                <div
+                  className={`flex size-[88px] shrink-0 items-center justify-center rounded-full border-[6px] ${bandDial(readiness)}`}
+                >
+                  <span className={`text-[26px] font-extrabold ${bandText(readiness)}`}>
+                    {readiness}
+                  </span>
+                </div>
+                <div className="min-w-[220px] flex-1">
+                  <div className="mb-2 flex flex-wrap gap-2">
+                    {componentChips.map((c) => (
+                      <span
+                        key={c.label}
+                        className={`rounded-full border border-zinc-200 bg-zinc-50 px-2.5 py-1 text-xs dark:border-zinc-800 dark:bg-zinc-950 ${
+                          c.value === null
+                            ? "text-zinc-400 dark:text-zinc-500"
+                            : "text-zinc-900 dark:text-zinc-100"
+                        }`}
+                      >
+                        {c.label}: {c.value === null ? "n/a" : c.value}
+                        {c.value !== null && c.weight > 0
+                          ? ` (${Math.round(c.weight * 100)}%)`
+                          : ""}
+                      </span>
+                    ))}
+                  </div>
+                  <p className="m-0 text-xs text-zinc-400 dark:text-zinc-500">{formula}</p>
+                </div>
               </div>
-              <div style={{ flex: 1, minWidth: 220 }}>
-                <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginBottom: 8 }}>
-                  {componentChips.map((c) => (
-                    <span
-                      key={c.label}
-                      style={{
-                        fontSize: 12,
-                        padding: "4px 10px",
-                        borderRadius: 999,
-                        border: `1px solid ${colors.border}`,
-                        color: c.value === null ? colors.textMuted : colors.text,
-                        backgroundColor: colors.bg,
-                      }}
+
+              {topics.length === 0 ? (
+                <div className="rounded-xl border border-zinc-200 bg-white p-6 text-center dark:border-zinc-800 dark:bg-zinc-900">
+                  <p className="m-0 text-[13px] text-zinc-400 dark:text-zinc-500">
+                    No per-topic history yet — practice quizzes and exam attempts will
+                    show up here.
+                  </p>
+                </div>
+              ) : (
+                <div className="flex flex-col gap-2.5">
+                  {topics.map((t, i) => (
+                    <div
+                      key={`${t.label}-${i}`}
+                      className="rounded-[10px] border border-zinc-200 bg-white px-4 py-3 dark:border-zinc-800 dark:bg-zinc-900"
                     >
-                      {c.label}: {c.value === null ? "n/a" : c.value}
-                      {c.value !== null && c.weight > 0
-                        ? ` (${Math.round(c.weight * 100)}%)`
-                        : ""}
-                    </span>
+                      <div className="mb-1.5 flex items-center justify-between gap-3">
+                        <span className="overflow-hidden text-sm font-semibold text-ellipsis whitespace-nowrap text-zinc-900 dark:text-zinc-100">
+                          {t.source === "exam" ? "📄 " : "✏️ "}
+                          {t.label}
+                        </span>
+                        <div className="flex shrink-0 items-center gap-2.5">
+                          <span className={`text-[13px] font-bold ${bandText(t.mastery)}`}>
+                            {t.mastery}
+                          </span>
+                          <button
+                            onClick={() =>
+                              sendFollowUpMessage(
+                                `Generate a practice quiz on "${t.label}" with lms_practice_quiz — focus on my misses. (Course: ${course_title})`
+                              )
+                            }
+                            className="cursor-pointer rounded-md border border-violet-600 bg-transparent px-2.5 py-1 text-xs font-semibold text-violet-600 dark:border-violet-400 dark:text-violet-400"
+                          >
+                            Practice this
+                          </button>
+                        </div>
+                      </div>
+                      <div className="mb-1.5 h-1.5 overflow-hidden rounded-[3px] bg-zinc-100 dark:bg-zinc-800">
+                        <div
+                          className={`h-full rounded-[3px] ${bandFill(t.mastery)}`}
+                          style={{ width: `${Math.max(0, Math.min(100, t.mastery))}%` }}
+                        />
+                      </div>
+                      <p className="m-0 text-xs text-zinc-400 dark:text-zinc-500">
+                        {t.evidence}
+                      </p>
+                    </div>
                   ))}
                 </div>
-                <p style={{ margin: 0, fontSize: 12, color: colors.textMuted }}>{formula}</p>
-              </div>
-            </div>
-
-            {topics.length === 0 ? (
-              <div
-                style={{
-                  backgroundColor: colors.surface,
-                  border: `1px solid ${colors.border}`,
-                  borderRadius: 12,
-                  padding: 24,
-                  textAlign: "center",
-                }}
-              >
-                <p style={{ margin: 0, color: colors.textMuted, fontSize: 13 }}>
-                  No per-topic history yet — practice quizzes and exam attempts will
-                  show up here.
-                </p>
-              </div>
-            ) : (
-              <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
-                {topics.map((t, i) => (
-                  <div
-                    key={`${t.label}-${i}`}
-                    style={{
-                      backgroundColor: colors.surface,
-                      border: `1px solid ${colors.border}`,
-                      borderRadius: 10,
-                      padding: "12px 16px",
-                    }}
-                  >
-                    <div
-                      style={{
-                        display: "flex",
-                        alignItems: "center",
-                        justifyContent: "space-between",
-                        gap: 12,
-                        marginBottom: 6,
-                      }}
-                    >
-                      <span
-                        style={{
-                          fontSize: 14,
-                          fontWeight: 600,
-                          color: colors.text,
-                          overflow: "hidden",
-                          textOverflow: "ellipsis",
-                          whiteSpace: "nowrap",
-                        }}
-                      >
-                        {t.source === "exam" ? "📄 " : "✏️ "}
-                        {t.label}
-                      </span>
-                      <div style={{ display: "flex", alignItems: "center", gap: 10, flexShrink: 0 }}>
-                        <span style={{ fontSize: 13, fontWeight: 700, color: bandColor(t.mastery) }}>
-                          {t.mastery}
-                        </span>
-                        <button
-                          onClick={() =>
-                            sendFollowUpMessage(
-                              `Generate a practice quiz on "${t.label}" with lms_practice_quiz — focus on my misses. (Course: ${course_title})`
-                            )
-                          }
-                          style={{
-                            padding: "4px 10px",
-                            fontSize: 12,
-                            fontWeight: 600,
-                            color: colors.accent,
-                            backgroundColor: "transparent",
-                            border: `1px solid ${colors.accent}`,
-                            borderRadius: 6,
-                            cursor: "pointer",
-                          }}
-                        >
-                          Practice this
-                        </button>
-                      </div>
-                    </div>
-                    <div
-                      style={{
-                        height: 6,
-                        borderRadius: 3,
-                        backgroundColor: dark ? "#27272a" : "#f3f4f6",
-                        overflow: "hidden",
-                        marginBottom: 6,
-                      }}
-                    >
-                      <div
-                        style={{
-                          width: `${Math.max(0, Math.min(100, t.mastery))}%`,
-                          height: "100%",
-                          borderRadius: 3,
-                          backgroundColor: bandColor(t.mastery),
-                        }}
-                      />
-                    </div>
-                    <p style={{ margin: 0, fontSize: 12, color: colors.textMuted }}>
-                      {t.evidence}
-                    </p>
-                  </div>
-                ))}
-              </div>
-            )}
-          </>
-        )}
+              )}
+            </>
+          )}
+        </div>
       </div>
     </McpUseProvider>
   );

--- a/mcp-server/resources/exam-submissions/widget.tsx
+++ b/mcp-server/resources/exam-submissions/widget.tsx
@@ -7,6 +7,7 @@ import {
   type WidgetMetadata,
 } from "mcp-use/react";
 import { z } from "zod";
+import { Markdown } from "../shared/markdown";
 
 // ── Schema ──────────────────────────────────────────────────────────────────
 
@@ -38,21 +39,26 @@ type Props = z.infer<typeof propsSchema>;
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
-function reviewPill(
-  status: string | null,
-  theme: "light" | "dark"
-): { bg: string; text: string } {
-  const dark = theme === "dark";
+function reviewPill(status: string | null): { bg: string; text: string } {
   switch ((status ?? "pending").toLowerCase()) {
     case "approved":
     case "graded":
-      return { bg: dark ? "#14532d" : "#dcfce7", text: dark ? "#86efac" : "#166534" };
+      return {
+        bg: "bg-green-100 dark:bg-green-900",
+        text: "text-green-600 dark:text-green-400",
+      };
     case "rejected":
     case "failed":
-      return { bg: dark ? "#7f1d1d" : "#fee2e2", text: dark ? "#fca5a5" : "#991b1b" };
+      return {
+        bg: "bg-red-100 dark:bg-red-950",
+        text: "text-red-600 dark:text-red-400",
+      };
     case "pending":
     default:
-      return { bg: dark ? "#422006" : "#fef3c7", text: dark ? "#fcd34d" : "#92400e" };
+      return {
+        bg: "bg-amber-100 dark:bg-amber-950",
+        text: "text-amber-600 dark:text-amber-400",
+      };
   }
 }
 
@@ -95,46 +101,14 @@ export default function ExamSubmissions() {
 
   const dark = theme === "dark";
 
-  const colors = {
-    bg: dark ? "#0f0f0f" : "#fafafa",
-    surface: dark ? "#1a1a1a" : "#ffffff",
-    border: dark ? "#2a2a2a" : "#e5e7eb",
-    text: dark ? "#f4f4f5" : "#111827",
-    textSecondary: dark ? "#a1a1aa" : "#6b7280",
-    textMuted: dark ? "#71717a" : "#9ca3af",
-    accent: dark ? "#a78bfa" : "#7c3aed",
-    rowHover: dark ? "#222222" : "#f9fafb",
-    rowExpanded: dark ? "#1e1b2e" : "#faf5ff",
-    detailBg: dark ? "#161616" : "#f5f3ff",
-    detailBorder: dark ? "#3d2e6b" : "#ddd6fe",
-    headerBg: dark ? "#141414" : "#f3f4f6",
-  };
-
   if (isPending) {
     return (
       <McpUseProvider autoSize>
-        <div
-          style={{
-            padding: 40,
-            textAlign: "center",
-            color: colors.textMuted,
-            backgroundColor: colors.bg,
-            fontFamily: "system-ui, sans-serif",
-          }}
-        >
-          <div
-            style={{
-              width: 36,
-              height: 36,
-              border: `3px solid ${colors.border}`,
-              borderTop: `3px solid ${colors.accent}`,
-              borderRadius: "50%",
-              margin: "0 auto 12px",
-              animation: "spin 0.8s linear infinite",
-            }}
-          />
-          <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
-          <p style={{ margin: 0, fontSize: 14 }}>Loading submissions…</p>
+        <div className={dark ? "dark" : ""}>
+          <div className="bg-zinc-50 p-10 text-center font-sans text-zinc-400 dark:bg-zinc-950 dark:text-zinc-500">
+            <div className="mx-auto mb-3 size-9 animate-spin rounded-full border-[3px] border-zinc-200 border-t-violet-600 dark:border-zinc-800 dark:border-t-violet-400" />
+            <p className="m-0 text-sm">Loading submissions…</p>
+          </div>
         </div>
       </McpUseProvider>
     );
@@ -166,244 +140,152 @@ export default function ExamSubmissions() {
 
   return (
     <McpUseProvider autoSize>
-      <div
-        style={{
-          fontFamily: "system-ui, -apple-system, sans-serif",
-          backgroundColor: colors.bg,
-          padding: 24,
-        }}
-      >
-        {/* Header */}
-        <div style={{ marginBottom: 16 }}>
-          <h2
-            style={{
-              margin: 0,
-              fontSize: 18,
-              fontWeight: 600,
-              color: colors.text,
-              letterSpacing: "-0.01em",
-            }}
-          >
-            Exam #{exam_id} — Submissions
-          </h2>
-          <p style={{ margin: "2px 0 0", fontSize: 13, color: colors.textSecondary }}>
-            {total} submission{total !== 1 ? "s" : ""} · Click a row to see details
-          </p>
-        </div>
-
-        {/* Table */}
-        <div
-          style={{
-            backgroundColor: colors.surface,
-            border: `1px solid ${colors.border}`,
-            borderRadius: 12,
-            overflow: "hidden",
-          }}
-        >
-          {/* Header row */}
-          <div
-            style={{
-              display: "grid",
-              gridTemplateColumns: "1fr 80px 120px 100px",
-              gap: 0,
-              backgroundColor: colors.headerBg,
-              borderBottom: `1px solid ${colors.border}`,
-              padding: "9px 16px",
-            }}
-          >
-            {["Student", "Score", "Date", "Status"].map((col) => (
-              <span
-                key={col}
-                style={{
-                  fontSize: 11,
-                  fontWeight: 700,
-                  color: colors.textMuted,
-                  textTransform: "uppercase",
-                  letterSpacing: "0.05em",
-                }}
-              >
-                {col}
-              </span>
-            ))}
+      <div className={dark ? "dark" : ""}>
+        <div className="bg-zinc-50 p-6 font-sans dark:bg-zinc-950">
+          {/* Header */}
+          <div className="mb-4">
+            <h2 className="m-0 text-lg font-semibold tracking-tight text-zinc-900 dark:text-zinc-100">
+              Exam #{exam_id} — Submissions
+            </h2>
+            <p className="mt-0.5 mb-0 text-[13px] text-zinc-500 dark:text-zinc-400">
+              {total} submission{total !== 1 ? "s" : ""} · Click a row to see details
+            </p>
           </div>
 
-          {/* Empty state */}
-          {submissions.length === 0 && (
-            <div
-              style={{
-                padding: 40,
-                textAlign: "center",
-                color: colors.textMuted,
-              }}
-            >
-              <div style={{ fontSize: 32, marginBottom: 10 }}>📋</div>
-              <p style={{ margin: 0, fontSize: 14 }}>No submissions yet</p>
-            </div>
-          )}
-
-          {/* Data rows */}
-          {submissions.map((sub, idx) => {
-            const pill = reviewPill(sub.review_status, theme);
-            const isExpanded = expandedId === sub.id;
-            const isLoadingThis = loadingId === sub.id;
-            const detail = detailMap[sub.id];
-            const isLast = idx === submissions.length - 1 && !isExpanded;
-
-            return (
-              <div key={sub.id}>
-                <div
-                  onClick={() => handleRowClick(sub.id)}
-                  style={{
-                    display: "grid",
-                    gridTemplateColumns: "1fr 80px 120px 100px",
-                    gap: 0,
-                    padding: "12px 16px",
-                    borderBottom: isLast ? "none" : `1px solid ${colors.border}`,
-                    backgroundColor: isExpanded ? colors.rowExpanded : "transparent",
-                    cursor: "pointer",
-                    transition: "background-color 0.12s",
-                  }}
-                  onMouseEnter={(e) => {
-                    if (!isExpanded)
-                      (e.currentTarget as HTMLDivElement).style.backgroundColor =
-                        colors.rowHover;
-                  }}
-                  onMouseLeave={(e) => {
-                    if (!isExpanded)
-                      (e.currentTarget as HTMLDivElement).style.backgroundColor = "transparent";
-                  }}
+          {/* Table */}
+          <div className="overflow-x-auto overflow-y-hidden rounded-xl border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
+            {/* Header row */}
+            <div className="grid min-w-[480px] grid-cols-[minmax(140px,1fr)_80px_120px_100px] border-b border-zinc-200 bg-zinc-100 px-4 py-[9px] dark:border-zinc-800 dark:bg-zinc-800">
+              {["Student", "Score", "Date", "Status"].map((col) => (
+                <span
+                  key={col}
+                  className="text-[11px] font-bold tracking-wider text-zinc-400 uppercase dark:text-zinc-500"
                 >
-                  <span
-                    style={{
-                      fontSize: 13,
-                      fontWeight: 500,
-                      color: colors.text,
-                      overflow: "hidden",
-                      textOverflow: "ellipsis",
-                      whiteSpace: "nowrap",
-                    }}
-                  >
-                    {sub.student_name}
-                  </span>
-                  <span style={{ fontSize: 13, color: colors.text, fontWeight: 600 }}>
-                    {sub.score != null ? `${sub.score}%` : "—"}
-                  </span>
-                  <span style={{ fontSize: 12, color: colors.textSecondary }}>
-                    {formatDate(sub.submission_date)}
-                  </span>
-                  <span
-                    style={{
-                      display: "inline-flex",
-                      alignItems: "center",
-                    }}
-                  >
-                    <span
-                      style={{
-                        padding: "2px 8px",
-                        borderRadius: 8,
-                        fontSize: 11,
-                        fontWeight: 600,
-                        backgroundColor: pill.bg,
-                        color: pill.text,
-                      }}
-                    >
-                      {sub.review_status ?? "pending"}
-                    </span>
-                  </span>
-                </div>
+                  {col}
+                </span>
+              ))}
+            </div>
 
-                {/* Expanded detail panel */}
-                {isExpanded && (
+            {/* Empty state */}
+            {submissions.length === 0 && (
+              <div className="p-10 text-center text-zinc-400 dark:text-zinc-500">
+                <div className="mb-2.5 text-3xl">📋</div>
+                <p className="m-0 text-sm">No submissions yet</p>
+              </div>
+            )}
+
+            {/* Data rows */}
+            {submissions.map((sub, idx) => {
+              const pill = reviewPill(sub.review_status);
+              const isExpanded = expandedId === sub.id;
+              const isLoadingThis = loadingId === sub.id;
+              const detail = detailMap[sub.id];
+              const isLast = idx === submissions.length - 1 && !isExpanded;
+
+              return (
+                <div key={sub.id}>
                   <div
-                    style={{
-                      padding: "14px 16px",
-                      backgroundColor: colors.detailBg,
-                      borderTop: `1px solid ${colors.detailBorder}`,
-                      borderBottom:
-                        idx === submissions.length - 1
-                          ? "none"
-                          : `1px solid ${colors.border}`,
+                    role="button"
+                    tabIndex={0}
+                    aria-expanded={isExpanded}
+                    onClick={() => handleRowClick(sub.id)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        handleRowClick(sub.id);
+                      }
                     }}
+                    className={`grid min-w-[480px] cursor-pointer grid-cols-[minmax(140px,1fr)_80px_120px_100px] px-4 py-3 transition-colors ${
+                      isLast ? "" : "border-b border-zinc-200 dark:border-zinc-800"
+                    } ${
+                      isExpanded
+                        ? "bg-violet-50 dark:bg-violet-950"
+                        : "bg-transparent hover:bg-zinc-50 dark:hover:bg-zinc-800"
+                    }`}
                   >
-                    {isLoadingThis ? (
-                      <p style={{ margin: 0, fontSize: 13, color: colors.textMuted }}>
-                        Loading details…
-                      </p>
-                    ) : detail ? (
-                      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-                        <div style={{ display: "flex", gap: 20, flexWrap: "wrap" }}>
-                          {detail.score != null && (
+                    <span className="overflow-hidden text-[13px] font-medium text-ellipsis whitespace-nowrap text-zinc-900 dark:text-zinc-100">
+                      {sub.student_name}
+                    </span>
+                    <span className="text-[13px] font-semibold text-zinc-900 dark:text-zinc-100">
+                      {sub.score != null ? `${sub.score}%` : "—"}
+                    </span>
+                    <span className="text-xs text-zinc-500 dark:text-zinc-400">
+                      {formatDate(sub.submission_date)}
+                    </span>
+                    <span className="inline-flex items-center">
+                      <span
+                        className={`rounded-lg px-2 py-0.5 text-[11px] font-semibold ${pill.bg} ${pill.text}`}
+                      >
+                        {sub.review_status ?? "pending"}
+                      </span>
+                    </span>
+                  </div>
+
+                  {/* Expanded detail panel */}
+                  {isExpanded && (
+                    <div
+                      className={`box-border min-w-[480px] border-t border-t-violet-200 bg-violet-50 px-4 py-3.5 dark:border-t-violet-900 dark:bg-violet-950 ${
+                        idx === submissions.length - 1
+                          ? ""
+                          : "border-b border-b-zinc-200 dark:border-b-zinc-800"
+                      }`}
+                    >
+                      {isLoadingThis ? (
+                        <p className="m-0 text-[13px] text-zinc-400 dark:text-zinc-500">
+                          Loading details…
+                        </p>
+                      ) : detail ? (
+                        <div className="flex flex-col gap-2">
+                          <div className="flex flex-wrap gap-5">
+                            {detail.score != null && (
+                              <div>
+                                <span className="block text-[11px] text-zinc-400 dark:text-zinc-500">
+                                  Score
+                                </span>
+                                <span className="text-xl font-bold text-violet-600 dark:text-violet-400">
+                                  {detail.score}%
+                                </span>
+                              </div>
+                            )}
+                            {detail.review_status && (
+                              <div>
+                                <span className="block text-[11px] text-zinc-400 dark:text-zinc-500">
+                                  Review status
+                                </span>
+                                <span
+                                  className={`text-[13px] font-semibold ${
+                                    reviewPill(detail.review_status).text
+                                  }`}
+                                >
+                                  {detail.review_status}
+                                </span>
+                              </div>
+                            )}
+                          </div>
+                          {detail.feedback && (
                             <div>
-                              <span
-                                style={{ fontSize: 11, color: colors.textMuted, display: "block" }}
-                              >
-                                Score
+                              <span className="mb-1 block text-[11px] text-zinc-400 dark:text-zinc-500">
+                                Feedback
                               </span>
-                              <span
-                                style={{
-                                  fontSize: 20,
-                                  fontWeight: 700,
-                                  color: colors.accent,
-                                }}
-                              >
-                                {detail.score}%
-                              </span>
-                            </div>
-                          )}
-                          {detail.review_status && (
-                            <div>
-                              <span
-                                style={{ fontSize: 11, color: colors.textMuted, display: "block" }}
-                              >
-                                Review status
-                              </span>
-                              <span
-                                style={{
-                                  fontSize: 13,
-                                  fontWeight: 600,
-                                  color: reviewPill(detail.review_status, theme).text,
-                                }}
-                              >
-                                {detail.review_status}
-                              </span>
+                              <Markdown
+                                content={detail.feedback}
+                                dark={dark}
+                                fontSize={13}
+                              />
                             </div>
                           )}
                         </div>
-                        {detail.feedback && (
-                          <div>
-                            <span
-                              style={{
-                                fontSize: 11,
-                                color: colors.textMuted,
-                                display: "block",
-                                marginBottom: 4,
-                              }}
-                            >
-                              Feedback
-                            </span>
-                            <p
-                              style={{
-                                margin: 0,
-                                fontSize: 13,
-                                color: colors.textSecondary,
-                                lineHeight: 1.6,
-                              }}
-                            >
-                              {detail.feedback}
-                            </p>
-                          </div>
-                        )}
-                      </div>
-                    ) : (
-                      <p style={{ margin: 0, fontSize: 13, color: colors.textMuted }}>
-                        No additional detail available.
-                      </p>
-                    )}
-                  </div>
-                )}
-              </div>
-            );
-          })}
+                      ) : (
+                        <p className="m-0 text-[13px] text-zinc-400 dark:text-zinc-500">
+                          No additional detail available.
+                        </p>
+                      )}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
         </div>
       </div>
     </McpUseProvider>

--- a/mcp-server/resources/flashcards/widget.tsx
+++ b/mcp-server/resources/flashcards/widget.tsx
@@ -7,6 +7,7 @@ import {
   type WidgetMetadata,
 } from "mcp-use/react";
 import { z } from "zod";
+import { Markdown } from "../shared/markdown";
 
 // Props produced by lms_get_due_reviews (Epic #348 Phase 4, #355).
 const propsSchema = z.object({
@@ -45,29 +46,19 @@ const RATING_META: Array<{ rating: Rating; label: string; hint: string }> = [
   { rating: "easy", label: "Easy", hint: "" },
 ];
 
+// Border + text classes per rating (fail / warn / pass / accent).
+const ratingColor: Record<Rating, string> = {
+  again: "border-red-600 text-red-600 dark:border-red-400 dark:text-red-400",
+  hard: "border-amber-600 text-amber-600 dark:border-amber-400 dark:text-amber-400",
+  good: "border-green-600 text-green-600 dark:border-green-400 dark:text-green-400",
+  easy: "border-violet-600 text-violet-600 dark:border-violet-400 dark:text-violet-400",
+};
+
 export default function Flashcards() {
   const { props, isPending, sendFollowUpMessage } = useWidget<Props>();
   const { callTool } = useCallTool("lms_grade_review");
   const theme = useWidgetTheme();
   const dark = theme === "dark";
-  const colors = {
-    bg: dark ? "#0f0f0f" : "#fafafa",
-    surface: dark ? "#1a1a1a" : "#ffffff",
-    border: dark ? "#2a2a2a" : "#e5e7eb",
-    text: dark ? "#f4f4f5" : "#111827",
-    textSecondary: dark ? "#a1a1aa" : "#6b7280",
-    textMuted: dark ? "#71717a" : "#9ca3af",
-    accent: dark ? "#a78bfa" : "#7c3aed",
-    pass: dark ? "#4ade80" : "#16a34a",
-    warn: dark ? "#fbbf24" : "#d97706",
-    fail: dark ? "#f87171" : "#dc2626",
-  };
-  const ratingColor: Record<Rating, string> = {
-    again: colors.fail,
-    hard: colors.warn,
-    good: colors.pass,
-    easy: colors.accent,
-  };
 
   const [index, setIndex] = useState(0);
   const [flipped, setFlipped] = useState(false);
@@ -78,30 +69,15 @@ export default function Flashcards() {
     easy: 0,
   });
   const [againFronts, setAgainFronts] = useState<string[]>([]);
+  const [failedSaves, setFailedSaves] = useState(0);
 
   if (isPending) {
     return (
       <McpUseProvider autoSize>
-        <div
-          style={{
-            fontFamily: "system-ui, -apple-system, sans-serif",
-            padding: 40,
-            display: "flex",
-            justifyContent: "center",
-            backgroundColor: colors.bg,
-          }}
-        >
-          <div
-            style={{
-              width: 24,
-              height: 24,
-              border: `3px solid ${colors.border}`,
-              borderTopColor: colors.accent,
-              borderRadius: "50%",
-              animation: "spin 0.8s linear infinite",
-            }}
-          />
-          <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
+        <div className={dark ? "dark" : ""}>
+          <div className="flex justify-center bg-zinc-50 p-10 font-sans dark:bg-zinc-950">
+            <div className="size-6 animate-spin rounded-full border-[3px] border-zinc-200 border-t-violet-600 dark:border-zinc-800 dark:border-t-violet-400" />
+          </div>
         </div>
       </McpUseProvider>
     );
@@ -114,43 +90,34 @@ export default function Flashcards() {
 
   const rate = (rating: Rating) => {
     if (!card) return;
-    // Fire-and-forget: SM-2 scheduling happens server-side; the session
-    // advances immediately so the flow stays snappy.
-    callTool({ card_id: card.id, rating });
+    // The session advances immediately so the flow stays snappy; SM-2
+    // scheduling happens server-side. Failures surface as a session notice.
+    callTool(
+      { card_id: card.id, rating },
+      { onError: () => setFailedSaves((n) => n + 1) }
+    );
     setCounts((c) => ({ ...c, [rating]: c[rating] + 1 }));
     if (rating === "again") setAgainFronts((f) => [...f, card.front]);
     setFlipped(false);
     setIndex((i) => i + 1);
   };
 
-  const container: React.CSSProperties = {
-    fontFamily: "system-ui, -apple-system, sans-serif",
-    backgroundColor: colors.bg,
-    padding: 24,
-    maxWidth: 560,
-    margin: "0 auto",
-  };
+  const container = "mx-auto max-w-[560px] bg-zinc-50 p-6 font-sans dark:bg-zinc-950";
 
   if (cards.length === 0) {
     return (
       <McpUseProvider autoSize>
-        <div style={container}>
-          <div
-            style={{
-              backgroundColor: colors.surface,
-              border: `1px solid ${colors.border}`,
-              borderRadius: 12,
-              padding: 40,
-              textAlign: "center",
-            }}
-          >
-            <div style={{ fontSize: 32, marginBottom: 8 }}>🎉</div>
-            <p style={{ margin: 0, color: colors.text, fontWeight: 600, fontSize: 15 }}>
-              Deck clear — nothing due
-            </p>
-            <p style={{ margin: "6px 0 0", color: colors.textMuted, fontSize: 13 }}>
-              Ask the tutor to make flashcards from what you're studying.
-            </p>
+        <div className={dark ? "dark" : ""}>
+          <div className={container}>
+            <div className="rounded-xl border border-zinc-200 bg-white p-10 text-center dark:border-zinc-800 dark:bg-zinc-900">
+              <div className="mb-2 text-[32px]">🎉</div>
+              <p className="m-0 text-[15px] font-semibold text-zinc-900 dark:text-zinc-100">
+                Deck clear — nothing due
+              </p>
+              <p className="mt-1.5 mb-0 text-[13px] text-zinc-400 dark:text-zinc-500">
+                Ask the tutor to make flashcards from what you're studying.
+              </p>
+            </div>
           </div>
         </div>
       </McpUseProvider>
@@ -168,68 +135,43 @@ export default function Flashcards() {
         : ". All comfortable — what should I tackle next?");
     return (
       <McpUseProvider autoSize>
-        <div style={container}>
-          <div
-            style={{
-              backgroundColor: colors.surface,
-              border: `1px solid ${colors.border}`,
-              borderRadius: 12,
-              padding: 32,
-              textAlign: "center",
-            }}
-          >
-            <div style={{ fontSize: 32, marginBottom: 8 }}>
-              {counts.again > 0 ? "💪" : "🏆"}
-            </div>
-            <p style={{ margin: 0, color: colors.text, fontWeight: 700, fontSize: 16 }}>
-              Session done — {cards.length} card{cards.length === 1 ? "" : "s"} reviewed
-            </p>
-            <div
-              style={{
-                display: "flex",
-                gap: 8,
-                justifyContent: "center",
-                flexWrap: "wrap",
-                margin: "14px 0 4px",
-              }}
-            >
-              {RATING_META.map((r) => (
-                <span
-                  key={r.rating}
-                  style={{
-                    fontSize: 12,
-                    fontWeight: 600,
-                    padding: "4px 10px",
-                    borderRadius: 999,
-                    border: `1px solid ${ratingColor[r.rating]}`,
-                    color: ratingColor[r.rating],
-                  }}
-                >
-                  {r.label}: {counts[r.rating]}
-                </span>
-              ))}
-            </div>
-            {againFronts.length > 0 && (
-              <p style={{ margin: "10px 0 0", fontSize: 13, color: colors.textSecondary }}>
-                Tricky: {againFronts.join(" · ")}
+        <div className={dark ? "dark" : ""}>
+          <div className={container}>
+            <div className="rounded-xl border border-zinc-200 bg-white p-8 text-center dark:border-zinc-800 dark:bg-zinc-900">
+              <div className="mb-2 text-[32px]">
+                {counts.again > 0 ? "💪" : "🏆"}
+              </div>
+              <p className="m-0 text-base font-bold text-zinc-900 dark:text-zinc-100">
+                Session done — {cards.length} card{cards.length === 1 ? "" : "s"} reviewed
               </p>
-            )}
-            <button
-              onClick={() => sendFollowUpMessage(summary)}
-              style={{
-                marginTop: 18,
-                padding: "8px 16px",
-                fontSize: 13,
-                fontWeight: 600,
-                color: "#ffffff",
-                backgroundColor: colors.accent,
-                border: "none",
-                borderRadius: 8,
-                cursor: "pointer",
-              }}
-            >
-              {againFronts.length > 0 ? "Drill my misses" : "What's next?"}
-            </button>
+              <div className="mx-0 mt-3.5 mb-1 flex flex-wrap justify-center gap-2">
+                {RATING_META.map((r) => (
+                  <span
+                    key={r.rating}
+                    className={`rounded-full border px-2.5 py-1 text-xs font-semibold ${ratingColor[r.rating]}`}
+                  >
+                    {r.label}: {counts[r.rating]}
+                  </span>
+                ))}
+              </div>
+              {againFronts.length > 0 && (
+                <p className="mt-2.5 mb-0 text-[13px] text-zinc-500 dark:text-zinc-400">
+                  Tricky: {againFronts.join(" · ")}
+                </p>
+              )}
+              {failedSaves > 0 && (
+                <p className="mt-2.5 mb-0 text-xs text-red-600 dark:text-red-400">
+                  {failedSaves} rating{failedSaves === 1 ? "" : "s"} failed to save —
+                  those cards will stay due.
+                </p>
+              )}
+              <button
+                onClick={() => sendFollowUpMessage(summary)}
+                className="mt-4.5 cursor-pointer rounded-lg border-none bg-violet-600 px-4 py-2 text-[13px] font-semibold text-white dark:bg-violet-400"
+              >
+                {againFronts.length > 0 ? "Drill my misses" : "What's next?"}
+              </button>
+            </div>
           </div>
         </div>
       </McpUseProvider>
@@ -238,120 +180,90 @@ export default function Flashcards() {
 
   return (
     <McpUseProvider autoSize>
-      <div style={container}>
-        <div
-          style={{
-            display: "flex",
-            justifyContent: "space-between",
-            alignItems: "baseline",
-            marginBottom: 12,
-          }}
-        >
-          <span style={{ fontSize: 13, fontWeight: 600, color: colors.textSecondary }}>
-            Card {index + 1} of {cards.length}
-            {total_due > cards.length ? ` (${total_due} due)` : ""}
-          </span>
-          <span style={{ fontSize: 12, color: colors.textMuted }}>
-            {card.repetitions === 0
-              ? "new card"
-              : `seen ${card.repetitions}×, last interval ${card.interval_days}d`}
-          </span>
-        </div>
-
-        <div
-          style={{
-            height: 4,
-            borderRadius: 2,
-            backgroundColor: dark ? "#27272a" : "#f3f4f6",
-            overflow: "hidden",
-            marginBottom: 16,
-          }}
-        >
-          <div
-            style={{
-              width: `${Math.round((reviewed / cards.length) * 100)}%`,
-              height: "100%",
-              backgroundColor: colors.accent,
-              borderRadius: 2,
-            }}
-          />
-        </div>
-
-        <div
-          role="button"
-          tabIndex={0}
-          onClick={() => setFlipped((f) => !f)}
-          onKeyDown={(e) => {
-            if (e.key === " " || e.key === "Enter") {
-              e.preventDefault();
-              setFlipped((f) => !f);
-            }
-          }}
-          style={{
-            backgroundColor: colors.surface,
-            border: `1px solid ${flipped ? colors.accent : colors.border}`,
-            borderRadius: 12,
-            padding: "36px 28px",
-            minHeight: 120,
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-            justifyContent: "center",
-            textAlign: "center",
-            cursor: "pointer",
-            userSelect: "none",
-          }}
-        >
-          <span
-            style={{
-              fontSize: 11,
-              fontWeight: 700,
-              letterSpacing: 1,
-              textTransform: "uppercase",
-              color: flipped ? colors.accent : colors.textMuted,
-              marginBottom: 10,
-            }}
-          >
-            {flipped ? "Answer" : "Prompt"}
-          </span>
-          <span style={{ fontSize: 17, fontWeight: 600, color: colors.text, lineHeight: 1.45 }}>
-            {flipped ? card.back : card.front}
-          </span>
-          {!flipped && (
-            <span style={{ marginTop: 14, fontSize: 12, color: colors.textMuted }}>
-              Click or press space to reveal
+      <div className={dark ? "dark" : ""}>
+        <div className={container}>
+          <div className="mb-3 flex items-baseline justify-between">
+            <span className="text-[13px] font-semibold text-zinc-500 dark:text-zinc-400">
+              Card {index + 1} of {cards.length}
+              {total_due > cards.length ? ` (${total_due} due)` : ""}
             </span>
+            <span className="text-xs text-zinc-400 dark:text-zinc-500">
+              {card.repetitions === 0
+                ? "new card"
+                : `seen ${card.repetitions}×, last interval ${card.interval_days}d`}
+            </span>
+          </div>
+
+          <div className="mb-4 h-1 overflow-hidden rounded-full bg-zinc-100 dark:bg-zinc-800">
+            <div
+              className="h-full rounded-full bg-violet-600 dark:bg-violet-400"
+              style={{ width: `${Math.round((reviewed / cards.length) * 100)}%` }}
+            />
+          </div>
+
+          <div
+            role="button"
+            tabIndex={0}
+            onClick={() => setFlipped((f) => !f)}
+            onKeyDown={(e) => {
+              if (e.key === " " || e.key === "Enter") {
+                e.preventDefault();
+                setFlipped((f) => !f);
+              }
+            }}
+            className={`flex min-h-[120px] cursor-pointer flex-col items-center justify-center rounded-xl border bg-white px-7 py-9 text-center select-none dark:bg-zinc-900 ${
+              flipped
+                ? "border-violet-600 dark:border-violet-400"
+                : "border-zinc-200 dark:border-zinc-800"
+            }`}
+          >
+            <span
+              className={`mb-2.5 text-[11px] font-bold tracking-[1px] uppercase ${
+                flipped
+                  ? "text-violet-600 dark:text-violet-400"
+                  : "text-zinc-400 dark:text-zinc-500"
+              }`}
+            >
+              {flipped ? "Answer" : "Prompt"}
+            </span>
+            <div className="w-full text-left font-semibold break-words">
+              <Markdown
+                content={flipped ? card.back : card.front}
+                dark={dark}
+                fontSize={16}
+              />
+            </div>
+            {!flipped && (
+              <span className="mt-3.5 text-xs text-zinc-400 dark:text-zinc-500">
+                Click or press space to reveal
+              </span>
+            )}
+          </div>
+
+          {failedSaves > 0 && (
+            <p className="mt-2.5 mb-0 text-xs text-red-600 dark:text-red-400">
+              {failedSaves} rating{failedSaves === 1 ? "" : "s"} failed to save —
+              those cards will stay due.
+            </p>
+          )}
+
+          {flipped && (
+            <div className="mt-3.5 flex gap-2">
+              {RATING_META.map((r) => (
+                <button
+                  key={r.rating}
+                  onClick={() => rate(r.rating)}
+                  className={`flex-1 cursor-pointer rounded-lg border bg-transparent px-0 py-2.5 text-[13px] font-bold ${ratingColor[r.rating]}`}
+                >
+                  {r.label}
+                  {r.hint && (
+                    <span className="block text-[10px] font-medium">{r.hint}</span>
+                  )}
+                </button>
+              ))}
+            </div>
           )}
         </div>
-
-        {flipped && (
-          <div style={{ display: "flex", gap: 8, marginTop: 14 }}>
-            {RATING_META.map((r) => (
-              <button
-                key={r.rating}
-                onClick={() => rate(r.rating)}
-                style={{
-                  flex: 1,
-                  padding: "10px 0",
-                  fontSize: 13,
-                  fontWeight: 700,
-                  color: ratingColor[r.rating],
-                  backgroundColor: "transparent",
-                  border: `1px solid ${ratingColor[r.rating]}`,
-                  borderRadius: 8,
-                  cursor: "pointer",
-                }}
-              >
-                {r.label}
-                {r.hint && (
-                  <span style={{ display: "block", fontSize: 10, fontWeight: 500 }}>
-                    {r.hint}
-                  </span>
-                )}
-              </button>
-            ))}
-          </div>
-        )}
       </div>
     </McpUseProvider>
   );

--- a/mcp-server/resources/gamification-profile/widget.tsx
+++ b/mcp-server/resources/gamification-profile/widget.tsx
@@ -50,22 +50,19 @@ type Props = z.infer<typeof propsSchema>;
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
-function tierColor(
-  tier: string | null,
-  dark: boolean
-): { bg: string; text: string } {
+function tierClass(tier: string | null): string {
   switch ((tier ?? "").toLowerCase()) {
     case "gold":
-      return { bg: dark ? "#422006" : "#fef3c7", text: dark ? "#fcd34d" : "#92400e" };
+      return "bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300";
     case "silver":
-      return { bg: dark ? "#334155" : "#f1f5f9", text: dark ? "#cbd5e1" : "#475569" };
+      return "bg-slate-100 text-slate-600 dark:bg-slate-700 dark:text-slate-300";
     case "bronze":
-      return { bg: dark ? "#431407" : "#ffedd5", text: dark ? "#fdba74" : "#9a3412" };
+      return "bg-orange-100 text-orange-800 dark:bg-orange-950 dark:text-orange-300";
     case "platinum":
     case "diamond":
-      return { bg: dark ? "#164e63" : "#cffafe", text: dark ? "#67e8f9" : "#155e75" };
+      return "bg-cyan-100 text-cyan-800 dark:bg-cyan-900 dark:text-cyan-300";
     default:
-      return { bg: dark ? "#2e1065" : "#f5f3ff", text: dark ? "#a78bfa" : "#7c3aed" };
+      return "bg-violet-50 text-violet-600 dark:bg-violet-950 dark:text-violet-400";
   }
 }
 
@@ -82,43 +79,14 @@ export default function GamificationProfile() {
   const theme = useWidgetTheme();
   const dark = theme === "dark";
 
-  const colors = {
-    bg: dark ? "#0f0f0f" : "#fafafa",
-    surface: dark ? "#1a1a1a" : "#ffffff",
-    border: dark ? "#2a2a2a" : "#e5e7eb",
-    text: dark ? "#f4f4f5" : "#111827",
-    textSecondary: dark ? "#a1a1aa" : "#6b7280",
-    textMuted: dark ? "#71717a" : "#9ca3af",
-    accent: dark ? "#a78bfa" : "#7c3aed",
-    accentBg: dark ? "#2e1065" : "#f5f3ff",
-    track: dark ? "#27272a" : "#f4f4f5",
-  };
-
   if (isPending) {
     return (
       <McpUseProvider autoSize>
-        <div
-          style={{
-            padding: 40,
-            textAlign: "center",
-            color: colors.textMuted,
-            backgroundColor: colors.bg,
-            fontFamily: "system-ui, sans-serif",
-          }}
-        >
-          <div
-            style={{
-              width: 36,
-              height: 36,
-              border: `3px solid ${colors.border}`,
-              borderTop: `3px solid ${colors.accent}`,
-              borderRadius: "50%",
-              margin: "0 auto 12px",
-              animation: "spin 0.8s linear infinite",
-            }}
-          />
-          <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
-          <p style={{ margin: 0, fontSize: 14 }}>Loading your progress…</p>
+        <div className={dark ? "dark" : ""}>
+          <div className="bg-zinc-50 p-10 text-center font-sans text-zinc-400 dark:bg-zinc-950 dark:text-zinc-500">
+            <div className="mx-auto mb-3 size-9 animate-spin rounded-full border-[3px] border-zinc-200 border-t-violet-600 dark:border-zinc-800 dark:border-t-violet-400" />
+            <p className="m-0 text-sm">Loading your progress…</p>
+          </div>
         </div>
       </McpUseProvider>
     );
@@ -127,31 +95,17 @@ export default function GamificationProfile() {
   if (!props.has_profile) {
     return (
       <McpUseProvider autoSize>
-        <div
-          style={{
-            fontFamily: "system-ui, sans-serif",
-            backgroundColor: colors.bg,
-            padding: 24,
-            maxWidth: 680,
-            margin: "0 auto",
-          }}
-        >
-          <div
-            style={{
-              backgroundColor: colors.surface,
-              border: `1px solid ${colors.border}`,
-              borderRadius: 12,
-              padding: 40,
-              textAlign: "center",
-            }}
-          >
-            <div style={{ fontSize: 32, marginBottom: 8 }}>⚡</div>
-            <p style={{ margin: 0, color: colors.text, fontWeight: 600, fontSize: 15 }}>
-              No XP yet
-            </p>
-            <p style={{ margin: "6px 0 0", color: colors.textMuted, fontSize: 13 }}>
-              Complete a lesson to start earning XP and unlocking achievements.
-            </p>
+        <div className={dark ? "dark" : ""}>
+          <div className="mx-auto max-w-[680px] bg-zinc-50 p-6 font-sans dark:bg-zinc-950">
+            <div className="rounded-xl border border-zinc-200 bg-white p-10 text-center dark:border-zinc-800 dark:bg-zinc-900">
+              <div className="mb-2 text-[32px]">⚡</div>
+              <p className="m-0 text-[15px] font-semibold text-zinc-900 dark:text-zinc-100">
+                No XP yet
+              </p>
+              <p className="mt-1.5 mb-0 text-[13px] text-zinc-400 dark:text-zinc-500">
+                Complete a lesson to start earning XP and unlocking achievements.
+              </p>
+            </div>
           </div>
         </div>
       </McpUseProvider>
@@ -180,263 +134,114 @@ export default function GamificationProfile() {
 
   return (
     <McpUseProvider autoSize>
-      <div
-        style={{
-          fontFamily: "system-ui, -apple-system, sans-serif",
-          backgroundColor: colors.bg,
-          padding: 24,
-          maxWidth: 680,
-          margin: "0 auto",
-        }}
-      >
-        {/* Level hero */}
-        <div
-          style={{
-            backgroundColor: colors.surface,
-            border: `1px solid ${colors.border}`,
-            borderRadius: 12,
-            padding: 20,
-            marginBottom: 14,
-          }}
-        >
-          <div
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: 14,
-              marginBottom: 14,
-            }}
-          >
-            <div
-              style={{
-                width: 52,
-                height: 52,
-                borderRadius: 14,
-                backgroundColor: colors.accentBg,
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-                fontSize: 26,
-                flexShrink: 0,
-              }}
-            >
-              {props.level_icon ?? "⭐"}
+      <div className={dark ? "dark" : ""}>
+        <div className="mx-auto max-w-[680px] bg-zinc-50 p-6 font-sans dark:bg-zinc-950">
+          {/* Level hero */}
+          <div className="mb-3.5 rounded-xl border border-zinc-200 bg-white p-5 dark:border-zinc-800 dark:bg-zinc-900">
+            <div className="mb-3.5 flex items-center gap-3.5">
+              <div className="flex size-[52px] shrink-0 items-center justify-center rounded-[14px] bg-violet-50 text-[26px] dark:bg-violet-950">
+                {props.level_icon ?? "⭐"}
+              </div>
+              <div className="min-w-0">
+                <div className="text-lg font-bold tracking-tight text-zinc-900 dark:text-zinc-100">
+                  Level {props.level}
+                  {props.level_title ? ` · ${props.level_title}` : ""}
+                </div>
+                <div className="mt-0.5 text-[13px] text-zinc-500 dark:text-zinc-400">
+                  {props.total_xp.toLocaleString()} XP total
+                </div>
+              </div>
             </div>
-            <div style={{ minWidth: 0 }}>
+
+            {/* XP progress to next level */}
+            <div className="h-2.5 overflow-hidden rounded-full bg-zinc-100 dark:bg-zinc-800">
               <div
-                style={{
-                  fontSize: 18,
-                  fontWeight: 750,
-                  color: colors.text,
-                  letterSpacing: "-0.02em",
-                }}
-              >
-                Level {props.level}
-                {props.level_title ? ` · ${props.level_title}` : ""}
-              </div>
-              <div style={{ fontSize: 13, color: colors.textSecondary, marginTop: 2 }}>
-                {props.total_xp.toLocaleString()} XP total
-              </div>
+                className="h-full rounded-full bg-violet-600 transition-[width] duration-400 ease-out dark:bg-violet-400"
+                style={{ width: `${levelPct}%` }}
+              />
+            </div>
+            <div className="mt-1.5 flex justify-between text-xs text-zinc-400 dark:text-zinc-500">
+              {props.next_level && props.xp_needed !== null ? (
+                <>
+                  <span>
+                    {props.xp_needed.toLocaleString()} XP to level{" "}
+                    {props.next_level.level}
+                  </span>
+                  <span className="tabular-nums">{levelPct}%</span>
+                </>
+              ) : (
+                <span>Max level reached 🎉</span>
+              )}
             </div>
           </div>
 
-          {/* XP progress to next level */}
-          <div
-            style={{
-              height: 10,
-              borderRadius: 999,
-              backgroundColor: colors.track,
-              overflow: "hidden",
-            }}
-          >
-            <div
-              style={{
-                height: "100%",
-                width: `${levelPct}%`,
-                borderRadius: 999,
-                backgroundColor: colors.accent,
-                transition: "width 0.4s ease",
-              }}
-            />
+          {/* Stat tiles */}
+          <div className="mb-3.5 grid grid-cols-[repeat(auto-fit,minmax(130px,1fr))] gap-2.5">
+            {stats.map((s) => (
+              <div
+                key={s.label}
+                className="rounded-xl border border-zinc-200 bg-white px-3.5 py-3 dark:border-zinc-800 dark:bg-zinc-900"
+              >
+                <div className="text-lg">{s.icon}</div>
+                <div className="mt-1 text-base font-bold tabular-nums text-zinc-900 dark:text-zinc-100">
+                  {s.value}
+                </div>
+                <div className="mt-px text-[11.5px] text-zinc-400 dark:text-zinc-500">
+                  {s.label}
+                </div>
+              </div>
+            ))}
           </div>
-          <div
-            style={{
-              marginTop: 6,
-              fontSize: 12,
-              color: colors.textMuted,
-              display: "flex",
-              justifyContent: "space-between",
-            }}
-          >
-            {props.next_level && props.xp_needed !== null ? (
-              <>
-                <span>
-                  {props.xp_needed.toLocaleString()} XP to level{" "}
-                  {props.next_level.level}
-                </span>
-                <span style={{ fontVariantNumeric: "tabular-nums" }}>{levelPct}%</span>
-              </>
+
+          {/* Achievements */}
+          <div className="overflow-hidden rounded-xl border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
+            <div className="border-b border-zinc-200 px-4 py-3 dark:border-zinc-800">
+              <span className="text-[13px] font-semibold text-zinc-900 dark:text-zinc-100">
+                Achievements ({props.achievements.length})
+              </span>
+            </div>
+
+            {props.achievements.length === 0 ? (
+              <div className="p-6 text-center text-[13px] text-zinc-400 dark:text-zinc-500">
+                No achievements earned yet — keep learning!
+              </div>
             ) : (
-              <span>Max level reached 🎉</span>
-            )}
-          </div>
-        </div>
-
-        {/* Stat tiles */}
-        <div
-          style={{
-            display: "grid",
-            gridTemplateColumns: "repeat(auto-fit, minmax(130px, 1fr))",
-            gap: 10,
-            marginBottom: 14,
-          }}
-        >
-          {stats.map((s) => (
-            <div
-              key={s.label}
-              style={{
-                backgroundColor: colors.surface,
-                border: `1px solid ${colors.border}`,
-                borderRadius: 12,
-                padding: "12px 14px",
-              }}
-            >
-              <div style={{ fontSize: 18 }}>{s.icon}</div>
-              <div
-                style={{
-                  fontSize: 16,
-                  fontWeight: 750,
-                  color: colors.text,
-                  marginTop: 4,
-                  fontVariantNumeric: "tabular-nums",
-                }}
-              >
-                {s.value}
-              </div>
-              <div style={{ fontSize: 11.5, color: colors.textMuted, marginTop: 1 }}>
-                {s.label}
-              </div>
-            </div>
-          ))}
-        </div>
-
-        {/* Achievements */}
-        <div
-          style={{
-            backgroundColor: colors.surface,
-            border: `1px solid ${colors.border}`,
-            borderRadius: 12,
-            overflow: "hidden",
-          }}
-        >
-          <div
-            style={{
-              padding: "12px 16px",
-              borderBottom: `1px solid ${colors.border}`,
-            }}
-          >
-            <span style={{ fontSize: 13, fontWeight: 600, color: colors.text }}>
-              Achievements ({props.achievements.length})
-            </span>
-          </div>
-
-          {props.achievements.length === 0 ? (
-            <div
-              style={{
-                padding: 24,
-                textAlign: "center",
-                color: colors.textMuted,
-                fontSize: 13,
-              }}
-            >
-              No achievements earned yet — keep learning!
-            </div>
-          ) : (
-            <div
-              style={{
-                display: "grid",
-                gridTemplateColumns: "repeat(auto-fill, minmax(210px, 1fr))",
-                gap: 10,
-                padding: 14,
-              }}
-            >
-              {props.achievements.map((a) => {
-                const tier = tierColor(a.tier, dark);
-                return (
+              <div className="grid grid-cols-[repeat(auto-fill,minmax(210px,1fr))] gap-2.5 p-3.5">
+                {props.achievements.map((a) => (
                   <div
                     key={a.slug + a.earned_at}
-                    style={{
-                      border: `1px solid ${colors.border}`,
-                      borderRadius: 10,
-                      padding: 12,
-                    }}
+                    className="rounded-[10px] border border-zinc-200 p-3 dark:border-zinc-800"
                   >
-                    <div
-                      style={{
-                        display: "flex",
-                        alignItems: "center",
-                        gap: 8,
-                        marginBottom: 6,
-                      }}
-                    >
-                      <span style={{ fontSize: 20 }}>{a.icon ?? "🏅"}</span>
-                      <span
-                        style={{
-                          fontSize: 13,
-                          fontWeight: 650,
-                          color: colors.text,
-                          lineHeight: 1.25,
-                        }}
-                      >
+                    <div className="mb-1.5 flex items-center gap-2">
+                      <span className="text-xl">{a.icon ?? "🏅"}</span>
+                      <span className="text-[13px] leading-tight font-semibold text-zinc-900 dark:text-zinc-100">
                         {a.title}
                       </span>
                     </div>
                     {a.description && (
-                      <div
-                        style={{
-                          fontSize: 11.5,
-                          color: colors.textMuted,
-                          lineHeight: 1.45,
-                          marginBottom: 8,
-                        }}
-                      >
+                      <div className="mb-2 text-[11.5px] leading-[1.45] text-zinc-400 dark:text-zinc-500">
                         {a.description}
                       </div>
                     )}
-                    <div
-                      style={{
-                        display: "flex",
-                        alignItems: "center",
-                        justifyContent: "space-between",
-                        gap: 6,
-                      }}
-                    >
+                    <div className="flex items-center justify-between gap-1.5">
                       {a.tier ? (
                         <span
-                          style={{
-                            padding: "2px 8px",
-                            borderRadius: 8,
-                            fontSize: 10.5,
-                            fontWeight: 700,
-                            textTransform: "capitalize",
-                            backgroundColor: tier.bg,
-                            color: tier.text,
-                          }}
+                          className={`rounded-lg px-2 py-0.5 text-[10.5px] font-bold capitalize ${tierClass(a.tier)}`}
                         >
                           {a.tier}
                         </span>
                       ) : (
                         <span />
                       )}
-                      <span style={{ fontSize: 11, color: colors.textMuted }}>
+                      <span className="text-[11px] text-zinc-400 dark:text-zinc-500">
                         {formatDate(a.earned_at)}
                       </span>
                     </div>
                   </div>
-                );
-              })}
-            </div>
-          )}
+                ))}
+              </div>
+            )}
+          </div>
         </div>
       </div>
     </McpUseProvider>

--- a/mcp-server/resources/lesson-preview/widget.tsx
+++ b/mcp-server/resources/lesson-preview/widget.tsx
@@ -5,6 +5,7 @@ import {
   type WidgetMetadata,
 } from "mcp-use/react";
 import { z } from "zod";
+import { Markdown } from "../shared/markdown";
 
 // ── Schema ──────────────────────────────────────────────────────────────────
 
@@ -44,18 +45,14 @@ type Props = z.infer<typeof propsSchema>;
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
-function statusPill(
-  status: string,
-  theme: "light" | "dark"
-): { bg: string; text: string } {
-  const dark = theme === "dark";
+function statusPill(status: string): string {
   switch (status.toLowerCase()) {
     case "published":
-      return { bg: dark ? "#14532d" : "#dcfce7", text: dark ? "#86efac" : "#166534" };
+      return "bg-green-100 text-green-600 dark:bg-green-900 dark:text-green-400";
     case "draft":
-      return { bg: dark ? "#3f3f46" : "#f4f4f5", text: dark ? "#a1a1aa" : "#52525b" };
+      return "bg-zinc-100 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400";
     default:
-      return { bg: dark ? "#422006" : "#fef3c7", text: dark ? "#fcd34d" : "#92400e" };
+      return "bg-amber-100 text-amber-600 dark:bg-amber-950 dark:text-amber-400";
   }
 }
 
@@ -127,336 +124,128 @@ export default function LessonPreview() {
 
   const dark = theme === "dark";
 
-  const colors = {
-    bg: dark ? "#0f0f0f" : "#fafafa",
-    surface: dark ? "#1a1a1a" : "#ffffff",
-    border: dark ? "#2a2a2a" : "#e5e7eb",
-    text: dark ? "#f4f4f5" : "#111827",
-    textSecondary: dark ? "#a1a1aa" : "#6b7280",
-    textMuted: dark ? "#71717a" : "#9ca3af",
-    accent: dark ? "#a78bfa" : "#7c3aed",
-    accentBg: dark ? "#2e1065" : "#f5f3ff",
-    codeBg: dark ? "#141414" : "#f8f7ff",
-    codeBorder: dark ? "#2a2a2a" : "#ede9fe",
-    contentText: dark ? "#d4d4d8" : "#1f2937",
-    videoBg: dark ? "#18181b" : "#f0f9ff",
-    videoBorder: dark ? "#1e3a5f" : "#bae6fd",
-    videoText: dark ? "#38bdf8" : "#0369a1",
-    resBg: dark ? "#141414" : "#fafafa",
-    resHover: dark ? "#222" : "#f3f4f6",
-  };
-
   if (isPending) {
     return (
       <McpUseProvider autoSize>
-        <div
-          style={{
-            padding: 40,
-            textAlign: "center",
-            color: colors.textMuted,
-            backgroundColor: colors.bg,
-            fontFamily: "system-ui, sans-serif",
-          }}
-        >
-          <div
-            style={{
-              width: 36,
-              height: 36,
-              border: `3px solid ${colors.border}`,
-              borderTop: `3px solid ${colors.accent}`,
-              borderRadius: "50%",
-              margin: "0 auto 12px",
-              animation: "spin 0.8s linear infinite",
-            }}
-          />
-          <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
-          <p style={{ margin: 0, fontSize: 14 }}>Loading lesson…</p>
+        <div className={dark ? "dark" : ""}>
+          <div className="bg-zinc-50 p-10 text-center font-sans text-zinc-400 dark:bg-zinc-950 dark:text-zinc-500">
+            <div className="mx-auto mb-3 size-9 animate-spin rounded-full border-[3px] border-zinc-200 border-t-violet-600 dark:border-zinc-800 dark:border-t-violet-400" />
+            <p className="m-0 text-sm">Loading lesson…</p>
+          </div>
         </div>
       </McpUseProvider>
     );
   }
 
   const { lesson, resources } = props;
-  const pill = statusPill(lesson.status, theme);
 
   return (
     <McpUseProvider autoSize>
-      <div
-        style={{
-          fontFamily: "system-ui, -apple-system, sans-serif",
-          backgroundColor: colors.bg,
-          padding: 24,
-          maxWidth: 760,
-          margin: "0 auto",
-        }}
-      >
-        {/* Lesson header */}
-        <div style={{ marginBottom: 20 }}>
-          {/* Breadcrumb-ish sequence + status */}
-          <div
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: 8,
-              marginBottom: 10,
-            }}
-          >
-            <span
-              style={{
-                padding: "2px 8px",
-                borderRadius: 8,
-                fontSize: 11,
-                fontWeight: 700,
-                backgroundColor: colors.accentBg,
-                color: colors.accent,
-              }}
-            >
-              Lesson {lesson.sequence}
-            </span>
-            <span
-              style={{
-                padding: "2px 8px",
-                borderRadius: 8,
-                fontSize: 11,
-                fontWeight: 600,
-                backgroundColor: pill.bg,
-                color: pill.text,
-              }}
-            >
-              {lesson.status}
-            </span>
+      <div className={dark ? "dark" : ""}>
+        <div className="mx-auto max-w-[760px] bg-zinc-50 p-6 font-sans dark:bg-zinc-950">
+          {/* Lesson header */}
+          <div className="mb-5">
+            {/* Breadcrumb-ish sequence + status */}
+            <div className="mb-2.5 flex items-center gap-2">
+              <span className="rounded-lg bg-violet-50 px-2 py-0.5 text-[11px] font-bold text-violet-600 dark:bg-violet-950 dark:text-violet-400">
+                Lesson {lesson.sequence}
+              </span>
+              <span
+                className={`rounded-lg px-2 py-0.5 text-[11px] font-semibold ${statusPill(
+                  lesson.status
+                )}`}
+              >
+                {lesson.status}
+              </span>
+            </div>
+
+            <h1 className="m-0 text-2xl leading-tight font-bold tracking-tight text-zinc-900 dark:text-zinc-100">
+              {lesson.title}
+            </h1>
+
+            {lesson.description && (
+              <p className="mt-2.5 mb-0 text-[15px] leading-relaxed text-zinc-500 dark:text-zinc-400">
+                {lesson.description}
+              </p>
+            )}
           </div>
 
-          <h1
-            style={{
-              margin: 0,
-              fontSize: 24,
-              fontWeight: 700,
-              color: colors.text,
-              letterSpacing: "-0.02em",
-              lineHeight: 1.25,
-            }}
-          >
-            {lesson.title}
-          </h1>
-
-          {lesson.description && (
-            <p
-              style={{
-                margin: "10px 0 0",
-                fontSize: 15,
-                color: colors.textSecondary,
-                lineHeight: 1.6,
-              }}
-            >
-              {lesson.description}
-            </p>
-          )}
-        </div>
-
-        {/* Video link */}
-        {lesson.video_url && (
-          <div
-            style={{
-              marginBottom: 20,
-              padding: "12px 16px",
-              borderRadius: 10,
-              backgroundColor: colors.videoBg,
-              border: `1px solid ${colors.videoBorder}`,
-              display: "flex",
-              alignItems: "center",
-              gap: 10,
-            }}
-          >
-            <span style={{ fontSize: 20 }}>▶️</span>
-            <div>
-              <div
-                style={{
-                  fontSize: 12,
-                  fontWeight: 600,
-                  color: colors.textMuted,
-                  textTransform: "uppercase",
-                  letterSpacing: "0.05em",
-                  marginBottom: 2,
-                }}
-              >
-                Video lesson
+          {/* Video link */}
+          {lesson.video_url && (
+            <div className="mb-5 flex items-center gap-2.5 rounded-[10px] border border-sky-200 bg-sky-50 px-4 py-3 dark:border-sky-900 dark:bg-sky-950">
+              <span className="text-xl">▶️</span>
+              <div>
+                <div className="mb-0.5 text-xs font-semibold tracking-wider text-zinc-400 uppercase dark:text-zinc-500">
+                  Video lesson
+                </div>
+                <a
+                  href={lesson.video_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-[13px] font-medium break-all text-sky-700 no-underline dark:text-sky-400"
+                >
+                  {lesson.video_url}
+                </a>
               </div>
-              <a
-                href={lesson.video_url}
-                target="_blank"
-                rel="noopener noreferrer"
-                style={{
-                  fontSize: 13,
-                  color: colors.videoText,
-                  fontWeight: 500,
-                  textDecoration: "none",
-                  wordBreak: "break-all",
-                }}
-              >
-                {lesson.video_url}
-              </a>
             </div>
-          </div>
-        )}
+          )}
 
-        {/* Content reading pane */}
-        {lesson.content ? (
-          <div
-            style={{
-              backgroundColor: colors.surface,
-              border: `1px solid ${colors.border}`,
-              borderRadius: 12,
-              padding: 20,
-              marginBottom: 20,
-            }}
-          >
-            <div
-              style={{
-                fontSize: 11,
-                fontWeight: 700,
-                color: colors.textMuted,
-                textTransform: "uppercase",
-                letterSpacing: "0.06em",
-                marginBottom: 12,
-              }}
-            >
-              Content (preview)
-            </div>
-            <pre
-              style={{
-                margin: 0,
-                padding: 16,
-                borderRadius: 8,
-                backgroundColor: colors.codeBg,
-                border: `1px solid ${colors.codeBorder}`,
-                fontSize: 13.5,
-                lineHeight: 1.7,
-                color: colors.contentText,
-                whiteSpace: "pre-wrap",
-                wordBreak: "break-word",
-                fontFamily:
-                  '"Noto Sans", "Georgia", ui-serif, serif',
-                overflowX: "auto",
-              }}
-            >
-              {lesson.content}
-            </pre>
-          </div>
-        ) : (
-          <div
-            style={{
-              backgroundColor: colors.surface,
-              border: `1px solid ${colors.border}`,
-              borderRadius: 12,
-              padding: 32,
-              textAlign: "center",
-              color: colors.textMuted,
-              marginBottom: 20,
-              fontSize: 13,
-            }}
-          >
-            No written content for this lesson.
-          </div>
-        )}
-
-        {/* Attached resources */}
-        <div
-          style={{
-            backgroundColor: colors.surface,
-            border: `1px solid ${colors.border}`,
-            borderRadius: 12,
-            overflow: "hidden",
-          }}
-        >
-          <div
-            style={{
-              padding: "12px 16px",
-              borderBottom: `1px solid ${colors.border}`,
-              backgroundColor: colors.resBg,
-            }}
-          >
-            <span
-              style={{
-                fontSize: 13,
-                fontWeight: 600,
-                color: colors.text,
-              }}
-            >
-              Attached resources ({resources.length})
-            </span>
-          </div>
-
-          {resources.length === 0 ? (
-            <div
-              style={{
-                padding: 24,
-                textAlign: "center",
-                color: colors.textMuted,
-                fontSize: 13,
-              }}
-            >
-              No files attached to this lesson.
+          {/* Content reading pane */}
+          {lesson.content ? (
+            <div className="mb-5 rounded-xl border border-zinc-200 bg-white p-5 dark:border-zinc-800 dark:bg-zinc-900">
+              <div className="mb-3 text-[11px] font-bold tracking-[0.06em] text-zinc-400 uppercase dark:text-zinc-500">
+                Content (preview)
+              </div>
+              <Markdown content={lesson.content} dark={dark} fontSize={14} />
             </div>
           ) : (
-            <div>
-              {resources.map((res, idx) => (
-                <div
-                  key={res.id}
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    gap: 12,
-                    padding: "11px 16px",
-                    borderBottom:
-                      idx === resources.length - 1
-                        ? "none"
-                        : `1px solid ${colors.border}`,
-                    transition: "background-color 0.1s",
-                  }}
-                  onMouseEnter={(e) => {
-                    (e.currentTarget as HTMLDivElement).style.backgroundColor =
-                      colors.resHover;
-                  }}
-                  onMouseLeave={(e) => {
-                    (e.currentTarget as HTMLDivElement).style.backgroundColor =
-                      "transparent";
-                  }}
-                >
-                  <span style={{ fontSize: 20, flexShrink: 0 }}>
-                    {fileIcon(res.mime_type)}
-                  </span>
-                  <div style={{ flex: 1, minWidth: 0 }}>
-                    <div
-                      style={{
-                        fontSize: 13,
-                        fontWeight: 500,
-                        color: colors.text,
-                        overflow: "hidden",
-                        textOverflow: "ellipsis",
-                        whiteSpace: "nowrap",
-                      }}
-                    >
-                      {res.file_name}
-                    </div>
-                    <div style={{ fontSize: 11, color: colors.textMuted, marginTop: 1 }}>
-                      {humanMime(res.mime_type)}
-                    </div>
-                  </div>
-                  <span
-                    style={{
-                      fontSize: 12,
-                      color: colors.textMuted,
-                      flexShrink: 0,
-                      fontVariantNumeric: "tabular-nums",
-                    }}
-                  >
-                    {humanFileSize(res.file_size)}
-                  </span>
-                </div>
-              ))}
+            <div className="mb-5 rounded-xl border border-zinc-200 bg-white p-8 text-center text-[13px] text-zinc-400 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-500">
+              No written content for this lesson.
             </div>
           )}
+
+          {/* Attached resources */}
+          <div className="overflow-hidden rounded-xl border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
+            <div className="border-b border-zinc-200 bg-zinc-50 px-4 py-3 dark:border-zinc-800 dark:bg-zinc-950">
+              <span className="text-[13px] font-semibold text-zinc-900 dark:text-zinc-100">
+                Attached resources ({resources.length})
+              </span>
+            </div>
+
+            {resources.length === 0 ? (
+              <div className="p-6 text-center text-[13px] text-zinc-400 dark:text-zinc-500">
+                No files attached to this lesson.
+              </div>
+            ) : (
+              <div>
+                {resources.map((res, idx) => (
+                  <div
+                    key={res.id}
+                    className={`flex items-center gap-3 px-4 py-[11px] transition-colors duration-100 hover:bg-zinc-100 dark:hover:bg-zinc-800 ${
+                      idx === resources.length - 1
+                        ? ""
+                        : "border-b border-zinc-200 dark:border-zinc-800"
+                    }`}
+                  >
+                    <span className="shrink-0 text-xl">
+                      {fileIcon(res.mime_type)}
+                    </span>
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-[13px] font-medium text-zinc-900 dark:text-zinc-100">
+                        {res.file_name}
+                      </div>
+                      <div className="mt-px text-[11px] text-zinc-400 dark:text-zinc-500">
+                        {humanMime(res.mime_type)}
+                      </div>
+                    </div>
+                    <span className="shrink-0 text-xs text-zinc-400 tabular-nums dark:text-zinc-500">
+                      {humanFileSize(res.file_size)}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
         </div>
       </div>
     </McpUseProvider>

--- a/mcp-server/resources/lesson-viewer/widget.tsx
+++ b/mcp-server/resources/lesson-viewer/widget.tsx
@@ -7,6 +7,7 @@ import {
   type WidgetMetadata,
 } from "mcp-use/react";
 import { z } from "zod";
+import { Markdown } from "../shared/markdown";
 
 // ── Schema ──────────────────────────────────────────────────────────────────
 
@@ -60,54 +61,15 @@ export default function LessonViewer() {
   const [askedTutor, setAskedTutor] = useState(false);
 
   const dark = theme === "dark";
-  const colors = {
-    bg: dark ? "#0f0f0f" : "#fafafa",
-    surface: dark ? "#1a1a1a" : "#ffffff",
-    border: dark ? "#2a2a2a" : "#e5e7eb",
-    text: dark ? "#f4f4f5" : "#111827",
-    textSecondary: dark ? "#a1a1aa" : "#6b7280",
-    textMuted: dark ? "#71717a" : "#9ca3af",
-    accent: dark ? "#a78bfa" : "#7c3aed",
-    accentBg: dark ? "#2e1065" : "#f5f3ff",
-    codeBg: dark ? "#141414" : "#f8f7ff",
-    codeBorder: dark ? "#2a2a2a" : "#ede9fe",
-    contentText: dark ? "#d4d4d8" : "#1f2937",
-    videoBg: dark ? "#18181b" : "#f0f9ff",
-    videoBorder: dark ? "#1e3a5f" : "#bae6fd",
-    videoText: dark ? "#38bdf8" : "#0369a1",
-    done: dark ? "#4ade80" : "#16a34a",
-    doneBg: dark ? "#14532d" : "#dcfce7",
-    lockBg: dark ? "#422006" : "#fef3c7",
-    lockText: dark ? "#fcd34d" : "#92400e",
-    errBg: dark ? "#450a0a" : "#fef2f2",
-    errText: dark ? "#fca5a5" : "#b91c1c",
-  };
 
   if (isPending) {
     return (
       <McpUseProvider autoSize>
-        <div
-          style={{
-            padding: 40,
-            textAlign: "center",
-            color: colors.textMuted,
-            backgroundColor: colors.bg,
-            fontFamily: "system-ui, sans-serif",
-          }}
-        >
-          <div
-            style={{
-              width: 36,
-              height: 36,
-              border: `3px solid ${colors.border}`,
-              borderTop: `3px solid ${colors.accent}`,
-              borderRadius: "50%",
-              margin: "0 auto 12px",
-              animation: "spin 0.8s linear infinite",
-            }}
-          />
-          <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
-          <p style={{ margin: 0, fontSize: 14 }}>Opening lesson…</p>
+        <div className={dark ? "dark" : ""}>
+          <div className="bg-zinc-50 p-10 text-center font-sans text-zinc-400 dark:bg-zinc-950 dark:text-zinc-500">
+            <div className="mx-auto mb-3 size-9 animate-spin rounded-full border-[3px] border-zinc-200 border-t-violet-600 dark:border-zinc-800 dark:border-t-violet-400" />
+            <p className="m-0 text-sm">Opening lesson…</p>
+          </div>
         </div>
       </McpUseProvider>
     );
@@ -125,290 +87,125 @@ export default function LessonViewer() {
 
   return (
     <McpUseProvider autoSize>
-      <div
-        style={{
-          fontFamily: "system-ui, -apple-system, sans-serif",
-          backgroundColor: colors.bg,
-          padding: 24,
-          maxWidth: 760,
-          margin: "0 auto",
-        }}
-      >
-        {/* Header */}
-        <div style={{ marginBottom: 18 }}>
-          <div
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: 8,
-              marginBottom: 10,
-              flexWrap: "wrap",
-            }}
-          >
-            <span
-              style={{
-                padding: "2px 8px",
-                borderRadius: 8,
-                fontSize: 11,
-                fontWeight: 700,
-                backgroundColor: colors.accentBg,
-                color: colors.accent,
-              }}
-            >
-              Lesson {lesson.sequence}
-            </span>
-            <span style={{ fontSize: 12, color: colors.textMuted }}>
-              {course_title}
-            </span>
-            {completed && (
-              <span
-                style={{
-                  padding: "2px 8px",
-                  borderRadius: 8,
-                  fontSize: 11,
-                  fontWeight: 700,
-                  backgroundColor: colors.doneBg,
-                  color: colors.done,
-                }}
-              >
-                ✓ Completed
+      <div className={dark ? "dark" : ""}>
+        <div className="mx-auto max-w-[760px] bg-zinc-50 p-6 font-sans dark:bg-zinc-950">
+          {/* Header */}
+          <div className="mb-[18px]">
+            <div className="mb-2.5 flex flex-wrap items-center gap-2">
+              <span className="rounded-lg bg-violet-50 px-2 py-0.5 text-[11px] font-bold text-violet-600 dark:bg-violet-950 dark:text-violet-400">
+                Lesson {lesson.sequence}
               </span>
-            )}
-          </div>
-
-          <h1
-            style={{
-              margin: 0,
-              fontSize: 24,
-              fontWeight: 700,
-              color: colors.text,
-              letterSpacing: "-0.02em",
-              lineHeight: 1.25,
-            }}
-          >
-            {lesson.title}
-          </h1>
-
-          {lesson.description && (
-            <p
-              style={{
-                margin: "10px 0 0",
-                fontSize: 15,
-                color: colors.textSecondary,
-                lineHeight: 1.6,
-              }}
-            >
-              {lesson.description}
-            </p>
-          )}
-        </div>
-
-        {locked ? (
-          <div
-            style={{
-              backgroundColor: colors.lockBg,
-              borderRadius: 12,
-              padding: 28,
-              textAlign: "center",
-              marginBottom: 20,
-            }}
-          >
-            <div style={{ fontSize: 28, marginBottom: 8 }}>🔒</div>
-            <p
-              style={{
-                margin: 0,
-                fontWeight: 650,
-                fontSize: 14,
-                color: colors.lockText,
-              }}
-            >
-              This lesson is locked
-            </p>
-            <p style={{ margin: "6px 0 0", fontSize: 13, color: colors.lockText }}>
-              Complete{locked_by ? ` "${locked_by.title}"` : " the previous lesson"}{" "}
-              first — this course requires sequential completion.
-            </p>
-          </div>
-        ) : (
-          <>
-            {/* Video link */}
-            {lesson.video_url && (
-              <div
-                style={{
-                  marginBottom: 20,
-                  padding: "12px 16px",
-                  borderRadius: 10,
-                  backgroundColor: colors.videoBg,
-                  border: `1px solid ${colors.videoBorder}`,
-                  display: "flex",
-                  alignItems: "center",
-                  gap: 10,
-                }}
-              >
-                <span style={{ fontSize: 20 }}>▶️</span>
-                <div style={{ minWidth: 0 }}>
-                  <div
-                    style={{
-                      fontSize: 12,
-                      fontWeight: 600,
-                      color: colors.textMuted,
-                      textTransform: "uppercase",
-                      letterSpacing: "0.05em",
-                      marginBottom: 2,
-                    }}
-                  >
-                    Video lesson
-                  </div>
-                  <a
-                    href={lesson.video_url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    style={{
-                      fontSize: 13,
-                      color: colors.videoText,
-                      fontWeight: 500,
-                      textDecoration: "none",
-                      wordBreak: "break-all",
-                    }}
-                  >
-                    {lesson.video_url}
-                  </a>
-                </div>
-              </div>
-            )}
-
-            {/* Content */}
-            {lesson.content ? (
-              <div
-                style={{
-                  backgroundColor: colors.surface,
-                  border: `1px solid ${colors.border}`,
-                  borderRadius: 12,
-                  padding: 20,
-                  marginBottom: 20,
-                }}
-              >
-                <pre
-                  style={{
-                    margin: 0,
-                    padding: 16,
-                    borderRadius: 8,
-                    backgroundColor: colors.codeBg,
-                    border: `1px solid ${colors.codeBorder}`,
-                    fontSize: 13.5,
-                    lineHeight: 1.7,
-                    color: colors.contentText,
-                    whiteSpace: "pre-wrap",
-                    wordBreak: "break-word",
-                    fontFamily: '"Noto Sans", "Georgia", ui-serif, serif',
-                    overflowX: "auto",
-                  }}
-                >
-                  {lesson.content}
-                </pre>
-              </div>
-            ) : (
-              <div
-                style={{
-                  backgroundColor: colors.surface,
-                  border: `1px solid ${colors.border}`,
-                  borderRadius: 12,
-                  padding: 32,
-                  textAlign: "center",
-                  color: colors.textMuted,
-                  marginBottom: 20,
-                  fontSize: 13,
-                }}
-              >
-                No written content for this lesson
-                {lesson.video_url ? " — watch the video above." : "."}
-              </div>
-            )}
-
-            {/* Error from mark-complete */}
-            {isError && (
-              <div
-                style={{
-                  backgroundColor: colors.errBg,
-                  color: colors.errText,
-                  borderRadius: 10,
-                  padding: "10px 14px",
-                  fontSize: 13,
-                  marginBottom: 14,
-                }}
-              >
-                {error instanceof Error
-                  ? error.message
-                  : "Could not mark the lesson complete."}
-              </div>
-            )}
-
-            {/* Mark complete + tutor entry */}
-            <div
-              style={{
-                display: "flex",
-                justifyContent: "flex-end",
-                gap: 10,
-                flexWrap: "wrap",
-              }}
-            >
-              <button
-                onClick={() => {
-                  if (askedTutor) return;
-                  setAskedTutor(true);
-                  sendFollowUpMessage(
-                    `I'm reading lesson ${lesson.sequence} "${lesson.title}" of "${course_title}" (lesson_id ${lesson.id}) and I don't fully understand it. Tutor me on it Socratically: use the socratic-tutor approach, don't just give answers, and quiz me at the end with lms_practice_quiz.`
-                  );
-                }}
-                disabled={askedTutor}
-                style={{
-                  padding: "9px 18px",
-                  borderRadius: 10,
-                  fontSize: 13.5,
-                  fontWeight: 650,
-                  cursor: askedTutor ? "default" : "pointer",
-                  backgroundColor: "transparent",
-                  color: askedTutor ? colors.done : colors.accent,
-                  border: `1.5px solid ${askedTutor ? colors.done : colors.accent}`,
-                }}
-              >
-                {askedTutor ? "Asked the tutor ✓" : "I don't understand this 🙋"}
-              </button>
-              {completed ? (
-                <span
-                  style={{
-                    padding: "9px 18px",
-                    borderRadius: 10,
-                    fontSize: 13.5,
-                    fontWeight: 650,
-                    backgroundColor: colors.doneBg,
-                    color: colors.done,
-                  }}
-                >
-                  ✓ Lesson completed
+              <span className="text-xs text-zinc-400 dark:text-zinc-500">
+                {course_title}
+              </span>
+              {completed && (
+                <span className="rounded-lg bg-green-100 px-2 py-0.5 text-[11px] font-bold text-green-600 dark:bg-green-900 dark:text-green-400">
+                  ✓ Completed
                 </span>
-              ) : (
-                <button
-                  onClick={handleComplete}
-                  disabled={isCompleting}
-                  style={{
-                    padding: "9px 18px",
-                    borderRadius: 10,
-                    fontSize: 13.5,
-                    fontWeight: 650,
-                    border: "none",
-                    cursor: isCompleting ? "wait" : "pointer",
-                    backgroundColor: colors.accent,
-                    color: "#ffffff",
-                    opacity: isCompleting ? 0.7 : 1,
-                  }}
-                >
-                  {isCompleting ? "Marking…" : "Mark lesson complete"}
-                </button>
               )}
             </div>
-          </>
-        )}
+
+            <h1 className="m-0 text-2xl leading-tight font-bold tracking-tight text-zinc-900 dark:text-zinc-100">
+              {lesson.title}
+            </h1>
+
+            {lesson.description && (
+              <p className="mt-2.5 mb-0 text-[15px] leading-relaxed text-zinc-500 dark:text-zinc-400">
+                {lesson.description}
+              </p>
+            )}
+          </div>
+
+          {locked ? (
+            <div className="mb-5 rounded-xl bg-amber-100 p-7 text-center dark:bg-amber-950">
+              <div className="mb-2 text-[28px]">🔒</div>
+              <p className="m-0 text-sm font-semibold text-amber-800 dark:text-amber-300">
+                This lesson is locked
+              </p>
+              <p className="mt-1.5 mb-0 text-[13px] text-amber-800 dark:text-amber-300">
+                Complete{locked_by ? ` "${locked_by.title}"` : " the previous lesson"}{" "}
+                first — this course requires sequential completion.
+              </p>
+            </div>
+          ) : (
+            <>
+              {/* Video link */}
+              {lesson.video_url && (
+                <div className="mb-5 flex items-center gap-2.5 rounded-[10px] border border-sky-200 bg-sky-50 px-4 py-3 dark:border-sky-900 dark:bg-sky-950">
+                  <span className="text-xl">▶️</span>
+                  <div className="min-w-0">
+                    <div className="mb-0.5 text-xs font-semibold tracking-wider text-zinc-400 uppercase dark:text-zinc-500">
+                      Video lesson
+                    </div>
+                    <a
+                      href={lesson.video_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-[13px] font-medium break-all text-sky-700 no-underline dark:text-sky-400"
+                    >
+                      {lesson.video_url}
+                    </a>
+                  </div>
+                </div>
+              )}
+
+              {/* Content */}
+              {lesson.content ? (
+                <div className="mb-5 rounded-xl border border-zinc-200 bg-white p-5 dark:border-zinc-800 dark:bg-zinc-900">
+                  <Markdown content={lesson.content} dark={dark} fontSize={14} />
+                </div>
+              ) : (
+                <div className="mb-5 rounded-xl border border-zinc-200 bg-white p-8 text-center text-[13px] text-zinc-400 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-500">
+                  No written content for this lesson
+                  {lesson.video_url ? " — watch the video above." : "."}
+                </div>
+              )}
+
+              {/* Error from mark-complete */}
+              {isError && (
+                <div className="mb-3.5 rounded-[10px] bg-red-50 px-3.5 py-2.5 text-[13px] text-red-700 dark:bg-red-950 dark:text-red-400">
+                  {error instanceof Error
+                    ? error.message
+                    : "Could not mark the lesson complete."}
+                </div>
+              )}
+
+              {/* Mark complete + tutor entry */}
+              <div className="flex flex-wrap justify-end gap-2.5">
+                <button
+                  onClick={() => {
+                    if (askedTutor) return;
+                    setAskedTutor(true);
+                    sendFollowUpMessage(
+                      `I'm reading lesson ${lesson.sequence} "${lesson.title}" of "${course_title}" (lesson_id ${lesson.id}) and I don't fully understand it. Tutor me on it Socratically: use the socratic-tutor approach, don't just give answers, and quiz me at the end with lms_practice_quiz.`
+                    );
+                  }}
+                  disabled={askedTutor}
+                  className={`cursor-pointer rounded-[10px] border-[1.5px] bg-transparent px-[18px] py-[9px] text-[13.5px] font-semibold disabled:cursor-default ${
+                    askedTutor
+                      ? "border-green-600 text-green-600 dark:border-green-400 dark:text-green-400"
+                      : "border-violet-600 text-violet-600 dark:border-violet-400 dark:text-violet-400"
+                  }`}
+                >
+                  {askedTutor ? "Asked the tutor ✓" : "I don't understand this 🙋"}
+                </button>
+                {completed ? (
+                  <span className="rounded-[10px] bg-green-100 px-[18px] py-[9px] text-[13.5px] font-semibold text-green-600 dark:bg-green-900 dark:text-green-400">
+                    ✓ Lesson completed
+                  </span>
+                ) : (
+                  <button
+                    onClick={handleComplete}
+                    disabled={isCompleting}
+                    className="cursor-pointer rounded-[10px] border-none bg-violet-600 px-[18px] py-[9px] text-[13.5px] font-semibold text-white disabled:cursor-wait disabled:opacity-70 dark:bg-violet-400"
+                  >
+                    {isCompleting ? "Marking…" : "Mark lesson complete"}
+                  </button>
+                )}
+              </div>
+            </>
+          )}
+        </div>
       </div>
     </McpUseProvider>
   );

--- a/mcp-server/resources/my-exam-results/widget.tsx
+++ b/mcp-server/resources/my-exam-results/widget.tsx
@@ -6,6 +6,7 @@ import {
   type WidgetMetadata,
 } from "mcp-use/react";
 import { z } from "zod";
+import { Markdown } from "../shared/markdown";
 
 // ── Schema ──────────────────────────────────────────────────────────────────
 
@@ -61,48 +62,15 @@ export default function MyExamResults() {
   const [expanded, setExpanded] = useState<Set<number>>(new Set());
 
   const dark = theme === "dark";
-  const colors = {
-    bg: dark ? "#0f0f0f" : "#fafafa",
-    surface: dark ? "#1a1a1a" : "#ffffff",
-    border: dark ? "#2a2a2a" : "#e5e7eb",
-    text: dark ? "#f4f4f5" : "#111827",
-    textSecondary: dark ? "#a1a1aa" : "#6b7280",
-    textMuted: dark ? "#71717a" : "#9ca3af",
-    accent: dark ? "#a78bfa" : "#7c3aed",
-    pass: dark ? "#4ade80" : "#16a34a",
-    passBg: dark ? "#14532d" : "#dcfce7",
-    fail: dark ? "#f87171" : "#dc2626",
-    failBg: dark ? "#450a0a" : "#fee2e2",
-    pendingBg: dark ? "#3f3f46" : "#f4f4f5",
-    pendingText: dark ? "#a1a1aa" : "#52525b",
-    feedbackBg: dark ? "#141414" : "#f8f7ff",
-  };
 
   if (isPending) {
     return (
       <McpUseProvider autoSize>
-        <div
-          style={{
-            padding: 40,
-            textAlign: "center",
-            color: colors.textMuted,
-            backgroundColor: colors.bg,
-            fontFamily: "system-ui, sans-serif",
-          }}
-        >
-          <div
-            style={{
-              width: 36,
-              height: 36,
-              border: `3px solid ${colors.border}`,
-              borderTop: `3px solid ${colors.accent}`,
-              borderRadius: "50%",
-              margin: "0 auto 12px",
-              animation: "spin 0.8s linear infinite",
-            }}
-          />
-          <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
-          <p style={{ margin: 0, fontSize: 14 }}>Loading your exam results…</p>
+        <div className={dark ? "dark" : ""}>
+          <div className="bg-zinc-50 p-10 text-center font-sans text-zinc-400 dark:bg-zinc-950 dark:text-zinc-500">
+            <div className="mx-auto mb-3 size-9 animate-spin rounded-full border-[3px] border-zinc-200 border-t-violet-600 dark:border-zinc-800 dark:border-t-violet-400" />
+            <p className="m-0 text-sm">Loading your exam results…</p>
+          </div>
         </div>
       </McpUseProvider>
     );
@@ -121,181 +89,102 @@ export default function MyExamResults() {
 
   return (
     <McpUseProvider autoSize>
-      <div
-        style={{
-          fontFamily: "system-ui, -apple-system, sans-serif",
-          backgroundColor: colors.bg,
-          padding: 24,
-          maxWidth: 760,
-          margin: "0 auto",
-        }}
-      >
-        <div
-          style={{
-            display: "flex",
-            alignItems: "baseline",
-            justifyContent: "space-between",
-            marginBottom: 18,
-            flexWrap: "wrap",
-            gap: 8,
-          }}
-        >
-          <h1
-            style={{
-              margin: 0,
-              fontSize: 22,
-              fontWeight: 700,
-              color: colors.text,
-              letterSpacing: "-0.02em",
-            }}
-          >
-            My Exam Results
-          </h1>
-          <span style={{ fontSize: 13, color: colors.textSecondary }}>
-            {total} submission{total === 1 ? "" : "s"}
-            {average_score !== null ? ` · ${average_score} avg score` : ""}
-          </span>
-        </div>
-
-        {results.length === 0 ? (
-          <div
-            style={{
-              backgroundColor: colors.surface,
-              border: `1px solid ${colors.border}`,
-              borderRadius: 12,
-              padding: 40,
-              textAlign: "center",
-            }}
-          >
-            <div style={{ fontSize: 32, marginBottom: 8 }}>📝</div>
-            <p style={{ margin: 0, color: colors.text, fontWeight: 600, fontSize: 15 }}>
-              No exam submissions yet
-            </p>
-            <p style={{ margin: "6px 0 0", color: colors.textMuted, fontSize: 13 }}>
-              Your scores and feedback will appear here after you take an exam.
-            </p>
+      <div className={dark ? "dark" : ""}>
+        <div className="mx-auto max-w-[760px] bg-zinc-50 p-6 font-sans dark:bg-zinc-950">
+          <div className="mb-[18px] flex flex-wrap items-baseline justify-between gap-2">
+            <h1 className="m-0 text-[22px] font-bold tracking-tight text-zinc-900 dark:text-zinc-100">
+              My Exam Results
+            </h1>
+            <span className="text-[13px] text-zinc-500 dark:text-zinc-400">
+              {total} submission{total === 1 ? "" : "s"}
+              {average_score !== null
+                ? ` · ${Math.round(average_score)} avg score`
+                : ""}
+            </span>
           </div>
-        ) : (
-          <div
-            style={{
-              backgroundColor: colors.surface,
-              border: `1px solid ${colors.border}`,
-              borderRadius: 12,
-              overflow: "hidden",
-            }}
-          >
-            {results.map((r, idx) => {
-              const graded = r.score !== null;
-              const passed = graded && (r.score ?? 0) >= PASS_THRESHOLD;
-              const isOpen = expanded.has(r.submission_id);
-              return (
-                <div
-                  key={r.submission_id}
-                  style={{
-                    borderBottom:
-                      idx === results.length - 1
-                        ? "none"
-                        : `1px solid ${colors.border}`,
-                  }}
-                >
+
+          {results.length === 0 ? (
+            <div className="rounded-xl border border-zinc-200 bg-white p-10 text-center dark:border-zinc-800 dark:bg-zinc-900">
+              <div className="mb-2 text-3xl">📝</div>
+              <p className="m-0 text-[15px] font-semibold text-zinc-900 dark:text-zinc-100">
+                No exam submissions yet
+              </p>
+              <p className="mt-1.5 mb-0 text-[13px] text-zinc-400 dark:text-zinc-500">
+                Your scores and feedback will appear here after you take an exam.
+              </p>
+            </div>
+          ) : (
+            <div className="overflow-hidden rounded-xl border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
+              {results.map((r, idx) => {
+                const graded = r.score !== null;
+                const passed = graded && (r.score ?? 0) >= PASS_THRESHOLD;
+                const isOpen = expanded.has(r.submission_id);
+                return (
                   <div
-                    style={{
-                      display: "flex",
-                      alignItems: "center",
-                      gap: 12,
-                      padding: "13px 16px",
-                      cursor: r.feedback ? "pointer" : "default",
-                    }}
-                    onClick={() => r.feedback && toggle(r.submission_id)}
+                    key={r.submission_id}
+                    className={
+                      idx === results.length - 1
+                        ? ""
+                        : "border-b border-zinc-200 dark:border-zinc-800"
+                    }
                   >
-                    {/* Score badge */}
-                    <span
-                      style={{
-                        flexShrink: 0,
-                        minWidth: 46,
-                        textAlign: "center",
-                        padding: "5px 8px",
-                        borderRadius: 10,
-                        fontSize: 14,
-                        fontWeight: 750,
-                        fontVariantNumeric: "tabular-nums",
-                        backgroundColor: graded
-                          ? passed
-                            ? colors.passBg
-                            : colors.failBg
-                          : colors.pendingBg,
-                        color: graded
-                          ? passed
-                            ? colors.pass
-                            : colors.fail
-                          : colors.pendingText,
+                    <div
+                      role={r.feedback ? "button" : undefined}
+                      tabIndex={r.feedback ? 0 : undefined}
+                      aria-expanded={r.feedback ? isOpen : undefined}
+                      className={`flex items-center gap-3 px-4 py-[13px] ${
+                        r.feedback ? "cursor-pointer" : "cursor-default"
+                      }`}
+                      onClick={() => r.feedback && toggle(r.submission_id)}
+                      onKeyDown={(e) => {
+                        if (r.feedback && (e.key === "Enter" || e.key === " ")) {
+                          e.preventDefault();
+                          toggle(r.submission_id);
+                        }
                       }}
                     >
-                      {graded ? Math.round(r.score ?? 0) : "—"}
-                    </span>
+                      {/* Score badge */}
+                      <span
+                        className={`min-w-[46px] shrink-0 rounded-[10px] px-2 py-[5px] text-center text-sm font-bold tabular-nums ${
+                          graded
+                            ? passed
+                              ? "bg-green-100 text-green-600 dark:bg-green-900 dark:text-green-400"
+                              : "bg-red-100 text-red-600 dark:bg-red-950 dark:text-red-400"
+                            : "bg-zinc-100 text-zinc-500 dark:bg-zinc-700 dark:text-zinc-400"
+                        }`}
+                      >
+                        {graded ? Math.round(r.score ?? 0) : "—"}
+                      </span>
 
-                    <div style={{ flex: 1, minWidth: 0 }}>
-                      <div
-                        style={{
-                          fontSize: 14,
-                          fontWeight: 600,
-                          color: colors.text,
-                          overflow: "hidden",
-                          textOverflow: "ellipsis",
-                          whiteSpace: "nowrap",
-                        }}
-                      >
-                        {r.exam_title}
+                      <div className="min-w-0 flex-1">
+                        <div className="overflow-hidden text-sm font-semibold text-ellipsis whitespace-nowrap text-zinc-900 dark:text-zinc-100">
+                          {r.exam_title}
+                        </div>
+                        <div className="mt-0.5 text-xs text-zinc-400 dark:text-zinc-500">
+                          {r.course_title ? `${r.course_title} · ` : ""}
+                          {formatDate(r.submitted_at)}
+                          {r.review_status ? ` · ${r.review_status}` : ""}
+                        </div>
                       </div>
-                      <div
-                        style={{
-                          fontSize: 12,
-                          color: colors.textMuted,
-                          marginTop: 2,
-                        }}
-                      >
-                        {r.course_title ? `${r.course_title} · ` : ""}
-                        {formatDate(r.submitted_at)}
-                        {r.review_status ? ` · ${r.review_status}` : ""}
-                      </div>
+
+                      {r.feedback && (
+                        <span className="shrink-0 text-xs font-semibold text-violet-600 dark:text-violet-400">
+                          {isOpen ? "Hide feedback ▲" : "Feedback ▼"}
+                        </span>
+                      )}
                     </div>
 
-                    {r.feedback && (
-                      <span
-                        style={{
-                          flexShrink: 0,
-                          fontSize: 12,
-                          color: colors.accent,
-                          fontWeight: 600,
-                        }}
-                      >
-                        {isOpen ? "Hide feedback ▲" : "Feedback ▼"}
-                      </span>
+                    {isOpen && r.feedback && (
+                      <div className="mr-4 mb-[13px] ml-[74px] rounded-[10px] border border-zinc-200 bg-violet-50 px-3.5 py-2.5 text-[13px] leading-relaxed text-zinc-500 dark:border-zinc-800 dark:bg-violet-950 dark:text-zinc-400">
+                        <Markdown content={r.feedback} dark={dark} fontSize={13} />
+                      </div>
                     )}
                   </div>
-
-                  {isOpen && r.feedback && (
-                    <div
-                      style={{
-                        margin: "0 16px 13px 74px",
-                        padding: "10px 14px",
-                        borderRadius: 10,
-                        backgroundColor: colors.feedbackBg,
-                        border: `1px solid ${colors.border}`,
-                        fontSize: 13,
-                        lineHeight: 1.6,
-                        color: colors.textSecondary,
-                        whiteSpace: "pre-wrap",
-                      }}
-                    >
-                      {r.feedback}
-                    </div>
-                  )}
-                </div>
-              );
-            })}
-          </div>
-        )}
+                );
+              })}
+            </div>
+          )}
+        </div>
       </div>
     </McpUseProvider>
   );

--- a/mcp-server/resources/my-learning/widget.tsx
+++ b/mcp-server/resources/my-learning/widget.tsx
@@ -52,45 +52,14 @@ export default function MyLearning() {
   const theme = useWidgetTheme();
   const dark = theme === "dark";
 
-  const colors = {
-    bg: dark ? "#0f0f0f" : "#fafafa",
-    surface: dark ? "#1a1a1a" : "#ffffff",
-    border: dark ? "#2a2a2a" : "#e5e7eb",
-    text: dark ? "#f4f4f5" : "#111827",
-    textSecondary: dark ? "#a1a1aa" : "#6b7280",
-    textMuted: dark ? "#71717a" : "#9ca3af",
-    accent: dark ? "#a78bfa" : "#7c3aed",
-    accentBg: dark ? "#2e1065" : "#f5f3ff",
-    track: dark ? "#27272a" : "#f4f4f5",
-    done: dark ? "#4ade80" : "#16a34a",
-    doneBg: dark ? "#14532d" : "#dcfce7",
-  };
-
   if (isPending) {
     return (
       <McpUseProvider autoSize>
-        <div
-          style={{
-            padding: 40,
-            textAlign: "center",
-            color: colors.textMuted,
-            backgroundColor: colors.bg,
-            fontFamily: "system-ui, sans-serif",
-          }}
-        >
-          <div
-            style={{
-              width: 36,
-              height: 36,
-              border: `3px solid ${colors.border}`,
-              borderTop: `3px solid ${colors.accent}`,
-              borderRadius: "50%",
-              margin: "0 auto 12px",
-              animation: "spin 0.8s linear infinite",
-            }}
-          />
-          <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
-          <p style={{ margin: 0, fontSize: 14 }}>Loading your courses…</p>
+        <div className={dark ? "dark" : ""}>
+          <div className="bg-zinc-50 p-10 text-center font-sans text-zinc-400 dark:bg-zinc-950 dark:text-zinc-500">
+            <div className="mx-auto mb-3 size-9 animate-spin rounded-full border-[3px] border-zinc-200 border-t-violet-600 dark:border-zinc-800 dark:border-t-violet-400" />
+            <p className="m-0 text-sm">Loading your courses…</p>
+          </div>
         </div>
       </McpUseProvider>
     );
@@ -100,191 +69,94 @@ export default function MyLearning() {
 
   return (
     <McpUseProvider autoSize>
-      <div
-        style={{
-          fontFamily: "system-ui, -apple-system, sans-serif",
-          backgroundColor: colors.bg,
-          padding: 24,
-          maxWidth: 760,
-          margin: "0 auto",
-        }}
-      >
-        {/* Header */}
-        <div
-          style={{
-            display: "flex",
-            alignItems: "baseline",
-            justifyContent: "space-between",
-            marginBottom: 18,
-            flexWrap: "wrap",
-            gap: 8,
-          }}
-        >
-          <h1
-            style={{
-              margin: 0,
-              fontSize: 22,
-              fontWeight: 700,
-              color: colors.text,
-              letterSpacing: "-0.02em",
-            }}
-          >
-            My Learning
-          </h1>
-          <span style={{ fontSize: 13, color: colors.textSecondary }}>
-            {total} course{total === 1 ? "" : "s"} · {average_progress}% average
-            progress
-          </span>
-        </div>
-
-        {courses.length === 0 ? (
-          <div
-            style={{
-              backgroundColor: colors.surface,
-              border: `1px solid ${colors.border}`,
-              borderRadius: 12,
-              padding: 40,
-              textAlign: "center",
-            }}
-          >
-            <div style={{ fontSize: 32, marginBottom: 8 }}>🎓</div>
-            <p style={{ margin: 0, color: colors.text, fontWeight: 600, fontSize: 15 }}>
-              No enrolled courses yet
-            </p>
-            <p style={{ margin: "6px 0 0", color: colors.textMuted, fontSize: 13 }}>
-              Browse the catalog to find your first course.
-            </p>
+      <div className={dark ? "dark" : ""}>
+        <div className="mx-auto max-w-3xl bg-zinc-50 p-6 font-sans dark:bg-zinc-950">
+          {/* Header */}
+          <div className="mb-4 flex flex-wrap items-baseline justify-between gap-2">
+            <h1 className="m-0 text-[22px] font-bold tracking-tight text-zinc-900 dark:text-zinc-100">
+              My Learning
+            </h1>
+            <span className="text-[13px] text-zinc-500 dark:text-zinc-400">
+              {total} course{total === 1 ? "" : "s"} · {average_progress}%
+              average progress
+            </span>
           </div>
-        ) : (
-          <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-            {courses.map((course) => {
-              const done = course.progress >= 100;
-              return (
-                <div
-                  key={course.id}
-                  style={{
-                    backgroundColor: colors.surface,
-                    border: `1px solid ${colors.border}`,
-                    borderRadius: 12,
-                    padding: 16,
-                  }}
-                >
+
+          {courses.length === 0 ? (
+            <div className="rounded-xl border border-zinc-200 bg-white p-10 text-center dark:border-zinc-800 dark:bg-zinc-900">
+              <div className="mb-2 text-3xl">🎓</div>
+              <p className="m-0 text-[15px] font-semibold text-zinc-900 dark:text-zinc-100">
+                No enrolled courses yet
+              </p>
+              <p className="mt-1.5 mb-0 text-[13px] text-zinc-400 dark:text-zinc-500">
+                Browse the catalog to find your first course.
+              </p>
+            </div>
+          ) : (
+            <div className="flex flex-col gap-3">
+              {courses.map((course) => {
+                const done = course.progress >= 100;
+                return (
                   <div
-                    style={{
-                      display: "flex",
-                      justifyContent: "space-between",
-                      alignItems: "flex-start",
-                      gap: 12,
-                      marginBottom: 8,
-                    }}
+                    key={course.id}
+                    className="rounded-xl border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900"
                   >
-                    <div style={{ minWidth: 0 }}>
-                      <div
-                        style={{
-                          fontSize: 15,
-                          fontWeight: 650,
-                          color: colors.text,
-                          lineHeight: 1.3,
-                        }}
-                      >
-                        {course.title}
-                      </div>
-                      {course.description && (
-                        <div
-                          style={{
-                            fontSize: 12.5,
-                            color: colors.textMuted,
-                            marginTop: 3,
-                            display: "-webkit-box",
-                            WebkitLineClamp: 2,
-                            WebkitBoxOrient: "vertical",
-                            overflow: "hidden",
-                          }}
-                        >
-                          {course.description}
+                    <div className="mb-2 flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <div className="text-[15px] leading-snug font-semibold text-zinc-900 dark:text-zinc-100">
+                          {course.title}
                         </div>
-                      )}
+                        {course.description && (
+                          <div className="mt-1 line-clamp-2 text-[12.5px] text-zinc-400 dark:text-zinc-500">
+                            {course.description}
+                          </div>
+                        )}
+                      </div>
+                      <span
+                        className={`shrink-0 rounded-full px-2.5 py-0.5 text-xs font-bold tabular-nums ${
+                          done
+                            ? "bg-green-100 text-green-600 dark:bg-green-900 dark:text-green-400"
+                            : "bg-violet-50 text-violet-600 dark:bg-violet-950 dark:text-violet-400"
+                        }`}
+                      >
+                        {course.progress}%
+                      </span>
                     </div>
-                    <span
-                      style={{
-                        flexShrink: 0,
-                        padding: "3px 10px",
-                        borderRadius: 999,
-                        fontSize: 12,
-                        fontWeight: 700,
-                        backgroundColor: done ? colors.doneBg : colors.accentBg,
-                        color: done ? colors.done : colors.accent,
-                        fontVariantNumeric: "tabular-nums",
-                      }}
-                    >
-                      {course.progress}%
-                    </span>
-                  </div>
 
-                  {/* Progress bar */}
-                  <div
-                    style={{
-                      height: 8,
-                      borderRadius: 999,
-                      backgroundColor: colors.track,
-                      overflow: "hidden",
-                      marginBottom: 10,
-                    }}
-                  >
-                    <div
-                      style={{
-                        height: "100%",
-                        width: `${Math.min(course.progress, 100)}%`,
-                        borderRadius: 999,
-                        backgroundColor: done ? colors.done : colors.accent,
-                        transition: "width 0.4s ease",
-                      }}
-                    />
-                  </div>
+                    {/* Progress bar */}
+                    <div className="mb-2.5 h-2 overflow-hidden rounded-full bg-zinc-100 dark:bg-zinc-800">
+                      <div
+                        className={`h-full rounded-full transition-[width] duration-400 ease-out ${
+                          done
+                            ? "bg-green-600 dark:bg-green-400"
+                            : "bg-violet-600 dark:bg-violet-400"
+                        }`}
+                        style={{ width: `${Math.min(course.progress, 100)}%` }}
+                      />
+                    </div>
 
-                  <div
-                    style={{
-                      display: "flex",
-                      justifyContent: "space-between",
-                      alignItems: "center",
-                      gap: 12,
-                      flexWrap: "wrap",
-                    }}
-                  >
-                    <span style={{ fontSize: 12, color: colors.textSecondary }}>
-                      {course.lessons_completed}/{course.lessons_total} lessons
-                      completed
-                    </span>
-                    {done ? (
-                      <span
-                        style={{
-                          fontSize: 12,
-                          fontWeight: 600,
-                          color: colors.done,
-                        }}
-                      >
-                        ✓ Course complete
+                    <div className="flex flex-wrap items-center justify-between gap-3">
+                      <span className="text-xs text-zinc-500 dark:text-zinc-400">
+                        {course.lessons_completed}/{course.lessons_total} lessons
+                        completed
                       </span>
-                    ) : course.next_lesson ? (
-                      <span
-                        style={{
-                          fontSize: 12,
-                          color: colors.textSecondary,
-                          backgroundColor: colors.track,
-                          borderRadius: 8,
-                          padding: "3px 8px",
-                        }}
-                      >
-                        Next: Lesson {course.next_lesson.sequence} ·{" "}
-                        {course.next_lesson.title}
-                      </span>
-                    ) : null}
+                      {done ? (
+                        <span className="text-xs font-semibold text-green-600 dark:text-green-400">
+                          ✓ Course complete
+                        </span>
+                      ) : course.next_lesson ? (
+                        <span className="rounded-lg bg-zinc-100 px-2 py-0.5 text-xs text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">
+                          Next: Lesson {course.next_lesson.sequence} ·{" "}
+                          {course.next_lesson.title}
+                        </span>
+                      ) : null}
+                    </div>
                   </div>
-                </div>
-              );
-            })}
-          </div>
-        )}
+                );
+              })}
+            </div>
+          )}
+        </div>
       </div>
     </McpUseProvider>
   );

--- a/mcp-server/resources/practice-player/widget.tsx
+++ b/mcp-server/resources/practice-player/widget.tsx
@@ -136,6 +136,26 @@ function shuffled<T>(items: T[]): T[] {
   return out;
 }
 
+// ── Shared class helpers ─────────────────────────────────────────────────────
+
+const containerClass =
+  "mx-auto max-w-[680px] bg-zinc-50 p-6 font-sans dark:bg-zinc-950";
+
+/** Choice/option button. `layout` lets true/false + match variants override
+ *  the default block/full-width/left-aligned shape without class conflicts. */
+const choiceClass = (selected: boolean, layout = "block w-full text-left") =>
+  `mb-2 cursor-pointer rounded-[10px] border-[1.5px] px-3.5 py-2.5 text-sm text-zinc-900 dark:text-zinc-100 ${layout} ${
+    selected
+      ? "border-violet-600 bg-violet-50 font-semibold dark:border-violet-400 dark:bg-violet-950"
+      : "border-zinc-200 bg-white font-normal dark:border-zinc-800 dark:bg-zinc-900"
+  }`;
+
+const primaryBtnClass =
+  "cursor-pointer rounded-[10px] border-none bg-violet-600 px-4.5 py-[9px] text-[13.5px] font-semibold text-white dark:bg-violet-400";
+
+const inputClass =
+  "box-border w-full rounded-[10px] border-[1.5px] border-zinc-200 bg-white px-3 py-2.5 text-sm text-zinc-900 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-100";
+
 // ── Component ────────────────────────────────────────────────────────────────
 
 export default function PracticePlayer() {
@@ -153,21 +173,6 @@ export default function PracticePlayer() {
   const [pendingLeft, setPendingLeft] = useState<string | null>(null);
 
   const dark = theme === "dark";
-  const colors = {
-    bg: dark ? "#0f0f0f" : "#fafafa",
-    surface: dark ? "#1a1a1a" : "#ffffff",
-    border: dark ? "#2a2a2a" : "#e5e7eb",
-    text: dark ? "#f4f4f5" : "#111827",
-    textSecondary: dark ? "#a1a1aa" : "#6b7280",
-    textMuted: dark ? "#71717a" : "#9ca3af",
-    accent: dark ? "#a78bfa" : "#7c3aed",
-    accentBg: dark ? "#2e1065" : "#f5f3ff",
-    done: dark ? "#4ade80" : "#16a34a",
-    doneBg: dark ? "#14532d" : "#dcfce7",
-    wrong: dark ? "#fca5a5" : "#b91c1c",
-    wrongBg: dark ? "#450a0a" : "#fef2f2",
-    inputBg: dark ? "#141414" : "#ffffff",
-  };
 
   const shuffledRights = useMemo(
     () =>
@@ -191,22 +196,30 @@ export default function PracticePlayer() {
   if (isPending) {
     return (
       <McpUseProvider autoSize>
-        <div
-          style={{
-            padding: 40,
-            textAlign: "center",
-            color: colors.textMuted,
-            backgroundColor: colors.bg,
-            fontFamily: "system-ui, sans-serif",
-          }}
-        >
-          Setting up practice…
+        <div className={dark ? "dark" : ""}>
+          <div className="bg-zinc-50 p-10 text-center font-sans text-zinc-400 dark:bg-zinc-950 dark:text-zinc-500">
+            Setting up practice…
+          </div>
         </div>
       </McpUseProvider>
     );
   }
 
   const { topic, questions } = props;
+
+  if (questions.length === 0) {
+    return (
+      <McpUseProvider autoSize>
+        <div className={dark ? "dark" : ""}>
+          <div className="bg-zinc-50 p-10 text-center font-sans text-sm text-zinc-400 dark:bg-zinc-950 dark:text-zinc-500">
+            No practice questions could be generated for “{topic}”. Ask the
+            tutor to try a different topic or lesson.
+          </div>
+        </div>
+      </McpUseProvider>
+    );
+  }
+
   const q = questions[index];
   const answer = answers[q?.id];
   const hasFreeText = questions.some((x) => x.type === "free_text");
@@ -266,7 +279,9 @@ export default function PracticePlayer() {
     const correctCount = closed.filter((x) =>
       isCorrect(x, effectiveAnswer(x))
     ).length;
-    const score = Math.round((correctCount / closed.length) * 100);
+    const score = closed.length
+      ? Math.round((correctCount / closed.length) * 100)
+      : 0;
     const missed = results.filter((r) => r.correct === false);
 
     recordAttempt(
@@ -297,32 +312,6 @@ export default function PracticePlayer() {
     );
   };
 
-  // ── Shared small styles ────────────────────────────────────────────────────
-  const choiceStyle = (selected: boolean): React.CSSProperties => ({
-    display: "block",
-    width: "100%",
-    textAlign: "left",
-    padding: "10px 14px",
-    marginBottom: 8,
-    borderRadius: 10,
-    fontSize: 14,
-    cursor: "pointer",
-    border: `1.5px solid ${selected ? colors.accent : colors.border}`,
-    backgroundColor: selected ? colors.accentBg : colors.surface,
-    color: colors.text,
-    fontWeight: selected ? 650 : 400,
-  });
-  const primaryBtn: React.CSSProperties = {
-    padding: "9px 18px",
-    borderRadius: 10,
-    fontSize: 13.5,
-    fontWeight: 650,
-    border: "none",
-    cursor: "pointer",
-    backgroundColor: colors.accent,
-    color: "#ffffff",
-  };
-
   // ── Results screen ─────────────────────────────────────────────────────────
   if (phase === "results") {
     const results = questions.map((x) => ({
@@ -334,55 +323,43 @@ export default function PracticePlayer() {
 
     return (
       <McpUseProvider autoSize>
-        <div
-          style={{
-            fontFamily: "system-ui, -apple-system, sans-serif",
-            backgroundColor: colors.bg,
-            padding: 24,
-            maxWidth: 680,
-            margin: "0 auto",
-          }}
-        >
-          <h2 style={{ margin: "0 0 4px", fontSize: 20, color: colors.text }}>
-            {hasFreeText ? "Answers sent" : `${correctCount}/${closedTotal} correct`}
-          </h2>
-          <p style={{ margin: "0 0 16px", fontSize: 13, color: colors.textSecondary }}>
-            {topic}
-            {hasFreeText
-              ? " — your free-text answers went to the tutor for grading."
-              : isRecording
-                ? " — recording your attempt…"
-                : " — attempt recorded. The tutor will pick it up from here."}
-          </p>
-          {results.map(({ q: rq, correct }) => (
-            <div
-              key={rq.id}
-              style={{
-                backgroundColor:
+        <div className={dark ? "dark" : ""}>
+          <div className={containerClass}>
+            <h2 className="m-0 mb-1 text-xl text-zinc-900 dark:text-zinc-100">
+              {hasFreeText ? "Answers sent" : `${correctCount}/${closedTotal} correct`}
+            </h2>
+            <p className="m-0 mb-4 text-[13px] text-zinc-500 dark:text-zinc-400">
+              {topic}
+              {hasFreeText
+                ? " — your free-text answers went to the tutor for grading."
+                : isRecording
+                  ? " — recording your attempt…"
+                  : " — attempt recorded. The tutor will pick it up from here."}
+            </p>
+            {results.map(({ q: rq, correct }) => (
+              <div
+                key={rq.id}
+                className={`mb-2 rounded-[10px] border border-zinc-200 px-3.5 py-2.5 text-[13.5px] dark:border-zinc-800 ${
                   correct === null
-                    ? colors.surface
+                    ? "bg-white dark:bg-zinc-900"
                     : correct
-                      ? colors.doneBg
-                      : colors.wrongBg,
-                border: `1px solid ${colors.border}`,
-                borderRadius: 10,
-                padding: "10px 14px",
-                marginBottom: 8,
-                fontSize: 13.5,
-              }}
-            >
-              <div style={{ fontWeight: 650, color: colors.text, marginBottom: 4 }}>
-                {correct === null ? "✍️" : correct ? "✓" : "✗"} {rq.prompt}
+                      ? "bg-green-100 dark:bg-green-900"
+                      : "bg-red-50 dark:bg-red-950"
+                }`}
+              >
+                <div className="mb-1 font-semibold text-zinc-900 dark:text-zinc-100">
+                  {correct === null ? "✍️" : correct ? "✓" : "✗"} {rq.prompt}
+                </div>
+                <div className="text-zinc-500 dark:text-zinc-400">
+                  Your answer: {answerText(rq, effectiveAnswer(rq))}
+                  {correct === false && (
+                    <> · Correct: {expectedAnswerText(rq)}</>
+                  )}
+                  {correct === null && <> · Awaiting tutor grading</>}
+                </div>
               </div>
-              <div style={{ color: colors.textSecondary }}>
-                Your answer: {answerText(rq, effectiveAnswer(rq))}
-                {correct === false && (
-                  <> · Correct: {expectedAnswerText(rq)}</>
-                )}
-                {correct === null && <> · Awaiting tutor grading</>}
-              </div>
-            </div>
-          ))}
+            ))}
+          </div>
         </div>
       </McpUseProvider>
     );
@@ -391,292 +368,198 @@ export default function PracticePlayer() {
   // ── Question screen ────────────────────────────────────────────────────────
   return (
     <McpUseProvider autoSize>
-      <div
-        style={{
-          fontFamily: "system-ui, -apple-system, sans-serif",
-          backgroundColor: colors.bg,
-          padding: 24,
-          maxWidth: 680,
-          margin: "0 auto",
-        }}
-      >
-        {/* Header + progress dots */}
-        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 14, flexWrap: "wrap", gap: 8 }}>
-          <span
-            style={{
-              padding: "2px 8px",
-              borderRadius: 8,
-              fontSize: 11,
-              fontWeight: 700,
-              backgroundColor: colors.accentBg,
-              color: colors.accent,
-            }}
-          >
-            Practice · {topic}
-          </span>
-          <div style={{ display: "flex", gap: 5 }} aria-label={`Question ${index + 1} of ${questions.length}`}>
-            {questions.map((dot, i) => (
-              <span
-                key={dot.id}
-                style={{
-                  width: 8,
-                  height: 8,
-                  borderRadius: "50%",
-                  backgroundColor:
+      <div className={dark ? "dark" : ""}>
+        <div className={containerClass}>
+          {/* Header + progress dots */}
+          <div className="mb-3.5 flex flex-wrap items-center justify-between gap-2">
+            <span className="rounded-lg bg-violet-50 px-2 py-0.5 text-[11px] font-bold text-violet-600 dark:bg-violet-950 dark:text-violet-400">
+              Practice · {topic}
+            </span>
+            <div
+              className="flex gap-[5px]"
+              aria-label={`Question ${index + 1} of ${questions.length}`}
+            >
+              {questions.map((dot, i) => (
+                <span
+                  key={dot.id}
+                  className={`size-2 rounded-full ${
                     i === index
-                      ? colors.accent
+                      ? "bg-violet-600 dark:bg-violet-400"
                       : answers[dot.id] !== undefined
-                        ? colors.done
-                        : colors.border,
-                }}
-              />
-            ))}
-          </div>
-        </div>
-
-        <h2
-          style={{
-            margin: "0 0 14px",
-            fontSize: 17,
-            fontWeight: 650,
-            color: colors.text,
-            lineHeight: 1.4,
-          }}
-        >
-          {index + 1}. {q.prompt}
-        </h2>
-
-        {/* Per-type input */}
-        {q.type === "multiple_choice" &&
-          (q.options ?? []).map((opt, i) => (
-            <button key={i} onClick={() => setAnswer(i)} style={choiceStyle(answer === i)}>
-              {opt}
-            </button>
-          ))}
-
-        {q.type === "true_false" && (
-          <div style={{ display: "flex", gap: 10 }}>
-            {[true, false].map((v) => (
-              <button
-                key={String(v)}
-                onClick={() => setAnswer(v)}
-                style={{ ...choiceStyle(answer === v), width: "auto", flex: 1, textAlign: "center" }}
-              >
-                {v ? "True" : "False"}
-              </button>
-            ))}
-          </div>
-        )}
-
-        {(q.type === "fill_blank" || q.type === "free_text") && (
-          q.type === "free_text" ? (
-            <textarea
-              value={(answer as string) ?? ""}
-              onChange={(e) => setAnswer(e.target.value)}
-              rows={5}
-              placeholder="Write your answer — the tutor will grade it"
-              style={{
-                width: "100%",
-                boxSizing: "border-box",
-                padding: "10px 12px",
-                borderRadius: 10,
-                border: `1.5px solid ${colors.border}`,
-                backgroundColor: colors.inputBg,
-                color: colors.text,
-                fontSize: 14,
-                fontFamily: "inherit",
-                resize: "vertical",
-              }}
-            />
-          ) : (
-            <input
-              type="text"
-              value={(answer as string) ?? ""}
-              onChange={(e) => setAnswer(e.target.value)}
-              placeholder="Type your answer"
-              style={{
-                width: "100%",
-                boxSizing: "border-box",
-                padding: "10px 12px",
-                borderRadius: 10,
-                border: `1.5px solid ${colors.border}`,
-                backgroundColor: colors.inputBg,
-                color: colors.text,
-                fontSize: 14,
-              }}
-            />
-          )
-        )}
-
-        {q.type === "match" && (
-          <div>
-            <p style={{ margin: "0 0 8px", fontSize: 12, color: colors.textMuted }}>
-              Tap an item on the left, then its match on the right.
-            </p>
-            <div style={{ display: "flex", gap: 12 }}>
-              <div style={{ flex: 1 }}>
-                {(q.pairs ?? []).map((p) => {
-                  const matched = ((answer as Record<string, string>) ?? {})[p.left];
-                  return (
-                    <button
-                      key={p.left}
-                      onClick={() => setPendingLeft(p.left)}
-                      style={{
-                        ...choiceStyle(pendingLeft === p.left),
-                        borderColor:
-                          pendingLeft === p.left
-                            ? colors.accent
-                            : matched
-                              ? colors.done
-                              : colors.border,
-                      }}
-                    >
-                      {p.left}
-                      {matched && (
-                        <span style={{ color: colors.textMuted, fontWeight: 400 }}>
-                          {" "}→ {matched}
-                        </span>
-                      )}
-                    </button>
-                  );
-                })}
-              </div>
-              <div style={{ flex: 1 }}>
-                {(shuffledRights[q.id] ?? []).map((right) => (
-                  <button
-                    key={right}
-                    onClick={() => {
-                      if (!pendingLeft) return;
-                      setAnswer({
-                        ...(((answer as Record<string, string>) ?? {})),
-                        [pendingLeft]: right,
-                      });
-                      setPendingLeft(null);
-                    }}
-                    disabled={!pendingLeft}
-                    style={{
-                      ...choiceStyle(false),
-                      opacity: pendingLeft ? 1 : 0.6,
-                      cursor: pendingLeft ? "pointer" : "default",
-                    }}
-                  >
-                    {right}
-                  </button>
-                ))}
-              </div>
+                        ? "bg-green-600 dark:bg-green-400"
+                        : "bg-zinc-200 dark:bg-zinc-800"
+                  }`}
+                />
+              ))}
             </div>
           </div>
-        )}
 
-        {q.type === "order" && (
-          <div>
-            <p style={{ margin: "0 0 8px", fontSize: 12, color: colors.textMuted }}>
-              Arrange with the ↑ / ↓ buttons.
-            </p>
-            {(((answer as string[]) ?? initialOrders[q.id]) ?? []).map(
-              (item, i, arr) => (
-                <div
-                  key={item}
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    gap: 8,
-                    padding: "8px 12px",
-                    marginBottom: 6,
-                    borderRadius: 10,
-                    border: `1.5px solid ${colors.border}`,
-                    backgroundColor: colors.surface,
-                    color: colors.text,
-                    fontSize: 14,
-                  }}
+          <h2 className="m-0 mb-3.5 text-[17px] leading-[1.4] font-semibold text-zinc-900 dark:text-zinc-100">
+            {index + 1}. {q.prompt}
+          </h2>
+
+          {/* Per-type input */}
+          {q.type === "multiple_choice" &&
+            (q.options ?? []).map((opt, i) => (
+              <button key={i} onClick={() => setAnswer(i)} className={choiceClass(answer === i)}>
+                {opt}
+              </button>
+            ))}
+
+          {q.type === "true_false" && (
+            <div className="flex gap-2.5">
+              {[true, false].map((v) => (
+                <button
+                  key={String(v)}
+                  onClick={() => setAnswer(v)}
+                  className={choiceClass(answer === v, "flex-1 text-center")}
                 >
-                  <span style={{ flex: 1 }}>{item}</span>
-                  <button
-                    aria-label={`Move "${item}" up`}
-                    disabled={i === 0}
-                    onClick={() => {
-                      const next = [...arr];
-                      [next[i - 1], next[i]] = [next[i], next[i - 1]];
-                      setAnswer(next);
-                    }}
-                    style={{
-                      border: `1px solid ${colors.border}`,
-                      borderRadius: 8,
-                      backgroundColor: colors.bg,
-                      color: colors.text,
-                      cursor: i === 0 ? "default" : "pointer",
-                      opacity: i === 0 ? 0.4 : 1,
-                      padding: "4px 9px",
-                    }}
-                  >
-                    ↑
-                  </button>
-                  <button
-                    aria-label={`Move "${item}" down`}
-                    disabled={i === arr.length - 1}
-                    onClick={() => {
-                      const next = [...arr];
-                      [next[i], next[i + 1]] = [next[i + 1], next[i]];
-                      setAnswer(next);
-                    }}
-                    style={{
-                      border: `1px solid ${colors.border}`,
-                      borderRadius: 8,
-                      backgroundColor: colors.bg,
-                      color: colors.text,
-                      cursor: i === arr.length - 1 ? "default" : "pointer",
-                      opacity: i === arr.length - 1 ? 0.4 : 1,
-                      padding: "4px 9px",
-                    }}
-                  >
-                    ↓
-                  </button>
-                </div>
-              )
-            )}
-          </div>
-        )}
+                  {v ? "True" : "False"}
+                </button>
+              ))}
+            </div>
+          )}
 
-        {/* Nav */}
-        <div
-          style={{
-            display: "flex",
-            justifyContent: "space-between",
-            marginTop: 18,
-          }}
-        >
-          <button
-            onClick={() => setIndex((i) => Math.max(0, i - 1))}
-            disabled={index === 0}
-            style={{
-              ...primaryBtn,
-              backgroundColor: "transparent",
-              color: colors.textSecondary,
-              border: `1px solid ${colors.border}`,
-              opacity: index === 0 ? 0.4 : 1,
-              cursor: index === 0 ? "default" : "pointer",
-            }}
-          >
-            Back
-          </button>
-          <button
-            onClick={() => {
-              // order questions default to the presented arrangement
-              if (q.type === "order" && answers[q.id] === undefined) {
-                setAnswer(initialOrders[q.id] ?? []);
-              }
-              if (isLast) finish();
-              else setIndex((i) => i + 1);
-            }}
-            disabled={!answeredCurrent}
-            style={{
-              ...primaryBtn,
-              opacity: answeredCurrent ? 1 : 0.5,
-              cursor: answeredCurrent ? "pointer" : "default",
-            }}
-          >
-            {isLast ? "Finish" : "Next"}
-          </button>
+          {(q.type === "fill_blank" || q.type === "free_text") && (
+            q.type === "free_text" ? (
+              <textarea
+                value={(answer as string) ?? ""}
+                onChange={(e) => setAnswer(e.target.value)}
+                rows={5}
+                placeholder="Write your answer — the tutor will grade it"
+                className={`${inputClass} resize-y [font-family:inherit]`}
+              />
+            ) : (
+              <input
+                type="text"
+                value={(answer as string) ?? ""}
+                onChange={(e) => setAnswer(e.target.value)}
+                placeholder="Type your answer"
+                className={inputClass}
+              />
+            )
+          )}
+
+          {q.type === "match" && (
+            <div>
+              <p className="m-0 mb-2 text-xs text-zinc-400 dark:text-zinc-500">
+                Tap an item on the left, then its match on the right.
+              </p>
+              <div className="flex gap-3">
+                <div className="flex-1">
+                  {(q.pairs ?? []).map((p) => {
+                    const matched = ((answer as Record<string, string>) ?? {})[p.left];
+                    const border =
+                      pendingLeft === p.left
+                        ? "border-violet-600 bg-violet-50 font-semibold dark:border-violet-400 dark:bg-violet-950"
+                        : matched
+                          ? "border-green-600 bg-white font-normal dark:border-green-400 dark:bg-zinc-900"
+                          : "border-zinc-200 bg-white font-normal dark:border-zinc-800 dark:bg-zinc-900";
+                    return (
+                      <button
+                        key={p.left}
+                        onClick={() => setPendingLeft(p.left)}
+                        className={`mb-2 block w-full cursor-pointer rounded-[10px] border-[1.5px] px-3.5 py-2.5 text-left text-sm text-zinc-900 dark:text-zinc-100 ${border}`}
+                      >
+                        {p.left}
+                        {matched && (
+                          <span className="font-normal text-zinc-400 dark:text-zinc-500">
+                            {" "}→ {matched}
+                          </span>
+                        )}
+                      </button>
+                    );
+                  })}
+                </div>
+                <div className="flex-1">
+                  {(shuffledRights[q.id] ?? []).map((right) => (
+                    <button
+                      key={right}
+                      onClick={() => {
+                        if (!pendingLeft) return;
+                        setAnswer({
+                          ...(((answer as Record<string, string>) ?? {})),
+                          [pendingLeft]: right,
+                        });
+                        setPendingLeft(null);
+                      }}
+                      disabled={!pendingLeft}
+                      className={`${choiceClass(false)} disabled:cursor-default disabled:opacity-60`}
+                    >
+                      {right}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            </div>
+          )}
+
+          {q.type === "order" && (
+            <div>
+              <p className="m-0 mb-2 text-xs text-zinc-400 dark:text-zinc-500">
+                Arrange with the ↑ / ↓ buttons.
+              </p>
+              {(((answer as string[]) ?? initialOrders[q.id]) ?? []).map(
+                (item, i, arr) => (
+                  <div
+                    key={item}
+                    className="mb-1.5 flex items-center gap-2 rounded-[10px] border-[1.5px] border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-100"
+                  >
+                    <span className="flex-1">{item}</span>
+                    <button
+                      aria-label={`Move "${item}" up`}
+                      disabled={i === 0}
+                      onClick={() => {
+                        const next = [...arr];
+                        [next[i - 1], next[i]] = [next[i], next[i - 1]];
+                        setAnswer(next);
+                      }}
+                      className="cursor-pointer rounded-lg border border-zinc-200 bg-zinc-50 px-[9px] py-1 text-zinc-900 disabled:cursor-default disabled:opacity-40 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-100"
+                    >
+                      ↑
+                    </button>
+                    <button
+                      aria-label={`Move "${item}" down`}
+                      disabled={i === arr.length - 1}
+                      onClick={() => {
+                        const next = [...arr];
+                        [next[i], next[i + 1]] = [next[i + 1], next[i]];
+                        setAnswer(next);
+                      }}
+                      className="cursor-pointer rounded-lg border border-zinc-200 bg-zinc-50 px-[9px] py-1 text-zinc-900 disabled:cursor-default disabled:opacity-40 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-100"
+                    >
+                      ↓
+                    </button>
+                  </div>
+                )
+              )}
+            </div>
+          )}
+
+          {/* Nav */}
+          <div className="mt-4.5 flex justify-between">
+            <button
+              onClick={() => setIndex((i) => Math.max(0, i - 1))}
+              disabled={index === 0}
+              className="cursor-pointer rounded-[10px] border border-zinc-200 bg-transparent px-4.5 py-[9px] text-[13.5px] font-semibold text-zinc-500 disabled:cursor-default disabled:opacity-40 dark:border-zinc-800 dark:text-zinc-400"
+            >
+              Back
+            </button>
+            <button
+              onClick={() => {
+                // order questions default to the presented arrangement
+                if (q.type === "order" && answers[q.id] === undefined) {
+                  setAnswer(initialOrders[q.id] ?? []);
+                }
+                if (isLast) finish();
+                else setIndex((i) => i + 1);
+              }}
+              disabled={!answeredCurrent}
+              className={`${primaryBtnClass} disabled:cursor-default disabled:opacity-50`}
+            >
+              {isLast ? "Finish" : "Next"}
+            </button>
+          </div>
         </div>
       </div>
     </McpUseProvider>

--- a/mcp-server/resources/school-overview/widget.tsx
+++ b/mcp-server/resources/school-overview/widget.tsx
@@ -53,25 +53,24 @@ type Course = z.infer<typeof courseSchema>;
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
-function statusPill(status: string, theme: "light" | "dark") {
-  const dark = theme === "dark";
+function statusPill(status: string): string {
   switch (status.toLowerCase()) {
     case "published":
-      return { bg: dark ? "#14532d" : "#dcfce7", text: dark ? "#86efac" : "#166534" };
+      return "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300";
     case "draft":
-      return { bg: dark ? "#3f3f46" : "#f4f4f5", text: dark ? "#a1a1aa" : "#52525b" };
+      return "bg-zinc-100 text-zinc-600 dark:bg-zinc-700 dark:text-zinc-400";
     case "archived":
-      return { bg: dark ? "#1e1b4b" : "#ede9fe", text: dark ? "#a5b4fc" : "#4338ca" };
+      return "bg-indigo-100 text-indigo-700 dark:bg-indigo-950 dark:text-indigo-300";
     default:
-      return { bg: dark ? "#422006" : "#fef3c7", text: dark ? "#fcd34d" : "#92400e" };
+      return "bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300";
   }
 }
 
-function completionColor(pct: number, dark: boolean): string {
-  if (pct >= 80) return dark ? "#22c55e" : "#16a34a";
-  if (pct >= 40) return dark ? "#a78bfa" : "#7c3aed";
-  if (pct > 0) return dark ? "#f59e0b" : "#d97706";
-  return dark ? "#52525b" : "#d4d4d8";
+function completionColor(pct: number): string {
+  if (pct >= 80) return "bg-green-600 dark:bg-green-400";
+  if (pct >= 40) return "bg-violet-600 dark:bg-violet-400";
+  if (pct > 0) return "bg-amber-600 dark:bg-amber-400";
+  return "bg-zinc-300 dark:bg-zinc-600";
 }
 
 // ── Component ────────────────────────────────────────────────────────────────
@@ -81,44 +80,14 @@ export default function SchoolOverview() {
   const theme = useWidgetTheme();
   const dark = theme === "dark";
 
-  const colors = {
-    bg: dark ? "#0f0f0f" : "#fafafa",
-    surface: dark ? "#1a1a1a" : "#ffffff",
-    border: dark ? "#2a2a2a" : "#e5e7eb",
-    text: dark ? "#f4f4f5" : "#111827",
-    textSecondary: dark ? "#a1a1aa" : "#6b7280",
-    textMuted: dark ? "#71717a" : "#9ca3af",
-    accent: dark ? "#a78bfa" : "#7c3aed",
-    track: dark ? "#27272a" : "#f1f5f9",
-    riskText: dark ? "#fca5a5" : "#dc2626",
-    sectionBg: dark ? "#141414" : "#f9fafb",
-  };
-
   if (isPending) {
     return (
       <McpUseProvider autoSize>
-        <div
-          style={{
-            padding: 40,
-            textAlign: "center",
-            color: colors.textMuted,
-            backgroundColor: colors.bg,
-            fontFamily: "system-ui, sans-serif",
-          }}
-        >
-          <div
-            style={{
-              width: 36,
-              height: 36,
-              border: `3px solid ${colors.border}`,
-              borderTop: `3px solid ${colors.accent}`,
-              borderRadius: "50%",
-              margin: "0 auto 12px",
-              animation: "spin 0.8s linear infinite",
-            }}
-          />
-          <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
-          <p style={{ margin: 0, fontSize: 14 }}>Crunching school stats…</p>
+        <div className={dark ? "dark" : ""}>
+          <div className="bg-zinc-50 p-10 text-center font-sans text-zinc-400 dark:bg-zinc-950 dark:text-zinc-500">
+            <div className="mx-auto mb-3 size-9 animate-spin rounded-full border-[3px] border-zinc-200 border-t-violet-600 dark:border-zinc-800 dark:border-t-violet-400" />
+            <p className="m-0 text-sm">Crunching school stats…</p>
+          </div>
         </div>
       </McpUseProvider>
     );
@@ -130,191 +99,142 @@ export default function SchoolOverview() {
     label: string,
     value: string,
     sub?: string,
-    accent?: string
+    accentClass?: string
   ) => (
-    <div
-      style={{
-        backgroundColor: colors.surface,
-        border: `1px solid ${colors.border}`,
-        borderRadius: 12,
-        padding: "14px 16px",
-        minWidth: 0,
-      }}
-    >
-      <div style={{ fontSize: 24, fontWeight: 700, color: accent ?? colors.text, lineHeight: 1.1 }}>
+    <div className="min-w-0 rounded-xl border border-zinc-200 bg-white px-4 py-3.5 dark:border-zinc-800 dark:bg-zinc-900">
+      <div
+        className={`text-2xl leading-[1.1] font-bold ${
+          accentClass ?? "text-zinc-900 dark:text-zinc-100"
+        }`}
+      >
         {value}
       </div>
-      <div style={{ fontSize: 12, color: colors.textSecondary, marginTop: 4, fontWeight: 500 }}>
+      <div className="mt-1 text-xs font-medium text-zinc-500 dark:text-zinc-400">
         {label}
       </div>
-      {sub && <div style={{ fontSize: 11, color: colors.textMuted, marginTop: 2 }}>{sub}</div>}
+      {sub && (
+        <div className="mt-0.5 text-[11px] text-zinc-400 dark:text-zinc-500">
+          {sub}
+        </div>
+      )}
     </div>
   );
 
   return (
     <McpUseProvider autoSize>
-      <div
-        style={{
-          fontFamily: "system-ui, -apple-system, sans-serif",
-          backgroundColor: colors.bg,
-          padding: 24,
-        }}
-      >
-        {/* Header */}
-        <div style={{ marginBottom: 16 }}>
-          <h2
-            style={{
-              margin: 0,
-              fontSize: 20,
-              fontWeight: 700,
-              color: colors.text,
-              letterSpacing: "-0.01em",
-            }}
-          >
-            {school.name}
-          </h2>
-          <div style={{ fontSize: 13, color: colors.textMuted, marginTop: 2 }}>
-            School overview
+      <div className={dark ? "dark" : ""}>
+        <div className="bg-zinc-50 p-6 font-sans dark:bg-zinc-950">
+          {/* Header */}
+          <div className="mb-4">
+            <h2 className="m-0 text-xl font-bold tracking-tight text-zinc-900 dark:text-zinc-100">
+              {school.name}
+            </h2>
+            <div className="mt-0.5 text-[13px] text-zinc-400 dark:text-zinc-500">
+              School overview
+            </div>
           </div>
-        </div>
 
-        {/* KPI grid */}
-        <div
-          style={{
-            display: "grid",
-            gridTemplateColumns: "repeat(auto-fill, minmax(150px, 1fr))",
-            gap: 12,
-            marginBottom: 22,
-          }}
-        >
-          {kpi(
-            "Courses",
-            String(school.courses_total),
-            `${school.courses_published} published · ${school.courses_draft} draft`
-          )}
-          {kpi("Students", String(school.students), `${school.active_enrollments} active enrollments`)}
-          {kpi("Published lessons", String(school.published_lessons))}
-          {kpi("Avg completion", `${school.completion_rate}%`, undefined, colors.accent)}
-          {kpi(
-            "Avg exam score",
-            school.avg_exam_score == null ? "—" : `${school.avg_exam_score}%`,
-            `${school.exam_submissions} submissions`
-          )}
-          {kpi(
-            "At-risk students",
-            String(school.at_risk_students),
-            "active · 0 lessons done",
-            school.at_risk_students > 0 ? colors.riskText : colors.text
-          )}
-        </div>
+          {/* KPI grid */}
+          <div className="mb-[22px] grid grid-cols-[repeat(auto-fill,minmax(150px,1fr))] gap-3">
+            {kpi(
+              "Courses",
+              String(school.courses_total),
+              `${school.courses_published} published · ${school.courses_draft} draft`
+            )}
+            {kpi(
+              "Students",
+              String(school.students),
+              `${school.active_enrollments} active enrollments`
+            )}
+            {kpi("Published lessons", String(school.published_lessons))}
+            {kpi(
+              "Avg completion",
+              `${school.completion_rate}%`,
+              undefined,
+              "text-violet-600 dark:text-violet-400"
+            )}
+            {kpi(
+              "Avg exam score",
+              school.avg_exam_score == null ? "—" : `${school.avg_exam_score}%`,
+              `${school.exam_submissions} submissions`
+            )}
+            {kpi(
+              "At-risk students",
+              String(school.at_risk_students),
+              "active · 0 lessons done",
+              school.at_risk_students > 0
+                ? "text-red-600 dark:text-red-400"
+                : undefined
+            )}
+          </div>
 
-        {/* Per-course breakdown */}
-        <h3
-          style={{
-            margin: "0 0 12px",
-            fontSize: 14,
-            fontWeight: 600,
-            color: colors.text,
-          }}
-        >
-          Courses ({courses.length})
-        </h3>
+          {/* Per-course breakdown */}
+          <h3 className="mt-0 mb-3 text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+            Courses ({courses.length})
+          </h3>
 
-        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-          {courses.map((c: Course) => {
-            const pill = statusPill(c.status, theme);
-            return (
+          <div className="flex flex-col gap-2">
+            {courses.map((c: Course) => (
               <div
                 key={c.id}
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  gap: 14,
-                  padding: "12px 14px",
-                  borderRadius: 12,
-                  backgroundColor: colors.surface,
-                  border: `1px solid ${colors.border}`,
-                }}
+                className="flex items-center gap-3.5 rounded-xl border border-zinc-200 bg-white px-3.5 py-3 dark:border-zinc-800 dark:bg-zinc-900"
               >
                 {/* Title + status + completion bar */}
-                <div style={{ flex: 1, minWidth: 0 }}>
-                  <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 6 }}>
-                    <span
-                      style={{
-                        fontSize: 14,
-                        fontWeight: 600,
-                        color: colors.text,
-                        overflow: "hidden",
-                        textOverflow: "ellipsis",
-                        whiteSpace: "nowrap",
-                      }}
-                    >
+                <div className="min-w-0 flex-1">
+                  <div className="mb-1.5 flex items-center gap-2">
+                    <span className="truncate text-sm font-semibold text-zinc-900 dark:text-zinc-100">
                       {c.title}
                     </span>
                     <span
-                      style={{
-                        padding: "1px 7px",
-                        borderRadius: 7,
-                        fontSize: 10.5,
-                        fontWeight: 600,
-                        backgroundColor: pill.bg,
-                        color: pill.text,
-                        flexShrink: 0,
-                      }}
+                      className={`shrink-0 rounded-[7px] px-[7px] py-px text-[10.5px] font-semibold ${statusPill(c.status)}`}
                     >
                       {c.status}
                     </span>
                   </div>
-                  <div
-                    style={{
-                      height: 6,
-                      borderRadius: 3,
-                      backgroundColor: colors.track,
-                      overflow: "hidden",
-                    }}
-                  >
+                  <div className="h-1.5 overflow-hidden rounded-[3px] bg-zinc-100 dark:bg-zinc-800">
                     <div
-                      style={{
-                        height: "100%",
-                        width: `${c.completion_rate}%`,
-                        backgroundColor: completionColor(c.completion_rate, dark),
-                        borderRadius: 3,
-                      }}
+                      className={`h-full rounded-[3px] ${completionColor(c.completion_rate)}`}
+                      style={{ width: `${c.completion_rate}%` }}
                     />
                   </div>
                 </div>
 
-                <div style={{ textAlign: "right", flexShrink: 0, minWidth: 64 }}>
-                  <div style={{ fontSize: 14, fontWeight: 700, color: colors.text }}>
+                <div className="min-w-16 shrink-0 text-right">
+                  <div className="text-sm font-bold text-zinc-900 dark:text-zinc-100">
                     {c.active_enrollments}
                   </div>
-                  <div style={{ fontSize: 11, color: colors.textMuted }}>enrolled</div>
+                  <div className="text-[11px] text-zinc-400 dark:text-zinc-500">
+                    enrolled
+                  </div>
                 </div>
 
-                <div style={{ textAlign: "right", flexShrink: 0, minWidth: 56 }}>
-                  <div style={{ fontSize: 14, fontWeight: 700, color: colors.text }}>
+                <div className="min-w-14 shrink-0 text-right">
+                  <div className="text-sm font-bold text-zinc-900 dark:text-zinc-100">
                     {c.completion_rate}%
                   </div>
-                  <div style={{ fontSize: 11, color: colors.textMuted }}>
-                    {c.published_lessons} lesson{c.published_lessons === 1 ? "" : "s"}
+                  <div className="text-[11px] text-zinc-400 dark:text-zinc-500">
+                    {c.published_lessons} lesson
+                    {c.published_lessons === 1 ? "" : "s"}
                   </div>
                 </div>
 
-                <div style={{ textAlign: "right", flexShrink: 0, minWidth: 56 }}>
-                  <div style={{ fontSize: 14, fontWeight: 700, color: colors.text }}>
+                <div className="min-w-14 shrink-0 text-right">
+                  <div className="text-sm font-bold text-zinc-900 dark:text-zinc-100">
                     {c.exam_avg == null ? "—" : `${c.exam_avg}%`}
                   </div>
-                  <div style={{ fontSize: 11, color: colors.textMuted }}>exam avg</div>
+                  <div className="text-[11px] text-zinc-400 dark:text-zinc-500">
+                    exam avg
+                  </div>
                 </div>
               </div>
-            );
-          })}
+            ))}
 
-          {courses.length === 0 && (
-            <p style={{ margin: 0, padding: 24, textAlign: "center", fontSize: 13, color: colors.textMuted }}>
-              No courses yet.
-            </p>
-          )}
+            {courses.length === 0 && (
+              <p className="m-0 p-6 text-center text-[13px] text-zinc-400 dark:text-zinc-500">
+                No courses yet.
+              </p>
+            )}
+          </div>
         </div>
       </div>
     </McpUseProvider>

--- a/mcp-server/resources/shared/markdown.tsx
+++ b/mcp-server/resources/shared/markdown.tsx
@@ -1,0 +1,241 @@
+import type { CSSProperties } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+/**
+ * Theme-aware markdown renderer shared by lesson widgets.
+ * Lesson content is MDX: standard markdown renders; raw HTML / custom JSX
+ * components are stripped by react-markdown's default (safe) behavior.
+ */
+
+type Palette = {
+  text: string;
+  heading: string;
+  secondary: string;
+  border: string;
+  link: string;
+  codeText: string;
+  codeBg: string;
+  codeBorder: string;
+  quoteBar: string;
+  quoteText: string;
+  tableHeadBg: string;
+};
+
+function palette(dark: boolean): Palette {
+  return {
+    text: dark ? "#d4d4d8" : "#1f2937",
+    heading: dark ? "#f4f4f5" : "#111827",
+    secondary: dark ? "#a1a1aa" : "#6b7280",
+    border: dark ? "#2a2a2a" : "#e5e7eb",
+    link: dark ? "#a78bfa" : "#7c3aed",
+    codeText: dark ? "#e4e4e7" : "#374151",
+    codeBg: dark ? "#141414" : "#f4f4f5",
+    codeBorder: dark ? "#2a2a2a" : "#e4e4e7",
+    quoteBar: dark ? "#3f3f46" : "#d4d4d8",
+    quoteText: dark ? "#a1a1aa" : "#4b5563",
+    tableHeadBg: dark ? "#1a1a1a" : "#fafafa",
+  };
+}
+
+function headingStyle(c: Palette, size: number, top: number): CSSProperties {
+  return {
+    margin: `${top}px 0 8px`,
+    fontSize: size,
+    fontWeight: 700,
+    color: c.heading,
+    lineHeight: 1.3,
+    letterSpacing: "-0.01em",
+  };
+}
+
+export function Markdown({
+  content,
+  dark,
+  fontSize = 14,
+}: {
+  content: string;
+  dark: boolean;
+  fontSize?: number;
+}) {
+  const c = palette(dark);
+
+  const block: CSSProperties = {
+    margin: "0 0 12px",
+    fontSize,
+    lineHeight: 1.7,
+    color: c.text,
+  };
+
+  return (
+    <div
+      style={{
+        fontFamily: '"Noto Sans", system-ui, -apple-system, sans-serif',
+        maxWidth: "72ch",
+        overflowWrap: "break-word",
+      }}
+    >
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={{
+          h1: ({ children }) => (
+            <h2 style={headingStyle(c, fontSize + 6, 20)}>{children}</h2>
+          ),
+          h2: ({ children }) => (
+            <h3 style={headingStyle(c, fontSize + 4, 18)}>{children}</h3>
+          ),
+          h3: ({ children }) => (
+            <h4 style={headingStyle(c, fontSize + 2, 16)}>{children}</h4>
+          ),
+          h4: ({ children }) => (
+            <h5 style={headingStyle(c, fontSize + 1, 14)}>{children}</h5>
+          ),
+          p: ({ children }) => <p style={block}>{children}</p>,
+          ul: ({ children }) => (
+            <ul style={{ ...block, paddingLeft: 22 }}>{children}</ul>
+          ),
+          ol: ({ children }) => (
+            <ol style={{ ...block, paddingLeft: 22 }}>{children}</ol>
+          ),
+          li: ({ children }) => (
+            <li style={{ marginBottom: 4 }}>{children}</li>
+          ),
+          a: ({ href, children }) => (
+            <a
+              href={href}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{
+                color: c.link,
+                fontWeight: 500,
+                textDecorationColor: c.link,
+              }}
+            >
+              {children}
+            </a>
+          ),
+          strong: ({ children }) => (
+            <strong style={{ fontWeight: 700, color: c.heading }}>
+              {children}
+            </strong>
+          ),
+          blockquote: ({ children }) => (
+            <blockquote
+              style={{
+                margin: "0 0 12px",
+                padding: "4px 0 4px 14px",
+                borderLeft: `1px solid ${c.quoteBar}`,
+                color: c.quoteText,
+                fontStyle: "italic",
+              }}
+            >
+              {children}
+            </blockquote>
+          ),
+          code: ({ className, children }) => {
+            const isBlock = /language-/.test(className ?? "");
+            if (isBlock) {
+              return <code className={className}>{children}</code>;
+            }
+            return (
+              <code
+                style={{
+                  fontFamily:
+                    'ui-monospace, "SF Mono", Menlo, Consolas, monospace',
+                  fontSize: fontSize - 1.5,
+                  padding: "1.5px 5px",
+                  borderRadius: 5,
+                  backgroundColor: c.codeBg,
+                  border: `1px solid ${c.codeBorder}`,
+                  color: c.codeText,
+                }}
+              >
+                {children}
+              </code>
+            );
+          },
+          pre: ({ children }) => (
+            <pre
+              style={{
+                margin: "0 0 12px",
+                padding: 14,
+                borderRadius: 8,
+                backgroundColor: c.codeBg,
+                border: `1px solid ${c.codeBorder}`,
+                fontSize: fontSize - 1,
+                lineHeight: 1.6,
+                color: c.codeText,
+                overflowX: "auto",
+                fontFamily:
+                  'ui-monospace, "SF Mono", Menlo, Consolas, monospace',
+              }}
+            >
+              {children}
+            </pre>
+          ),
+          hr: () => (
+            <hr
+              style={{
+                border: "none",
+                borderTop: `1px solid ${c.border}`,
+                margin: "18px 0",
+              }}
+            />
+          ),
+          table: ({ children }) => (
+            <div style={{ overflowX: "auto", marginBottom: 12 }}>
+              <table
+                style={{
+                  borderCollapse: "collapse",
+                  fontSize: fontSize - 1,
+                  minWidth: 320,
+                }}
+              >
+                {children}
+              </table>
+            </div>
+          ),
+          th: ({ children }) => (
+            <th
+              style={{
+                textAlign: "left",
+                padding: "7px 12px",
+                border: `1px solid ${c.border}`,
+                backgroundColor: c.tableHeadBg,
+                color: c.heading,
+                fontWeight: 650,
+              }}
+            >
+              {children}
+            </th>
+          ),
+          td: ({ children }) => (
+            <td
+              style={{
+                padding: "7px 12px",
+                border: `1px solid ${c.border}`,
+                color: c.text,
+              }}
+            >
+              {children}
+            </td>
+          ),
+          img: ({ src, alt }) => (
+            <img
+              src={src}
+              alt={alt ?? ""}
+              loading="lazy"
+              style={{
+                maxWidth: "100%",
+                borderRadius: 8,
+                border: `1px solid ${c.border}`,
+              }}
+            />
+          ),
+        }}
+      >
+        {content}
+      </ReactMarkdown>
+    </div>
+  );
+}

--- a/mcp-server/resources/student-progress-roster/widget.tsx
+++ b/mcp-server/resources/student-progress-roster/widget.tsx
@@ -65,12 +65,12 @@ function relativeDate(s: string | null): string {
   }
 }
 
-function progressColor(pct: number | null, dark: boolean): string {
-  if (pct == null) return dark ? "#52525b" : "#d4d4d8";
-  if (pct >= 80) return dark ? "#22c55e" : "#16a34a";
-  if (pct >= 40) return dark ? "#a78bfa" : "#7c3aed";
-  if (pct > 0) return dark ? "#f59e0b" : "#d97706";
-  return dark ? "#ef4444" : "#dc2626";
+function progressColor(pct: number | null): string {
+  if (pct == null) return "bg-zinc-300 dark:bg-zinc-600";
+  if (pct >= 80) return "bg-green-600 dark:bg-green-400";
+  if (pct >= 40) return "bg-violet-600 dark:bg-violet-400";
+  if (pct > 0) return "bg-amber-600 dark:bg-amber-400";
+  return "bg-red-600 dark:bg-red-400";
 }
 
 function initials(name: string | null, id: string): string {
@@ -89,47 +89,14 @@ export default function StudentProgressRoster() {
   const dark = theme === "dark";
   const [atRiskOnly, setAtRiskOnly] = useState(false);
 
-  const colors = {
-    bg: dark ? "#0f0f0f" : "#fafafa",
-    surface: dark ? "#1a1a1a" : "#ffffff",
-    border: dark ? "#2a2a2a" : "#e5e7eb",
-    text: dark ? "#f4f4f5" : "#111827",
-    textSecondary: dark ? "#a1a1aa" : "#6b7280",
-    textMuted: dark ? "#71717a" : "#9ca3af",
-    accent: dark ? "#a78bfa" : "#7c3aed",
-    accentBg: dark ? "#2e1065" : "#f5f3ff",
-    sectionBg: dark ? "#141414" : "#f9fafb",
-    track: dark ? "#27272a" : "#f1f5f9",
-    riskBg: dark ? "#7f1d1d" : "#fee2e2",
-    riskText: dark ? "#fca5a5" : "#991b1b",
-    avatarBg: dark ? "#27272a" : "#ede9fe",
-  };
-
   if (isPending) {
     return (
       <McpUseProvider autoSize>
-        <div
-          style={{
-            padding: 40,
-            textAlign: "center",
-            color: colors.textMuted,
-            backgroundColor: colors.bg,
-            fontFamily: "system-ui, sans-serif",
-          }}
-        >
-          <div
-            style={{
-              width: 36,
-              height: 36,
-              border: `3px solid ${colors.border}`,
-              borderTop: `3px solid ${colors.accent}`,
-              borderRadius: "50%",
-              margin: "0 auto 12px",
-              animation: "spin 0.8s linear infinite",
-            }}
-          />
-          <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
-          <p style={{ margin: 0, fontSize: 14 }}>Loading roster…</p>
+        <div className={dark ? "dark" : ""}>
+          <div className="bg-zinc-50 p-10 text-center font-sans text-zinc-400 dark:bg-zinc-950 dark:text-zinc-500">
+            <div className="mx-auto mb-3 size-9 animate-spin rounded-full border-[3px] border-zinc-200 border-t-violet-600 dark:border-zinc-800 dark:border-t-violet-400" />
+            <p className="m-0 text-sm">Loading roster…</p>
+          </div>
         </div>
       </McpUseProvider>
     );
@@ -138,226 +105,146 @@ export default function StudentProgressRoster() {
   const { course, students, summary } = props;
   const visible = atRiskOnly ? students.filter((s) => s.at_risk) : students;
 
-  const stat = (label: string, value: string, accent?: string) => (
-    <div style={{ textAlign: "center" }}>
-      <div style={{ fontSize: 20, fontWeight: 700, color: accent ?? colors.text }}>{value}</div>
-      <div style={{ fontSize: 11, color: colors.textMuted, marginTop: 2 }}>{label}</div>
+  const stat = (label: string, value: string, accentClass?: string) => (
+    <div className="text-center">
+      <div
+        className={`text-xl font-bold ${
+          accentClass ?? "text-zinc-900 dark:text-zinc-100"
+        }`}
+      >
+        {value}
+      </div>
+      <div className="mt-0.5 text-[11px] text-zinc-400 dark:text-zinc-500">
+        {label}
+      </div>
     </div>
   );
 
   return (
     <McpUseProvider autoSize>
-      <div
-        style={{
-          fontFamily: "system-ui, -apple-system, sans-serif",
-          backgroundColor: colors.bg,
-          padding: 24,
-        }}
-      >
-        {/* Header */}
-        <div style={{ marginBottom: 4 }}>
-          <h2
-            style={{
-              margin: 0,
-              fontSize: 19,
-              fontWeight: 700,
-              color: colors.text,
-              letterSpacing: "-0.01em",
-            }}
-          >
-            {course.title}
-          </h2>
-          <div style={{ fontSize: 13, color: colors.textMuted, marginTop: 2 }}>
-            Student roster · {course.published_lessons} published lesson
-            {course.published_lessons === 1 ? "" : "s"}
+      <div className={dark ? "dark" : ""}>
+        <div className="bg-zinc-50 p-6 font-sans dark:bg-zinc-950">
+          {/* Header */}
+          <div className="mb-1">
+            <h2 className="m-0 text-[19px] font-bold tracking-tight text-zinc-900 dark:text-zinc-100">
+              {course.title}
+            </h2>
+            <div className="mt-0.5 text-[13px] text-zinc-400 dark:text-zinc-500">
+              Student roster · {course.published_lessons} published lesson
+              {course.published_lessons === 1 ? "" : "s"}
+            </div>
           </div>
-        </div>
 
-        {/* Summary */}
-        <div
-          style={{
-            display: "flex",
-            gap: 24,
-            padding: "14px 18px",
-            margin: "14px 0",
-            borderRadius: 12,
-            backgroundColor: colors.surface,
-            border: `1px solid ${colors.border}`,
-            width: "fit-content",
-          }}
-        >
-          {stat("Students", String(summary.total))}
-          {stat("Avg progress", `${summary.avg_progress}%`, colors.accent)}
-          {stat(
-            "At risk",
-            String(summary.at_risk),
-            summary.at_risk > 0 ? colors.riskText : colors.text
-          )}
-        </div>
+          {/* Summary */}
+          <div className="my-3.5 flex w-fit gap-6 rounded-xl border border-zinc-200 bg-white px-[18px] py-3.5 dark:border-zinc-800 dark:bg-zinc-900">
+            {stat("Students", String(summary.total))}
+            {stat(
+              "Avg progress",
+              `${summary.avg_progress}%`,
+              "text-violet-600 dark:text-violet-400"
+            )}
+            {stat(
+              "At risk",
+              String(summary.at_risk),
+              summary.at_risk > 0 ? "text-red-600 dark:text-red-400" : undefined
+            )}
+          </div>
 
-        {/* Filter */}
-        {summary.at_risk > 0 && (
-          <button
-            onClick={() => setAtRiskOnly((v) => !v)}
-            style={{
-              padding: "6px 14px",
-              borderRadius: 8,
-              border: `1px solid ${atRiskOnly ? colors.riskText : colors.border}`,
-              backgroundColor: atRiskOnly ? colors.riskBg : "transparent",
-              color: atRiskOnly ? colors.riskText : colors.textSecondary,
-              fontSize: 12.5,
-              fontWeight: 500,
-              cursor: "pointer",
-              marginBottom: 12,
-            }}
-          >
-            {atRiskOnly ? "✓ At risk only" : "Show at risk only"}
-          </button>
-        )}
-
-        {/* Rows */}
-        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-          {visible.map((s: Student) => {
-            const pct = s.progress_pct;
-            const name = s.student_name ?? s.student_id.slice(0, 8);
-            return (
-              <div
-                key={s.student_id}
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  gap: 14,
-                  padding: "12px 14px",
-                  borderRadius: 12,
-                  backgroundColor: colors.surface,
-                  border: `1px solid ${s.at_risk ? (dark ? "#7f1d1d" : "#fecaca") : colors.border}`,
-                }}
-              >
-                {/* Avatar */}
-                <div
-                  style={{
-                    width: 36,
-                    height: 36,
-                    borderRadius: "50%",
-                    backgroundColor: colors.avatarBg,
-                    color: colors.accent,
-                    fontSize: 13,
-                    fontWeight: 700,
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                    flexShrink: 0,
-                    textTransform: "uppercase",
-                  }}
-                >
-                  {initials(s.student_name, s.student_id)}
-                </div>
-
-                {/* Name + progress bar */}
-                <div style={{ flex: 1, minWidth: 0 }}>
-                  <div
-                    style={{
-                      display: "flex",
-                      alignItems: "center",
-                      gap: 8,
-                      marginBottom: 6,
-                    }}
-                  >
-                    <span
-                      style={{
-                        fontSize: 14,
-                        fontWeight: 600,
-                        color: colors.text,
-                        overflow: "hidden",
-                        textOverflow: "ellipsis",
-                        whiteSpace: "nowrap",
-                      }}
-                    >
-                      {name}
-                    </span>
-                    {s.at_risk && (
-                      <span
-                        style={{
-                          padding: "1px 7px",
-                          borderRadius: 6,
-                          fontSize: 10.5,
-                          fontWeight: 700,
-                          backgroundColor: colors.riskBg,
-                          color: colors.riskText,
-                          flexShrink: 0,
-                        }}
-                      >
-                        AT RISK
-                      </span>
-                    )}
-                    {s.status !== "active" && (
-                      <span style={{ fontSize: 11, color: colors.textMuted, flexShrink: 0 }}>
-                        {s.status}
-                      </span>
-                    )}
-                  </div>
-                  <div
-                    style={{
-                      height: 6,
-                      borderRadius: 3,
-                      backgroundColor: colors.track,
-                      overflow: "hidden",
-                    }}
-                  >
-                    <div
-                      style={{
-                        height: "100%",
-                        width: `${pct ?? 0}%`,
-                        backgroundColor: progressColor(pct, dark),
-                        borderRadius: 3,
-                        transition: "width 0.3s",
-                      }}
-                    />
-                  </div>
-                </div>
-
-                {/* Metrics */}
-                <div style={{ textAlign: "right", flexShrink: 0, minWidth: 56 }}>
-                  <div style={{ fontSize: 14, fontWeight: 700, color: colors.text }}>
-                    {pct == null ? "—" : `${pct}%`}
-                  </div>
-                  <div style={{ fontSize: 11, color: colors.textMuted }}>
-                    {s.completed_lessons}/{course.published_lessons} lessons
-                  </div>
-                </div>
-
-                <div style={{ textAlign: "right", flexShrink: 0, minWidth: 64 }}>
-                  <div style={{ fontSize: 14, fontWeight: 700, color: colors.text }}>
-                    {s.exam_avg == null ? "—" : `${s.exam_avg}%`}
-                  </div>
-                  <div style={{ fontSize: 11, color: colors.textMuted }}>
-                    {s.exam_count} exam{s.exam_count === 1 ? "" : "s"}
-                  </div>
-                </div>
-
-                <div style={{ textAlign: "right", flexShrink: 0, minWidth: 80 }}>
-                  <div style={{ fontSize: 12, color: colors.textSecondary }}>
-                    {relativeDate(s.last_active)}
-                  </div>
-                  <div style={{ fontSize: 11, color: colors.textMuted }}>last active</div>
-                </div>
-              </div>
-            );
-          })}
-
-          {visible.length === 0 && (
-            <p
-              style={{
-                margin: 0,
-                padding: 24,
-                textAlign: "center",
-                fontSize: 13,
-                color: colors.textMuted,
-              }}
+          {/* Filter */}
+          {summary.at_risk > 0 && (
+            <button
+              onClick={() => setAtRiskOnly((v) => !v)}
+              className={`mb-3 cursor-pointer rounded-lg border px-3.5 py-1.5 text-[12.5px] font-medium ${
+                atRiskOnly
+                  ? "border-red-600 bg-red-50 text-red-600 dark:border-red-400 dark:bg-red-950 dark:text-red-400"
+                  : "border-zinc-200 bg-transparent text-zinc-500 dark:border-zinc-800 dark:text-zinc-400"
+              }`}
             >
-              {atRiskOnly ? "No at-risk students. 🎉" : "No students enrolled."}
-            </p>
+              {atRiskOnly ? "✓ At risk only" : "Show at risk only"}
+            </button>
           )}
+
+          {/* Rows */}
+          <div className="flex flex-col gap-2">
+            {visible.map((s: Student) => {
+              const pct = s.progress_pct;
+              const name = s.student_name ?? s.student_id.slice(0, 8);
+              return (
+                <div
+                  key={s.student_id}
+                  className={`flex flex-wrap items-center gap-3.5 rounded-xl border bg-white px-3.5 py-3 dark:bg-zinc-900 ${
+                    s.at_risk
+                      ? "border-red-200 dark:border-red-900"
+                      : "border-zinc-200 dark:border-zinc-800"
+                  }`}
+                >
+                  {/* Avatar */}
+                  <div className="flex size-9 shrink-0 items-center justify-center rounded-full bg-violet-50 text-[13px] font-bold text-violet-600 uppercase dark:bg-violet-950 dark:text-violet-400">
+                    {initials(s.student_name, s.student_id)}
+                  </div>
+
+                  {/* Name + progress bar */}
+                  <div className="min-w-40 flex-1">
+                    <div className="mb-1.5 flex items-center gap-2">
+                      <span className="truncate text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+                        {name}
+                      </span>
+                      {s.at_risk && (
+                        <span className="shrink-0 rounded-md bg-red-50 px-[7px] py-px text-[10.5px] font-bold text-red-600 dark:bg-red-950 dark:text-red-400">
+                          AT RISK
+                        </span>
+                      )}
+                      {s.status !== "active" && (
+                        <span className="shrink-0 text-[11px] text-zinc-400 dark:text-zinc-500">
+                          {s.status}
+                        </span>
+                      )}
+                    </div>
+                    <div className="h-1.5 overflow-hidden rounded-[3px] bg-zinc-100 dark:bg-zinc-800">
+                      <div
+                        className={`h-full rounded-[3px] transition-[width] duration-300 ${progressColor(pct)}`}
+                        style={{ width: `${pct ?? 0}%` }}
+                      />
+                    </div>
+                  </div>
+
+                  {/* Metrics */}
+                  <div className="min-w-14 shrink-0 text-right">
+                    <div className="text-sm font-bold text-zinc-900 dark:text-zinc-100">
+                      {pct == null ? "—" : `${pct}%`}
+                    </div>
+                    <div className="text-[11px] text-zinc-400 dark:text-zinc-500">
+                      {s.completed_lessons}/{course.published_lessons} lessons
+                    </div>
+                  </div>
+
+                  <div className="min-w-16 shrink-0 text-right">
+                    <div className="text-sm font-bold text-zinc-900 dark:text-zinc-100">
+                      {s.exam_avg == null ? "—" : `${s.exam_avg}%`}
+                    </div>
+                    <div className="text-[11px] text-zinc-400 dark:text-zinc-500">
+                      {s.exam_count} exam{s.exam_count === 1 ? "" : "s"}
+                    </div>
+                  </div>
+
+                  <div className="min-w-20 shrink-0 text-right">
+                    <div className="text-xs text-zinc-500 dark:text-zinc-400">
+                      {relativeDate(s.last_active)}
+                    </div>
+                    <div className="text-[11px] text-zinc-400 dark:text-zinc-500">
+                      last active
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+
+            {visible.length === 0 && (
+              <p className="m-0 p-6 text-center text-[13px] text-zinc-400 dark:text-zinc-500">
+                {atRiskOnly ? "No at-risk students. 🎉" : "No students enrolled."}
+              </p>
+            )}
+          </div>
         </div>
       </div>
     </McpUseProvider>

--- a/mcp-server/resources/study-plan/widget.tsx
+++ b/mcp-server/resources/study-plan/widget.tsx
@@ -63,43 +63,18 @@ export default function StudyPlan() {
   const { callTool } = useCallTool("lms_complete_study_goal");
   const theme = useWidgetTheme();
   const dark = theme === "dark";
-  const colors = {
-    bg: dark ? "#0f0f0f" : "#fafafa",
-    surface: dark ? "#1a1a1a" : "#ffffff",
-    border: dark ? "#2a2a2a" : "#e5e7eb",
-    text: dark ? "#f4f4f5" : "#111827",
-    textSecondary: dark ? "#a1a1aa" : "#6b7280",
-    textMuted: dark ? "#71717a" : "#9ca3af",
-    accent: dark ? "#a78bfa" : "#7c3aed",
-    pass: dark ? "#4ade80" : "#16a34a",
-  };
 
   // Optimistic check-off: goal ids marked done locally while the tool runs.
   const [checked, setChecked] = useState<Set<number>>(new Set());
+  const [saveError, setSaveError] = useState(false);
 
   if (isPending) {
     return (
       <McpUseProvider autoSize>
-        <div
-          style={{
-            fontFamily: "system-ui, -apple-system, sans-serif",
-            padding: 40,
-            display: "flex",
-            justifyContent: "center",
-            backgroundColor: colors.bg,
-          }}
-        >
-          <div
-            style={{
-              width: 24,
-              height: 24,
-              border: `3px solid ${colors.border}`,
-              borderTopColor: colors.accent,
-              borderRadius: "50%",
-              animation: "spin 0.8s linear infinite",
-            }}
-          />
-          <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
+        <div className={dark ? "dark" : ""}>
+          <div className="flex justify-center bg-zinc-50 p-10 font-sans dark:bg-zinc-950">
+            <div className="size-6 animate-spin rounded-full border-[3px] border-zinc-200 border-t-violet-600 dark:border-zinc-800 dark:border-t-violet-400" />
+          </div>
         </div>
       </McpUseProvider>
     );
@@ -120,7 +95,21 @@ export default function StudyPlan() {
   const check = (g: Goal) => {
     if (isDone(g)) return;
     setChecked((s) => new Set(s).add(g.id));
-    callTool({ goal_id: g.id });
+    callTool(
+      { goal_id: g.id },
+      {
+        onSuccess: () => setSaveError(false),
+        // Revert the optimistic check so the UI never lies about a failed save.
+        onError: () => {
+          setChecked((s) => {
+            const next = new Set(s);
+            next.delete(g.id);
+            return next;
+          });
+          setSaveError(true);
+        },
+      }
+    );
   };
 
   // Progress ring geometry (SVG circle, r=26).
@@ -129,231 +118,160 @@ export default function StudyPlan() {
 
   return (
     <McpUseProvider autoSize>
-      <div
-        style={{
-          fontFamily: "system-ui, -apple-system, sans-serif",
-          backgroundColor: colors.bg,
-          padding: 24,
-          maxWidth: 640,
-          margin: "0 auto",
-        }}
-      >
-        <div
-          style={{
-            backgroundColor: colors.surface,
-            border: `1px solid ${colors.border}`,
-            borderRadius: 12,
-            padding: 20,
-            display: "flex",
-            alignItems: "center",
-            gap: 16,
-            marginBottom: 16,
-          }}
-        >
-          <svg width={64} height={64} viewBox="0 0 64 64" style={{ flexShrink: 0 }}>
-            <circle
-              cx={32}
-              cy={32}
-              r={R}
-              fill="none"
-              stroke={dark ? "#27272a" : "#f3f4f6"}
-              strokeWidth={6}
-            />
-            <circle
-              cx={32}
-              cy={32}
-              r={R}
-              fill="none"
-              stroke={allDone ? colors.pass : colors.accent}
-              strokeWidth={6}
-              strokeLinecap="round"
-              strokeDasharray={CIRC}
-              strokeDashoffset={CIRC * (1 - progress / 100)}
-              transform="rotate(-90 32 32)"
-            />
-            <text
-              x={32}
-              y={37}
-              textAnchor="middle"
-              style={{ fontSize: 14, fontWeight: 800, fill: colors.text }}
-            >
-              {progress}%
-            </text>
-          </svg>
-          <div style={{ flex: 1, minWidth: 0 }}>
-            <h2 style={{ margin: 0, fontSize: 17, fontWeight: 700, color: colors.text }}>
-              Week of {weekLabel}
-            </h2>
-            <p style={{ margin: "4px 0 0", fontSize: 13, color: colors.textSecondary }}>
-              {goals.length === 0
-                ? "No goals yet this week"
-                : `${doneCount} of ${goals.length} goals done`}
-              {context.due_reviews > 0 ? ` · ${context.due_reviews} flashcards due` : ""}
-            </p>
-          </div>
-        </div>
-
-        {allDone && (
-          <div
-            style={{
-              backgroundColor: dark ? "#14532d" : "#dcfce7",
-              border: `1px solid ${colors.pass}`,
-              borderRadius: 12,
-              padding: "14px 18px",
-              marginBottom: 16,
-              display: "flex",
-              alignItems: "center",
-              gap: 10,
-            }}
-          >
-            <span style={{ fontSize: 22 }}>🎉</span>
-            <span style={{ fontSize: 14, fontWeight: 700, color: colors.pass }}>
-              Week complete — every goal done!
-            </span>
-          </div>
-        )}
-
-        {goals.length === 0 ? (
-          <div
-            style={{
-              backgroundColor: colors.surface,
-              border: `1px solid ${colors.border}`,
-              borderRadius: 12,
-              padding: 32,
-              textAlign: "center",
-              marginBottom: 16,
-            }}
-          >
-            <div style={{ fontSize: 30, marginBottom: 8 }}>🗓️</div>
-            <p style={{ margin: 0, color: colors.text, fontWeight: 600, fontSize: 15 }}>
-              Nothing planned yet
-            </p>
-            {context.next_lessons.length > 0 && (
-              <p style={{ margin: "8px 0 0", fontSize: 13, color: colors.textSecondary }}>
-                Up next:{" "}
-                {context.next_lessons
-                  .slice(0, 3)
-                  .map((l) => `"${l.lesson_title}" (${l.course_title})`)
-                  .join(" · ")}
+      <div className={dark ? "dark" : ""}>
+        <div className="mx-auto max-w-[640px] bg-zinc-50 p-6 font-sans dark:bg-zinc-950">
+          <div className="mb-4 flex items-center gap-4 rounded-xl border border-zinc-200 bg-white p-5 dark:border-zinc-800 dark:bg-zinc-900">
+            <svg width={64} height={64} viewBox="0 0 64 64" className="shrink-0">
+              <circle
+                cx={32}
+                cy={32}
+                r={R}
+                fill="none"
+                strokeWidth={6}
+                className="stroke-zinc-100 dark:stroke-zinc-800"
+              />
+              <circle
+                cx={32}
+                cy={32}
+                r={R}
+                fill="none"
+                strokeWidth={6}
+                strokeLinecap="round"
+                strokeDasharray={CIRC}
+                strokeDashoffset={CIRC * (1 - progress / 100)}
+                transform="rotate(-90 32 32)"
+                className={
+                  allDone
+                    ? "stroke-green-600 dark:stroke-green-400"
+                    : "stroke-violet-600 dark:stroke-violet-400"
+                }
+              />
+              <text
+                x={32}
+                y={37}
+                textAnchor="middle"
+                className="fill-zinc-900 text-sm font-extrabold dark:fill-zinc-100"
+              >
+                {progress}%
+              </text>
+            </svg>
+            <div className="min-w-0 flex-1">
+              <h2 className="m-0 text-[17px] font-bold text-zinc-900 dark:text-zinc-100">
+                Week of {weekLabel}
+              </h2>
+              <p className="mt-1 mb-0 text-[13px] text-zinc-500 dark:text-zinc-400">
+                {goals.length === 0
+                  ? "No goals yet this week"
+                  : `${doneCount} of ${goals.length} goals done`}
+                {context.due_reviews > 0 ? ` · ${context.due_reviews} flashcards due` : ""}
               </p>
-            )}
+            </div>
+          </div>
+
+          {allDone && (
+            <div className="mb-4 flex items-center gap-2.5 rounded-xl border border-green-600 bg-green-100 px-4.5 py-3.5 dark:border-green-400 dark:bg-green-900">
+              <span className="text-[22px]">🎉</span>
+              <span className="text-sm font-bold text-green-600 dark:text-green-400">
+                Week complete — every goal done!
+              </span>
+            </div>
+          )}
+
+          {saveError && (
+            <div className="mb-3 rounded-[10px] bg-red-50 px-[13px] py-[9px] text-[13px] text-red-700 dark:bg-red-950 dark:text-red-400">
+              Could not save that goal — it has been unchecked. Try again.
+            </div>
+          )}
+
+          {goals.length === 0 ? (
+            <div className="mb-4 rounded-xl border border-zinc-200 bg-white p-8 text-center dark:border-zinc-800 dark:bg-zinc-900">
+              <div className="mb-2 text-3xl">🗓️</div>
+              <p className="m-0 text-[15px] font-semibold text-zinc-900 dark:text-zinc-100">
+                Nothing planned yet
+              </p>
+              {context.next_lessons.length > 0 && (
+                <p className="mt-2 mb-0 text-[13px] text-zinc-500 dark:text-zinc-400">
+                  Up next:{" "}
+                  {context.next_lessons
+                    .slice(0, 3)
+                    .map((l) => `"${l.lesson_title}" (${l.course_title})`)
+                    .join(" · ")}
+                </p>
+              )}
+              <button
+                onClick={() =>
+                  sendFollowUpMessage(
+                    "Help me plan this week: propose study goals from my next lessons, weak spots, and due flashcards, then save them with lms_set_study_plan."
+                  )
+                }
+                className="mt-4 cursor-pointer rounded-lg border-none bg-violet-600 px-4 py-2 text-[13px] font-semibold text-white dark:bg-violet-400"
+              >
+                Plan my week
+              </button>
+            </div>
+          ) : (
+            <div className="mb-4 flex flex-col gap-3.5">
+              {KIND_ORDER.filter((k) => goals.some((g) => g.kind === k)).map((kind) => (
+                <div key={kind}>
+                  <p className="m-0 mb-1.5 text-[11px] font-bold tracking-[1px] text-zinc-400 uppercase dark:text-zinc-500">
+                    {KIND_META[kind].icon} {KIND_META[kind].label}
+                  </p>
+                  <div className="flex flex-col gap-1.5">
+                    {goals
+                      .filter((g) => g.kind === kind)
+                      .map((g) => {
+                        const done = isDone(g);
+                        return (
+                          <button
+                            key={g.id}
+                            onClick={() => check(g)}
+                            disabled={done}
+                            className={`flex w-full items-center gap-2.5 rounded-[10px] border bg-white px-3.5 py-2.5 text-left dark:bg-zinc-900 ${
+                              done
+                                ? "cursor-default border-green-600 dark:border-green-400"
+                                : "cursor-pointer border-zinc-200 dark:border-zinc-800"
+                            }`}
+                          >
+                            <span
+                              className={`flex size-4.5 shrink-0 items-center justify-center rounded-[5px] text-xs font-extrabold text-white ${
+                                done
+                                  ? "border-none bg-green-600 dark:bg-green-400"
+                                  : "border-2 border-zinc-400 bg-transparent dark:border-zinc-500"
+                              }`}
+                            >
+                              {done ? "✓" : ""}
+                            </span>
+                            <span
+                              className={`text-sm ${
+                                done
+                                  ? "text-zinc-400 line-through dark:text-zinc-500"
+                                  : "text-zinc-900 dark:text-zinc-100"
+                              }`}
+                            >
+                              {g.title}
+                            </span>
+                          </button>
+                        );
+                      })}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {goals.length > 0 && (
             <button
               onClick={() =>
                 sendFollowUpMessage(
-                  "Help me plan this week: propose study goals from my next lessons, weak spots, and due flashcards, then save them with lms_set_study_plan."
+                  "Let's plan next week: look at what I finished and missed this week, my next lessons, and due flashcards, then propose next week's goals and save them with lms_set_study_plan."
                 )
               }
-              style={{
-                marginTop: 16,
-                padding: "8px 16px",
-                fontSize: 13,
-                fontWeight: 600,
-                color: "#ffffff",
-                backgroundColor: colors.accent,
-                border: "none",
-                borderRadius: 8,
-                cursor: "pointer",
-              }}
+              className="cursor-pointer rounded-lg border border-violet-600 bg-transparent px-4 py-2 text-[13px] font-semibold text-violet-600 dark:border-violet-400 dark:text-violet-400"
             >
-              Plan my week
+              Plan next week with me
             </button>
-          </div>
-        ) : (
-          <div style={{ display: "flex", flexDirection: "column", gap: 14, marginBottom: 16 }}>
-            {KIND_ORDER.filter((k) => goals.some((g) => g.kind === k)).map((kind) => (
-              <div key={kind}>
-                <p
-                  style={{
-                    margin: "0 0 6px",
-                    fontSize: 11,
-                    fontWeight: 700,
-                    letterSpacing: 1,
-                    textTransform: "uppercase",
-                    color: colors.textMuted,
-                  }}
-                >
-                  {KIND_META[kind].icon} {KIND_META[kind].label}
-                </p>
-                <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-                  {goals
-                    .filter((g) => g.kind === kind)
-                    .map((g) => {
-                      const done = isDone(g);
-                      return (
-                        <button
-                          key={g.id}
-                          onClick={() => check(g)}
-                          disabled={done}
-                          style={{
-                            display: "flex",
-                            alignItems: "center",
-                            gap: 10,
-                            width: "100%",
-                            textAlign: "left",
-                            backgroundColor: colors.surface,
-                            border: `1px solid ${done ? colors.pass : colors.border}`,
-                            borderRadius: 10,
-                            padding: "10px 14px",
-                            cursor: done ? "default" : "pointer",
-                          }}
-                        >
-                          <span
-                            style={{
-                              width: 18,
-                              height: 18,
-                              borderRadius: 5,
-                              flexShrink: 0,
-                              display: "flex",
-                              alignItems: "center",
-                              justifyContent: "center",
-                              fontSize: 12,
-                              fontWeight: 800,
-                              color: "#ffffff",
-                              backgroundColor: done ? colors.pass : "transparent",
-                              border: done ? "none" : `2px solid ${colors.textMuted}`,
-                            }}
-                          >
-                            {done ? "✓" : ""}
-                          </span>
-                          <span
-                            style={{
-                              fontSize: 14,
-                              color: done ? colors.textMuted : colors.text,
-                              textDecoration: done ? "line-through" : "none",
-                            }}
-                          >
-                            {g.title}
-                          </span>
-                        </button>
-                      );
-                    })}
-                </div>
-              </div>
-            ))}
-          </div>
-        )}
-
-        {goals.length > 0 && (
-          <button
-            onClick={() =>
-              sendFollowUpMessage(
-                "Let's plan next week: look at what I finished and missed this week, my next lessons, and due flashcards, then propose next week's goals and save them with lms_set_study_plan."
-              )
-            }
-            style={{
-              padding: "8px 16px",
-              fontSize: 13,
-              fontWeight: 600,
-              color: colors.accent,
-              backgroundColor: "transparent",
-              border: `1px solid ${colors.accent}`,
-              borderRadius: 8,
-              cursor: "pointer",
-            }}
-          >
-            Plan next week with me
-          </button>
-        )}
+          )}
+        </div>
       </div>
     </McpUseProvider>
   );

--- a/mcp-server/resources/submission-grader/widget.tsx
+++ b/mcp-server/resources/submission-grader/widget.tsx
@@ -7,6 +7,7 @@ import {
   type WidgetMetadata,
 } from "mcp-use/react";
 import { z } from "zod";
+import { Markdown } from "../shared/markdown";
 
 // ── Schema ──────────────────────────────────────────────────────────────────
 
@@ -65,30 +66,25 @@ type Props = z.infer<typeof propsSchema>;
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
-function statusPill(
-  status: string,
-  theme: "light" | "dark"
-): { bg: string; text: string; label: string } {
-  const dark = theme === "dark";
-  const map: Record<string, { bg: string; text: string; label: string }> = {
+function statusPill(status: string): { classes: string; label: string } {
+  const map: Record<string, { classes: string; label: string }> = {
     teacher_reviewed: {
-      bg: dark ? "#14532d" : "#dcfce7",
-      text: dark ? "#86efac" : "#166534",
+      classes:
+        "bg-green-100 text-green-600 dark:bg-green-900 dark:text-green-400",
       label: "Teacher reviewed",
     },
     ai_reviewed: {
-      bg: dark ? "#1e1b4b" : "#ede9fe",
-      text: dark ? "#a5b4fc" : "#4338ca",
+      classes:
+        "bg-violet-50 text-violet-600 dark:bg-violet-950 dark:text-violet-400",
       label: "AI reviewed",
     },
     pending_teacher_review: {
-      bg: dark ? "#422006" : "#fef3c7",
-      text: dark ? "#fcd34d" : "#92400e",
+      classes:
+        "bg-amber-100 text-amber-600 dark:bg-amber-950 dark:text-amber-400",
       label: "Awaiting review",
     },
     pending: {
-      bg: dark ? "#3f3f46" : "#f4f4f5",
-      text: dark ? "#a1a1aa" : "#52525b",
+      classes: "bg-zinc-100 text-zinc-500 dark:bg-zinc-700 dark:text-zinc-400",
       label: "Pending",
     },
   };
@@ -129,50 +125,14 @@ export default function SubmissionGrader() {
     "lms_grade_submission"
   );
 
-  const colors = {
-    bg: dark ? "#0f0f0f" : "#fafafa",
-    surface: dark ? "#1a1a1a" : "#ffffff",
-    border: dark ? "#2a2a2a" : "#e5e7eb",
-    text: dark ? "#f4f4f5" : "#111827",
-    textSecondary: dark ? "#a1a1aa" : "#6b7280",
-    textMuted: dark ? "#71717a" : "#9ca3af",
-    accent: dark ? "#a78bfa" : "#7c3aed",
-    accentBg: dark ? "#2e1065" : "#f5f3ff",
-    sectionBg: dark ? "#141414" : "#f9fafb",
-    answerBg: dark ? "#11203a" : "#eff6ff",
-    answerBorder: dark ? "#1e3a5f" : "#bfdbfe",
-    codeBg: dark ? "#0a0a0a" : "#f6f8fa",
-    okBg: dark ? "#14532d" : "#dcfce7",
-    okText: dark ? "#86efac" : "#166534",
-    errBg: dark ? "#7f1d1d" : "#fee2e2",
-    errText: dark ? "#fca5a5" : "#991b1b",
-  };
-
   if (isPending) {
     return (
       <McpUseProvider autoSize>
-        <div
-          style={{
-            padding: 40,
-            textAlign: "center",
-            color: colors.textMuted,
-            backgroundColor: colors.bg,
-            fontFamily: "system-ui, sans-serif",
-          }}
-        >
-          <div
-            style={{
-              width: 36,
-              height: 36,
-              border: `3px solid ${colors.border}`,
-              borderTop: `3px solid ${colors.accent}`,
-              borderRadius: "50%",
-              margin: "0 auto 12px",
-              animation: "spin 0.8s linear infinite",
-            }}
-          />
-          <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
-          <p style={{ margin: 0, fontSize: 14 }}>Loading submission…</p>
+        <div className={dark ? "dark" : ""}>
+          <div className="bg-zinc-50 p-10 text-center font-sans text-zinc-400 dark:bg-zinc-950 dark:text-zinc-500">
+            <div className="mx-auto mb-3 size-9 animate-spin rounded-full border-[3px] border-zinc-200 border-t-violet-600 dark:border-zinc-800 dark:border-t-violet-400" />
+            <p className="m-0 text-sm">Loading submission…</p>
+          </div>
         </div>
       </McpUseProvider>
     );
@@ -180,7 +140,7 @@ export default function SubmissionGrader() {
 
   const { submission, questions, summary } = props;
   const status = localStatus ?? submission.review_status;
-  const pill = statusPill(status, theme);
+  const pill = statusPill(status);
 
   const scoreVal = score ?? (submission.score != null ? String(submission.score) : "");
   const feedbackVal = feedback ?? submission.feedback ?? "";
@@ -202,321 +162,195 @@ export default function SubmissionGrader() {
   };
 
   const studentName = submission.student_name ?? submission.student_id.slice(0, 8);
+  const saveDisabled = saving || (!dirty && status === "teacher_reviewed");
 
   return (
     <McpUseProvider autoSize>
-      <div
-        style={{
-          fontFamily: "system-ui, -apple-system, sans-serif",
-          backgroundColor: colors.bg,
-          padding: 24,
-        }}
-      >
-        {/* Header */}
-        <div
-          style={{
-            display: "flex",
-            justifyContent: "space-between",
-            alignItems: "flex-start",
-            gap: 12,
-            marginBottom: 4,
-          }}
-        >
-          <div>
-            <h2
-              style={{
-                margin: 0,
-                fontSize: 19,
-                fontWeight: 700,
-                color: colors.text,
-                letterSpacing: "-0.01em",
-              }}
-            >
-              {studentName}
-            </h2>
-            <div style={{ fontSize: 13, color: colors.textMuted, marginTop: 2 }}>
-              {submission.exam_title} · submitted {formatDate(submission.date)}
+      <div className={dark ? "dark" : ""}>
+        <div className="bg-zinc-50 p-6 font-sans dark:bg-zinc-950">
+          {/* Header */}
+          <div className="mb-1 flex items-start justify-between gap-3">
+            <div>
+              <h2 className="m-0 text-[19px] font-bold tracking-tight text-zinc-900 dark:text-zinc-100">
+                {studentName}
+              </h2>
+              <div className="mt-0.5 text-[13px] text-zinc-400 dark:text-zinc-500">
+                {submission.exam_title} · submitted {formatDate(submission.date)}
+              </div>
             </div>
+            <span
+              className={`shrink-0 rounded-[10px] px-2.5 py-[3px] text-xs font-semibold whitespace-nowrap ${pill.classes}`}
+            >
+              {pill.label}
+            </span>
           </div>
-          <span
-            style={{
-              padding: "3px 10px",
-              borderRadius: 10,
-              fontSize: 12,
-              fontWeight: 600,
-              backgroundColor: pill.bg,
-              color: pill.text,
-              whiteSpace: "nowrap",
-              flexShrink: 0,
-            }}
-          >
-            {pill.label}
-          </span>
-        </div>
 
-        {/* Grade panel */}
-        <div
-          style={{
-            backgroundColor: colors.surface,
-            border: `1px solid ${colors.border}`,
-            borderRadius: 12,
-            padding: 18,
-            margin: "16px 0",
-          }}
-        >
-          <div style={{ display: "flex", gap: 18, flexWrap: "wrap", alignItems: "flex-end" }}>
-            <label style={{ display: "block" }}>
-              <span
-                style={{
-                  display: "block",
-                  fontSize: 12,
-                  fontWeight: 600,
-                  color: colors.textSecondary,
-                  marginBottom: 6,
-                }}
-              >
-                Score (0–100)
+          {/* Grade panel */}
+          <div className="my-4 rounded-xl border border-zinc-200 bg-white p-[18px] dark:border-zinc-800 dark:bg-zinc-900">
+            <div className="flex flex-wrap items-end gap-[18px]">
+              <label className="block">
+                <span className="mb-1.5 block text-xs font-semibold text-zinc-500 dark:text-zinc-400">
+                  Score (0–100)
+                </span>
+                <input
+                  type="number"
+                  min={0}
+                  max={100}
+                  value={scoreVal}
+                  placeholder="—"
+                  onChange={(e) => setScore(e.target.value)}
+                  className="w-[90px] rounded-lg border border-zinc-200 bg-zinc-100 px-2.5 py-2 text-lg font-bold text-zinc-900 dark:border-zinc-800 dark:bg-zinc-800 dark:text-zinc-100"
+                />
+              </label>
+
+              <div className="pb-2 text-[13px] text-zinc-400 dark:text-zinc-500">
+                AI points:{" "}
+                <strong className="text-zinc-900 dark:text-zinc-100">
+                  {summary.total_points_earned}
+                  {summary.total_points_possible ? ` / ${summary.total_points_possible}` : ""}
+                </strong>{" "}
+                · {summary.graded_count}/{summary.question_count} graded
+              </div>
+            </div>
+
+            <label className="mt-3.5 block">
+              <span className="mb-1.5 block text-xs font-semibold text-zinc-500 dark:text-zinc-400">
+                Feedback to student
               </span>
-              <input
-                type="number"
-                min={0}
-                max={100}
-                value={scoreVal}
-                placeholder="—"
-                onChange={(e) => setScore(e.target.value)}
-                style={{
-                  width: 90,
-                  padding: "8px 10px",
-                  borderRadius: 8,
-                  border: `1px solid ${colors.border}`,
-                  backgroundColor: colors.codeBg,
-                  color: colors.text,
-                  fontSize: 18,
-                  fontWeight: 700,
-                }}
+              <textarea
+                value={feedbackVal}
+                onChange={(e) => setFeedback(e.target.value)}
+                placeholder="Write overall feedback…"
+                className="box-border h-[90px] w-full resize-y rounded-lg border border-zinc-200 bg-zinc-100 p-2.5 text-[13.5px] leading-normal text-zinc-900 [font-family:inherit] dark:border-zinc-800 dark:bg-zinc-800 dark:text-zinc-100"
               />
             </label>
 
-            <div style={{ fontSize: 13, color: colors.textMuted, paddingBottom: 8 }}>
-              AI points: <strong style={{ color: colors.text }}>
-                {summary.total_points_earned}
-                {summary.total_points_possible ? ` / ${summary.total_points_possible}` : ""}
-              </strong>{" "}
-              · {summary.graded_count}/{summary.question_count} graded
+            <div className="mt-3 flex items-center gap-3">
+              <button
+                onClick={handleSave}
+                disabled={saveDisabled}
+                className={`rounded-lg border-none px-5 py-2 text-[13px] font-semibold transition-all ${
+                  saveDisabled
+                    ? "bg-zinc-200 text-zinc-400 dark:bg-zinc-800 dark:text-zinc-500"
+                    : "bg-violet-600 text-white dark:bg-violet-400"
+                } ${saving ? "cursor-not-allowed opacity-70" : "cursor-pointer"}`}
+              >
+                {saving
+                  ? "Saving…"
+                  : status === "teacher_reviewed" && !dirty
+                    ? "Saved ✓"
+                    : "Save grade"}
+              </button>
+              {saveFailed && (
+                <span className="text-[13px] text-red-600 dark:text-red-400">
+                  {saveError instanceof Error ? saveError.message : "Save failed"}
+                </span>
+              )}
             </div>
           </div>
 
-          <label style={{ display: "block", marginTop: 14 }}>
-            <span
-              style={{
-                display: "block",
-                fontSize: 12,
-                fontWeight: 600,
-                color: colors.textSecondary,
-                marginBottom: 6,
-              }}
-            >
-              Feedback to student
-            </span>
-            <textarea
-              value={feedbackVal}
-              onChange={(e) => setFeedback(e.target.value)}
-              placeholder="Write overall feedback…"
-              style={{
-                width: "100%",
-                boxSizing: "border-box",
-                height: 90,
-                padding: 10,
-                borderRadius: 8,
-                border: `1px solid ${colors.border}`,
-                backgroundColor: colors.codeBg,
-                color: colors.text,
-                fontSize: 13.5,
-                lineHeight: 1.5,
-                resize: "vertical",
-                fontFamily: "inherit",
-              }}
-            />
-          </label>
-
-          <div style={{ display: "flex", alignItems: "center", gap: 12, marginTop: 12 }}>
-            <button
-              onClick={handleSave}
-              disabled={saving || (!dirty && status === "teacher_reviewed")}
-              style={{
-                padding: "8px 20px",
-                borderRadius: 8,
-                border: "none",
-                backgroundColor:
-                  saving || (!dirty && status === "teacher_reviewed")
-                    ? colors.border
-                    : colors.accent,
-                color:
-                  saving || (!dirty && status === "teacher_reviewed")
-                    ? colors.textMuted
-                    : "#ffffff",
-                fontSize: 13,
-                fontWeight: 600,
-                cursor: saving ? "not-allowed" : "pointer",
-                opacity: saving ? 0.7 : 1,
-                transition: "all 0.15s",
-              }}
-            >
-              {saving
-                ? "Saving…"
-                : status === "teacher_reviewed" && !dirty
-                  ? "Saved ✓"
-                  : "Save grade"}
-            </button>
-            {saveFailed && (
-              <span style={{ fontSize: 13, color: colors.errText }}>
-                {saveError instanceof Error ? saveError.message : "Save failed"}
-              </span>
-            )}
-          </div>
-        </div>
-
-        {/* Questions */}
-        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-          {questions.map((q, i) => {
-            const correct = q.is_correct;
-            const badge =
-              correct === true
-                ? { bg: colors.okBg, text: colors.okText, label: "Correct" }
-                : correct === false
-                  ? { bg: colors.errBg, text: colors.errText, label: "Incorrect" }
-                  : null;
-            return (
-              <div
-                key={q.question_id}
-                style={{
-                  backgroundColor: colors.surface,
-                  border: `1px solid ${colors.border}`,
-                  borderRadius: 12,
-                  padding: 16,
-                }}
-              >
+          {/* Questions */}
+          <div className="flex flex-col gap-3">
+            {questions.map((q, i) => {
+              const correct = q.is_correct;
+              const badge =
+                correct === true
+                  ? {
+                      classes:
+                        "bg-green-100 text-green-600 dark:bg-green-900 dark:text-green-400",
+                      label: "Correct",
+                    }
+                  : correct === false
+                    ? {
+                        classes:
+                          "bg-red-100 text-red-600 dark:bg-red-950 dark:text-red-400",
+                        label: "Incorrect",
+                      }
+                    : null;
+              return (
                 <div
-                  style={{
-                    display: "flex",
-                    justifyContent: "space-between",
-                    alignItems: "flex-start",
-                    gap: 10,
-                    marginBottom: 8,
-                  }}
+                  key={q.question_id}
+                  className="rounded-xl border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900"
                 >
-                  <div style={{ display: "flex", gap: 8, alignItems: "baseline" }}>
-                    <span
-                      style={{
-                        fontSize: 12,
-                        fontWeight: 700,
-                        color: colors.accent,
-                      }}
-                    >
-                      Q{i + 1}
-                    </span>
-                    <span style={{ fontSize: 11, color: colors.textMuted }}>
-                      {q.type.replace(/_/g, " ")}
-                    </span>
-                  </div>
-                  <div style={{ display: "flex", gap: 8, alignItems: "center", flexShrink: 0 }}>
-                    {q.points_possible != null && (
-                      <span style={{ fontSize: 12, fontWeight: 600, color: colors.text }}>
-                        {q.points_earned ?? 0}/{q.points_possible} pts
+                  <div className="mb-2 flex items-start justify-between gap-2.5">
+                    <div className="flex items-baseline gap-2">
+                      <span className="text-xs font-bold text-violet-600 dark:text-violet-400">
+                        Q{i + 1}
                       </span>
-                    )}
-                    {badge && (
-                      <span
-                        style={{
-                          padding: "2px 8px",
-                          borderRadius: 8,
-                          fontSize: 11,
-                          fontWeight: 600,
-                          backgroundColor: badge.bg,
-                          color: badge.text,
-                        }}
-                      >
-                        {badge.label}
+                      <span className="text-[11px] text-zinc-400 dark:text-zinc-500">
+                        {q.type.replace(/_/g, " ")}
                       </span>
-                    )}
+                    </div>
+                    <div className="flex shrink-0 items-center gap-2">
+                      {q.points_possible != null && (
+                        <span className="text-xs font-semibold text-zinc-900 dark:text-zinc-100">
+                          {q.points_earned ?? 0}/{q.points_possible} pts
+                        </span>
+                      )}
+                      {badge && (
+                        <span
+                          className={`rounded-lg px-2 py-0.5 text-[11px] font-semibold ${badge.classes}`}
+                        >
+                          {badge.label}
+                        </span>
+                      )}
+                    </div>
                   </div>
-                </div>
 
-                <p
-                  style={{
-                    margin: "0 0 10px",
-                    fontSize: 14,
-                    color: colors.text,
-                    lineHeight: 1.5,
-                    fontWeight: 500,
-                  }}
-                >
-                  {q.text}
-                </p>
-
-                {/* Options for MC/TF, highlighting the correct one */}
-                {q.options.length > 0 && (
-                  <div style={{ display: "flex", flexDirection: "column", gap: 4, marginBottom: 10 }}>
-                    {q.options.map((o, oi) => (
-                      <div
-                        key={oi}
-                        style={{
-                          fontSize: 12.5,
-                          padding: "4px 8px",
-                          borderRadius: 6,
-                          color: o.is_correct ? colors.okText : colors.textSecondary,
-                          backgroundColor: o.is_correct ? colors.okBg : "transparent",
-                          fontWeight: o.is_correct ? 600 : 400,
-                        }}
-                      >
-                        {o.is_correct ? "✓ " : "○ "}
-                        {o.text}
-                      </div>
-                    ))}
+                  <div className="mb-2.5 font-medium">
+                    <Markdown content={q.text} dark={dark} fontSize={14} />
                   </div>
-                )}
 
-                {/* Student answer */}
-                <div
-                  style={{
-                    padding: "8px 12px",
-                    borderRadius: 8,
-                    backgroundColor: colors.answerBg,
-                    border: `1px solid ${colors.answerBorder}`,
-                    marginBottom: q.ai_feedback ? 8 : 0,
-                  }}
-                >
-                  <div style={{ fontSize: 11, color: colors.textMuted, marginBottom: 2 }}>
-                    Student answer
-                  </div>
+                  {/* Options for MC/TF, highlighting the correct one */}
+                  {q.options.length > 0 && (
+                    <div className="mb-2.5 flex flex-col gap-1">
+                      {q.options.map((o, oi) => (
+                        <div
+                          key={oi}
+                          className={`rounded-md px-2 py-1 text-[12.5px] ${
+                            o.is_correct
+                              ? "bg-green-100 font-semibold text-green-600 dark:bg-green-900 dark:text-green-400"
+                              : "bg-transparent font-normal text-zinc-500 dark:text-zinc-400"
+                          }`}
+                        >
+                          {o.is_correct ? "✓ " : "○ "}
+                          {o.text}
+                        </div>
+                      ))}
+                    </div>
+                  )}
+
+                  {/* Student answer */}
                   <div
-                    style={{
-                      fontSize: 13.5,
-                      color: colors.text,
-                      whiteSpace: "pre-wrap",
-                      wordBreak: "break-word",
-                    }}
+                    className={`rounded-lg border border-blue-200 bg-blue-50 px-3 py-2 dark:border-blue-900 dark:bg-blue-950 ${
+                      q.ai_feedback ? "mb-2" : "mb-0"
+                    }`}
                   >
-                    {q.student_answer ?? <em style={{ color: colors.textMuted }}>(no answer)</em>}
+                    <div className="mb-0.5 text-[11px] text-zinc-400 dark:text-zinc-500">
+                      Student answer
+                    </div>
+                    <div className="text-[13.5px] break-words whitespace-pre-wrap text-zinc-900 dark:text-zinc-100">
+                      {q.student_answer ?? (
+                        <em className="text-zinc-400 dark:text-zinc-500">(no answer)</em>
+                      )}
+                    </div>
                   </div>
-                </div>
 
-                {/* AI feedback + confidence */}
-                {q.ai_feedback && (
-                  <div style={{ fontSize: 12.5, color: colors.textSecondary, lineHeight: 1.5 }}>
-                    <span style={{ fontWeight: 600 }}>AI feedback: </span>
-                    {q.ai_feedback}
-                    {q.ai_confidence != null && (
-                      <span style={{ color: colors.textMuted }}>
-                        {" "}
-                        ({Math.round(q.ai_confidence * 100)}% confidence)
+                  {/* AI feedback + confidence */}
+                  {q.ai_feedback && (
+                    <div className="text-[12.5px] leading-normal text-zinc-500 dark:text-zinc-400">
+                      <span className="font-semibold">
+                        AI feedback
+                        {q.ai_confidence != null &&
+                          ` (${Math.round(q.ai_confidence * 100)}% confidence)`}
                       </span>
-                    )}
-                  </div>
-                )}
-              </div>
-            );
-          })}
+                      <Markdown content={q.ai_feedback} dark={dark} fontSize={12.5} />
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
         </div>
       </div>
     </McpUseProvider>


### PR DESCRIPTION
## Summary

- **Fixes raw-markdown bug**: `lesson-viewer` (and 5 other widgets) rendered lesson content as literal markdown source (`# Precolonia`, `## Temas principales`). New shared theme-aware `Markdown` component (`resources/shared/markdown.tsx`, react-markdown + remark-gfm — safe by default, raw HTML stripped) now renders content in lesson-viewer, lesson-preview, flashcards, my-exam-results, exam-submissions, submission-grader.
- **Full Tailwind conversion**: all 17 widgets migrated from inline-style objects to Tailwind v4 classes. Consistent palette (zinc surfaces, violet accent, green/amber/red semantics), dark mode via `.dark` wrapper on root driven by `useWidgetTheme()`. `my-learning` is the canonical reference conversion. Dynamic values (progress-bar widths, SVG dasharray, bg-image URLs) stay inline by design.
- **Audit fixes (P1/P2)**:
  - `practice-player`: empty-questions guard + NaN score on zero closed questions
  - `study-plan` / `flashcards` / `course-catalog`: optimistic updates now revert on tool-call failure with visible error notices (`role="alert"`)
  - `my-exam-results` / `exam-submissions`: keyboard a11y on expandable rows (role, tabIndex, aria-expanded, Enter/Space)
  - `exam-submissions` / `student-progress-roster`: horizontal overflow fixes on narrow widths
  - hover-state JS hacks replaced with `hover:` classes
- **Untouched on purpose**: `artifact-sandbox` iframe `sandbox="allow-scripts allow-forms"` (no `allow-same-origin`) byte-identical — security-critical.

## Verification

- `npm run build` (mcp-server): ✓ typecheck, ✓ 17/17 widgets built
- Grep: zero leftover `colors.` style objects; 17/17 widgets use the dark-wrapper root pattern
- Visual in inspector via Chrome (dark mode, student account): `lms_my_learning`, `lms_view_lesson` (markdown + code block render correctly), `lms_my_gamification`
- Render unit test (renderToStaticMarkup) for the shared Markdown component

## Notes

- Deps added: `react-markdown@^10.1.0`, `remark-gfm@^4.0.1`
- Lesson-viewer schema declares `summary`/`embed_code` but widget never renders them — rendering `embed_code` is an XSS/CSP decision, deferred
- Prod follow-up (separate): Dokploy `MCP_SERVER_URL` should be origin-only (mcp-use appends request path when serving path-suffixed OAuth protected-resource metadata)

🤖 Generated with [Claude Code](https://claude.com/claude-code)