### PR TITLE
fix(dashboard): settings 404 + student MCP connection view

### DIFF
--- a/app/[locale]/dashboard/settings/page.tsx
+++ b/app/[locale]/dashboard/settings/page.tsx
@@ -1,0 +1,65 @@
+import Link from 'next/link'
+import { redirect } from 'next/navigation'
+import { getTranslations } from 'next-intl/server'
+import { getUserRole } from '@/lib/supabase/get-user-role'
+import { getCurrentTenant, getCurrentUserId } from '@/lib/supabase/tenant'
+import { createClient } from '@/lib/supabase/server'
+import { ProfileForm } from '@/components/student/profile-form'
+import { ConnectClaudeCard } from '@/components/dashboard/connect-claude-card'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+
+// Shared settings entry point for the sidebar/user-nav links. Admins and
+// students already have richer settings surfaces; teachers get their account
+// settings inline here.
+export default async function DashboardSettingsPage() {
+  const role = await getUserRole()
+  if (role === 'admin') redirect('/dashboard/admin/settings')
+  if (role === 'student') redirect('/dashboard/student/profile')
+  if (role !== 'teacher') redirect('/dashboard')
+
+  const userId = await getCurrentUserId()
+  if (!userId) redirect('/auth/login')
+
+  const supabase = await createClient()
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('*')
+    .eq('id', userId)
+    .single()
+
+  const tenant = await getCurrentTenant()
+  const platformDomain = process.env.NEXT_PUBLIC_PLATFORM_DOMAIN || 'localhost:3000'
+  const connectorUrl = tenant?.slug
+    ? `https://${tenant.slug}.${platformDomain}/api/mcp`
+    : `https://${platformDomain}/api/mcp`
+
+  const t = await getTranslations('dashboard.accountSettings')
+
+  return (
+    <div className="p-6 lg:p-8">
+      <div className="max-w-3xl space-y-6">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">{t('title')}</h1>
+          <p className="text-sm text-muted-foreground mt-0.5">{t('subtitle')}</p>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm">{t('accountTitle')}</CardTitle>
+            <CardDescription>{t('accountSubtitle')}</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ProfileForm profile={profile} />
+          </CardContent>
+        </Card>
+
+        <ConnectClaudeCard connectorUrl={connectorUrl} />
+
+        <Link href="/dashboard/teacher/api-tokens">
+          <Button variant="outline">{t('manageTokens')}</Button>
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/app/[locale]/dashboard/student/ai-assistant/page.tsx
+++ b/app/[locale]/dashboard/student/ai-assistant/page.tsx
@@ -1,0 +1,44 @@
+import { getTranslations } from 'next-intl/server'
+import { getCurrentTenant } from '@/lib/supabase/tenant'
+import { ConnectClaudeCard } from '@/components/dashboard/connect-claude-card'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { IconCircleCheck } from '@tabler/icons-react'
+
+export default async function StudentAiAssistantPage() {
+  const t = await getTranslations('dashboard.student.aiAssistant')
+  const tenant = await getCurrentTenant()
+  const platformDomain = process.env.NEXT_PUBLIC_PLATFORM_DOMAIN || 'localhost:3000'
+  const connectorUrl = tenant?.slug
+    ? `https://${tenant.slug}.${platformDomain}/api/mcp`
+    : `https://${platformDomain}/api/mcp`
+
+  return (
+    <div className="p-6 lg:p-8">
+      <div className="max-w-3xl space-y-6">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">{t('title')}</h1>
+          <p className="text-sm text-muted-foreground mt-0.5">{t('subtitle')}</p>
+        </div>
+
+        <ConnectClaudeCard connectorUrl={connectorUrl} />
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm">{t('whatYouCanDo.title')}</CardTitle>
+            <CardDescription>{t('whatYouCanDo.description')}</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ul className="space-y-2.5 text-sm text-muted-foreground">
+              {(['item1', 'item2', 'item3', 'item4', 'item5'] as const).map((key) => (
+                <li key={key} className="flex items-start gap-2">
+                  <IconCircleCheck className="size-4 mt-0.5 shrink-0 text-primary" />
+                  <span>{t(`whatYouCanDo.${key}`)}</span>
+                </li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/app/[locale]/dashboard/student/profile/actions.ts
+++ b/app/[locale]/dashboard/student/profile/actions.ts
@@ -27,5 +27,6 @@ export async function updateProfile(formData: FormData) {
     if (error) throw new Error(error.message);
 
     revalidatePath("/dashboard/student/profile");
+    revalidatePath("/dashboard/settings");
     return { success: true };
 }

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -19,6 +19,7 @@ import {
     IconReceipt,
     IconSearch,
     IconSettings,
+    IconSparkles,
     IconUsers,
 } from "@tabler/icons-react"
 
@@ -223,6 +224,7 @@ export function AppSidebar({ userRole, ...props }: AppSidebarProps) {
                     ],
                 },
                 { title: t('community'), href: "/dashboard/student/community", icon: IconMessages },
+                { title: t('aiAssistant'), href: "/dashboard/student/ai-assistant", icon: IconSparkles },
                 {
                     title: t('myBilling'), href: "/dashboard/student/billing", icon: IconReceipt,
                     items: [

--- a/components/dashboard/api-tokens-page.tsx
+++ b/components/dashboard/api-tokens-page.tsx
@@ -24,6 +24,7 @@ import {
 import { IconPlus, IconCopy, IconTrash, IconBan, IconCheck, IconChevronDown, IconChevronUp } from '@tabler/icons-react'
 import { toast } from 'sonner'
 import { createMcpToken, revokeMcpToken, deleteMcpToken, type McpToken } from '@/app/actions/mcp-tokens'
+import { ConnectClaudeCard } from '@/components/dashboard/connect-claude-card'
 
 interface ApiTokensPageProps {
   tokens: McpToken[]
@@ -39,18 +40,10 @@ export default function ApiTokensPage({ tokens, mcpUrl }: ApiTokensPageProps) {
   const [isPending, startTransition] = useTransition()
   const [copied, setCopied] = useState(false)
   const [copiedConfig, setCopiedConfig] = useState(false)
-  const [copiedUrl, setCopiedUrl] = useState(false)
   const [showInstructions, setShowInstructions] = useState(false)
 
   // OAuth custom-connector URL — same endpoint without the /cli token path.
   const connectorUrl = mcpUrl.replace(/\/cli$/, '')
-
-  const copyConnectorUrl = async () => {
-    await navigator.clipboard.writeText(connectorUrl)
-    setCopiedUrl(true)
-    toast.success(t('connectClaude.copied'))
-    setTimeout(() => setCopiedUrl(false), 2000)
-  }
 
   const handleCreate = () => {
     if (!tokenName.trim()) {
@@ -240,29 +233,7 @@ export default function ApiTokensPage({ tokens, mcpUrl }: ApiTokensPageProps) {
       </div>
 
       {/* Connect Claude (OAuth custom connector) */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-sm">{t('connectClaude.title')}</CardTitle>
-          <CardDescription>{t('connectClaude.description')}</CardDescription>
-        </CardHeader>
-        <CardContent className="text-sm space-y-4">
-          <div>
-            <Label className="text-xs text-muted-foreground mb-1.5 block">{t('connectClaude.urlLabel')}</Label>
-            <div className="flex items-center gap-2">
-              <Input readOnly value={connectorUrl} className="font-mono text-xs" />
-              <Button variant="outline" size="icon" onClick={copyConnectorUrl}>
-                {copiedUrl ? <IconCheck className="size-4" /> : <IconCopy className="size-4" />}
-              </Button>
-            </div>
-          </div>
-          <ol className="list-decimal list-inside space-y-2 text-muted-foreground">
-            <li>{t('connectClaude.step1')}</li>
-            <li>{t('connectClaude.step2')}</li>
-            <li>{t('connectClaude.step3')}</li>
-            <li>{t('connectClaude.step4')}</li>
-          </ol>
-        </CardContent>
-      </Card>
+      <ConnectClaudeCard connectorUrl={connectorUrl} />
 
       {/* Advanced: API token instructions */}
       <Card>

--- a/components/dashboard/connect-claude-card.tsx
+++ b/components/dashboard/connect-claude-card.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import { useState } from 'react'
+import { useTranslations } from 'next-intl'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { IconCheck, IconCopy } from '@tabler/icons-react'
+import { toast } from 'sonner'
+
+interface ConnectClaudeCardProps {
+  connectorUrl: string
+}
+
+export function ConnectClaudeCard({ connectorUrl }: ConnectClaudeCardProps) {
+  const t = useTranslations('components.connectClaude')
+  const [copied, setCopied] = useState(false)
+
+  const copyConnectorUrl = async () => {
+    await navigator.clipboard.writeText(connectorUrl)
+    setCopied(true)
+    toast.success(t('copied'))
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm">{t('title')}</CardTitle>
+        <CardDescription>{t('description')}</CardDescription>
+      </CardHeader>
+      <CardContent className="text-sm space-y-4">
+        <div>
+          <Label className="text-xs text-muted-foreground mb-1.5 block">{t('urlLabel')}</Label>
+          <div className="flex items-center gap-2">
+            <Input readOnly value={connectorUrl} className="font-mono text-xs" />
+            <Button variant="outline" size="icon" onClick={copyConnectorUrl}>
+              {copied ? <IconCheck className="size-4" /> : <IconCopy className="size-4" />}
+            </Button>
+          </div>
+        </div>
+        <ol className="list-decimal list-inside space-y-2 text-muted-foreground">
+          <li>{t('step1')}</li>
+          <li>{t('step2')}</li>
+          <li>{t('step3')}</li>
+          <li>{t('step4')}</li>
+        </ol>
+      </CardContent>
+    </Card>
+  )
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -153,7 +153,27 @@
     }
   },
   "dashboard": {
+    "accountSettings": {
+      "title": "Settings",
+      "subtitle": "Manage your account and integrations.",
+      "accountTitle": "Account Details",
+      "accountSubtitle": "Update your personal information",
+      "manageTokens": "Manage API tokens"
+    },
     "student": {
+      "aiAssistant": {
+        "title": "AI Assistant",
+        "subtitle": "Connect Claude to your school and learn with an AI tutor that knows your courses.",
+        "whatYouCanDo": {
+          "title": "What you can do",
+          "description": "Once connected, ask Claude to:",
+          "item1": "Walk you through your lessons and mark them complete as you go",
+          "item2": "Quiz you with practice questions and flashcards built from your courses",
+          "item3": "Check your exam readiness and drill your weak spots",
+          "item4": "Build a weekly study plan and keep you on track",
+          "item5": "Tutor you through anything you don't understand — and pass your question to your teacher if needed"
+        }
+      },
       "billing": {
         "title": "Billing",
         "subtitle": "Your purchases, active subscription, and downloadable invoices.",
@@ -2770,16 +2790,6 @@
         "title": "Connect AI Assistants",
         "description": "Connect Claude or other MCP clients to your LMS.",
         "createToken": "Create Token",
-        "connectClaude": {
-          "title": "Connect Claude",
-          "description": "Add the LMS as a custom connector — no token needed, you sign in with your LMS account.",
-          "urlLabel": "Connector URL",
-          "step1": "Copy the connector URL above.",
-          "step2": "In Claude (claude.ai or the desktop app), open Settings → Connectors → Add custom connector.",
-          "step3": "Paste the URL and click Add.",
-          "step4": "When Claude asks to authorize, sign in with your LMS account and approve — the LMS tools appear in your chats.",
-          "copied": "Connector URL copied"
-        },
         "howToConnect": {
           "title": "Advanced: API tokens (CLI and other MCP clients)",
           "description": "Use a token for clients that don't support OAuth sign-in.",
@@ -3135,6 +3145,7 @@
     "myCertificates": "My Certificates",
     "progressReport": "Progress Report",
     "pointStore": "Point Store",
+    "aiAssistant": "AI Assistant",
     "settings": "Settings",
     "logout": "Logout",
     "platform": "LMS Platform",
@@ -3212,6 +3223,16 @@
     "ago": "ago"
   },
   "components": {
+    "connectClaude": {
+      "title": "Connect Claude",
+      "description": "Add the LMS as a custom connector — no token needed, you sign in with your LMS account.",
+      "urlLabel": "Connector URL",
+      "step1": "Copy the connector URL above.",
+      "step2": "In Claude (claude.ai or the desktop app), open Settings → Connectors → Add custom connector.",
+      "step3": "Paste the URL and click Add.",
+      "step4": "When Claude asks to authorize, sign in with your LMS account and approve — the LMS tools appear in your chats.",
+      "copied": "Connector URL copied"
+    },
     "courseProgress": {
       "progress": "Progress",
       "lessons": "lessons"

--- a/messages/es.json
+++ b/messages/es.json
@@ -153,7 +153,27 @@
     }
   },
   "dashboard": {
+    "accountSettings": {
+      "title": "Configuración",
+      "subtitle": "Administra tu cuenta e integraciones.",
+      "accountTitle": "Detalles de la Cuenta",
+      "accountSubtitle": "Actualiza tu información personal",
+      "manageTokens": "Administrar tokens de API"
+    },
     "student": {
+      "aiAssistant": {
+        "title": "Asistente de IA",
+        "subtitle": "Conecta Claude a tu escuela y aprende con un tutor de IA que conoce tus cursos.",
+        "whatYouCanDo": {
+          "title": "Qué puedes hacer",
+          "description": "Una vez conectado, pídele a Claude que:",
+          "item1": "Te guíe por tus lecciones y las marque como completadas a medida que avanzas",
+          "item2": "Te haga preguntas de práctica y tarjetas de memoria basadas en tus cursos",
+          "item3": "Revise tu preparación para exámenes y refuerce tus puntos débiles",
+          "item4": "Cree un plan de estudio semanal y te mantenga al día",
+          "item5": "Te explique lo que no entiendas — y envíe tu pregunta a tu profesor si hace falta"
+        }
+      },
       "billing": {
         "title": "Facturación",
         "subtitle": "Tus compras, suscripción activa y facturas descargables.",
@@ -2336,16 +2356,6 @@
         "title": "Conectar Asistentes de IA",
         "description": "Conecta Claude u otros clientes MCP a tu LMS.",
         "createToken": "Crear Token",
-        "connectClaude": {
-          "title": "Conectar Claude",
-          "description": "Agrega el LMS como conector personalizado — sin tokens, inicias sesión con tu cuenta del LMS.",
-          "urlLabel": "URL del conector",
-          "step1": "Copia la URL del conector de arriba.",
-          "step2": "En Claude (claude.ai o la app de escritorio), abre Configuración → Conectores → Agregar conector personalizado.",
-          "step3": "Pega la URL y haz clic en Agregar.",
-          "step4": "Cuando Claude pida autorización, inicia sesión con tu cuenta del LMS y aprueba — las herramientas del LMS aparecerán en tus chats.",
-          "copied": "URL del conector copiada"
-        },
         "howToConnect": {
           "title": "Avanzado: tokens de API (CLI y otros clientes MCP)",
           "description": "Usa un token para clientes que no soportan inicio de sesión OAuth.",
@@ -2979,6 +2989,7 @@
     "myCertificates": "Mis Certificados",
     "progressReport": "Informe de Progreso",
     "pointStore": "Tienda de Puntos",
+    "aiAssistant": "Asistente de IA",
     "settings": "Configuración",
     "logout": "Cerrar Sesión",
     "platform": "Plataforma LMS",
@@ -3057,6 +3068,16 @@
     "ago": "atrás"
   },
   "components": {
+    "connectClaude": {
+      "title": "Conectar Claude",
+      "description": "Agrega el LMS como conector personalizado — sin tokens, inicias sesión con tu cuenta del LMS.",
+      "urlLabel": "URL del conector",
+      "step1": "Copia la URL del conector de arriba.",
+      "step2": "En Claude (claude.ai o la app de escritorio), abre Configuración → Conectores → Agregar conector personalizado.",
+      "step3": "Pega la URL y haz clic en Agregar.",
+      "step4": "Cuando Claude pida autorización, inicia sesión con tu cuenta del LMS y aprueba — las herramientas del LMS aparecerán en tus chats.",
+      "copied": "URL del conector copiada"
+    },
     "courseProgress": {
       "progress": "Progreso",
       "lessons": "lecciones"


### PR DESCRIPTION
## Problem

1. **Settings 404** — the sidebar footer button and both user-nav items (Profile, Settings) link to `/dashboard/settings`, but that route never existed; only `/dashboard/admin/settings` did. Every role hit a 404.
2. **No student MCP view** — the "Connect Claude" instructions (connector URL + steps) only existed on the teacher/admin API-tokens pages. Students had no way to discover how to connect to the MCP server, despite having 26 student-scoped tools (tutor, practice, flashcards, study plans…).

## Changes

- **New `/dashboard/settings` route** — role-aware entry point for the existing links:
  - admin → redirect to `/dashboard/admin/settings`
  - student → redirect to `/dashboard/student/profile`
  - teacher → inline account page (profile form + Connect Claude card + link to API tokens), since teachers had no settings surface at all
- **New `/dashboard/student/ai-assistant` page** — tenant connector URL (`https://<slug>.<domain>/api/mcp`), the 4 connect-in-Claude steps, and a "what you can do" capability list. New **AI Assistant** entry in the student sidebar.
- **Shared `ConnectClaudeCard`** — extracted from `api-tokens-page.tsx`; i18n strings moved to `components.connectClaude` (en/es, translations unchanged).

## Verified

- Playwright against local dev: admin `/dashboard/settings` → Platform Settings; student → profile (no 404); AI Assistant page renders in `/en` and `/es`; refactored admin api-tokens page unchanged visually.
- `tsc --noEmit` and ESLint clean; en/es message key parity checked.

Pre-existing issues noticed (not addressed here): `sidebar.profile` key exists only in es.json (unused), and logging in as `creator@codeacademy.com` on the code-academy subdomain bounces to `/join-school` despite an active membership row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)