### PR TITLE
feat(student): mobile-first lesson experience — AI chat takeover, keyboard-safe layout, UX polish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          # Node 24 matches local dev; npm 10 (Node 20) can't validate the
+          # npm-11 lockfile and lint-staged@17 requires Node >=22.
+          node-version: 24
           cache: npm
       - name: Install
         run: npm ci

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+# Keep CI and local installs resolving identically: lockfiles in this repo
+# are generated with legacy-peer-deps (peer dependencies are not auto-installed),
+# so npm ci must validate with the same setting.
+legacy-peer-deps=true

--- a/app/[locale]/dashboard/student/courses/[courseId]/exams/[examId]/exam-taker.tsx
+++ b/app/[locale]/dashboard/student/courses/[courseId]/exams/[examId]/exam-taker.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
+import { useEventListener } from 'usehooks-ts'
 import Link from 'next/link'
 import { createClient } from '@/lib/supabase/client'
 import { Button } from '@/components/ui/button'
@@ -56,29 +57,18 @@ export function ExamTaker({
   const router = useRouter()
   const supabase = createClient()
 
-  // Timer effect
-  useEffect(() => {
-    if (timeLeft === null || timeLeft <= 0) return
-
-    const timer = setInterval(() => {
-      setTimeLeft((prev) => {
-        if (prev === null || prev <= 1) {
-          clearInterval(timer)
-          handleSubmit() // Auto-submit when time runs out
-          return 0
-        }
-        return prev - 1
-      })
-    }, 1000)
-
-    return () => clearInterval(timer)
-  }, [timeLeft])
-
   const formatTime = (seconds: number) => {
     const mins = Math.floor(seconds / 60)
     const secs = seconds % 60
     return `${mins}:${secs.toString().padStart(2, '0')}`
   }
+
+  // Warn before leaving (refresh/close tab) with unsubmitted answers
+  useEventListener('beforeunload', (e) => {
+    if (Object.keys(answers).length === 0 || submitting) return
+    e.preventDefault()
+    e.returnValue = ''
+  })
 
   const currentQuestion = questions[currentQuestionIndex]
   const isFirstQuestion = currentQuestionIndex === 0
@@ -160,13 +150,31 @@ export function ExamTaker({
     }
   }
 
+  // Timer effect (declared after handleSubmit so the auto-submit reference is valid)
+  useEffect(() => {
+    if (timeLeft === null || timeLeft <= 0) return
+
+    const timer = setInterval(() => {
+      setTimeLeft((prev) => {
+        if (prev === null || prev <= 1) {
+          clearInterval(timer)
+          handleSubmit() // Auto-submit when time runs out
+          return 0
+        }
+        return prev - 1
+      })
+    }, 1000)
+
+    return () => clearInterval(timer)
+  }, [timeLeft])
+
   if (questions.length === 0) {
     return (
       <div className="container mx-auto max-w-2xl py-20 px-4 text-center">
         <div className="bg-card border rounded-3xl p-12 shadow-soft">
           <IconFileText className="mx-auto mb-6 h-16 w-16 text-muted-foreground/30" />
           <h2 className="text-2xl font-bold mb-2">No Questions Found</h2>
-          <p className="text-muted-foreground mb-8 text-lg">This exam doesn't have any questions yet. Please check back later.</p>
+          <p className="text-muted-foreground mb-8 text-lg">This exam doesn&apos;t have any questions yet. Please check back later.</p>
           <Link href={`/dashboard/student/courses/${courseId}/exams`}>
             <Button variant="outline" className="rounded-2xl h-12 px-8 font-bold">
               <IconChevronLeft className="mr-2 h-5 w-5" />

--- a/app/[locale]/dashboard/student/courses/[courseId]/lessons/[lessonId]/lesson-content.tsx
+++ b/app/[locale]/dashboard/student/courses/[courseId]/lessons/[lessonId]/lesson-content.tsx
@@ -1,19 +1,18 @@
 'use client'
 
 import { MDXClient, type SerializeResult } from 'next-mdx-remote-client'
-import { useState, useEffect } from 'react'
 import { lessonMdxComponents } from '@/components/lesson/mdx-components'
 import { IconPlayerPlay } from '@tabler/icons-react'
+import { useTranslations } from 'next-intl'
 
 interface LessonContentProps {
-  content: string | null
+  mdx: SerializeResult | null
   videoUrl: string | null
   embedCode: string | null
 }
 
-export function LessonContent({ content, videoUrl, embedCode }: LessonContentProps) {
-  const [mdxResult, setMdxResult] = useState<SerializeResult | null>(null)
-  const [isLoading, setIsLoading] = useState(false)
+export function LessonContent({ mdx, videoUrl, embedCode }: LessonContentProps) {
+  const t = useTranslations('components.lessons')
 
   const getEmbedUrl = (url: string): string | null => {
     const ytMatch = url.match(/(?:youtube\.com\/watch\?v=|youtu\.be\/)([\w-]{11})/)
@@ -24,60 +23,14 @@ export function LessonContent({ content, videoUrl, embedCode }: LessonContentPro
   }
 
   const videoEmbedUrl = videoUrl ? getEmbedUrl(videoUrl) : null
-
-  useEffect(() => {
-    if (!content) {
-      setMdxResult(null)
-      return
-    }
-
-    let cancelled = false
-    setIsLoading(true)
-
-    async function compileMDX() {
-      try {
-        const { serialize } = await import('next-mdx-remote-client/serialize')
-        const result = await serialize({
-          source: content!,
-          options: {
-            mdxOptions: {
-              development: process.env.NODE_ENV === 'development',
-            },
-          },
-        })
-
-        if (!cancelled) {
-          setMdxResult(result)
-          setIsLoading(false)
-        }
-      } catch (err) {
-        if (!cancelled) {
-          console.error('MDX compilation error:', err)
-          setMdxResult({
-            error: err instanceof Error ? err : new Error('Failed to compile MDX'),
-            frontmatter: {},
-            scope: {},
-          })
-          setIsLoading(false)
-        }
-      }
-    }
-
-    compileMDX()
-
-    return () => {
-      cancelled = true
-    }
-  }, [content])
-
-  const hasError = mdxResult && 'error' in mdxResult
-  const hasCompiledSource = mdxResult && 'compiledSource' in mdxResult
+  const hasError = mdx !== null && 'error' in mdx
+  const hasCompiledSource = mdx !== null && 'compiledSource' in mdx
 
   return (
     <div className="space-y-8">
       {/* Video embed */}
       {videoEmbedUrl && (
-        <div className="relative aspect-video w-full overflow-hidden rounded-xl bg-black shadow-lg ring-1 ring-white/10">
+        <div className="relative aspect-video w-full overflow-hidden rounded-xl bg-black shadow-lg ring-1 ring-border">
           <iframe
             src={videoEmbedUrl}
             title="Video"
@@ -97,42 +50,32 @@ export function LessonContent({ content, videoUrl, embedCode }: LessonContentPro
       )}
 
       {/* MDX content */}
-      {content && (
+      {mdx && (
         <article className="prose prose-neutral dark:prose-invert max-w-none prose-headings:font-bold prose-headings:tracking-tight prose-h1:text-xl sm:prose-h1:text-2xl prose-h2:text-lg sm:prose-h2:text-xl prose-h3:text-base sm:prose-h3:text-lg prose-p:leading-[1.8] prose-p:text-foreground/80 prose-li:text-foreground/80 prose-pre:bg-[#1e1e2e] prose-pre:border prose-pre:border-white/5 prose-pre:rounded-xl prose-pre:shadow-md prose-pre:overflow-x-auto prose-pre:text-[13px] sm:prose-pre:text-sm prose-code:before:content-none prose-code:after:content-none prose-code:bg-muted prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded-md prose-code:text-[13px] sm:prose-code:text-sm prose-code:font-medium prose-img:rounded-xl prose-img:shadow-lg prose-img:max-w-full prose-blockquote:border-primary/30 prose-blockquote:bg-primary/5 prose-blockquote:rounded-r-lg prose-blockquote:py-1 prose-a:text-primary prose-a:no-underline hover:prose-a:underline prose-hr:border-border [&_table]:block [&_table]:overflow-x-auto">
-          {isLoading && (
-            <div className="space-y-4 py-2">
-              <div className="h-4 bg-muted rounded-lg w-4/5 animate-pulse" />
-              <div className="h-4 bg-muted rounded-lg w-3/5 animate-pulse" />
-              <div className="h-4 bg-muted rounded-lg w-4/6 animate-pulse" />
-              <div className="h-20 bg-muted rounded-xl w-full animate-pulse mt-4" />
-              <div className="h-4 bg-muted rounded-lg w-2/3 animate-pulse" />
-            </div>
-          )}
-
-          {hasError && mdxResult && 'error' in mdxResult && (
+          {hasError && 'error' in mdx && (
             <div className="rounded-xl border border-destructive/30 bg-destructive/5 p-5 text-destructive">
-              <p className="font-semibold text-sm">Error loading content</p>
-              <p className="text-xs mt-1 opacity-80">{mdxResult.error.message}</p>
+              <p className="font-semibold text-sm">{t('contentError')}</p>
+              <p className="text-xs mt-1 opacity-80">{mdx.error.message}</p>
             </div>
           )}
 
-          {hasCompiledSource && mdxResult && 'compiledSource' in mdxResult && (
+          {hasCompiledSource && 'compiledSource' in mdx && (
             <MDXClient
-              compiledSource={mdxResult.compiledSource}
-              scope={mdxResult.scope}
+              compiledSource={mdx.compiledSource}
+              scope={mdx.scope}
               components={lessonMdxComponents}
             />
           )}
         </article>
       )}
 
-      {!content && !videoEmbedUrl && !embedCode && (
+      {!mdx && !videoEmbedUrl && !embedCode && (
         <div className="rounded-xl border border-dashed bg-muted/20 p-12 text-center">
           <div className="w-12 h-12 rounded-xl bg-muted flex items-center justify-center mx-auto mb-3">
             <IconPlayerPlay className="h-5 w-5 text-muted-foreground/40" />
           </div>
           <p className="text-sm text-muted-foreground font-medium">
-            No content available for this lesson.
+            {t('noContent')}
           </p>
         </div>
       )}

--- a/app/[locale]/dashboard/student/courses/[courseId]/lessons/[lessonId]/lesson-navigation.tsx
+++ b/app/[locale]/dashboard/student/courses/[courseId]/lessons/[lessonId]/lesson-navigation.tsx
@@ -204,20 +204,20 @@ export function LessonNavigation({
         </div>
       </div>
     )}
-    <footer className="shrink-0 border-t bg-card/80 backdrop-blur-sm px-3 py-2 sm:px-4 sm:py-3 md:px-6">
+    <footer className="shrink-0 border-t bg-card/80 backdrop-blur-sm px-3 pt-2 pb-[max(0.5rem,env(safe-area-inset-bottom))] sm:px-4 sm:py-3 md:px-6">
       <div className="flex items-center justify-between gap-2 sm:gap-3 max-w-4xl mx-auto">
         {/* Previous */}
         <div className="flex-1 flex justify-start">
           {prevLessonId ? (
             <Link href={`/dashboard/student/courses/${courseId}/lessons/${prevLessonId}`}>
-              <Button variant="ghost" size="sm" title={`${t('previous')} (←)`} className="gap-1.5 text-muted-foreground hover:text-foreground">
+              <Button variant="ghost" size="sm" title={`${t('previous')} (←)`} className="gap-1.5 text-muted-foreground hover:text-foreground max-sm:h-10 max-sm:min-w-10">
                 <IconArrowLeft className="h-4 w-4" />
                 <span className="hidden sm:inline">{t('previous')}</span>
               </Button>
             </Link>
           ) : (
             <Link href={`/dashboard/student/courses/${courseId}`}>
-              <Button variant="ghost" size="sm" className="gap-1.5 text-muted-foreground hover:text-foreground">
+              <Button variant="ghost" size="sm" className="gap-1.5 text-muted-foreground hover:text-foreground max-sm:h-10 max-sm:min-w-10">
                 <IconArrowLeft className="h-4 w-4" />
                 <span className="hidden sm:inline">{t('backToCourse')}</span>
               </Button>
@@ -234,7 +234,7 @@ export function LessonNavigation({
           variant={completed ? 'secondary' : 'default'}
           size="sm"
           className={cn(
-            'gap-2 px-5 font-semibold transition-all duration-300',
+            'gap-2 px-5 font-semibold transition-all duration-300 max-sm:h-10',
             completed && 'bg-emerald-500/10 text-emerald-600 hover:bg-emerald-500/20 border border-emerald-500/20'
           )}
         >
@@ -253,13 +253,13 @@ export function LessonNavigation({
         <div className="flex-1 flex justify-end">
           {nextLessonId ? (
             requireSequentialCompletion && !completed ? (
-              <Button size="sm" className="gap-1.5" disabled title={t('completeFirst')}>
+              <Button size="sm" className="gap-1.5 max-sm:h-10 max-sm:min-w-10" disabled title={t('completeFirst')}>
                 <span className="hidden sm:inline">{t('next')}</span>
                 <IconArrowRight className="h-4 w-4" />
               </Button>
             ) : (
               <Link href={`/dashboard/student/courses/${courseId}/lessons/${nextLessonId}`}>
-                <Button size="sm" title={`${t('next')} (→)`} className="gap-1.5">
+                <Button size="sm" title={`${t('next')} (→)`} className="gap-1.5 max-sm:h-10 max-sm:min-w-10">
                   <span className="hidden sm:inline">{t('next')}</span>
                   <IconArrowRight className="h-4 w-4" />
                 </Button>
@@ -267,7 +267,7 @@ export function LessonNavigation({
             )
           ) : (
             <Link href={`/dashboard/student/courses/${courseId}`}>
-              <Button size="sm" className="gap-1.5">
+              <Button size="sm" className="gap-1.5 max-sm:h-10 max-sm:min-w-10">
                 <span className="hidden sm:inline">{t('finishCourse')}</span>
                 <IconCheck className="h-4 w-4" />
               </Button>

--- a/app/[locale]/dashboard/student/courses/[courseId]/lessons/[lessonId]/lesson-navigation.tsx
+++ b/app/[locale]/dashboard/student/courses/[courseId]/lessons/[lessonId]/lesson-navigation.tsx
@@ -89,7 +89,7 @@ export function LessonNavigation({
 
       if (error) {
         console.error('Failed to uncomplete lesson:', error)
-        toast.error('Failed to update lesson status')
+        toast.error(t('updateFailed'))
         setCompleted(true)
         setLoading(false)
         return
@@ -148,7 +148,7 @@ export function LessonNavigation({
 
       if (error) {
         console.error('Failed to complete lesson:', error)
-        toast.error('Failed to mark lesson as complete')
+        toast.error(t('completeFailed'))
         setCompleted(false)
         setLoading(false)
         return
@@ -166,11 +166,11 @@ export function LessonNavigation({
 
       if (cert?.verification_code) {
         setCertificateCode(cert.verification_code)
-        toast.success('Certificate Earned!', {
-          description: 'You have completed all requirements and earned a certificate for this course.',
+        toast.success(t('certificateEarnedTitle'), {
+          description: t('certificateEarnedDescription'),
           duration: 8000,
           action: {
-            label: 'View',
+            label: t('view'),
             onClick: () => router.push(`/verify/${cert.verification_code}`),
           },
         })
@@ -193,12 +193,12 @@ export function LessonNavigation({
         <div className="flex items-center justify-center gap-3 max-w-4xl mx-auto">
           <IconCertificate className="h-5 w-5 text-emerald-600 dark:text-emerald-400 shrink-0" />
           <span className="text-sm font-semibold text-emerald-800 dark:text-emerald-200">
-            Certificate earned for this course!
+            {t('certificateBanner')}
           </span>
           <Link href={`/verify/${certificateCode}`}>
             <Button variant="outline" size="sm" className="border-emerald-300 dark:border-emerald-700 text-emerald-700 dark:text-emerald-300 hover:bg-emerald-100 dark:hover:bg-emerald-900/40 font-semibold gap-1.5">
               <IconCertificate className="h-3.5 w-3.5" />
-              View
+              {t('view')}
             </Button>
           </Link>
         </div>

--- a/app/[locale]/dashboard/student/courses/[courseId]/lessons/[lessonId]/lesson-navigation.tsx
+++ b/app/[locale]/dashboard/student/courses/[courseId]/lessons/[lessonId]/lesson-navigation.tsx
@@ -1,8 +1,9 @@
 'use client'
 
 import { useState, useTransition, useRef } from 'react'
-import { useRouter } from 'next/navigation'
+import { useRouter } from 'next-nprogress-bar'
 import Link from 'next/link'
+import { useHotkey } from '@tanstack/react-hotkeys'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { createClient } from '@/lib/supabase/client'
@@ -26,6 +27,8 @@ interface LessonNavigationProps {
   nextLessonId?: number
   tenantId: string
   requireSequentialCompletion?: boolean
+  completedCount?: number
+  totalLessons?: number
 }
 
 export function LessonNavigation({
@@ -36,6 +39,8 @@ export function LessonNavigation({
   nextLessonId,
   tenantId,
   requireSequentialCompletion = false,
+  completedCount = 0,
+  totalLessons = 0,
 }: LessonNavigationProps) {
   const t = useTranslations('components.lessonNavigation')
   const tGamification = useTranslations('components.gamification')
@@ -46,6 +51,20 @@ export function LessonNavigation({
   const router = useRouter()
   const supabase = createClient()
   const buttonRef = useRef<HTMLButtonElement>(null)
+
+  const nextBlocked = requireSequentialCompletion && !completed
+
+  useHotkey('ArrowLeft', () => {
+    if (prevLessonId) {
+      router.push(`/dashboard/student/courses/${courseId}/lessons/${prevLessonId}`)
+    }
+  }, { enabled: !!prevLessonId })
+
+  useHotkey('ArrowRight', () => {
+    if (nextLessonId && !nextBlocked) {
+      router.push(`/dashboard/student/courses/${courseId}/lessons/${nextLessonId}`)
+    }
+  }, { enabled: !!nextLessonId && !nextBlocked })
 
   async function handleComplete() {
     setLoading(true)
@@ -59,6 +78,9 @@ export function LessonNavigation({
     }
 
     if (completed) {
+      // Optimistic: flip immediately, revert on error
+      setCompleted(false)
+
       const { error } = await supabase
         .from('lesson_completions')
         .delete()
@@ -68,32 +90,42 @@ export function LessonNavigation({
       if (error) {
         console.error('Failed to uncomplete lesson:', error)
         toast.error('Failed to update lesson status')
+        setCompleted(true)
         setLoading(false)
         return
       }
 
-      setCompleted(false)
       setLoading(false)
       startTransition(() => { router.refresh() })
     } else {
-      const { error } = await supabase.from('lesson_completions').insert({
-        lesson_id: lessonId,
-        user_id: user.id,
-      })
-
-      if (error) {
-        console.error('Failed to complete lesson:', error)
-        toast.error('Failed to mark lesson as complete')
-        setLoading(false)
-        return
-      }
-
+      // Optimistic: celebrate immediately, revert on error
       setCompleted(true)
-      setLoading(false)
+      const isCourseNowComplete = totalLessons > 0 && completedCount + 1 >= totalLessons
+
       toast.success(tGamification('xpAwarded.lesson_completion'))
 
-      // Celebrate completion with a subtle confetti burst from the button
-      if (buttonRef.current) {
+      if (isCourseNowComplete) {
+        toast.success(t('courseComplete'), {
+          description: t('courseCompleteDescription'),
+          duration: 8000,
+        })
+        // Full-width celebration for finishing the whole course
+        confetti({
+          particleCount: 120,
+          spread: 100,
+          origin: { x: 0.2, y: 0.8 },
+          angle: 60,
+          disableForReducedMotion: true,
+        })
+        confetti({
+          particleCount: 120,
+          spread: 100,
+          origin: { x: 0.8, y: 0.8 },
+          angle: 120,
+          disableForReducedMotion: true,
+        })
+      } else if (buttonRef.current) {
+        // Subtle confetti burst from the button
         const rect = buttonRef.current.getBoundingClientRect()
         const x = (rect.left + rect.width / 2) / window.innerWidth
         const y = (rect.top + rect.height / 2) / window.innerHeight
@@ -108,6 +140,21 @@ export function LessonNavigation({
           disableForReducedMotion: true,
         })
       }
+
+      const { error } = await supabase.from('lesson_completions').insert({
+        lesson_id: lessonId,
+        user_id: user.id,
+      })
+
+      if (error) {
+        console.error('Failed to complete lesson:', error)
+        toast.error('Failed to mark lesson as complete')
+        setCompleted(false)
+        setLoading(false)
+        return
+      }
+
+      setLoading(false)
 
       // Check if a certificate was auto-issued after this lesson completion
       const { data: cert } = await supabase
@@ -163,7 +210,7 @@ export function LessonNavigation({
         <div className="flex-1 flex justify-start">
           {prevLessonId ? (
             <Link href={`/dashboard/student/courses/${courseId}/lessons/${prevLessonId}`}>
-              <Button variant="ghost" size="sm" className="gap-1.5 text-muted-foreground hover:text-foreground">
+              <Button variant="ghost" size="sm" title={`${t('previous')} (←)`} className="gap-1.5 text-muted-foreground hover:text-foreground">
                 <IconArrowLeft className="h-4 w-4" />
                 <span className="hidden sm:inline">{t('previous')}</span>
               </Button>
@@ -212,7 +259,7 @@ export function LessonNavigation({
               </Button>
             ) : (
               <Link href={`/dashboard/student/courses/${courseId}/lessons/${nextLessonId}`}>
-                <Button size="sm" className="gap-1.5">
+                <Button size="sm" title={`${t('next')} (→)`} className="gap-1.5">
                   <span className="hidden sm:inline">{t('next')}</span>
                   <IconArrowRight className="h-4 w-4" />
                 </Button>

--- a/app/[locale]/dashboard/student/courses/[courseId]/lessons/[lessonId]/loading.tsx
+++ b/app/[locale]/dashboard/student/courses/[courseId]/lessons/[lessonId]/loading.tsx
@@ -1,0 +1,53 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+export default function Loading() {
+  return (
+    <div className="flex h-screen bg-background overflow-hidden">
+      <main className="flex flex-1 flex-col overflow-hidden w-full">
+        {/* Course progress line placeholder */}
+        <div className="shrink-0 h-1 bg-muted" />
+
+        {/* Header */}
+        <header className="shrink-0 border-b bg-card/80 px-3 py-2.5 sm:px-4 sm:py-3 md:px-6">
+          <div className="max-w-4xl mx-auto space-y-1.5">
+            <Skeleton className="h-3 w-20" />
+            <Skeleton className="h-6 w-64" />
+          </div>
+        </header>
+
+        {/* Content */}
+        <div className="flex-1 overflow-hidden">
+          <div className="mx-auto max-w-4xl px-3 py-5 sm:px-4 sm:py-8 md:px-6 md:py-10 space-y-6">
+            <Skeleton className="aspect-video w-full rounded-xl" />
+            <div className="space-y-3">
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-11/12" />
+              <Skeleton className="h-4 w-4/5" />
+              <Skeleton className="h-4 w-2/3" />
+            </div>
+          </div>
+        </div>
+
+        {/* Navigation footer */}
+        <footer className="shrink-0 border-t px-3 py-2 sm:px-4 sm:py-3 md:px-6">
+          <div className="flex items-center justify-between max-w-4xl mx-auto">
+            <Skeleton className="h-8 w-24 rounded-md" />
+            <Skeleton className="h-8 w-36 rounded-md" />
+            <Skeleton className="h-8 w-24 rounded-md" />
+          </div>
+        </footer>
+      </main>
+
+      {/* Sidebar */}
+      <div className="hidden md:flex h-full w-72 shrink-0 border-l bg-card/50 flex-col gap-3 p-4">
+        <Skeleton className="h-5 w-40" />
+        {Array.from({ length: 8 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-3">
+            <Skeleton className="h-5 w-5 rounded-full shrink-0" />
+            <Skeleton className="h-4 flex-1" />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/app/[locale]/dashboard/student/courses/[courseId]/lessons/[lessonId]/page.tsx
+++ b/app/[locale]/dashboard/student/courses/[courseId]/lessons/[lessonId]/page.tsx
@@ -8,6 +8,7 @@ import { IconMenu2, IconSparkles, IconLock } from '@tabler/icons-react'
 import { LessonNavigation } from './lesson-navigation'
 import { LessonComments } from '@/components/student/lesson-comments'
 import dynamic from 'next/dynamic'
+import type { UIMessage } from 'ai'
 import { Skeleton } from '@/components/ui/skeleton'
 
 const LessonAIChat = dynamic(
@@ -24,6 +25,7 @@ const LessonAIChat = dynamic(
 import { Sheet, SheetContent, SheetTrigger, SheetHeader, SheetTitle, SheetDescription } from '@/components/ui/sheet'
 import { Button } from '@/components/ui/button'
 import { LessonCompletionBadge } from '@/components/student/lesson-completion-badge'
+import { AskTutorChip } from '@/components/student/ask-tutor-chip'
 import { LessonProgressLine } from '@/components/student/lesson-progress-line'
 import { LessonScrollArea } from '@/components/student/lesson-scroll-area'
 import { AnimatedSection } from '@/components/student/animated-section'
@@ -113,11 +115,12 @@ export default async function LessonPage({ params }: PageProps) {
 
     return {
       id: msg.id.toString(),
-      role: msg.sender,
+      role: msg.sender as 'user' | 'assistant',
       parts: parts,
       createdAt: msg.created_at
     };
-  });
+    // DB rows use a legacy part shape; the chat renders them via ToolInvocationPart
+  }) as unknown as UIMessage[];
 
   const isCurrentLessonCompleted = lessonData.lesson_completions?.length > 0;
 
@@ -248,7 +251,7 @@ export default async function LessonPage({ params }: PageProps) {
   // Locked lesson — show locked state
   if (isLocked && prevLessonForUnlock) {
     return (
-      <div className="flex h-screen bg-background overflow-hidden">
+      <div className="flex h-dvh bg-background overflow-hidden">
         <main className="flex flex-1 flex-col overflow-hidden w-full">
           <LessonProgressLine
             completed={completedCount}
@@ -296,7 +299,7 @@ export default async function LessonPage({ params }: PageProps) {
   }
 
   return (
-    <div className="flex h-screen bg-background overflow-hidden">
+    <div className="flex h-dvh bg-background overflow-hidden">
       {/* Main content */}
       <main className="flex flex-1 flex-col overflow-hidden w-full">
         {/* Course progress line */}
@@ -355,6 +358,9 @@ export default async function LessonPage({ params }: PageProps) {
               videoUrl={lesson.video_url}
               embedCode={lesson.embed_code}
             />
+
+            {/* Contextual tutor entry point (opens the AI chat pre-seeded) */}
+            {aiTask && !isCurrentLessonCompleted && <AskTutorChip />}
 
             {/* Lesson Resources */}
             {lessonResources && lessonResources.length > 0 && (

--- a/app/[locale]/dashboard/student/courses/[courseId]/lessons/[lessonId]/page.tsx
+++ b/app/[locale]/dashboard/student/courses/[courseId]/lessons/[lessonId]/page.tsx
@@ -3,6 +3,7 @@ import { redirect, notFound } from 'next/navigation'
 import Link from 'next/link'
 import { LessonSidebar } from '@/components/student/lesson-sidebar'
 import { LessonContent } from './lesson-content'
+import { serializeLessonMdx } from './serialize-lesson'
 import { LessonResources } from '@/components/student/lesson-resources'
 import { IconMenu2, IconSparkles, IconLock } from '@tabler/icons-react'
 import { LessonNavigation } from './lesson-navigation'
@@ -243,6 +244,8 @@ export default async function LessonPage({ params }: PageProps) {
     percent: sidebarLessons.length > 0 ? Math.round((completedCount / sidebarLessons.length) * 100) : 0,
   })
 
+  const lessonMdx = await serializeLessonMdx(lesson.content)
+
   const currentIndex = allLessons?.findIndex((l) => l.id === lesson.id) ?? -1
   const prevLesson = currentIndex > 0 ? allLessons?.[currentIndex - 1] : null
   const nextLesson =
@@ -279,7 +282,7 @@ export default async function LessonPage({ params }: PageProps) {
               <p className="text-sm text-muted-foreground mb-6">{t('completePreviousFirst')}</p>
               <Link href={`/dashboard/student/courses/${courseId}/lessons/${prevLessonForUnlock.id}`}>
                 <Button size="sm" className="gap-2">
-                  {prevLessonForUnlock.title}
+                  {t('goToLesson', { title: prevLessonForUnlock.title })}
                 </Button>
               </Link>
             </div>
@@ -354,7 +357,7 @@ export default async function LessonPage({ params }: PageProps) {
         <LessonScrollArea>
           <div className="mx-auto max-w-4xl px-3 py-5 sm:px-4 sm:py-8 md:px-6 md:py-10 space-y-8 sm:space-y-10">
             <LessonContent
-              content={lesson.content}
+              mdx={lessonMdx}
               videoUrl={lesson.video_url}
               embedCode={lesson.embed_code}
             />
@@ -387,16 +390,14 @@ export default async function LessonPage({ params }: PageProps) {
                     </div>
                   </div>
 
-                  {/* Task description */}
-                  <div className="px-3 py-3 sm:px-5 sm:py-4">
-                    <div className="bg-card border rounded-xl p-3 sm:p-4 shadow-sm">
-                      <h4 className="text-[10px] font-bold uppercase tracking-widest text-muted-foreground/70 mb-1.5 sm:mb-2">
-                        {t('currentTask')}
-                      </h4>
-                      <p className="text-sm text-foreground leading-relaxed">
-                        {aiTask.task_instructions}
-                      </p>
-                    </div>
+                  {/* Task description — plain block, the chat below is the interactive card */}
+                  <div className="px-4 py-3 sm:px-5 sm:py-4">
+                    <h4 className="text-[10px] font-bold uppercase tracking-widest text-muted-foreground/70 mb-1.5 sm:mb-2">
+                      {t('currentTask')}
+                    </h4>
+                    <p className="text-sm text-foreground leading-relaxed">
+                      {aiTask.task_instructions}
+                    </p>
                   </div>
 
                   {/* Chat */}

--- a/app/[locale]/dashboard/student/courses/[courseId]/lessons/[lessonId]/page.tsx
+++ b/app/[locale]/dashboard/student/courses/[courseId]/lessons/[lessonId]/page.tsx
@@ -24,6 +24,8 @@ const LessonAIChat = dynamic(
 import { Sheet, SheetContent, SheetTrigger, SheetHeader, SheetTitle, SheetDescription } from '@/components/ui/sheet'
 import { Button } from '@/components/ui/button'
 import { LessonCompletionBadge } from '@/components/student/lesson-completion-badge'
+import { LessonProgressLine } from '@/components/student/lesson-progress-line'
+import { LessonScrollArea } from '@/components/student/lesson-scroll-area'
 import { AnimatedSection } from '@/components/student/animated-section'
 import { getTranslations } from 'next-intl/server'
 import {getCurrentTenantId, getCurrentUserId } from '@/lib/supabase/tenant'
@@ -80,7 +82,13 @@ export default async function LessonPage({ params }: PageProps) {
     : lessonData.lessons_ai_tasks;
 
   const dbMessages = lessonData.lessons_ai_task_messages || [];
-  const initialMessages = dbMessages.map((msg: any) => {
+  const initialMessages = dbMessages.map((msg: {
+    id: number
+    message: string | null
+    sender: string
+    created_at: string
+    tool_invocations?: unknown
+  }) => {
     const parts = [];
 
     if (msg.message) {
@@ -95,7 +103,7 @@ export default async function LessonPage({ params }: PageProps) {
         ? msg.tool_invocations
         : [msg.tool_invocations];
 
-      invocations.forEach((invocation: any) => {
+      invocations.forEach((invocation: unknown) => {
         parts.push({
           type: 'tool-invocation',
           toolInvocation: invocation
@@ -128,7 +136,18 @@ export default async function LessonPage({ params }: PageProps) {
       comment_reactions: { comment_id: number; user_id: string; reaction_type: string }[]
     }
 
-    const allComments = (rawComments as RawComment[]).map((c) => ({
+    type CommentNode = {
+      id: number
+      content: string
+      created_at: string
+      user_id: string
+      parent_comment_id: number | null
+      user: { id: string; full_name: string | null; username: string | null; avatar_url: string | null }
+      reactions: { user_id: string; reaction_type: 'like' | 'dislike' | 'boring' | 'funny' }[]
+      replies: CommentNode[]
+    }
+
+    const allComments: CommentNode[] = (rawComments as RawComment[]).map((c) => ({
       id: c.id,
       content: c.content,
       created_at: c.created_at,
@@ -141,7 +160,7 @@ export default async function LessonPage({ params }: PageProps) {
         user_id: r.user_id,
         reaction_type: r.reaction_type as 'like' | 'dislike' | 'boring' | 'funny',
       })),
-      replies: [] as any[],
+      replies: [],
     }))
 
     // Build tree structure
@@ -214,6 +233,13 @@ export default async function LessonPage({ params }: PageProps) {
       isCompleted: completedLessonIds.has(l.id),
     })) || []
 
+  const completedCount = sidebarLessons.filter((l) => l.isCompleted).length
+  const progressLabel = t('courseProgress', {
+    completed: completedCount,
+    total: sidebarLessons.length,
+    percent: sidebarLessons.length > 0 ? Math.round((completedCount / sidebarLessons.length) * 100) : 0,
+  })
+
   const currentIndex = allLessons?.findIndex((l) => l.id === lesson.id) ?? -1
   const prevLesson = currentIndex > 0 ? allLessons?.[currentIndex - 1] : null
   const nextLesson =
@@ -224,6 +250,11 @@ export default async function LessonPage({ params }: PageProps) {
     return (
       <div className="flex h-screen bg-background overflow-hidden">
         <main className="flex flex-1 flex-col overflow-hidden w-full">
+          <LessonProgressLine
+            completed={completedCount}
+            total={sidebarLessons.length}
+            label={progressLabel}
+          />
           <header className="shrink-0 border-b bg-card/80 backdrop-blur-sm px-3 py-2.5 sm:px-4 sm:py-3 md:px-6">
             <div className="flex items-center justify-between max-w-4xl mx-auto">
               <div className="min-w-0 flex-1">
@@ -268,6 +299,13 @@ export default async function LessonPage({ params }: PageProps) {
     <div className="flex h-screen bg-background overflow-hidden">
       {/* Main content */}
       <main className="flex flex-1 flex-col overflow-hidden w-full">
+        {/* Course progress line */}
+        <LessonProgressLine
+          completed={completedCount}
+          total={sidebarLessons.length}
+          label={progressLabel}
+        />
+
         {/* Lesson header */}
         <header className="shrink-0 border-b bg-card/80 backdrop-blur-sm px-3 py-2.5 sm:px-4 sm:py-3 md:px-6">
           <div className="flex items-center justify-between max-w-4xl mx-auto">
@@ -309,8 +347,8 @@ export default async function LessonPage({ params }: PageProps) {
           </div>
         </header>
 
-        {/* Scrollable content area */}
-        <div className="flex-1 overflow-y-auto">
+        {/* Scrollable content area with reading progress */}
+        <LessonScrollArea>
           <div className="mx-auto max-w-4xl px-3 py-5 sm:px-4 sm:py-8 md:px-6 md:py-10 space-y-8 sm:space-y-10">
             <LessonContent
               content={lesson.content}
@@ -374,7 +412,7 @@ export default async function LessonPage({ params }: PageProps) {
               <LessonComments lessonId={lesson.id} userId={userId} initialComments={initialComments} />
             </section>
           </div>
-        </div>
+        </LessonScrollArea>
 
         {/* Navigation footer */}
         <LessonNavigation
@@ -385,6 +423,8 @@ export default async function LessonPage({ params }: PageProps) {
           nextLessonId={nextLesson?.id}
           tenantId={tenantId}
           requireSequentialCompletion={requireSequential}
+          completedCount={completedCount}
+          totalLessons={sidebarLessons.length}
         />
       </main>
 

--- a/app/[locale]/dashboard/student/courses/[courseId]/lessons/[lessonId]/serialize-lesson.ts
+++ b/app/[locale]/dashboard/student/courses/[courseId]/lessons/[lessonId]/serialize-lesson.ts
@@ -1,0 +1,28 @@
+import { serialize } from 'next-mdx-remote-client/serialize'
+import type { SerializeResult } from 'next-mdx-remote-client'
+
+/**
+ * Compiles lesson MDX on the server so the client only renders the
+ * precompiled source (no in-browser compiler, no loading skeleton).
+ */
+export async function serializeLessonMdx(
+  content: string | null
+): Promise<SerializeResult | null> {
+  if (!content) return null
+  try {
+    return await serialize({
+      source: content,
+      options: {
+        mdxOptions: {
+          development: process.env.NODE_ENV === 'development',
+        },
+      },
+    })
+  } catch (err) {
+    return {
+      error: err instanceof Error ? err : new Error('Failed to compile MDX'),
+      frontmatter: {},
+      scope: {},
+    } as SerializeResult
+  }
+}

--- a/app/[locale]/dashboard/student/courses/[courseId]/loading.tsx
+++ b/app/[locale]/dashboard/student/courses/[courseId]/loading.tsx
@@ -1,0 +1,39 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+export default function Loading() {
+  return (
+    <div className="p-6 space-y-6 max-w-5xl mx-auto">
+      {/* Breadcrumb / back link */}
+      <Skeleton className="h-4 w-40" />
+
+      {/* Course title + description */}
+      <div className="space-y-3">
+        <Skeleton className="h-9 w-2/3" />
+        <Skeleton className="h-4 w-1/2" />
+      </div>
+
+      {/* Progress summary */}
+      <div className="rounded-xl border p-4 space-y-2">
+        <div className="flex justify-between">
+          <Skeleton className="h-4 w-32" />
+          <Skeleton className="h-4 w-12" />
+        </div>
+        <Skeleton className="h-2 w-full rounded-full" />
+      </div>
+
+      {/* Lesson list */}
+      <div className="space-y-3">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div key={i} className="rounded-xl border p-4 flex items-center gap-4">
+            <Skeleton className="h-9 w-9 rounded-full shrink-0" />
+            <div className="flex-1 space-y-2">
+              <Skeleton className="h-4 w-1/2" />
+              <Skeleton className="h-3 w-1/4" />
+            </div>
+            <Skeleton className="h-8 w-20 rounded-md shrink-0" />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/app/[locale]/dashboard/teacher/courses/[courseId]/preview/lessons/[lessonId]/page.tsx
+++ b/app/[locale]/dashboard/teacher/courses/[courseId]/preview/lessons/[lessonId]/page.tsx
@@ -1,6 +1,7 @@
 import { createClient } from '@/lib/supabase/server'
 import { redirect, notFound } from 'next/navigation'
 import { LessonContent } from '@/app/[locale]/dashboard/student/courses/[courseId]/lessons/[lessonId]/lesson-content'
+import { serializeLessonMdx } from '@/app/[locale]/dashboard/student/courses/[courseId]/lessons/[lessonId]/serialize-lesson'
 import { IconMenu2, IconSparkles, IconArrowLeft, IconArrowRight } from '@tabler/icons-react'
 import { Sheet, SheetContent, SheetTrigger, SheetHeader, SheetTitle, SheetDescription } from '@/components/ui/sheet'
 import { Button } from '@/components/ui/button'
@@ -131,7 +132,7 @@ export default async function LessonPreviewPage({ params }: PageProps) {
           <div className="flex-1 overflow-y-auto">
             <div className="mx-auto max-w-4xl px-4 py-8 md:px-6 md:py-10 space-y-10">
               <LessonContent
-                content={lesson.content}
+                mdx={await serializeLessonMdx(lesson.content)}
                 videoUrl={lesson.video_url}
                 embedCode={lesson.embed_code}
               />

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono, Noto_Sans } from "next/font/google";
 import "../globals.css";
 import { Toaster } from "@/components/ui/sonner";
+import { RouteProgress } from "@/components/shared/route-progress";
 import { ThemeProvider } from "@/components/theme-provider";
 import { TenantProvider } from "@/components/tenant/tenant-provider"
 import { TenantCssVars } from "@/components/tenant/tenant-css-vars";
@@ -12,6 +13,7 @@ import { NextIntlClientProvider } from 'next-intl';
 import { getMessages, setRequestLocale } from 'next-intl/server';
 import { notFound } from 'next/navigation';
 import { locales } from '@/i18n';
+import type { StoredPreset } from '@/lib/themes/presets';
 
 const notoSans = Noto_Sans({ variable: '--font-sans', subsets: ["latin"] });
 
@@ -44,7 +46,7 @@ export default async function RootLayout({
   const { locale } = await params;
 
   // Validate that the incoming `locale` parameter is valid
-  if (!locales.includes(locale as any)) {
+  if (!locales.includes(locale as (typeof locales)[number])) {
     notFound();
   }
 
@@ -56,7 +58,8 @@ export default async function RootLayout({
 
   // Load tenant settings for branding overrides (use admin client to bypass RLS
   // since these are public tenant configuration, not user-specific data)
-  let tenantSettings: Record<string, any> = {};
+  // setting_value is jsonb: `{ value: string }` for branding keys, a StoredPreset for theme_preset
+  let tenantSettings: Record<string, { value?: string } | undefined> = {};
   if (tenant) {
     const sb = createAdminClient();
     const { data: settings } = await sb
@@ -65,7 +68,7 @@ export default async function RootLayout({
       .eq('tenant_id', tenant.id)
       .in('setting_key', ['site_name', 'logo_url', 'primary_color', 'secondary_color', 'favicon_url', 'theme_preset']);
     if (settings) {
-      tenantSettings = settings.reduce((acc: Record<string, any>, s) => {
+      tenantSettings = settings.reduce((acc: typeof tenantSettings, s) => {
         acc[s.setting_key] = s.setting_value;
         return acc;
       }, {});
@@ -81,7 +84,7 @@ export default async function RootLayout({
     secondary_color: tenantSettings.secondary_color?.value || tenant.secondary_color,
     plan: tenant.plan,
     settings: tenantSettings,
-    theme_preset: tenantSettings.theme_preset ?? null,
+    theme_preset: (tenantSettings.theme_preset as unknown as StoredPreset | undefined) ?? null,
   } : null;
 
   return (
@@ -105,6 +108,7 @@ export default async function RootLayout({
           >
             <TenantProvider tenant={tenantInfo}>
               <TenantCssVars />
+              <RouteProgress />
               {children}
               <Toaster />
             </TenantProvider>

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono, Noto_Sans } from "next/font/google";
 import "../globals.css";
 import { Toaster } from "@/components/ui/sonner";
@@ -30,6 +30,17 @@ const geistMono = Geist_Mono({
 export const metadata: Metadata = {
   title: "LMS V2",
   description: "The ultimate learning platform powered by Next.js 16 and Supabase.",
+};
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  // Keyboard shrinks the layout viewport so dvh-sized chat surfaces and
+  // docked composers stay visible (Chrome Android; iOS handled via
+  // visualViewport in lesson-ai-chat).
+  interactiveWidget: "resizes-content",
+  // Enables env(safe-area-inset-*) on notched devices.
+  viewportFit: "cover",
 };
 
 export function generateStaticParams() {

--- a/components/shared/route-progress.tsx
+++ b/components/shared/route-progress.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+import { AppProgressBar } from 'next-nprogress-bar'
+
+export function RouteProgress() {
+  return (
+    <AppProgressBar
+      height="3px"
+      color="var(--primary)"
+      options={{ showSpinner: false }}
+      shallowRouting
+    />
+  )
+}

--- a/components/student/ask-tutor-chip.tsx
+++ b/components/student/ask-tutor-chip.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { IconSparkles } from '@tabler/icons-react'
+import { useTranslations } from 'next-intl'
+
+/**
+ * Contextual entry point to the lesson AI tutor (Duolingo "Explain my answer"
+ * pattern). Dispatches a window event picked up by LessonAIChat, which opens
+ * the chat (full-screen overlay on mobile) and sends the prompt.
+ */
+export function AskTutorChip() {
+    const t = useTranslations('components.lessonAIChat.contextual')
+
+    return (
+        <div className="flex justify-start">
+            <button
+                type="button"
+                onClick={() =>
+                    window.dispatchEvent(
+                        new CustomEvent('lesson-tutor:ask', {
+                            detail: { prompt: t('prompt') },
+                        })
+                    )
+                }
+                className="inline-flex min-h-11 items-center gap-2 rounded-full border border-primary/20 bg-primary/5 px-4 py-2 text-sm font-medium text-primary transition-colors hover:bg-primary/10 active:scale-[0.98]"
+            >
+                <IconSparkles className="h-4 w-4" />
+                {t('chip')}
+            </button>
+        </div>
+    )
+}

--- a/components/student/lesson-ai-chat.tsx
+++ b/components/student/lesson-ai-chat.tsx
@@ -45,6 +45,16 @@ import { useRouter } from "next/navigation";
 import { DefaultChatTransport } from "ai";
 import confetti from "canvas-confetti";
 import { Button } from "@/components/ui/button";
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Suggestion, Suggestions } from "@/components/ai-elements/suggestion";
 import { Shimmer } from "@/components/ai-elements/shimmer";
 import {
@@ -134,6 +144,7 @@ function InnerLessonAIChat({
     const t = useTranslations('components.lessonAIChat');
     const [isCompleted, setIsCompleted] = useState(initialIsCompleted);
     const [isRestarting, setIsRestarting] = useState(false);
+    const [restartDialogOpen, setRestartDialogOpen] = useState(false);
     // Mobile-only: the chat lives behind a launcher and opens as a
     // full-screen overlay so it never fights the lesson page for scroll.
     const [mobileOpen, setMobileOpen] = useState(false);
@@ -221,9 +232,10 @@ function InnerLessonAIChat({
         sendMessage({ text: suggestion });
     };
 
-    const handleRestart = async () => {
-        if (!confirm(t('confirmRestart'))) return;
+    const handleRestart = () => setRestartDialogOpen(true);
 
+    const doRestart = async () => {
+        setRestartDialogOpen(false);
         setIsRestarting(true);
         try {
             const res = await fetch("/api/chat/lesson-task/restart", {
@@ -333,14 +345,11 @@ function InnerLessonAIChat({
                 {/* Completion Banner - Positioned at bottom, doesn't block messages */}
                 {isCompleted && (
                     <div className="absolute bottom-0 left-0 right-0 z-50 p-2 sm:p-4 pb-[max(0.5rem,env(safe-area-inset-bottom))] bg-gradient-to-t from-background via-background to-transparent pointer-events-none">
-                        <div className="pointer-events-auto bg-gradient-to-br from-green-500 to-emerald-600 rounded-xl sm:rounded-2xl shadow-2xl p-4 sm:p-6 space-y-3 sm:space-y-4 animate-in slide-in-from-bottom duration-500">
+                        <div className="pointer-events-auto bg-emerald-600 dark:bg-emerald-700 rounded-xl sm:rounded-2xl shadow-lg p-4 sm:p-6 space-y-3 sm:space-y-4 animate-in slide-in-from-bottom duration-500 motion-reduce:animate-none">
                             {/* Success Header */}
                             <div className="flex items-center gap-3 sm:gap-4">
-                                <div className="relative shrink-0">
-                                    <div className="absolute inset-0 bg-white rounded-full blur-lg opacity-30 animate-pulse"></div>
-                                    <div className="relative p-2 sm:p-3 bg-white/20 backdrop-blur-sm rounded-full border-2 border-white/30">
-                                        <IconCheck className="h-6 w-6 sm:h-8 sm:w-8 text-white stroke-[3]" />
-                                    </div>
+                                <div className="shrink-0 p-2 sm:p-3 bg-white/15 rounded-full">
+                                    <IconCheck className="h-6 w-6 sm:h-8 sm:w-8 text-white stroke-[3]" />
                                 </div>
                                 <div className="flex-1 min-w-0">
                                     <h3 className="text-base sm:text-xl font-bold text-white">
@@ -531,6 +540,21 @@ function InnerLessonAIChat({
                     </div>
                 </div>
             </div>
+
+            <AlertDialog open={restartDialogOpen} onOpenChange={setRestartDialogOpen}>
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>{t('restartDialog.title')}</AlertDialogTitle>
+                        <AlertDialogDescription>{t('confirmRestart')}</AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel>{t('restartDialog.cancel')}</AlertDialogCancel>
+                        <AlertDialogAction onClick={doRestart}>
+                            {t('restartDialog.confirm')}
+                        </AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
         </>
     );
 }

--- a/components/student/lesson-ai-chat.tsx
+++ b/components/student/lesson-ai-chat.tsx
@@ -29,8 +29,17 @@ import {
     usePromptInputController,
 } from "@/components/ai-elements/prompt-input";
 import { useChat } from "@ai-sdk/react";
-import { IconCheck, IconRobot, IconRotateClockwise2, IconTrophy } from "@tabler/icons-react";
-import { useState } from "react";
+import type { UIMessage } from "ai";
+import {
+    IconCheck,
+    IconChevronDown,
+    IconMessageCircle,
+    IconRobot,
+    IconRotateClockwise2,
+    IconSparkles,
+    IconTrophy,
+} from "@tabler/icons-react";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { useRouter } from "next/navigation";
 import { DefaultChatTransport } from "ai";
@@ -46,6 +55,7 @@ import {
     ToolOutput,
 } from "@/components/ai-elements/tool";
 import { useTranslations } from "next-intl";
+import { cn } from "@/lib/utils";
 
 const PromptInputAttachmentsDisplay = () => {
     const attachments = usePromptInputAttachments();
@@ -70,11 +80,48 @@ const PromptInputAttachmentsDisplay = () => {
     );
 };
 
+/**
+ * Tracks the visual viewport height while the mobile chat overlay is open so
+ * the input stays pinned above the on-screen keyboard on iOS Safari, which
+ * overlays the keyboard without resizing the layout viewport (dvh included).
+ */
+function useVisualViewportHeight(enabled: boolean) {
+    const [height, setHeight] = useState<number | null>(null);
+
+    useEffect(() => {
+        if (!enabled) return;
+        const vv = window.visualViewport;
+        if (!vv) return;
+
+        const update = () => setHeight(Math.round(vv.height));
+        update();
+        vv.addEventListener("resize", update);
+        vv.addEventListener("scroll", update);
+        return () => {
+            vv.removeEventListener("resize", update);
+            vv.removeEventListener("scroll", update);
+        };
+    }, [enabled]);
+
+    return enabled ? height : null;
+}
+
 interface LessonAIChatProps {
     lessonId: number;
     taskDescription: string;
     isCompleted?: boolean;
-    initialMessages?: any[];
+    initialMessages?: UIMessage[];
+}
+
+// Legacy tool-invocation part shape persisted in lessons_ai_task_messages.
+interface ToolInvocationPart {
+    toolInvocation?: {
+        toolCallId: string;
+        toolName: string;
+        state: string;
+        args?: unknown;
+        result?: unknown;
+    };
 }
 
 function InnerLessonAIChat({
@@ -87,7 +134,21 @@ function InnerLessonAIChat({
     const t = useTranslations('components.lessonAIChat');
     const [isCompleted, setIsCompleted] = useState(initialIsCompleted);
     const [isRestarting, setIsRestarting] = useState(false);
+    // Mobile-only: the chat lives behind a launcher and opens as a
+    // full-screen overlay so it never fights the lesson page for scroll.
+    const [mobileOpen, setMobileOpen] = useState(false);
+    const viewportHeight = useVisualViewportHeight(mobileOpen);
+    const shellRef = useRef<HTMLDivElement>(null);
     const { textInput } = usePromptInputController();
+
+    useEffect(() => {
+        if (!mobileOpen) return;
+        const onKeyDown = (e: KeyboardEvent) => {
+            if (e.key === "Escape") setMobileOpen(false);
+        };
+        window.addEventListener("keydown", onKeyDown);
+        return () => window.removeEventListener("keydown", onKeyDown);
+    }, [mobileOpen]);
 
     const suggestions = [
         t('suggestions.question'),
@@ -112,7 +173,7 @@ function InnerLessonAIChat({
         onToolCall: async ({ toolCall }) => {
             if (toolCall.toolName === "markLessonCompleted") {
                 setIsCompleted(true);
-                const args = (toolCall as any).args || {};
+                const args = (toolCall as { args?: { feedback?: string } }).args ?? {};
 
                 // Trigger confetti
                 confetti({
@@ -131,6 +192,21 @@ function InnerLessonAIChat({
     });
 
     const isLoading = status === 'submitted' || status === 'streaming';
+
+    // Contextual "ask the tutor" entry points elsewhere on the lesson page
+    // (see AskTutorChip) open the chat and send their prompt.
+    useEffect(() => {
+        const onAsk = (e: Event) => {
+            const prompt = (e as CustomEvent<{ prompt?: string }>).detail?.prompt;
+            if (!prompt || isCompleted) return;
+            setMobileOpen(true);
+            // Desktop: chat is embedded further down the page — bring it into view.
+            shellRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+            sendMessage({ text: prompt });
+        };
+        window.addEventListener("lesson-tutor:ask", onAsk);
+        return () => window.removeEventListener("lesson-tutor:ask", onAsk);
+    }, [isCompleted, sendMessage]);
 
     const onSubmit = (message: PromptInputMessage) => {
         if (!message.text && (!message.files || message.files.length === 0)) return;
@@ -164,7 +240,7 @@ function InnerLessonAIChat({
             } else {
                 toast.error(t('toast.restartFailed'));
             }
-        } catch (error) {
+        } catch {
             toast.error(t('toast.restartError'));
         } finally {
             setIsRestarting(false);
@@ -172,207 +248,290 @@ function InnerLessonAIChat({
     };
 
     return (
-        <div className="relative flex flex-col h-[min(600px,70vh)] sm:h-[600px] divide-y overflow-hidden bg-background sm:rounded-xl sm:border sm:shadow-sm">
-            {/* Completion Banner - Positioned at bottom, doesn't block messages */}
-            {isCompleted && (
-                <div className="absolute bottom-0 left-0 right-0 z-50 p-2 sm:p-4 bg-gradient-to-t from-background via-background to-transparent pointer-events-none">
-                    <div className="pointer-events-auto bg-gradient-to-br from-green-500 to-emerald-600 rounded-xl sm:rounded-2xl shadow-2xl p-4 sm:p-6 space-y-3 sm:space-y-4 animate-in slide-in-from-bottom duration-500">
-                        {/* Success Header */}
-                        <div className="flex items-center gap-3 sm:gap-4">
-                            <div className="relative shrink-0">
-                                <div className="absolute inset-0 bg-white rounded-full blur-lg opacity-30 animate-pulse"></div>
-                                <div className="relative p-2 sm:p-3 bg-white/20 backdrop-blur-sm rounded-full border-2 border-white/30">
-                                    <IconCheck className="h-6 w-6 sm:h-8 sm:w-8 text-white stroke-[3]" />
-                                </div>
+        <>
+            {/* Mobile launcher — replaces the embedded chat below the sm breakpoint */}
+            <div className={cn("sm:hidden px-3 pb-4", mobileOpen && "hidden")}>
+                {isCompleted ? (
+                    <div className="rounded-xl border border-green-500/20 bg-green-500/5 p-3 space-y-2.5">
+                        <div className="flex items-center gap-2.5">
+                            <div className="p-1.5 bg-green-500 rounded-lg shrink-0">
+                                <IconCheck className="h-4 w-4 text-white stroke-[3]" />
                             </div>
-                            <div className="flex-1 min-w-0">
-                                <h3 className="text-base sm:text-xl font-bold text-white">
-                                    {t('successHeader')} 🎉
-                                </h3>
-                                <p className="text-white/90 text-xs sm:text-sm">
-                                    {t('successDescription')}
-                                </p>
-                            </div>
+                            <p className="text-sm font-bold text-green-700 dark:text-green-400">
+                                {t('successHeader')}
+                            </p>
                         </div>
-
-                        {/* Stats + Action in a row on mobile */}
-                        <div className="flex items-center gap-2 sm:gap-3">
-                            <div className="flex-1 bg-white/10 backdrop-blur-sm rounded-lg p-2 sm:p-3 border border-white/20 text-center">
-                                <div className="text-lg sm:text-2xl font-bold text-white">
-                                    {messages.length}
-                                </div>
-                                <div className="text-[10px] sm:text-xs text-white/80">
-                                    {t('stats.messages')}
-                                </div>
-                            </div>
-                            <div className="flex-1 bg-white/10 backdrop-blur-sm rounded-lg p-2 sm:p-3 border border-white/20 text-center">
-                                <div className="text-lg sm:text-2xl font-bold text-white flex items-center justify-center">
-                                    <IconTrophy className="h-5 w-5 sm:h-6 sm:w-6" />
-                                </div>
-                                <div className="text-[10px] sm:text-xs text-white/80">
-                                    {t('stats.taskCompleted')}
-                                </div>
-                            </div>
-                            <Button
-                                onClick={handleRestart}
-                                disabled={isRestarting}
-                                variant="secondary"
-                                className="flex-1 h-full min-h-[52px] sm:min-h-[60px] bg-white text-green-600 hover:bg-white/90 font-semibold text-xs sm:text-sm rounded-lg"
-                            >
-                                {isRestarting ? (
-                                    <IconRotateClockwise2 className="h-4 w-4 animate-spin" />
-                                ) : (
-                                    <div className="flex flex-col items-center gap-0.5">
-                                        <IconRotateClockwise2 className="h-4 w-4" />
-                                        <span>{t('buttons.tryAgain')}</span>
-                                    </div>
-                                )}
-                            </Button>
-                        </div>
+                        <Button
+                            variant="outline"
+                            className="w-full h-11 rounded-xl gap-2 font-semibold"
+                            onClick={() => setMobileOpen(true)}
+                        >
+                            <IconMessageCircle className="h-4 w-4" />
+                            {t('mobile.review')}
+                        </Button>
                     </div>
-                </div>
-            )}
+                ) : (
+                    <div className="space-y-2">
+                        <Button
+                            className="w-full h-12 rounded-xl gap-2 text-base font-semibold shadow-sm"
+                            onClick={() => setMobileOpen(true)}
+                        >
+                            <IconSparkles className="h-5 w-5" />
+                            {messages.length > 0 ? t('mobile.continue') : t('mobile.start')}
+                        </Button>
+                        {messages.length > 0 && (
+                            <p className="text-center text-xs text-muted-foreground">
+                                {t('mobile.messagesCount', { count: messages.length })}
+                            </p>
+                        )}
+                    </div>
+                )}
+            </div>
 
-            <Conversation>
-                <ConversationContent className={`gap-4 sm:gap-8 p-3 sm:p-4 ${isCompleted ? "pb-48 sm:pb-64" : ""}`}>
-                    {messages.length === 0 && !isCompleted && (
-                        <div className="flex flex-col items-center justify-center min-h-full text-muted-foreground p-1 sm:p-6 text-center">
-                            <IconRobot className="h-8 w-8 sm:h-12 sm:w-12 mb-2 sm:mb-4 opacity-20" />
-                            <h3 className="text-sm sm:text-lg font-medium text-foreground mb-1 sm:mb-2">{t('emptyState.title')}</h3>
-                            <p className="max-w-xs mx-auto text-xs sm:text-sm">{t('emptyState.description')}</p>
+            {/*
+              Chat shell. Desktop: embedded card. Mobile: hidden until launched,
+              then a full-screen overlay sized to the visual viewport so the
+              input stays above the keyboard. Single instance keeps chat state
+              alive across open/close.
+            */}
+            <div
+                ref={shellRef}
+                role={mobileOpen ? "dialog" : undefined}
+                aria-modal={mobileOpen || undefined}
+                aria-label={mobileOpen ? t('mobile.title') : undefined}
+                style={viewportHeight ? { ['--chat-vvh' as string]: `${viewportHeight}px` } : undefined}
+                className={cn(
+                    "relative flex flex-col divide-y overflow-hidden bg-background",
+                    "sm:h-[600px] sm:rounded-xl sm:border sm:shadow-sm",
+                    mobileOpen
+                        ? "max-sm:fixed max-sm:inset-0 max-sm:z-50 max-sm:h-[var(--chat-vvh,100dvh)] max-sm:animate-in max-sm:slide-in-from-bottom-8 max-sm:fade-in max-sm:duration-300"
+                        : "max-sm:hidden"
+                )}
+            >
+                {/* Mobile overlay header */}
+                {mobileOpen && (
+                    <div className="sm:hidden flex items-center gap-3 px-3 pb-2.5 pt-[max(0.625rem,env(safe-area-inset-top))] bg-primary/[0.03] shrink-0">
+                        <div className="p-1.5 bg-primary/10 rounded-lg shrink-0">
+                            <IconSparkles className="h-4 w-4 text-primary" />
                         </div>
-                    )}
-
-                    {messages.map((message) => (
-                        <Message key={message.id} from={message.role as any}>
-                            <MessageContent>
-                                {message.parts.map((part, index) => {
-                                    if (part.type === 'text') {
-                                        return <MessageResponse key={index}>{part.text}</MessageResponse>;
-                                    }
-                                    if (part.type === 'tool-invocation') {
-                                        const toolInvocation = (part as any).toolInvocation;
-                                        if (!toolInvocation) return null;
-
-                                        // Special handling for markLessonCompleted
-                                        if (toolInvocation.toolName === 'markLessonCompleted') {
-                                            if (toolInvocation.state === 'result') {
-                                                return (
-                                                    <div key={toolInvocation.toolCallId} className="mt-3 sm:mt-4 p-3 sm:p-5 bg-gradient-to-br from-green-500/10 to-emerald-500/5 border border-green-500/20 rounded-xl sm:rounded-2xl text-green-700 dark:text-green-400 text-sm shadow-sm ring-1 ring-inset ring-green-500/10">
-                                                        <div className="flex items-start gap-3 sm:gap-4">
-                                                            <div className="p-2 bg-green-500 rounded-lg shadow-lg shadow-green-500/20">
-                                                                <IconCheck className="h-5 w-5 text-white" />
-                                                            </div>
-                                                            <div className="space-y-1">
-                                                                <p className="font-bold text-base text-green-900 dark:text-green-300">{t('targetAchieved')}</p>
-                                                                <p className="opacity-90 leading-relaxed text-sm">{(toolInvocation.result as any).feedback}</p>
-                                                            </div>
-                                                        </div>
-                                                    </div>
-                                                )
-                                            }
-                                            return null;
-                                        }
-
-                                        // Generic Tool Handling
-                                        const state = toolInvocation.state === 'result' ? 'output-available' : 'input-available';
-
-                                        return (
-                                            <Tool key={toolInvocation.toolCallId} defaultOpen={state === 'output-available'}>
-                                                <ToolHeader
-                                                    type="dynamic-tool"
-                                                    toolName={toolInvocation.toolName}
-                                                    state={state}
-                                                />
-                                                <ToolContent>
-                                                    <ToolInput input={toolInvocation.args} />
-                                                    <ToolOutput
-                                                        output={toolInvocation.result}
-                                                        errorText={undefined}
-                                                    />
-                                                </ToolContent>
-                                            </Tool>
-                                        );
-                                    }
-                                    return null;
-                                })}
-                            </MessageContent>
-                        </Message>
-                    ))}
-                    {
-                        status === 'submitted' && (
-                            <Message
-                                from='assistant'
-                            >
-                                <MessageContent>
-                                    <Shimmer className="text-sm">{t('generating')}</Shimmer>
-                                </MessageContent>
-                            </Message>
-                        )
-                    }
-                </ConversationContent>
-                <ConversationScrollButton />
-            </Conversation>
-
-            <div className="grid shrink-0 gap-2 sm:gap-3 pt-2 sm:pt-3 bg-background">
-                {!isCompleted && (
-                    <Suggestions className="px-3 sm:px-4">
-                        {suggestions.map((suggestion) => (
-                            <Suggestion
-                                key={suggestion}
-                                onClick={() => handleSuggestionClick(suggestion)}
-                                suggestion={suggestion}
-                            />
-                        ))}
-                    </Suggestions>
+                        <div className="min-w-0 flex-1">
+                            <p className="text-sm font-bold leading-tight">{t('mobile.title')}</p>
+                            <p className="text-xs text-muted-foreground truncate">{taskDescription}</p>
+                        </div>
+                        <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-10 w-10 shrink-0"
+                            onClick={() => setMobileOpen(false)}
+                            aria-label={t('mobile.close')}
+                        >
+                            <IconChevronDown className="h-5 w-5" />
+                        </Button>
+                    </div>
                 )}
 
-                <div className="w-full px-3 pb-3 sm:px-4 sm:pb-4">
-                    <PromptInput
-                        onSubmit={onSubmit}
-                        className="w-full"
-                    >
-                        <div className="px-3 pt-2 sm:pt-3">
-                            <PromptInputAttachmentsDisplay />
-                        </div>
-                        <PromptInputBody>
-                            <PromptInputTextarea
-                                placeholder={isCompleted ? t('placeholders.completed') : t('placeholders.typeAnswer')}
-                                disabled={isCompleted}
-                            />
-                        </PromptInputBody>
-                        <PromptInputFooter>
-                            <PromptInputTools>
-                                <div className="flex items-center gap-2">
-                                    {!isCompleted && (
-                                        <Button
-                                            type="button"
-                                            variant="outline"
-                                            size="icon"
-                                            className="h-8 w-8 rounded-full shadow-sm hover:shadow active:scale-95 transition-all text-muted-foreground hover:text-primary hover:border-primary/30"
-                                            onClick={handleRestart}
-                                            disabled={isRestarting || isLoading}
-                                            title={t('tooltips.restart')}
-                                            aria-label={t('tooltips.restart')}
-                                        >
-                                            <IconRotateClockwise2 className={`h-4 w-4 ${isRestarting ? 'animate-spin' : ''}`} />
-                                        </Button>
-                                    )}
+                {/* Completion Banner - Positioned at bottom, doesn't block messages */}
+                {isCompleted && (
+                    <div className="absolute bottom-0 left-0 right-0 z-50 p-2 sm:p-4 pb-[max(0.5rem,env(safe-area-inset-bottom))] bg-gradient-to-t from-background via-background to-transparent pointer-events-none">
+                        <div className="pointer-events-auto bg-gradient-to-br from-green-500 to-emerald-600 rounded-xl sm:rounded-2xl shadow-2xl p-4 sm:p-6 space-y-3 sm:space-y-4 animate-in slide-in-from-bottom duration-500">
+                            {/* Success Header */}
+                            <div className="flex items-center gap-3 sm:gap-4">
+                                <div className="relative shrink-0">
+                                    <div className="absolute inset-0 bg-white rounded-full blur-lg opacity-30 animate-pulse"></div>
+                                    <div className="relative p-2 sm:p-3 bg-white/20 backdrop-blur-sm rounded-full border-2 border-white/30">
+                                        <IconCheck className="h-6 w-6 sm:h-8 sm:w-8 text-white stroke-[3]" />
+                                    </div>
+                                </div>
+                                <div className="flex-1 min-w-0">
+                                    <h3 className="text-base sm:text-xl font-bold text-white">
+                                        {t('successHeader')} 🎉
+                                    </h3>
+                                    <p className="text-white/90 text-xs sm:text-sm">
+                                        {t('successDescription')}
+                                    </p>
+                                </div>
+                            </div>
 
-                                    {isCompleted && (
-                                        <div className="flex items-center gap-1.5 text-xs font-bold text-green-600 bg-green-500/10 px-3 py-1.5 rounded-full border border-green-500/20 shadow-sm animate-in fade-in zoom-in duration-300">
-                                            <IconCheck size={14} className="stroke-[3]" />
-                                            <span>{t('successHeader')}</span>
+                            {/* Stats + Action in a row on mobile */}
+                            <div className="flex items-center gap-2 sm:gap-3">
+                                <div className="flex-1 bg-white/10 backdrop-blur-sm rounded-lg p-2 sm:p-3 border border-white/20 text-center">
+                                    <div className="text-lg sm:text-2xl font-bold text-white">
+                                        {messages.length}
+                                    </div>
+                                    <div className="text-[10px] sm:text-xs text-white/80">
+                                        {t('stats.messages')}
+                                    </div>
+                                </div>
+                                <div className="flex-1 bg-white/10 backdrop-blur-sm rounded-lg p-2 sm:p-3 border border-white/20 text-center">
+                                    <div className="text-lg sm:text-2xl font-bold text-white flex items-center justify-center">
+                                        <IconTrophy className="h-5 w-5 sm:h-6 sm:w-6" />
+                                    </div>
+                                    <div className="text-[10px] sm:text-xs text-white/80">
+                                        {t('stats.taskCompleted')}
+                                    </div>
+                                </div>
+                                <Button
+                                    onClick={handleRestart}
+                                    disabled={isRestarting}
+                                    variant="secondary"
+                                    className="flex-1 h-full min-h-[52px] sm:min-h-[60px] bg-white text-green-600 hover:bg-white/90 font-semibold text-xs sm:text-sm rounded-lg"
+                                >
+                                    {isRestarting ? (
+                                        <IconRotateClockwise2 className="h-4 w-4 animate-spin" />
+                                    ) : (
+                                        <div className="flex flex-col items-center gap-0.5">
+                                            <IconRotateClockwise2 className="h-4 w-4" />
+                                            <span>{t('buttons.tryAgain')}</span>
                                         </div>
                                     )}
-                                </div>
-                            </PromptInputTools>
-                            {!isCompleted && <PromptInputSubmit status={status as any} />}
-                        </PromptInputFooter>
-                    </PromptInput>
+                                </Button>
+                            </div>
+                        </div>
+                    </div>
+                )}
+
+                <Conversation className="overscroll-contain [&>div]:overscroll-contain">
+                    <ConversationContent className={`gap-4 sm:gap-8 p-3 sm:p-4 ${isCompleted ? "pb-48 sm:pb-64" : ""}`}>
+                        {messages.length === 0 && !isCompleted && (
+                            <div className="flex flex-col items-center justify-center min-h-full text-muted-foreground p-1 sm:p-6 text-center">
+                                <IconRobot className="h-8 w-8 sm:h-12 sm:w-12 mb-2 sm:mb-4 opacity-20" />
+                                <h3 className="text-sm sm:text-lg font-medium text-foreground mb-1 sm:mb-2">{t('emptyState.title')}</h3>
+                                <p className="max-w-xs mx-auto text-xs sm:text-sm">{t('emptyState.description')}</p>
+                            </div>
+                        )}
+
+                        {messages.map((message) => (
+                            <Message key={message.id} from={message.role}>
+                                <MessageContent>
+                                    {message.parts.map((part, index) => {
+                                        if (part.type === 'text') {
+                                            return <MessageResponse key={index}>{part.text}</MessageResponse>;
+                                        }
+                                        if (part.type === 'tool-invocation') {
+                                            const toolInvocation = (part as unknown as ToolInvocationPart).toolInvocation;
+                                            if (!toolInvocation) return null;
+
+                                            // Special handling for markLessonCompleted
+                                            if (toolInvocation.toolName === 'markLessonCompleted') {
+                                                if (toolInvocation.state === 'result') {
+                                                    return (
+                                                        <div key={toolInvocation.toolCallId} className="mt-3 sm:mt-4 p-3 sm:p-5 bg-gradient-to-br from-green-500/10 to-emerald-500/5 border border-green-500/20 rounded-xl sm:rounded-2xl text-green-700 dark:text-green-400 text-sm shadow-sm ring-1 ring-inset ring-green-500/10">
+                                                            <div className="flex items-start gap-3 sm:gap-4">
+                                                                <div className="p-2 bg-green-500 rounded-lg shadow-lg shadow-green-500/20">
+                                                                    <IconCheck className="h-5 w-5 text-white" />
+                                                                </div>
+                                                                <div className="space-y-1">
+                                                                    <p className="font-bold text-base text-green-900 dark:text-green-300">{t('targetAchieved')}</p>
+                                                                    <p className="opacity-90 leading-relaxed text-sm">{(toolInvocation.result as { feedback?: string })?.feedback}</p>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                    )
+                                                }
+                                                return null;
+                                            }
+
+                                            // Generic Tool Handling
+                                            const state = toolInvocation.state === 'result' ? 'output-available' : 'input-available';
+
+                                            return (
+                                                <Tool key={toolInvocation.toolCallId} defaultOpen={state === 'output-available'}>
+                                                    <ToolHeader
+                                                        type="dynamic-tool"
+                                                        toolName={toolInvocation.toolName}
+                                                        state={state}
+                                                    />
+                                                    <ToolContent>
+                                                        <ToolInput input={toolInvocation.args} />
+                                                        <ToolOutput
+                                                            output={toolInvocation.result}
+                                                            errorText={undefined}
+                                                        />
+                                                    </ToolContent>
+                                                </Tool>
+                                            );
+                                        }
+                                        return null;
+                                    })}
+                                </MessageContent>
+                            </Message>
+                        ))}
+                        {
+                            status === 'submitted' && (
+                                <Message
+                                    from='assistant'
+                                >
+                                    <MessageContent>
+                                        <Shimmer className="text-sm">{t('generating')}</Shimmer>
+                                    </MessageContent>
+                                </Message>
+                            )
+                        }
+                    </ConversationContent>
+                    <ConversationScrollButton />
+                </Conversation>
+
+                <div className="grid shrink-0 gap-2 sm:gap-3 pt-2 sm:pt-3 bg-background">
+                    {!isCompleted && (
+                        <Suggestions className="px-3 sm:px-4">
+                            {suggestions.map((suggestion) => (
+                                <Suggestion
+                                    key={suggestion}
+                                    onClick={() => handleSuggestionClick(suggestion)}
+                                    suggestion={suggestion}
+                                />
+                            ))}
+                        </Suggestions>
+                    )}
+
+                    <div className="w-full px-3 sm:px-4 sm:pb-4 max-sm:pb-[max(0.75rem,env(safe-area-inset-bottom))]">
+                        <PromptInput
+                            onSubmit={onSubmit}
+                            className="w-full"
+                        >
+                            <div className="px-3 pt-2 sm:pt-3">
+                                <PromptInputAttachmentsDisplay />
+                            </div>
+                            <PromptInputBody>
+                                <PromptInputTextarea
+                                    className="text-base sm:text-sm"
+                                    placeholder={isCompleted ? t('placeholders.completed') : t('placeholders.typeAnswer')}
+                                    disabled={isCompleted}
+                                />
+                            </PromptInputBody>
+                            <PromptInputFooter>
+                                <PromptInputTools>
+                                    <div className="flex items-center gap-2">
+                                        {!isCompleted && (
+                                            <Button
+                                                type="button"
+                                                variant="outline"
+                                                size="icon"
+                                                className="h-8 w-8 rounded-full shadow-sm hover:shadow active:scale-95 transition-all text-muted-foreground hover:text-primary hover:border-primary/30"
+                                                onClick={handleRestart}
+                                                disabled={isRestarting || isLoading}
+                                                title={t('tooltips.restart')}
+                                                aria-label={t('tooltips.restart')}
+                                            >
+                                                <IconRotateClockwise2 className={`h-4 w-4 ${isRestarting ? 'animate-spin' : ''}`} />
+                                            </Button>
+                                        )}
+
+                                        {isCompleted && (
+                                            <div className="flex items-center gap-1.5 text-xs font-bold text-green-600 bg-green-500/10 px-3 py-1.5 rounded-full border border-green-500/20 shadow-sm animate-in fade-in zoom-in duration-300">
+                                                <IconCheck size={14} className="stroke-[3]" />
+                                                <span>{t('successHeader')}</span>
+                                            </div>
+                                        )}
+                                    </div>
+                                </PromptInputTools>
+                                {!isCompleted && <PromptInputSubmit status={status} />}
+                            </PromptInputFooter>
+                        </PromptInput>
+                    </div>
                 </div>
             </div>
-        </div>
+        </>
     );
 }
 

--- a/components/student/lesson-comments.tsx
+++ b/components/student/lesson-comments.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from 'react'
 import { createClient } from '@/lib/supabase/client'
-import { ScrollArea } from '@/components/ui/scroll-area'
 import { Button, buttonVariants } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
@@ -105,7 +104,7 @@ export function LessonComments({ lessonId, userId, initialComments = [] }: Lesso
 
         const reactions = reactionsData
           ?.filter(r => r.comment_id === c.id)
-          .map(r => ({ user_id: r.user_id, reaction_type: r.reaction_type as any })) || []
+          .map(r => ({ user_id: r.user_id, reaction_type: r.reaction_type as CommentReaction['reaction_type'] })) || []
 
         return {
           ...c,
@@ -208,7 +207,7 @@ export function LessonComments({ lessonId, userId, initialComments = [] }: Lesso
   }
 
   return (
-    <div className="flex flex-col h-full max-h-[800px]">
+    <div className="flex flex-col">
       <div className="mb-6">
         <h3 className="flex items-center gap-2 text-xl font-semibold mb-6">
           <IconMessage className="h-5 w-5" />
@@ -240,7 +239,8 @@ export function LessonComments({ lessonId, userId, initialComments = [] }: Lesso
         </div>
       </div>
 
-      <ScrollArea className="flex-1 -mr-4 pr-4">
+      {/* Comments flow with the page — no nested scroll region */}
+      <div>
         <div className="space-y-8 pb-8">
           {comments.length === 0 ? (
             <div className="text-center py-12 border rounded-lg border-dashed bg-muted/30">
@@ -271,7 +271,7 @@ export function LessonComments({ lessonId, userId, initialComments = [] }: Lesso
             ))
           )}
         </div>
-      </ScrollArea>
+      </div>
     </div>
   )
 }
@@ -283,7 +283,7 @@ export function LessonComments({ lessonId, userId, initialComments = [] }: Lesso
 interface CommentReplyFormProps {
   onSubmit: (content: string) => void
   submitting: boolean
-  t: any
+  t: ReturnType<typeof useTranslations>
 }
 
 function CommentReplyForm({ onSubmit, submitting, t }: CommentReplyFormProps) {
@@ -321,7 +321,7 @@ interface CommentItemProps {
   comment: Comment
   depth?: number
   userId: string
-  t: any
+  t: ReturnType<typeof useTranslations>
   locale: string
   replyingTo: number | null
   setReplyingTo: (id: number | null) => void

--- a/components/student/lesson-comments.tsx
+++ b/components/student/lesson-comments.tsx
@@ -6,6 +6,16 @@ import { Button, buttonVariants } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
 import { IconSend, IconMessage, IconUser, IconHeart, IconDots, IconMessageCircle, IconCornerDownRight } from '@tabler/icons-react'
 import { useRouter } from 'next/navigation'
 import { useTranslations } from 'next-intl'
@@ -49,6 +59,7 @@ export function LessonComments({ lessonId, userId, initialComments = [] }: Lesso
   const [newComment, setNewComment] = useState('')
   const [submitting, setSubmitting] = useState(false)
   const [replyingTo, setReplyingTo] = useState<number | null>(null)
+  const [deleteTargetId, setDeleteTargetId] = useState<number | null>(null)
 
   const router = useRouter()
   const supabase = createClient()
@@ -261,17 +272,39 @@ export function LessonComments({ lessonId, userId, initialComments = [] }: Lesso
                 onReply={handlePostComment}
                 submitting={submitting}
                 handleReaction={handleReaction}
-                onDelete={async (id) => {
-                  if (confirm(t('confirmDelete'))) {
-                    await supabase.from('lesson_comments').delete().eq('id', id)
-                    loadComments()
-                  }
-                }}
+                onDelete={(id) => setDeleteTargetId(id)}
               />
             ))
           )}
         </div>
       </div>
+
+      <AlertDialog
+        open={deleteTargetId !== null}
+        onOpenChange={(open) => { if (!open) setDeleteTargetId(null) }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t('deleteDialog.title')}</AlertDialogTitle>
+            <AlertDialogDescription>{t('confirmDelete')}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t('deleteDialog.cancel')}</AlertDialogCancel>
+            <AlertDialogAction
+              variant="destructive"
+              onClick={async () => {
+                const id = deleteTargetId
+                setDeleteTargetId(null)
+                if (id === null) return
+                await supabase.from('lesson_comments').delete().eq('id', id)
+                loadComments()
+              }}
+            >
+              {t('deleteDialog.confirm')}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   )
 }

--- a/components/student/lesson-progress-line.tsx
+++ b/components/student/lesson-progress-line.tsx
@@ -1,0 +1,21 @@
+import { Progress } from '@/components/ui/progress'
+
+interface LessonProgressLineProps {
+  completed: number
+  total: number
+  label: string
+}
+
+export function LessonProgressLine({ completed, total, label }: LessonProgressLineProps) {
+  if (total === 0) return null
+  const percent = Math.round((completed / total) * 100)
+
+  return (
+    <Progress
+      value={percent}
+      aria-label={label}
+      title={label}
+      className="shrink-0 gap-0 [&_[data-slot=progress-track]]:rounded-none"
+    />
+  )
+}

--- a/components/student/lesson-scroll-area.tsx
+++ b/components/student/lesson-scroll-area.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import { useRef, useState } from 'react'
+import { useEventListener } from 'usehooks-ts'
+
+export function LessonScrollArea({ children }: { children: React.ReactNode }) {
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const [progress, setProgress] = useState(0)
+
+  useEventListener(
+    'scroll',
+    () => {
+      const el = scrollRef.current
+      if (!el) return
+      const max = el.scrollHeight - el.clientHeight
+      setProgress(max > 0 ? Math.min(100, (el.scrollTop / max) * 100) : 0)
+    },
+    // usehooks-ts v3 types predate React 19's nullable RefObject
+    scrollRef as React.RefObject<HTMLDivElement>,
+    { passive: true }
+  )
+
+  return (
+    <div className="relative flex-1 min-h-0">
+      <div aria-hidden="true" className="pointer-events-none absolute inset-x-0 top-0 z-10">
+        <div
+          className="h-0.5 bg-primary/50 transition-[width] duration-150 ease-out"
+          style={{ width: `${progress}%` }}
+        />
+      </div>
+      <div ref={scrollRef} className="h-full overflow-y-auto">
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/components/student/lesson-scroll-area.tsx
+++ b/components/student/lesson-scroll-area.tsx
@@ -28,7 +28,7 @@ export function LessonScrollArea({ children }: { children: React.ReactNode }) {
           style={{ width: `${progress}%` }}
         />
       </div>
-      <div ref={scrollRef} className="h-full overflow-y-auto">
+      <div ref={scrollRef} className="h-full overflow-y-auto overscroll-y-contain">
         {children}
       </div>
     </div>

--- a/components/student/lesson-scroll-area.tsx
+++ b/components/student/lesson-scroll-area.tsx
@@ -23,8 +23,9 @@ export function LessonScrollArea({ children }: { children: React.ReactNode }) {
   return (
     <div className="relative flex-1 min-h-0">
       <div aria-hidden="true" className="pointer-events-none absolute inset-x-0 top-0 z-10">
+        {/* Reading progress — neutral so it can't be confused with the primary course-progress line above the header */}
         <div
-          className="h-0.5 bg-primary/50 transition-[width] duration-150 ease-out"
+          className="h-0.5 bg-foreground/25 transition-[width] duration-150 ease-out"
           style={{ width: `${progress}%` }}
         />
       </div>

--- a/components/student/lesson-sidebar.tsx
+++ b/components/student/lesson-sidebar.tsx
@@ -97,7 +97,7 @@ export function LessonSidebar({
                   <span className={cn(
                     'line-clamp-2 leading-snug text-[13px]',
                     isActive ? 'font-semibold' : 'font-medium',
-                    lesson.isCompleted && !isActive && 'line-through opacity-60',
+                    lesson.isCompleted && !isActive && 'opacity-70',
                     isLocked && 'opacity-50'
                   )}>
                     {lesson.title}

--- a/messages/en.json
+++ b/messages/en.json
@@ -3303,7 +3303,10 @@
       "downloadFile": "Download",
       "lessonLocked": "Lesson locked",
       "completePreviousFirst": "Complete the previous lesson to unlock this one.",
-      "courseProgress": "Course progress: {completed} of {total} lessons completed ({percent}%)"
+      "courseProgress": "Course progress: {completed} of {total} lessons completed ({percent}%)",
+      "goToLesson": "Go to: {title}",
+      "noContent": "No content available for this lesson.",
+      "contentError": "Error loading content"
     },
     "lessonAIChat": {
       "suggestions": {
@@ -3354,6 +3357,11 @@
       "contextual": {
         "chip": "I don't understand — ask the tutor",
         "prompt": "I don't understand this lesson. Can you explain it in a different way?"
+      },
+      "restartDialog": {
+        "title": "Restart conversation?",
+        "cancel": "Cancel",
+        "confirm": "Restart"
       }
     },
     "lessonSidebar": {
@@ -3372,7 +3380,13 @@
       "finishCourse": "Finish Course",
       "completeFirst": "Complete this lesson first",
       "courseComplete": "Course complete! 🎉",
-      "courseCompleteDescription": "You finished every lesson in this course. Amazing work!"
+      "courseCompleteDescription": "You finished every lesson in this course. Amazing work!",
+      "updateFailed": "Failed to update lesson status",
+      "completeFailed": "Failed to mark lesson as complete",
+      "certificateEarnedTitle": "Certificate Earned!",
+      "certificateEarnedDescription": "You have completed all requirements and earned a certificate for this course.",
+      "certificateBanner": "Certificate earned for this course!",
+      "view": "View"
     },
     "codeBlock": {
       "copy": "Copy",

--- a/messages/en.json
+++ b/messages/en.json
@@ -3618,6 +3618,11 @@
       "like": "Like",
       "delete": "Delete",
       "confirmDelete": "Are you sure you want to delete this comment?",
+      "deleteDialog": {
+        "title": "Delete comment?",
+        "cancel": "Cancel",
+        "confirm": "Delete"
+      },
       "posted": "Comment posted",
       "errorPosting": "Error posting comment",
       "errorLoading": "Error loading comments",

--- a/messages/en.json
+++ b/messages/en.json
@@ -3302,7 +3302,8 @@
       "resources": "Resources",
       "downloadFile": "Download",
       "lessonLocked": "Lesson locked",
-      "completePreviousFirst": "Complete the previous lesson to unlock this one."
+      "completePreviousFirst": "Complete the previous lesson to unlock this one.",
+      "courseProgress": "Course progress: {completed} of {total} lessons completed ({percent}%)"
     },
     "lessonAIChat": {
       "suggestions": {
@@ -3357,7 +3358,9 @@
       "complete": "Complete",
       "next": "Next",
       "finishCourse": "Finish Course",
-      "completeFirst": "Complete this lesson first"
+      "completeFirst": "Complete this lesson first",
+      "courseComplete": "Course complete! 🎉",
+      "courseCompleteDescription": "You finished every lesson in this course. Amazing work!"
     },
     "codeBlock": {
       "copy": "Copy",

--- a/messages/en.json
+++ b/messages/en.json
@@ -3342,6 +3342,18 @@
       },
       "tooltips": {
         "restart": "Restart Conversation"
+      },
+      "mobile": {
+        "title": "AI Tutor",
+        "start": "Start with the AI Tutor",
+        "continue": "Continue with the AI Tutor",
+        "review": "Review conversation",
+        "close": "Close chat",
+        "messagesCount": "{count, plural, one {# message} other {# messages}}"
+      },
+      "contextual": {
+        "chip": "I don't understand — ask the tutor",
+        "prompt": "I don't understand this lesson. Can you explain it in a different way?"
       }
     },
     "lessonSidebar": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -3187,6 +3187,18 @@
       },
       "tooltips": {
         "restart": "Reiniciar Conversación"
+      },
+      "mobile": {
+        "title": "Tutor IA",
+        "start": "Comenzar con el tutor IA",
+        "continue": "Continuar con el tutor IA",
+        "review": "Revisar conversación",
+        "close": "Cerrar chat",
+        "messagesCount": "{count, plural, one {# mensaje} other {# mensajes}}"
+      },
+      "contextual": {
+        "chip": "No entiendo — preguntar al tutor",
+        "prompt": "No entiendo esta lección. ¿Puedes explicármela de otra manera?"
       }
     },
     "lessonSidebar": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -3611,6 +3611,11 @@
       "like": "Me gusta",
       "delete": "Eliminar",
       "confirmDelete": "¿Estás seguro de que quieres eliminar este comentario?",
+      "deleteDialog": {
+        "title": "¿Eliminar comentario?",
+        "cancel": "Cancelar",
+        "confirm": "Eliminar"
+      },
       "posted": "Comentario publicado",
       "errorPosting": "Error al publicar el comentario",
       "errorLoading": "Error al cargar los comentarios",

--- a/messages/es.json
+++ b/messages/es.json
@@ -3147,7 +3147,8 @@
       "resources": "Recursos",
       "downloadFile": "Descargar",
       "lessonLocked": "Lección bloqueada",
-      "completePreviousFirst": "Completa la lección anterior para desbloquear esta."
+      "completePreviousFirst": "Completa la lección anterior para desbloquear esta.",
+      "courseProgress": "Progreso del curso: {completed} de {total} lecciones completadas ({percent}%)"
     },
     "lessonAIChat": {
       "suggestions": {
@@ -3202,7 +3203,9 @@
       "complete": "Completar",
       "next": "Siguiente",
       "finishCourse": "Finalizar Curso",
-      "completeFirst": "Completa esta lección primero"
+      "completeFirst": "Completa esta lección primero",
+      "courseComplete": "¡Curso completado! 🎉",
+      "courseCompleteDescription": "Terminaste todas las lecciones de este curso. ¡Excelente trabajo!"
     },
     "codeBlock": {
       "copy": "Copiar",

--- a/messages/es.json
+++ b/messages/es.json
@@ -3148,7 +3148,10 @@
       "downloadFile": "Descargar",
       "lessonLocked": "Lección bloqueada",
       "completePreviousFirst": "Completa la lección anterior para desbloquear esta.",
-      "courseProgress": "Progreso del curso: {completed} de {total} lecciones completadas ({percent}%)"
+      "courseProgress": "Progreso del curso: {completed} de {total} lecciones completadas ({percent}%)",
+      "goToLesson": "Ir a: {title}",
+      "noContent": "No hay contenido disponible para esta lección.",
+      "contentError": "Error al cargar el contenido"
     },
     "lessonAIChat": {
       "suggestions": {
@@ -3199,6 +3202,11 @@
       "contextual": {
         "chip": "No entiendo — preguntar al tutor",
         "prompt": "No entiendo esta lección. ¿Puedes explicármela de otra manera?"
+      },
+      "restartDialog": {
+        "title": "¿Reiniciar conversación?",
+        "cancel": "Cancelar",
+        "confirm": "Reiniciar"
       }
     },
     "lessonSidebar": {
@@ -3217,7 +3225,13 @@
       "finishCourse": "Finalizar Curso",
       "completeFirst": "Completa esta lección primero",
       "courseComplete": "¡Curso completado! 🎉",
-      "courseCompleteDescription": "Terminaste todas las lecciones de este curso. ¡Excelente trabajo!"
+      "courseCompleteDescription": "Terminaste todas las lecciones de este curso. ¡Excelente trabajo!",
+      "updateFailed": "No se pudo actualizar el estado de la lección",
+      "completeFailed": "No se pudo marcar la lección como completada",
+      "certificateEarnedTitle": "¡Certificado Obtenido!",
+      "certificateEarnedDescription": "Has completado todos los requisitos y obtenido un certificado para este curso.",
+      "certificateBanner": "¡Certificado obtenido para este curso!",
+      "view": "Ver"
     },
     "codeBlock": {
       "copy": "Copiar",

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "@solana/kit-plugin-signer": "^0.10.0",
         "@solana/pay": "^0.2.6",
         "@solana/spl-token": "^0.4.14",
-        "@solana/subscriptions": "^0.4.0-rc.1",
+        "@solana/subscriptions": "0.4.0-rc.1",
         "@solana/web3.js": "^1.98.4",
         "@streamdown/cjk": "^1.0.2",
         "@streamdown/code": "^1.1.0",
@@ -48,6 +48,7 @@
         "@supabase/supabase-js": "^2.99.0",
         "@tabler/icons-react": "^3.40.0",
         "@tailwindcss/typography": "^0.5.19",
+        "@tanstack/react-hotkeys": "^0.10.0",
         "@xyflow/react": "^12.10.1",
         "ai": "^6.0.116",
         "ansi-to-react": "^6.2.6",
@@ -71,6 +72,7 @@
         "next": "16.2.9",
         "next-intl": "^4.8.3",
         "next-mdx-remote-client": "^2.1.9",
+        "next-nprogress-bar": "^2.4.7",
         "next-themes": "^0.4.6",
         "qrcode": "^1.5.4",
         "react": "19.2.4",
@@ -92,6 +94,7 @@
         "tokenlens": "^1.3.1",
         "tw-animate-css": "^1.4.0",
         "use-stick-to-bottom": "^1.1.3",
+        "usehooks-ts": "^3.1.1",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -2160,9 +2163,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2178,9 +2178,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -2198,9 +2195,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2216,9 +2210,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -2236,9 +2227,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2254,9 +2242,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -2274,9 +2259,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2293,9 +2275,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2311,9 +2290,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2337,9 +2313,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2361,9 +2334,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2387,9 +2357,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2411,9 +2378,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2437,9 +2401,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2462,9 +2423,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2486,9 +2444,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2608,17 +2563,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/source-map": {
-      "version": "0.3.11",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
-      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.25"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -3002,9 +2946,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3020,9 +2961,6 @@
       "integrity": "sha512-qZTI3pf9SGc/obr8NkQAekBxmp1QK+kVm+VAf3BALLfFAj+1kUhkTxmrWpVos9R/UYIA8AWX2p6cGI5WdwzVUA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3040,9 +2978,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3058,9 +2993,6 @@
       "integrity": "sha512-QumimHkGEG6vM3PfEDWKyKen03NcqLOkeKB1EfcPe7VxzmEiCa4jNnMyBn/US5zcd/VE1CI+O8Ovb3lfjVHfGw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3689,9 +3621,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3711,9 +3640,6 @@
       "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3735,9 +3661,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3757,9 +3680,6 @@
       "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3781,9 +3701,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3803,9 +3720,6 @@
       "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3897,7 +3811,7 @@
       "version": "1.61.0",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
       "integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.61.0"
@@ -4629,9 +4543,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4644,9 +4555,6 @@
       "integrity": "sha512-2as0LgT7qQpyceQq6VUJYnumUMUrgGQCWIiDIN9DE0/tglsk6o66uCB4f3djRawAltvfCNLyZZrsqbPA6inCsA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4661,9 +4569,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4676,9 +4581,6 @@
       "integrity": "sha512-Ful8pM/2yYI83PViWdFdpZhdI8HJ5qsXANe5atypbHDf+KIBBDsZsbyy8hbXnULVvW9NsTh5DHwbcBftyLTfiw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4693,9 +4595,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4708,9 +4607,6 @@
       "integrity": "sha512-m9tsJz54LUXkSYM8+8PG81B9IKK5r+2T0clMq4QrS16xFosufU7firBDAZEsDheDs7wTlP7h3++S7lMsU955HA==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4725,9 +4621,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4740,9 +4633,6 @@
       "integrity": "sha512-vRWUAbYLGHBZS6Q8Msb2sfnf1fvJf+47t8l/TwOerM2qArzy+IeNMTHrYLHXh95h8MoatPHI5hhSZNs+mGXKPg==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4757,9 +4647,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4772,9 +4659,6 @@
       "integrity": "sha512-krrCDilhXOwFkSkO3Wm9I/f9H0L92XHHwy2fwxjukxIbh0dem8gZqOW5Y8BsHrpJv5qwlRBV+Wl4ZFyRWhUpwg==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4789,9 +4673,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4805,9 +4686,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4820,9 +4698,6 @@
       "integrity": "sha512-eRZevouTH2i1HeAVLqJuLnt256krQkGY0TN6WsTmsIhuzbh457HuWDMakKwmi0Cjadux983CoSr8Lim2QhUIFw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -6731,364 +6606,6 @@
         "@solana/sysvars": "^5.0"
       }
     },
-    "node_modules/@solana/subscriptions/node_modules/@solana/accounts": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-5.5.1.tgz",
-      "integrity": "sha512-TfOY9xixg5rizABuLVuZ9XI2x2tmWUC/OoN556xwfDlhBHBjKfszicYYOyD6nbFmwTGYarCmyGIdteXxTXIdhQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@solana/addresses": "5.5.1",
-        "@solana/codecs-core": "5.5.1",
-        "@solana/codecs-strings": "5.5.1",
-        "@solana/errors": "5.5.1",
-        "@solana/rpc-spec": "5.5.1",
-        "@solana/rpc-types": "5.5.1"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@solana/subscriptions/node_modules/@solana/addresses": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-5.5.1.tgz",
-      "integrity": "sha512-5xoah3Q9G30HQghu/9BiHLb5pzlPKRC3zydQDmE3O9H//WfayxTFppsUDCL6FjYUHqj/wzK6CWHySglc2RkpdA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@solana/assertions": "5.5.1",
-        "@solana/codecs-core": "5.5.1",
-        "@solana/codecs-strings": "5.5.1",
-        "@solana/errors": "5.5.1",
-        "@solana/nominal-types": "5.5.1"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@solana/subscriptions/node_modules/@solana/assertions": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-5.5.1.tgz",
-      "integrity": "sha512-YTCSWAlGwSlVPnWtWLm3ukz81wH4j2YaCveK+TjpvUU88hTy6fmUqxi0+hvAMAe4zKXpJyj3Az7BrLJRxbIm4Q==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@solana/errors": "5.5.1"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@solana/subscriptions/node_modules/@solana/codecs": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-5.5.1.tgz",
-      "integrity": "sha512-Vea29nJub/bXjfzEV7ZZQ/PWr1pYLZo3z0qW0LQL37uKKVzVFRQlwetd7INk3YtTD3xm9WUYr7bCvYUk3uKy2g==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@solana/codecs-core": "5.5.1",
-        "@solana/codecs-data-structures": "5.5.1",
-        "@solana/codecs-numbers": "5.5.1",
-        "@solana/codecs-strings": "5.5.1",
-        "@solana/options": "5.5.1"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@solana/subscriptions/node_modules/@solana/codecs-core": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-5.5.1.tgz",
-      "integrity": "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@solana/errors": "5.5.1"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@solana/subscriptions/node_modules/@solana/codecs-data-structures": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-5.5.1.tgz",
-      "integrity": "sha512-97bJWGyUY9WvBz3mX1UV3YPWGDTez6btCfD0ip3UVEXJbItVuUiOkzcO5iFDUtQT5riKT6xC+Mzl+0nO76gd0w==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@solana/codecs-core": "5.5.1",
-        "@solana/codecs-numbers": "5.5.1",
-        "@solana/errors": "5.5.1"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@solana/subscriptions/node_modules/@solana/codecs-numbers": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-5.5.1.tgz",
-      "integrity": "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@solana/codecs-core": "5.5.1",
-        "@solana/errors": "5.5.1"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@solana/subscriptions/node_modules/@solana/codecs-strings": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-5.5.1.tgz",
-      "integrity": "sha512-7klX4AhfHYA+uKKC/nxRGP2MntbYQCR3N6+v7bk1W/rSxYuhNmt+FN8aoThSZtWIKwN6BEyR1167ka8Co1+E7A==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@solana/codecs-core": "5.5.1",
-        "@solana/codecs-numbers": "5.5.1",
-        "@solana/errors": "5.5.1"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "fastestsmallesttextencoderdecoder": "^1.0.22",
-        "typescript": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "fastestsmallesttextencoderdecoder": {
-          "optional": true
-        },
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@solana/subscriptions/node_modules/@solana/errors": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-5.5.1.tgz",
-      "integrity": "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "chalk": "5.6.2",
-        "commander": "14.0.2"
-      },
-      "bin": {
-        "errors": "bin/cli.mjs"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@solana/subscriptions/node_modules/@solana/nominal-types": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-5.5.1.tgz",
-      "integrity": "sha512-I1ImR+kfrLFxN5z22UDiTWLdRZeKtU0J/pkWkO8qm/8WxveiwdIv4hooi8pb6JnlR4mSrWhq0pCIOxDYrL9GIQ==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@solana/subscriptions/node_modules/@solana/options": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/options/-/options-5.5.1.tgz",
-      "integrity": "sha512-eo971c9iLNLmk+yOFyo7yKIJzJ/zou6uKpy6mBuyb/thKtS/haiKIc3VLhyTXty3OH2PW8yOlORJnv4DexJB8A==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@solana/codecs-core": "5.5.1",
-        "@solana/codecs-data-structures": "5.5.1",
-        "@solana/codecs-numbers": "5.5.1",
-        "@solana/codecs-strings": "5.5.1",
-        "@solana/errors": "5.5.1"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@solana/subscriptions/node_modules/@solana/rpc-spec": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-5.5.1.tgz",
-      "integrity": "sha512-m3LX2bChm3E3by4mQrH4YwCAFY57QBzuUSWqlUw7ChuZ+oLLOq7b2czi4i6L4Vna67j3eCmB3e+4tqy1j5wy7Q==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@solana/errors": "5.5.1",
-        "@solana/rpc-spec-types": "5.5.1"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@solana/subscriptions/node_modules/@solana/rpc-spec-types": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-5.5.1.tgz",
-      "integrity": "sha512-6OFKtRpIEJQs8Jb2C4OO8KyP2h2Hy1MFhatMAoXA+0Ik8S3H+CicIuMZvGZ91mIu/tXicuOOsNNLu3HAkrakrw==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@solana/subscriptions/node_modules/@solana/rpc-types": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-5.5.1.tgz",
-      "integrity": "sha512-bibTFQ7PbHJJjGJPmfYC2I+/5CRFS4O2p9WwbFraX1Keeel+nRrt/NBXIy8veP5AEn2sVJIyJPpWBRpCx1oATA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@solana/addresses": "5.5.1",
-        "@solana/codecs-core": "5.5.1",
-        "@solana/codecs-numbers": "5.5.1",
-        "@solana/codecs-strings": "5.5.1",
-        "@solana/errors": "5.5.1",
-        "@solana/nominal-types": "5.5.1"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@solana/subscriptions/node_modules/@solana/sysvars": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-5.5.1.tgz",
-      "integrity": "sha512-k3Quq87Mm+geGUu1GWv6knPk0ALsfY6EKSJGw9xUJDHzY/RkYSBnh0RiOrUhtFm2TDNjOailg8/m0VHmi3reFA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@solana/accounts": "5.5.1",
-        "@solana/codecs": "5.5.1",
-        "@solana/errors": "5.5.1",
-        "@solana/rpc-types": "5.5.1"
-      },
-      "engines": {
-        "node": ">=20.18.0"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@solana/subscriptions/node_modules/commander": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.2.tgz",
-      "integrity": "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=20"
-      }
-    },
     "node_modules/@solana/sysvars": {
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-6.9.0.tgz",
@@ -7545,9 +7062,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7563,9 +7077,6 @@
       "integrity": "sha512-dXu/5vd4gh8symyhRF+4G7gOPkjmb4pONhh7sl+6GSiW0LOKZlfu5kXmyFbTz9smOT7jgr002qY9b1nujjXt2A==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -7583,9 +7094,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7601,9 +7109,6 @@
       "integrity": "sha512-0WUglRwyZtW+iMi7J3iFdrCxreZZIKf4egTwEQfIYRsqFax69A0OrFj+NIoFSE03xBT/IFRrg+S8K6f9Ky+4hA==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -7621,9 +7126,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -7639,9 +7141,6 @@
       "integrity": "sha512-/0qXIu1ZxggLuovLb22vFfKHq2AA4n6Whw5UwmVCHk4pkw7KWnPIQpMCEqUMPsNkFJig7PPp/TSYFu8ZEb2rtQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -7883,9 +7382,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7903,9 +7399,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7923,9 +7416,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7943,9 +7433,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8043,6 +7530,71 @@
       },
       "peerDependencies": {
         "tailwindcss": ">=3.0.0 || >=4.0.0 || insiders"
+      }
+    },
+    "node_modules/@tanstack/hotkeys": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/hotkeys/-/hotkeys-0.8.0.tgz",
+      "integrity": "sha512-vqH7X9nb0MTJ/O08++dB5bP9jgj4+BIPOUu/U+6myG86lDsirZSVSobpq5UQpE7nBuk62i8eIYeOhd+OMl/UrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/store": "^0.11.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-hotkeys": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-hotkeys/-/react-hotkeys-0.10.0.tgz",
+      "integrity": "sha512-GwOSndI5j3qBVYTmgP1mYyRTnlxb2MS17cwGlsavSxMQPSnmDf+m3LzMIpRMs+3zzQMjg3cYhHsFYizYlFI2tw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/hotkeys": "0.8.0",
+        "@tanstack/react-store": "^0.11.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@tanstack/react-store": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-store/-/react-store-0.11.0.tgz",
+      "integrity": "sha512-tX4YXh3PDkmpvGQWkWqKpzs/MSqbtuwY9dWdWhtV9Q50PmO+jOkUKIWIX4G85dwt7lxdHLXsiaEKPdKmC8F41w==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/store": "0.11.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/store": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/store/-/store-0.11.0.tgz",
+      "integrity": "sha512-WlzzCt3xi0G6pCAJu1U+2jiECwabETDpQDi3hfkFZvJii9AuZqEKbOiVarX1/bWhTNjU486yQtJCCasi/0q+Cw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tokenlens/core": {
@@ -8495,6 +8047,7 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json5": {
@@ -8560,6 +8113,7 @@
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -8569,7 +8123,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -9022,9 +8576,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9039,9 +8590,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9056,9 +8604,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9073,9 +8618,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9090,9 +8632,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9107,9 +8646,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9124,9 +8660,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9141,9 +8674,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9158,9 +8688,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9175,9 +8702,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9414,181 +8938,6 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/@webassemblyjs/ast": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
-      "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/helper-numbers": "1.13.2",
-        "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
-      }
-    },
-    "node_modules/@webassemblyjs/floating-point-hex-parser": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
-      "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@webassemblyjs/helper-api-error": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
-      "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@webassemblyjs/helper-buffer": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
-      "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@webassemblyjs/helper-numbers": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
-      "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/floating-point-hex-parser": "1.13.2",
-        "@webassemblyjs/helper-api-error": "1.13.2",
-        "@xtuc/long": "4.2.2"
-      }
-    },
-    "node_modules/@webassemblyjs/helper-wasm-bytecode": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
-      "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@webassemblyjs/helper-wasm-section": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
-      "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.14.1",
-        "@webassemblyjs/helper-buffer": "1.14.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
-        "@webassemblyjs/wasm-gen": "1.14.1"
-      }
-    },
-    "node_modules/@webassemblyjs/ieee754": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
-      "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@xtuc/ieee754": "^1.2.0"
-      }
-    },
-    "node_modules/@webassemblyjs/leb128": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
-      "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@xtuc/long": "4.2.2"
-      }
-    },
-    "node_modules/@webassemblyjs/utf8": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
-      "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@webassemblyjs/wasm-edit": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
-      "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.14.1",
-        "@webassemblyjs/helper-buffer": "1.14.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
-        "@webassemblyjs/helper-wasm-section": "1.14.1",
-        "@webassemblyjs/wasm-gen": "1.14.1",
-        "@webassemblyjs/wasm-opt": "1.14.1",
-        "@webassemblyjs/wasm-parser": "1.14.1",
-        "@webassemblyjs/wast-printer": "1.14.1"
-      }
-    },
-    "node_modules/@webassemblyjs/wasm-gen": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
-      "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.14.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
-        "@webassemblyjs/ieee754": "1.13.2",
-        "@webassemblyjs/leb128": "1.13.2",
-        "@webassemblyjs/utf8": "1.13.2"
-      }
-    },
-    "node_modules/@webassemblyjs/wasm-opt": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
-      "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.14.1",
-        "@webassemblyjs/helper-buffer": "1.14.1",
-        "@webassemblyjs/wasm-gen": "1.14.1",
-        "@webassemblyjs/wasm-parser": "1.14.1"
-      }
-    },
-    "node_modules/@webassemblyjs/wasm-parser": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
-      "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.14.1",
-        "@webassemblyjs/helper-api-error": "1.13.2",
-        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
-        "@webassemblyjs/ieee754": "1.13.2",
-        "@webassemblyjs/leb128": "1.13.2",
-        "@webassemblyjs/utf8": "1.13.2"
-      }
-    },
-    "node_modules/@webassemblyjs/wast-printer": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
-      "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.14.1",
-        "@xtuc/long": "4.2.2"
-      }
-    },
-    "node_modules/@xtuc/ieee754": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
-      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
-      "license": "BSD-3-Clause",
-      "peer": true
-    },
-    "node_modules/@xtuc/long": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
-      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
-      "license": "Apache-2.0",
-      "peer": true
-    },
     "node_modules/@xyflow/react": {
       "version": "12.11.0",
       "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.11.0.tgz",
@@ -9713,19 +9062,6 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^8"
-      }
-    },
-    "node_modules/acorn-import-phases": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
-      "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "peerDependencies": {
-        "acorn": "^8.14.0"
       }
     },
     "node_modules/acorn-jsx": {
@@ -10530,13 +9866,6 @@
         "ieee754": "^1.2.1"
       }
     },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/bufferutil": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
@@ -10798,16 +10127,6 @@
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "license": "ISC"
-    },
-    "node_modules/chrome-trace-event": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
-      "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=6.0"
-      }
     },
     "node_modules/cjs-module-lexer": {
       "version": "2.2.0",
@@ -11364,6 +10683,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cytoscape": {
@@ -13329,6 +12649,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
@@ -13341,6 +12662,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -13733,13 +13055,6 @@
         }
       ],
       "license": "BSD-3-Clause"
-    },
-    "node_modules/fastestsmallesttextencoderdecoder": {
-      "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
-      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==",
-      "license": "CC0-1.0",
-      "peer": true
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -14305,13 +13620,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/glob-to-regexp": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-      "license": "BSD-2-Clause",
-      "peer": true
-    },
     "node_modules/glob/node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -14419,6 +13727,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -15895,35 +15204,6 @@
         }
       }
     },
-    "node_modules/jayson/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
-    },
-    "node_modules/jest-worker": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
-      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/node": "*",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^8.0.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      }
-    },
     "node_modules/jiti": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
@@ -16312,9 +15592,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -16336,9 +15613,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -16360,9 +15634,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -16384,9 +15655,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -16579,9 +15847,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16597,9 +15862,6 @@
       "integrity": "sha512-mNuBOfX6GnDFT2i/kYPWud7eZGe57dDP0u4lwiSTQPRE0BxQbGZT2aEwX8LTwbonhbc6HSt50LamaZZzK4h4ig==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -16617,9 +15879,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16636,9 +15895,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -16646,20 +15902,6 @@
       ],
       "engines": {
         "node": ">= 20"
-      }
-    },
-    "node_modules/loader-runner": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.2.tgz",
-      "integrity": "sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=6.11.5"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/locate-path": {
@@ -16681,6 +15923,12 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
       "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -18417,13 +17665,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/neo-async": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/next": {
       "version": "16.2.9",
       "resolved": "https://registry.npmjs.org/next/-/next-16.2.9.tgz",
@@ -18535,6 +17776,15 @@
       "peerDependencies": {
         "react": ">= 19.1.0",
         "react-dom": ">= 19.1.0"
+      }
+    },
+    "node_modules/next-nprogress-bar": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/next-nprogress-bar/-/next-nprogress-bar-2.4.7.tgz",
+      "integrity": "sha512-OeveNQYFBhQhZ+RgrDnvHNUEQfHCmipymmD4AfAVE9pFV4jeWi7/nNK5f0lIk7ODRrtjyyr/n2YpkRbs5kUoMg==",
+      "license": "MIT",
+      "dependencies": {
+        "nprogress-v2": "^1.0.4"
       }
     },
     "node_modules/next-themes": {
@@ -18766,6 +18016,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/nprogress-v2": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/nprogress-v2/-/nprogress-v2-1.1.10.tgz",
+      "integrity": "sha512-MypWLNIPIM07SS0bAc/oac0vhVFz9vAHm7d1sj//Pnf3J03LQ3CuWrlDteIu6exq0fIvkDJ6tUDRWLaifsIt5w==",
+      "license": "MIT"
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -19396,7 +18652,7 @@
       "version": "1.61.0",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
       "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.61.0"
@@ -19415,7 +18671,7 @@
       "version": "1.61.0",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
       "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -20873,81 +20129,6 @@
       "integrity": "sha512-pFwF6H1XrSdYYNLfOcGlM28/j8CGLu8IvdrxqhjWULe2bPcKiKW4CV+OWqR/9fT52mywx65l7ysNkjLKBda7eA==",
       "license": "MIT"
     },
-    "node_modules/schema-utils": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
-      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/json-schema": "^7.0.9",
-        "ajv": "^8.9.0",
-        "ajv-formats": "^2.1.1",
-        "ajv-keywords": "^5.1.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/schema-utils/node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/schema-utils/node_modules/ajv-formats": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
-      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/schema-utils/node_modules/ajv-keywords": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
-      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3"
-      },
-      "peerDependencies": {
-        "ajv": "^8.8.2"
-      }
-    },
-    "node_modules/schema-utils/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -21523,27 +20704,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/source-map-support/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/space-separated-tokens": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
@@ -22045,22 +21205,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -22145,12 +21289,14 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.1.tgz",
       "integrity": "sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
       "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -22187,93 +21333,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/terser": {
-      "version": "5.48.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.48.0.tgz",
-      "integrity": "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==",
-      "license": "BSD-2-Clause",
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.15.0",
-        "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/terser-webpack-plugin": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.6.1.tgz",
-      "integrity": "sha512-201R5j+sJpK8nFWwKVyNfZot8FaJbLZDq5evriVzbV1wDtSXDjRUDRfJzHpAaxFDMEhsZL1QkeqM61wgsS3KaQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.25",
-        "jest-worker": "^27.4.5",
-        "schema-utils": "^4.3.0",
-        "terser": "^5.31.1"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.1.0"
-      },
-      "peerDependenciesMeta": {
-        "@minify-html/node": {
-          "optional": true
-        },
-        "@swc/core": {
-          "optional": true
-        },
-        "@swc/css": {
-          "optional": true
-        },
-        "@swc/html": {
-          "optional": true
-        },
-        "clean-css": {
-          "optional": true
-        },
-        "cssnano": {
-          "optional": true
-        },
-        "csso": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        },
-        "html-minifier-terser": {
-          "optional": true
-        },
-        "lightningcss": {
-          "optional": true
-        },
-        "postcss": {
-          "optional": true
-        },
-        "uglify-js": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/terser/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/text-encoding-utf-8": {
       "version": "1.0.2",
@@ -22720,6 +21779,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -23174,6 +22234,21 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/usehooks-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-3.1.1.tgz",
+      "integrity": "sha512-I4diPp9Cq6ieSUH2wu+fDAVQO43xwtulo+fKEidHUwZPnYImbtkTjzIJYcDcJqxgmX31GVqNFURodvcgHcW0pA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.debounce": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=16.15.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0  || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/utf-8-validate": {
@@ -24003,19 +23078,6 @@
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "license": "MIT"
     },
-    "node_modules/watchpack": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.2.tgz",
-      "integrity": "sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.2"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
@@ -24040,108 +23102,6 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
-    },
-    "node_modules/webpack": {
-      "version": "5.107.2",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.107.2.tgz",
-      "integrity": "sha512-v7RhXaJbpMlV0D7hC7lb2EbnxkoeUqf9qhKr6lozx3Q48pmFrqqNRmZFUEGmi7pSwm6fCQ2H1IjvCkHqdpVdjQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/estree": "^1.0.8",
-        "@types/json-schema": "^7.0.15",
-        "@webassemblyjs/ast": "^1.14.1",
-        "@webassemblyjs/wasm-edit": "^1.14.1",
-        "@webassemblyjs/wasm-parser": "^1.14.1",
-        "acorn": "^8.16.0",
-        "acorn-import-phases": "^1.0.3",
-        "browserslist": "^4.28.1",
-        "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.22.0",
-        "es-module-lexer": "^2.1.0",
-        "eslint-scope": "5.1.1",
-        "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.2.11",
-        "loader-runner": "^4.3.2",
-        "mime-db": "^1.54.0",
-        "neo-async": "^2.6.2",
-        "schema-utils": "^4.3.3",
-        "tapable": "^2.3.0",
-        "terser-webpack-plugin": "^5.5.0",
-        "watchpack": "^2.5.1",
-        "webpack-sources": "^3.5.0"
-      },
-      "bin": {
-        "webpack": "bin/webpack.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependenciesMeta": {
-        "webpack-cli": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/webpack-sources": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.5.0.tgz",
-      "integrity": "sha512-HPuy+uuoTCaaoEoI1LQ3JN9+vrPBvEesnnX1jADHy728cHSMlq4wUc4afYqahq2B1mhQVZxCXOkNTnXltr+2vQ==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
-    "node_modules/webpack/node_modules/enhanced-resolve": {
-      "version": "5.24.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.0.tgz",
-      "integrity": "sha512-SkE2t82KlkkxQRVMVLAGKxLfORGQfrkx5dkj+vlgXRVNEdPc4eZcR+J/Fvj8C+yKSFH5L0q3NFlyufOVQnCcYQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.4",
-        "tapable": "^2.3.3"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
-    "node_modules/webpack/node_modules/es-module-lexer": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
-      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/webpack/node_modules/eslint-scope": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-      "license": "BSD-2-Clause",
-      "peer": true,
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/webpack/node_modules/estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "license": "BSD-2-Clause",
-      "peer": true,
-      "engines": {
-        "node": ">=4.0"
-      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@supabase/supabase-js": "^2.99.0",
     "@tabler/icons-react": "^3.40.0",
     "@tailwindcss/typography": "^0.5.19",
+    "@tanstack/react-hotkeys": "^0.10.0",
     "@xyflow/react": "^12.10.1",
     "ai": "^6.0.116",
     "ansi-to-react": "^6.2.6",
@@ -91,6 +92,7 @@
     "next": "16.2.9",
     "next-intl": "^4.8.3",
     "next-mdx-remote-client": "^2.1.9",
+    "next-nprogress-bar": "^2.4.7",
     "next-themes": "^0.4.6",
     "qrcode": "^1.5.4",
     "react": "19.2.4",
@@ -112,6 +114,7 @@
     "tokenlens": "^1.3.1",
     "tw-animate-css": "^1.4.0",
     "use-stick-to-bottom": "^1.1.3",
+    "usehooks-ts": "^3.1.1",
     "zod": "^4.3.6"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Makes the student lesson page actually usable on mobile. Two commits:

**1. Lesson progress line + UX polish pack** — thin course-progress line, reading-progress indicator, lesson scroll area, route progress bar, loading skeletons.

**2. Mobile-first lesson AI chat + keyboard-safe layout** — fixes the three core mobile problems: the AI chat was a fixed-height scroll box embedded inside the page scroll (nested-scroll trap), the on-screen keyboard hid the chat input (iOS `vh` bug), and `h-screen` pushed the footer nav behind Safari's toolbar.

### Mobile chat: launcher → full-screen takeover

Researched how Khanmigo (mobile web), Duolingo Max, and Brilliant surface AI tutors on mobile — none embed a chat mid-page; they use contextual triggers that open a dedicated chat surface. Below `sm` the chat now lives behind a launcher card ("Start/Continue with the AI Tutor", message count, green completed state) and opens as a full-screen overlay:

- Height tracks `visualViewport` (iOS keyboard) with `100dvh` fallback — input always stays above the keyboard
- Safe-area insets top/bottom, Escape closes, `role="dialog"` + `aria-modal`
- Single mounted instance — chat state survives open/close
- `overscroll-contain` — chat scroll never chains into the lesson behind it
- 16px textarea on mobile (kills iOS focus auto-zoom)
- Desktop (`sm+`) unchanged

### Contextual tutor entry (Duolingo "Explain my answer" pattern)

New `AskTutorChip` under lesson content: one tap opens the chat (full-screen on mobile, scrolled into view on desktop) and auto-sends a localized "I don't understand this lesson" prompt. Hidden once the lesson is completed.

### Layout fixes

- `h-screen` → `h-dvh` on the lesson shell (footer nav visible with Safari's URL bar)
- Footer nav: `env(safe-area-inset-bottom)` padding + 40px minimum touch targets
- Lesson scroll area: `overscroll-y-contain` (no accidental pull-to-refresh)
- `viewport` export: `interactive-widget=resizes-content` (Android keyboard resizes layout) + `viewport-fit=cover` (enables safe-area env vars)
- Replaced legacy `any`s in the chat with typed `UIMessage` / tool-invocation shapes

### i18n

New `lessonAIChat.mobile.*` and `lessonAIChat.contextual.*` keys (en/es, plural-aware).

## Test plan

- [x] `npm run build` green (compile + typecheck)
- [x] ESLint clean on changed files
- [ ] On a phone (or DevTools 390×844): lesson scrolls as a single region; launcher opens full-screen chat; keyboard keeps the input visible (iOS Safari especially); chat scroll doesn't move the lesson; chip auto-sends and opens the chat; completed state shows the green launcher card; footer nav visible above the home indicator
- [ ] Desktop lesson page unchanged (inline chat, prev/next nav, sidebar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)