### PR TITLE
fix(mcp): widen mcp_audit_log user_role check — student tool calls now audited (#401)

### DIFF
--- a/mcp-server/src/audit.ts
+++ b/mcp-server/src/audit.ts
@@ -31,6 +31,13 @@ export interface AuditRecord {
   durationMs: number;
 }
 
+let insertFailures = 0;
+
+/** Total failed audit inserts since server start (monitoring/tests). */
+export function getAuditInsertFailureCount(): number {
+  return insertFailures;
+}
+
 /**
  * Record one tool call into `mcp_audit_log` using the service-role client.
  *
@@ -63,6 +70,21 @@ export function recordToolAudit(rec: AuditRecord): void {
       duration_ms: rec.durationMs,
     })
     .then(({ error }: { error: unknown }) => {
-      if (error) console.error("[audit] insert failed:", error);
+      if (error) {
+        insertFailures += 1;
+        // Loud + counted: a persistent failure here (e.g. constraint/schema
+        // drift, #401) means tool calls are going UNAUDITED.
+        console.error(
+          `[audit] INSERT FAILED (${insertFailures} since start) — tool call NOT audited`,
+          {
+            tool: rec.toolName,
+            userRole:
+              (payload.tenant_role as string | undefined) ??
+              (payload.user_role as string | undefined) ??
+              null,
+            error,
+          }
+        );
+      }
     });
 }

--- a/supabase/migrations/20260713130000_widen_mcp_audit_user_role_check.sql
+++ b/supabase/migrations/20260713130000_widen_mcp_audit_user_role_check.sql
@@ -1,0 +1,16 @@
+-- Widen mcp_audit_log.user_role CHECK to include 'student' (#401)
+--
+-- mcp_audit_log was created (20260213230911) when the MCP server only served
+-- teachers/admins. The student tool tier (Epic #348) was added later without
+-- widening this constraint, so the audit middleware's fire-and-forget insert
+-- fails on every student tool call and student calls are silently unaudited.
+--
+-- Metadata-only change: drop + re-add the CHECK. Existing rows are all
+-- teacher/admin and trivially satisfy the widened constraint.
+
+ALTER TABLE mcp_audit_log
+  DROP CONSTRAINT IF EXISTS mcp_audit_log_user_role_check;
+
+ALTER TABLE mcp_audit_log
+  ADD CONSTRAINT mcp_audit_log_user_role_check
+  CHECK (user_role IN ('student', 'teacher', 'admin'));


### PR DESCRIPTION
## Description

Student MCP tool calls were silently unaudited: `mcp_audit_log.user_role` has a CHECK constraint from the original migration (`20260213230911`, teacher/admin-only era) that rejects `'student'`, and the audit write in `mcp-server/src/audit.ts` is fire-and-forget, so the constraint violation only ever appeared in server logs.

### Changes made

- **New migration** `supabase/migrations/20260713130000_widen_mcp_audit_user_role_check.sql` — drops and re-adds `mcp_audit_log_user_role_check` as `CHECK (user_role IN ('student', 'teacher', 'admin'))`. Metadata-only (no table rewrite, no backfill); existing rows are all teacher/admin and satisfy the widened constraint.
- **Hardened audit failure path** in `mcp-server/src/audit.ts` — added a module-level failure counter (exposed via `getAuditInsertFailureCount()` for monitoring/tests) and made the insert-failure log loud and structured (`INSERT FAILED (n since start) — tool call NOT audited`, with tool name and user role), so future constraint/schema drift can't silently disable auditing again. Happy path unchanged; auditing stays fire-and-forget and remains a no-op when `SUPABASE_SERVICE_ROLE_KEY` is unset.

## Type of change

- [x] Bug fix (`bug`, `mcp-server`, `db-migration`)

## Relationship

Closes #401

## Migration status

- [x] **Local DB**: applied via `supabase migration up`; recorded in local history as `20260713130000 | widen_mcp_audit_user_role_check`.
- [x] **Cloud DB**: applied 2026-07-13 via Supabase MCP `apply_migration`; history version repaired to `20260713130000` to match the repo filename; constraint verified widened on cloud (`SELECT pg_get_constraintdef` includes `student`).

## Testing

- [x] Reproduced the bug pre-migration on local DB: `INSERT ... user_role = 'student'` fails with `violates check constraint "mcp_audit_log_user_role_check"` (exact error from the issue).
- [x] Post-migration on local DB: constraint reads `CHECK ((user_role = ANY (ARRAY['student'::text, 'teacher'::text, 'admin'::text])))`; the same student insert succeeds (test row inserted and deleted).
- [x] `cd mcp-server && npm run build` — passes (exit 0).

### QA verification steps

1. On a DB with the migration applied, run:
   `SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conname = 'mcp_audit_log_user_role_check';`
   → definition must include `'student'`.
2. Start the MCP server with `SUPABASE_SERVICE_ROLE_KEY` set, authenticate as a student (e.g. `alice@student.com` on Code Academy), and call any student tool (e.g. `lms_get_due_reviews`) via the inspector or JSON-RPC.
3. `SELECT user_id, user_role, tool_name, created_at FROM mcp_audit_log ORDER BY id DESC LIMIT 5;` → a row with `user_role = 'student'` and the called tool name must be present, and the server log must show no `[audit]` error.
4. Negative check for the hardening: point the server at a DB *without* the migration and repeat step 2 → server log shows `[audit] INSERT FAILED (1 since start) — tool call NOT audited` with tool name and role.
