### PR TITLE
fix(lesson): add missing Video MDX component

### DIFF
--- a/components/lesson/index.ts
+++ b/components/lesson/index.ts
@@ -27,6 +27,7 @@ export { Compare, CodeCompare, BeforeAfter } from './compare'
 
 // Rich media components
 export { Audio } from './audio'
+export { Video } from './video'
 export { Embed } from './embed'
 export { FileDownload } from './file-download'
 

--- a/components/lesson/mdx-components.tsx
+++ b/components/lesson/mdx-components.tsx
@@ -23,6 +23,7 @@ import {
   CodeCompare,
   BeforeAfter,
   Audio,
+  Video,
   Embed,
   FileDownload,
   Comparison,
@@ -114,6 +115,7 @@ export const lessonMdxComponents: MDXComponents = {
 
   // Rich media
   Audio,
+  Video,
   Embed,
   FileDownload,
 

--- a/components/lesson/video.tsx
+++ b/components/lesson/video.tsx
@@ -1,0 +1,63 @@
+import { cn } from '@/lib/utils'
+
+interface VideoProps {
+  url: string
+  title?: string
+  className?: string
+}
+
+/**
+ * Extract embed URL from a YouTube or Vimeo URL.
+ * Returns null if the URL is not recognized.
+ */
+function getEmbedUrl(url: string): string | null {
+  if (!url) return null
+
+  // YouTube: https://www.youtube.com/watch?v=ID or https://youtu.be/ID
+  const ytMatch = url.match(/(?:youtube\.com\/watch\?v=|youtu\.be\/)([\w-]{11})/)
+  if (ytMatch) {
+    return `https://www.youtube.com/embed/${ytMatch[1]}`
+  }
+
+  // Vimeo: https://vimeo.com/ID or https://vimeo.com/channels/staffpicks/ID
+  const vimeoMatch = url.match(/vimeo\.com\/(?:channels\/[^/]+\/|groups\/[^/]+\/videos\/|video\/)?(\d+)/)
+  if (vimeoMatch) {
+    return `https://player.vimeo.com/video/${vimeoMatch[1]}`
+  }
+
+  return null
+}
+
+export function Video({ url, title, className }: VideoProps) {
+  const embedUrl = getEmbedUrl(url)
+
+  if (!embedUrl) {
+    return (
+      <div className={cn('my-6 rounded-lg border bg-muted p-4 text-center text-sm text-muted-foreground', className)}>
+        Unable to load video.{' '}
+        {url && (
+          <a href={url} target="_blank" rel="noopener noreferrer" className="underline">
+            Open link
+          </a>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <div className={cn('my-6', className)}>
+      {title && (
+        <h4 className="mb-2 text-sm font-semibold">{title}</h4>
+      )}
+      <div className="aspect-video overflow-hidden rounded-lg border bg-muted">
+        <iframe
+          src={embedUrl}
+          className="h-full w-full"
+          allowFullScreen
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          title={title || 'Video'}
+        />
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Problem

Prod error on teacher lesson edit (and preview never loads):

```
Error: Expected component `Video` to be defined: you likely forgot to import, pass, or provide it.
```

## Root cause

Two authoring paths emit `<Video url="..." />` into lesson MDX content:
- The block editor serializer (`components/teacher/block-editor/serializer.ts:61`)
- The MCP server's `lms_list_mdx_components` tool, which advertises the tag to AI authors

…but `lessonMdxComponents` never registered a `Video` component, so any lesson containing a video block crashed the MDX renderer. This affected **both** the teacher edit preview (`MDXPreview`) and the **student lesson view** (`lesson-content.tsx`), which share the same component map.

## Fix

New `components/lesson/video.tsx` registered in the MDX map:
- Converts YouTube/Vimeo watch URLs to embed URLs (same parsing as the block editor's live preview)
- Renders a responsive `aspect-video` iframe
- Graceful fallback (message + external link) for unrecognized URLs instead of crashing

## Testing

- `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)