### PR TITLE
fix(mcp): missing exercise_type enum values + catalog enrolled/has_access split

### DIFF
--- a/mcp-server/resources/course-catalog/widget.tsx
+++ b/mcp-server/resources/course-catalog/widget.tsx
@@ -18,6 +18,7 @@ const courseSchema = z.object({
   tags: z.union([z.array(z.string()), z.string(), z.null()]),
   lesson_count: z.number(),
   enrolled: z.boolean(),
+  has_access: z.boolean(),
   covered_by_plan: z.boolean(),
 });
 
@@ -204,6 +205,10 @@ export default function CourseCatalog() {
                           >
                             {pendingIds.has(course.id) ? "Enrolling…" : "Enroll"}
                           </button>
+                        ) : course.has_access ? (
+                          <span className="rounded-full bg-violet-100 px-[9px] py-[3px] text-[11px] font-bold text-violet-600 dark:bg-violet-950 dark:text-violet-400">
+                            Access
+                          </span>
                         ) : (
                           <span className="text-[11px] text-zinc-400 dark:text-zinc-500">
                             Not in plan

--- a/mcp-server/src/tools/exercises.ts
+++ b/mcp-server/src/tools/exercises.ts
@@ -18,6 +18,9 @@ const exerciseTypes = [
   "true_false",
   "fill_in_the_blank",
   "discussion",
+  "audio_evaluation",
+  "video_evaluation",
+  "real_time_conversation",
   "artifact",
 ] as const;
 

--- a/mcp-server/src/tools/student.ts
+++ b/mcp-server/src/tools/student.ts
@@ -583,7 +583,7 @@ export function registerStudentTools(server: MCPServer) {
     {
       name: "lms_browse_catalog",
       description:
-        "Browse the school's published course catalog. Shows which courses the caller already has access to and which are covered by their subscription plan. Read-only — enrollment/purchase happens in the app.",
+        "Browse the school's published course catalog. Each course reports `enrolled` (explicitly enrolled — appears in lms_my_learning), `has_access` (entitled to view content), and `covered_by_plan` (an active subscription covers it — use lms_enroll_in_course to enroll). Purchases happen in the app.",
       schema: z.object({
         limit: PaginationSchema.limit,
         offset: PaginationSchema.offset,
@@ -639,13 +639,20 @@ export function registerStudentTools(server: MCPServer) {
           }
         }
 
-        const [coursesRes, entitlementsRes, subsRes] = await Promise.all([
+        const [coursesRes, entitlementsRes, enrollmentsRes, subsRes] = await Promise.all([
           coursesQuery,
           // entitlements is the access source of truth (course-access.ts).
           supabase
             .from("entitlements")
             .select("course_id, expires_at")
             .eq("user_id", userId)
+            .eq("status", "active"),
+          // enrollments is what lms_my_learning lists — access ≠ enrolled (#366).
+          supabase
+            .from("enrollments")
+            .select("course_id")
+            .eq("user_id", userId)
+            .eq("tenant_id", tenantId)
             .eq("status", "active"),
           supabase
             .from("subscriptions")
@@ -663,6 +670,10 @@ export function registerStudentTools(server: MCPServer) {
           (entitlementsRes.data ?? [])
             .filter((e) => !e.expires_at || e.expires_at > nowIso)
             .map((e) => e.course_id as number)
+        );
+
+        const enrolledSet = new Set(
+          (enrollmentsRes.data ?? []).map((e) => e.course_id as number)
         );
 
         const planIds = (subsRes.data ?? []).map((s) => s.plan_id as number);
@@ -684,7 +695,8 @@ export function registerStudentTools(server: MCPServer) {
           thumbnail_url: c.thumbnail_url,
           tags: c.tags,
           lesson_count: (c.lessons as unknown as Array<{ count: number }>)?.[0]?.count ?? 0,
-          enrolled: accessible.has(c.course_id),
+          enrolled: enrolledSet.has(c.course_id),
+          has_access: accessible.has(c.course_id) || enrolledSet.has(c.course_id),
           covered_by_plan: planCovered.has(c.course_id),
         }));
 
@@ -697,7 +709,7 @@ export function registerStudentTools(server: MCPServer) {
           output: text(
             courses.length === 0
               ? "No published courses found."
-              : `Found ${coursesRes.count ?? courses.length} course(s); you have access to ${courses.filter((c) => c.enrolled).length} of the ones shown.`
+              : `Found ${coursesRes.count ?? courses.length} course(s); of the ones shown you are enrolled in ${courses.filter((c) => c.enrolled).length} and have access to ${courses.filter((c) => c.has_access).length}.`
           ),
         });
       } catch (err) {


### PR DESCRIPTION
Fixes #366 (found during Phase 2 live-verification of epic #348).

## Changes

**1. `lms_create_exercise` / `lms_update_exercise` enum** (`mcp-server/src/tools/exercises.ts`)
Added `audio_evaluation`, `video_evaluation`, `real_time_conversation` to the shared `exerciseTypes` Zod enum — verified against the live Postgres `exercise_type` enum (15 labels; the Zod enum now matches all 11 exercise types). Teachers can now author these via MCP instead of seeding through SQL, matching `lms_complete_exercise` which already grades `real_time_conversation` (#362).

**2. `lms_browse_catalog` enrolled vs access** (`mcp-server/src/tools/student.ts`)
`enrolled` was computed from `entitlements` (has access), so a subscription-covered course never enrolled in reported `enrolled: true` while missing from `lms_my_learning`. The tool now returns both flags per course:
- `enrolled` — active `enrollments` row (same query shape as `lms_my_learning`: user + tenant + status active)
- `has_access` — active, unexpired `entitlements` (or enrolled)
- `covered_by_plan` — unchanged

Tool description and summary text updated to explain the distinction.

**3. `course-catalog` widget** (`mcp-server/resources/course-catalog/widget.tsx`)
Badge logic now keys off the right flag: ✓ Enrolled (actually enrolled) → Enroll button (plan-covered, not enrolled — previously hidden behind the false "Enrolled" badge) → Access badge (entitled but unenrolled, not plan-covered) → Not in plan.

## Verification
- `npm run build` in `mcp-server/` passes (widgets + TypeScript + type check, 75 tools / 17 widgets)
- Postgres enum labels confirmed via local DB query

🤖 Generated with [Claude Code](https://claude.com/claude-code)