### PR TITLE
feat(notifications): daily review-due digest + streak-at-risk nudge (#397)

### DIFF
--- a/app/api/cron/daily-digest/route.ts
+++ b/app/api/cron/daily-digest/route.ts
@@ -1,0 +1,49 @@
+/**
+ * Daily digest cron (issue #397) — run HOURLY (e.g. `0 * * * *`).
+ *
+ * Each tick checks every tenant's local hour against its configured send hour
+ * (tenant_settings key `daily_digest`, default 17:00 UTC) and nudge hour
+ * (default 20:00) and sends at most one digest + one streak nudge per student
+ * per day. Idempotent: re-runs within the same day never double-send.
+ * Secured by CRON_SECRET. Schedule in vercel.json and/or the server crontab
+ * (see docs/DEPLOYMENT.md §3.5).
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+import { timingSafeEqual } from 'crypto'
+import { runDailyDigest } from '@/lib/notifications/daily-digest'
+
+export const runtime = 'nodejs'
+
+function safeEqual(a: string, b: string): boolean {
+  const bufA = Buffer.from(a)
+  const bufB = Buffer.from(b)
+  return bufA.length === bufB.length && timingSafeEqual(bufA, bufB)
+}
+
+function getSupabaseAdmin() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (!url || !serviceKey) throw new Error('Supabase env vars not set')
+  return createClient(url, serviceKey)
+}
+
+export async function GET(req: NextRequest) {
+  const cronSecret = process.env.CRON_SECRET
+  const provided = req.headers.get('authorization')?.replace('Bearer ', '')
+  if (!cronSecret || !provided || !safeEqual(provided, cronSecret)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  try {
+    const result = await runDailyDigest(getSupabaseAdmin())
+    if (result.errors.length > 0) {
+      console.error('[daily-digest] partial errors', result.errors)
+    }
+    return NextResponse.json(result)
+  } catch (err) {
+    console.error('[daily-digest] run failed', err)
+    return NextResponse.json({ error: 'Digest run failed' }, { status: 500 })
+  }
+}

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -263,6 +263,8 @@ Since there's no Vercel cron, set up a system cron on the server:
 ```bash
 # crontab -e
 0 0 * * * curl -s -H "Authorization: Bearer YOUR_CRON_SECRET" https://lmsplatform.com/api/cron/expire-subscriptions
+# Daily digest + streak nudge — must run HOURLY (each tenant sends at its own local hour)
+0 * * * * curl -s -H "Authorization: Bearer YOUR_CRON_SECRET" https://lmsplatform.com/api/cron/daily-digest
 ```
 
 ---

--- a/lib/email/templates/daily-digest.ts
+++ b/lib/email/templates/daily-digest.ts
@@ -1,0 +1,117 @@
+import type { DigestLocale } from '@/lib/notifications/daily-digest'
+
+export interface DailyDigestEmailData {
+  schoolName: string
+  firstName: string
+  summary: string
+  dueCards: number
+  goalsPending: number
+  /** Streak to warn about; 0 = no streak line. */
+  streak: number
+  actionUrl: string
+}
+
+export interface StreakNudgeEmailData {
+  schoolName: string
+  firstName: string
+  streak: number
+  actionUrl: string
+}
+
+const DIGEST_COPY = {
+  en: {
+    subject: (school: string) => `Your day at ${school}`,
+    greeting: (name: string) => `Hi ${name},`,
+    intro: 'Here is what is waiting for you today:',
+    cards: (n: number) => `${n} review ${n === 1 ? 'card' : 'cards'} due`,
+    goals: (n: number) => `${n} study ${n === 1 ? 'goal' : 'goals'} left this week`,
+    streak: (n: number) => `Your ${n}-day streak ends tonight`,
+    cta: 'Pick up where you left off',
+    footer: 'A few minutes today keeps you on track.',
+  },
+  es: {
+    subject: (school: string) => `Tu día en ${school}`,
+    greeting: (name: string) => `Hola ${name},`,
+    intro: 'Esto es lo que te espera hoy:',
+    cards: (n: number) => `${n} ${n === 1 ? 'tarjeta pendiente' : 'tarjetas pendientes'} de repaso`,
+    goals: (n: number) => `${n} ${n === 1 ? 'meta' : 'metas'} de estudio esta semana`,
+    streak: (n: number) => `Tu racha de ${n} días termina esta noche`,
+    cta: 'Continúa donde lo dejaste',
+    footer: 'Unos minutos hoy te mantienen al día.',
+  },
+} as const
+
+const NUDGE_COPY = {
+  en: {
+    subject: (streak: number) => `Your ${streak}-day streak ends tonight`,
+    body: (name: string, streak: number) =>
+      `${name}, one quick practice session before the day ends keeps your ${streak}-day streak alive.`,
+    cta: 'Save my streak',
+  },
+  es: {
+    subject: (streak: number) => `Tu racha de ${streak} días termina esta noche`,
+    body: (name: string, streak: number) =>
+      `${name}, una sesión rápida de práctica antes de que termine el día mantiene viva tu racha de ${streak} días.`,
+    cta: 'Salvar mi racha',
+  },
+} as const
+
+function layout(schoolName: string, inner: string): string {
+  return `<!DOCTYPE html>
+<html>
+<body style="font-family:sans-serif;max-width:600px;margin:0 auto;padding:24px;color:#1a1a1a">
+${inner}
+  <hr style="border:none;border-top:1px solid #eee;margin:24px 0"/>
+  <p style="color:#999;font-size:12px">${schoolName}</p>
+</body>
+</html>`
+}
+
+function ctaButton(url: string, label: string): string {
+  return `<p style="text-align:center;margin:32px 0">
+    <a href="${url}" style="background:#2563eb;color:#fff;padding:12px 28px;border-radius:6px;text-decoration:none;font-weight:600">
+      ${label}
+    </a>
+  </p>`
+}
+
+export function dailyDigestEmailTemplate(
+  data: DailyDigestEmailData,
+  locale: DigestLocale
+): { subject: string; html: string } {
+  const copy = DIGEST_COPY[locale]
+  const items: string[] = []
+  if (data.dueCards > 0) items.push(copy.cards(data.dueCards))
+  if (data.goalsPending > 0) items.push(copy.goals(data.goalsPending))
+  if (data.streak > 0) items.push(copy.streak(data.streak))
+  const list = items.map((item) => `    <li style="margin:8px 0">${item}</li>`).join('\n')
+  return {
+    subject: copy.subject(data.schoolName),
+    html: layout(
+      data.schoolName,
+      `  <h2>${copy.greeting(data.firstName)}</h2>
+  <p>${copy.intro}</p>
+  <ul style="padding-left:20px">
+${list}
+  </ul>
+${ctaButton(data.actionUrl, copy.cta)}
+  <p style="color:#666;font-size:13px">${copy.footer}</p>`
+    ),
+  }
+}
+
+export function streakNudgeEmailTemplate(
+  data: StreakNudgeEmailData,
+  locale: DigestLocale
+): { subject: string; html: string } {
+  const copy = NUDGE_COPY[locale]
+  return {
+    subject: copy.subject(data.streak),
+    html: layout(
+      data.schoolName,
+      `  <h2>🔥 ${copy.subject(data.streak)}</h2>
+  <p>${copy.body(data.firstName, data.streak)}</p>
+${ctaButton(data.actionUrl, copy.cta)}`
+    ),
+  }
+}

--- a/lib/notifications/daily-digest.ts
+++ b/lib/notifications/daily-digest.ts
@@ -1,0 +1,426 @@
+/**
+ * Daily review-due digest + streak-at-risk nudge (issue #397).
+ *
+ * Called hourly by the cron route with a service-role client. For each tenant
+ * whose local hour matches its configured send hour we send one personalized
+ * "your day at <school>" notification per student with something to say (due
+ * review cards, incomplete study goals this week, streak at risk); at the
+ * nudge hour we send an optional second streak-saver to students with a
+ * streak >= 7 and still no activity today. Structural cap: max 2 sends/day.
+ *
+ * The service role bypasses RLS — every query and insert here carries
+ * tenant_id explicitly; that hygiene is load-bearing.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { sendEmail } from '@/lib/email/send'
+import { dailyDigestEmailTemplate, streakNudgeEmailTemplate } from '@/lib/email/templates/daily-digest'
+
+export type DigestLocale = 'en' | 'es'
+export type DigestKind = 'daily_digest' | 'streak_nudge'
+
+export interface DigestSettings {
+  sendHour: number
+  nudgeHour: number
+  timezone: string
+  locale: DigestLocale
+}
+
+export const DEFAULT_DIGEST_SETTINGS: DigestSettings = {
+  sendHour: 17,
+  nudgeHour: 20,
+  timezone: 'UTC',
+  locale: 'en',
+}
+
+/** Minimum streak worth mentioning as "ends tonight" in the digest. */
+export const DIGEST_STREAK_MIN = 3
+/** Minimum streak that earns the evening nudge (the Duolingo mechanic). */
+export const NUDGE_STREAK_MIN = 7
+
+interface CandidateRow {
+  tenant_id: string
+  user_id: string
+  email: string | null
+  full_name: string | null
+  due_cards: number
+  goals_pending: number
+  current_streak: number
+  last_activity_date: string | null
+}
+
+interface PreferencesRow {
+  user_id: string
+  in_app_enabled: boolean
+  email_enabled: boolean
+  email_frequency: string
+}
+
+export interface DigestRunResult {
+  tenantsConsidered: number
+  tenantsProcessed: number
+  digestsSent: number
+  nudgesSent: number
+  emailsSent: number
+  skippedAlreadySent: number
+  errors: string[]
+}
+
+/** Parse a tenant_settings `daily_digest` JSONB value, falling back per-field. */
+export function resolveDigestSettings(value: unknown): DigestSettings {
+  const v = (value ?? {}) as Record<string, unknown>
+  const int = (x: unknown): number | null => {
+    const n = typeof x === 'string' ? parseInt(x, 10) : typeof x === 'number' ? x : NaN
+    return Number.isInteger(n) && n >= 0 && n <= 23 ? n : null
+  }
+  return {
+    sendHour: int(v.send_hour) ?? DEFAULT_DIGEST_SETTINGS.sendHour,
+    nudgeHour: int(v.nudge_hour) ?? DEFAULT_DIGEST_SETTINGS.nudgeHour,
+    timezone: typeof v.timezone === 'string' && v.timezone ? v.timezone : DEFAULT_DIGEST_SETTINGS.timezone,
+    locale: v.locale === 'es' ? 'es' : DEFAULT_DIGEST_SETTINGS.locale,
+  }
+}
+
+/** Hour of day (0-23) in the given IANA timezone; invalid tz falls back to UTC. */
+export function localHour(now: Date, timezone: string): number {
+  try {
+    return parseInt(
+      new Intl.DateTimeFormat('en-US', { timeZone: timezone, hour: '2-digit', hourCycle: 'h23' }).format(now),
+      10
+    )
+  } catch {
+    return now.getUTCHours()
+  }
+}
+
+/** YYYY-MM-DD in the given IANA timezone; invalid tz falls back to UTC. */
+export function localDateStr(now: Date, timezone: string): string {
+  try {
+    return new Intl.DateTimeFormat('en-CA', {
+      timeZone: timezone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    }).format(now)
+  } catch {
+    return now.toISOString().slice(0, 10)
+  }
+}
+
+/** UTC yesterday as YYYY-MM-DD — matches award_xp()'s CURRENT_DATE streak math. */
+export function utcYesterday(now: Date): string {
+  const d = new Date(now.getTime() - 24 * 60 * 60 * 1000)
+  return d.toISOString().slice(0, 10)
+}
+
+/** Streak survives only if the student acts today: last activity was exactly yesterday. */
+export function isStreakAtRisk(lastActivityDate: string | null, streak: number, now: Date, min: number): boolean {
+  return streak >= min && lastActivityDate === utcYesterday(now)
+}
+
+const SUMMARY_COPY = {
+  en: {
+    cards: (n: number) => `${n} ${n === 1 ? 'card' : 'cards'} due`,
+    goals: (n: number) => `${n} ${n === 1 ? 'study goal' : 'study goals'} left this week`,
+    streak: (n: number) => `your ${n}-day streak ends tonight`,
+  },
+  es: {
+    cards: (n: number) => `${n} ${n === 1 ? 'tarjeta pendiente' : 'tarjetas pendientes'}`,
+    goals: (n: number) => `${n} ${n === 1 ? 'meta de estudio' : 'metas de estudio'} esta semana`,
+    streak: (n: number) => `tu racha de ${n} días termina esta noche`,
+  },
+} as const
+
+/** "12 cards due · 1 study goal left this week · your 14-day streak ends tonight" */
+export function buildSummary(
+  parts: { dueCards: number; goalsPending: number; streak: number; streakAtRisk: boolean },
+  locale: DigestLocale
+): string {
+  const copy = SUMMARY_COPY[locale]
+  const out: string[] = []
+  if (parts.dueCards > 0) out.push(copy.cards(parts.dueCards))
+  if (parts.goalsPending > 0) out.push(copy.goals(parts.goalsPending))
+  if (parts.streakAtRisk && parts.streak >= DIGEST_STREAK_MIN) out.push(copy.streak(parts.streak))
+  return out.join(' · ')
+}
+
+/** Same {{var}} interpolation as app/actions/admin/notification-templates.ts. */
+export function renderTemplate(template: string, variables: Record<string, string>): string {
+  let rendered = template
+  for (const [key, value] of Object.entries(variables)) {
+    rendered = rendered.replace(new RegExp(`{{${key}}}`, 'g'), value)
+  }
+  return rendered
+}
+
+/** Missing preferences row = schema defaults (in-app on, email on, immediate). */
+export function resolveChannels(row: PreferencesRow | undefined): { inApp: boolean; email: boolean } {
+  if (!row) return { inApp: true, email: true }
+  return {
+    inApp: row.in_app_enabled,
+    email: row.email_enabled && row.email_frequency !== 'never',
+  }
+}
+
+export function firstName(fullName: string | null, locale: DigestLocale): string {
+  const first = fullName?.trim().split(/\s+/)[0]
+  return first || (locale === 'es' ? 'estudiante' : 'there')
+}
+
+/** https://{slug}.{platform-domain} — same heuristic as the invitation email. */
+export function tenantBaseUrl(slug: string | null): string {
+  const platformDomain = process.env.NEXT_PUBLIC_PLATFORM_DOMAIN || 'localhost:3000'
+  const protocol = platformDomain.includes('localhost') || platformDomain.includes('lvh.me') ? 'http' : 'https'
+  return `${protocol}://${slug || 'app'}.${platformDomain}`
+}
+
+const FALLBACK_TEMPLATES: Record<DigestKind, Record<DigestLocale, { title: string; content: string }>> = {
+  daily_digest: {
+    en: { title: 'Your day at {{school_name}}', content: '{{summary}}. A few minutes today keeps you on track.' },
+    es: { title: 'Tu día en {{school_name}}', content: '{{summary}}. Unos minutos hoy te mantienen al día.' },
+  },
+  streak_nudge: {
+    en: {
+      title: 'Your {{streak}}-day streak ends tonight',
+      content: '{{first_name}}, one quick practice session before the day ends keeps your {{streak}}-day streak alive.',
+    },
+    es: {
+      title: 'Tu racha de {{streak}} días termina esta noche',
+      content: '{{first_name}}, una sesión rápida de práctica antes de que termine el día mantiene viva tu racha de {{streak}} días.',
+    },
+  },
+}
+
+interface TemplateRow {
+  id: number
+  name: string
+  title: string
+  content: string
+  tenant_id: string | null
+}
+
+/** Prefer a tenant-specific template row over the global seed, else fallback copy. */
+export function pickTemplate(
+  rows: TemplateRow[],
+  kind: DigestKind,
+  locale: DigestLocale,
+  tenantId: string
+): { id: number | null; title: string; content: string } {
+  const name = `${kind}_${locale}`
+  const candidates = rows.filter((r) => r.name === name)
+  const row = candidates.find((r) => r.tenant_id === tenantId) ?? candidates.find((r) => r.tenant_id === null)
+  if (row) return { id: row.id, title: row.title, content: row.content }
+  const fb = FALLBACK_TEMPLATES[kind][locale]
+  return { id: null, title: fb.title, content: fb.content }
+}
+
+/**
+ * Run one hourly tick. Idempotent per (user, kind, tenant-local day): re-runs
+ * and cron retries within the same day never double-send.
+ */
+export async function runDailyDigest(admin: SupabaseClient, now: Date = new Date()): Promise<DigestRunResult> {
+  const result: DigestRunResult = {
+    tenantsConsidered: 0,
+    tenantsProcessed: 0,
+    digestsSent: 0,
+    nudgesSent: 0,
+    emailsSent: 0,
+    skippedAlreadySent: 0,
+    errors: [],
+  }
+
+  const { data: candidates, error: candErr } = await admin.rpc('get_daily_digest_candidates')
+  if (candErr) {
+    result.errors.push(`candidates query failed: ${candErr.message}`)
+    return result
+  }
+  const rows = (candidates ?? []) as CandidateRow[]
+  if (rows.length === 0) return result
+
+  const byTenant = new Map<string, CandidateRow[]>()
+  for (const row of rows) {
+    const list = byTenant.get(row.tenant_id) ?? []
+    list.push(row)
+    byTenant.set(row.tenant_id, list)
+  }
+  const tenantIds = [...byTenant.keys()]
+  result.tenantsConsidered = tenantIds.length
+
+  const [{ data: tenants }, { data: settingRows }] = await Promise.all([
+    admin.from('tenants').select('id, name, slug').in('id', tenantIds),
+    admin.from('tenant_settings').select('tenant_id, setting_value').eq('setting_key', 'daily_digest').in('tenant_id', tenantIds),
+  ])
+  const tenantById = new Map((tenants ?? []).map((t) => [t.id as string, t as { id: string; name: string; slug: string | null }]))
+  const settingsByTenant = new Map((settingRows ?? []).map((s) => [s.tenant_id as string, s.setting_value]))
+
+  for (const tenantId of tenantIds) {
+    const tenant = tenantById.get(tenantId)
+    if (!tenant) continue
+    const settings = resolveDigestSettings(settingsByTenant.get(tenantId))
+    const hour = localHour(now, settings.timezone)
+
+    // Digest first; nudge second. If send_hour === nudge_hour both run in the
+    // same tick, still capped at 2 sends/day by construction.
+    const kinds: DigestKind[] = []
+    if (hour === settings.sendHour) kinds.push('daily_digest')
+    if (hour === settings.nudgeHour) kinds.push('streak_nudge')
+    if (kinds.length === 0) continue
+    result.tenantsProcessed++
+
+    const allCandidates = byTenant.get(tenantId) ?? []
+    const dateStr = localDateStr(now, settings.timezone)
+    const schoolName = tenant.name
+    const actionUrl = `${tenantBaseUrl(tenant.slug)}/${settings.locale}/dashboard/student?src=digest`
+
+    const { data: templateRows } = await admin
+      .from('notification_templates')
+      .select('id, name, title, content, tenant_id')
+      .in('name', [`daily_digest_${settings.locale}`, `streak_nudge_${settings.locale}`])
+      .or(`tenant_id.is.null,tenant_id.eq.${tenantId}`)
+
+    const userIds = allCandidates.map((c) => c.user_id)
+    const { data: prefRows } = await admin
+      .from('notification_preferences')
+      .select('user_id, in_app_enabled, email_enabled, email_frequency')
+      .in('user_id', userIds)
+    const prefsByUser = new Map(((prefRows ?? []) as PreferencesRow[]).map((p) => [p.user_id, p]))
+
+    for (const kind of kinds) {
+      const recipients = allCandidates.filter((c) =>
+        kind === 'daily_digest'
+          ? c.due_cards > 0 ||
+            c.goals_pending > 0 ||
+            isStreakAtRisk(c.last_activity_date, c.current_streak, now, DIGEST_STREAK_MIN)
+          : isStreakAtRisk(c.last_activity_date, c.current_streak, now, NUDGE_STREAK_MIN)
+      )
+      if (recipients.length === 0) continue
+
+      // Idempotency: users already notified (this kind, this tenant-local day).
+      const { data: sentRows, error: sentErr } = await admin
+        .from('notifications')
+        .select('target_user_ids')
+        .eq('tenant_id', tenantId)
+        .eq('metadata->>kind', kind)
+        .eq('metadata->>date', dateStr)
+      if (sentErr) {
+        result.errors.push(`tenant ${tenantId} ${kind}: idempotency check failed: ${sentErr.message}`)
+        continue
+      }
+      const alreadySent = new Set((sentRows ?? []).flatMap((r) => (r.target_user_ids ?? []) as string[]))
+
+      for (const candidate of recipients) {
+        if (alreadySent.has(candidate.user_id)) {
+          result.skippedAlreadySent++
+          continue
+        }
+        try {
+          const channels = resolveChannels(prefsByUser.get(candidate.user_id))
+          if (!channels.inApp && !channels.email) continue
+
+          const streakAtRisk = isStreakAtRisk(
+            candidate.last_activity_date,
+            candidate.current_streak,
+            now,
+            kind === 'daily_digest' ? DIGEST_STREAK_MIN : NUDGE_STREAK_MIN
+          )
+          const summary = buildSummary(
+            {
+              dueCards: candidate.due_cards,
+              goalsPending: candidate.goals_pending,
+              streak: candidate.current_streak,
+              streakAtRisk,
+            },
+            settings.locale
+          )
+          const vars: Record<string, string> = {
+            school_name: schoolName,
+            summary,
+            streak: String(candidate.current_streak),
+            first_name: firstName(candidate.full_name, settings.locale),
+          }
+          const template = pickTemplate((templateRows ?? []) as TemplateRow[], kind, settings.locale, tenantId)
+          const title = renderTemplate(template.title, vars)
+          const content = renderTemplate(template.content, vars)
+
+          const deliveryChannels = [...(channels.inApp ? ['in_app'] : []), ...(channels.email ? ['email'] : [])]
+          const { data: notification, error: insertErr } = await admin
+            .from('notifications')
+            .insert({
+              tenant_id: tenantId,
+              title,
+              content,
+              notification_type: 'info',
+              priority: 'normal',
+              target_type: 'user',
+              target_user_ids: [candidate.user_id],
+              delivery_channels: deliveryChannels,
+              status: 'sent',
+              sent_at: now.toISOString(),
+              template_id: template.id,
+              metadata: {
+                kind,
+                date: dateStr,
+                src: 'digest',
+                action_url: actionUrl,
+                due_cards: candidate.due_cards,
+                goals_pending: candidate.goals_pending,
+                streak: candidate.current_streak,
+              },
+            })
+            .select('id')
+            .single()
+          if (insertErr || !notification) {
+            result.errors.push(`tenant ${tenantId} ${kind} user ${candidate.user_id}: insert failed: ${insertErr?.message}`)
+            continue
+          }
+
+          let emailSent = false
+          if (channels.email && candidate.email) {
+            const emailTemplate =
+              kind === 'daily_digest'
+                ? dailyDigestEmailTemplate(
+                    {
+                      schoolName,
+                      firstName: vars.first_name,
+                      summary,
+                      dueCards: candidate.due_cards,
+                      goalsPending: candidate.goals_pending,
+                      streak: streakAtRisk ? candidate.current_streak : 0,
+                      actionUrl,
+                    },
+                    settings.locale
+                  )
+                : streakNudgeEmailTemplate(
+                    { schoolName, firstName: vars.first_name, streak: candidate.current_streak, actionUrl },
+                    settings.locale
+                  )
+            emailSent = await sendEmail({ to: candidate.email, ...emailTemplate })
+            if (emailSent) result.emailsSent++
+          }
+
+          const { error: userNotifErr } = await admin.from('user_notifications').insert({
+            notification_id: notification.id,
+            user_id: candidate.user_id,
+            email_sent: emailSent,
+            email_sent_at: emailSent ? now.toISOString() : null,
+          })
+          if (userNotifErr) {
+            result.errors.push(
+              `tenant ${tenantId} ${kind} user ${candidate.user_id}: user_notifications insert failed: ${userNotifErr.message}`
+            )
+            continue
+          }
+
+          if (kind === 'daily_digest') result.digestsSent++
+          else result.nudgesSent++
+        } catch (err) {
+          result.errors.push(
+            `tenant ${tenantId} ${kind} user ${candidate.user_id}: ${err instanceof Error ? err.message : String(err)}`
+          )
+        }
+      }
+    }
+  }
+
+  return result
+}

--- a/supabase/migrations/20260714150000_daily_digest.sql
+++ b/supabase/migrations/20260714150000_daily_digest.sql
@@ -1,0 +1,98 @@
+-- Daily review-due digest + streak-at-risk nudge (issue #397).
+--
+-- 1. get_daily_digest_candidates(): one-round-trip aggregation the digest cron
+--    calls with the service role. Returns every active student who has
+--    something to say today: due review cards, incomplete study goals for the
+--    current (Monday-anchored, UTC) week, or a streak at risk. Reads
+--    auth.users.email so the cron never has to page the admin API.
+-- 2. Seeds global (tenant_id IS NULL) notification_templates for the digest
+--    and the streak nudge in en/es. Tenants can override by inserting a row
+--    with the same name and their tenant_id.
+
+CREATE OR REPLACE FUNCTION public.get_daily_digest_candidates()
+RETURNS TABLE (
+    tenant_id uuid,
+    user_id uuid,
+    email text,
+    full_name text,
+    due_cards bigint,
+    goals_pending bigint,
+    current_streak integer,
+    last_activity_date date
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT
+        tu.tenant_id,
+        tu.user_id,
+        au.email::text,
+        p.full_name,
+        COALESCE(rc.due_count, 0) AS due_cards,
+        COALESCE(sg.pending_count, 0) AS goals_pending,
+        COALESCE(gp.current_streak, 0) AS current_streak,
+        gp.last_activity_date
+    FROM tenant_users tu
+    JOIN auth.users au ON au.id = tu.user_id
+    LEFT JOIN profiles p ON p.id = tu.user_id
+    LEFT JOIN gamification_profiles gp
+        ON gp.user_id = tu.user_id AND gp.tenant_id = tu.tenant_id
+    LEFT JOIN LATERAL (
+        SELECT count(*) AS due_count
+        FROM review_cards rc
+        WHERE rc.user_id = tu.user_id
+          AND rc.tenant_id = tu.tenant_id
+          AND rc.suspended = false
+          AND rc.due_at <= now()
+    ) rc ON true
+    LEFT JOIN LATERAL (
+        SELECT count(*) AS pending_count
+        FROM study_goals sg
+        WHERE sg.user_id = tu.user_id
+          AND sg.tenant_id = tu.tenant_id
+          AND sg.week_start = (date_trunc('week', (now() AT TIME ZONE 'utc')))::date
+          AND sg.done = false
+    ) sg ON true
+    WHERE tu.role = 'student'
+      AND tu.status = 'active'
+      AND (
+        COALESCE(rc.due_count, 0) > 0
+        OR COALESCE(sg.pending_count, 0) > 0
+        OR (COALESCE(gp.current_streak, 0) >= 3
+            AND gp.last_activity_date = CURRENT_DATE - 1)
+      );
+$$;
+
+-- Service-role only: the function reads auth.users and crosses tenants.
+REVOKE ALL ON FUNCTION public.get_daily_digest_candidates() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.get_daily_digest_candidates() FROM anon;
+REVOKE ALL ON FUNCTION public.get_daily_digest_candidates() FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.get_daily_digest_candidates() TO service_role;
+
+-- Global digest/nudge templates ({{var}} interpolation done by the cron).
+INSERT INTO notification_templates (name, title, content, category, variables, tenant_id)
+SELECT v.name, v.title, v.content, 'system', v.variables, NULL
+FROM (VALUES
+    ('daily_digest_en',
+     'Your day at {{school_name}}',
+     '{{summary}}. A few minutes today keeps you on track.',
+     '["school_name", "summary"]'::jsonb),
+    ('daily_digest_es',
+     'Tu día en {{school_name}}',
+     '{{summary}}. Unos minutos hoy te mantienen al día.',
+     '["school_name", "summary"]'::jsonb),
+    ('streak_nudge_en',
+     'Your {{streak}}-day streak ends tonight',
+     '{{first_name}}, one quick practice session before the day ends keeps your {{streak}}-day streak alive.',
+     '["first_name", "streak"]'::jsonb),
+    ('streak_nudge_es',
+     'Tu racha de {{streak}} días termina esta noche',
+     '{{first_name}}, una sesión rápida de práctica antes de que termine el día mantiene viva tu racha de {{streak}} días.',
+     '["first_name", "streak"]'::jsonb)
+) AS v(name, title, content, variables)
+WHERE NOT EXISTS (
+    SELECT 1 FROM notification_templates t
+    WHERE t.name = v.name AND t.tenant_id IS NULL
+);

--- a/tests/unit/daily-digest.test.ts
+++ b/tests/unit/daily-digest.test.ts
@@ -1,0 +1,295 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  buildSummary,
+  DEFAULT_DIGEST_SETTINGS,
+  firstName,
+  isStreakAtRisk,
+  localDateStr,
+  localHour,
+  pickTemplate,
+  renderTemplate,
+  resolveChannels,
+  resolveDigestSettings,
+  tenantBaseUrl,
+  utcYesterday,
+} from '@/lib/notifications/daily-digest'
+
+/**
+ * Pure helpers for the daily review-due digest + streak-at-risk nudge
+ * (issue #397). `runDailyDigest` itself needs a Supabase client and is
+ * intentionally out of scope here.
+ */
+
+describe('resolveDigestSettings', () => {
+  it('returns defaults for undefined', () => {
+    expect(resolveDigestSettings(undefined)).toEqual(DEFAULT_DIGEST_SETTINGS)
+  })
+
+  it('returns defaults for an empty object', () => {
+    expect(resolveDigestSettings({})).toEqual(DEFAULT_DIGEST_SETTINGS)
+  })
+
+  it('accepts a fully valid settings object', () => {
+    expect(
+      resolveDigestSettings({ send_hour: 8, nudge_hour: 21, timezone: 'America/Bogota', locale: 'es' })
+    ).toEqual({ sendHour: 8, nudgeHour: 21, timezone: 'America/Bogota', locale: 'es' })
+  })
+
+  it('rejects an out-of-range send_hour (25) and falls back to default', () => {
+    expect(resolveDigestSettings({ send_hour: 25 }).sendHour).toBe(DEFAULT_DIGEST_SETTINGS.sendHour)
+  })
+
+  it('rejects a negative send_hour (-1) and falls back to default', () => {
+    expect(resolveDigestSettings({ send_hour: -1 }).sendHour).toBe(DEFAULT_DIGEST_SETTINGS.sendHour)
+  })
+
+  it('rejects a non-numeric send_hour ("x") and falls back to default', () => {
+    expect(resolveDigestSettings({ send_hour: 'x' }).sendHour).toBe(DEFAULT_DIGEST_SETTINGS.sendHour)
+  })
+
+  it('rejects an out-of-range nudge_hour the same way', () => {
+    expect(resolveDigestSettings({ nudge_hour: 24 }).nudgeHour).toBe(DEFAULT_DIGEST_SETTINGS.nudgeHour)
+  })
+
+  it('maps any locale other than "es" to "en"', () => {
+    expect(resolveDigestSettings({ locale: 'fr' }).locale).toBe('en')
+    expect(resolveDigestSettings({ locale: 123 }).locale).toBe('en')
+    expect(resolveDigestSettings({ locale: 'es' }).locale).toBe('es')
+  })
+})
+
+describe('localHour', () => {
+  it('computes the hour in America/Bogota (UTC-5)', () => {
+    expect(localHour(new Date('2026-07-14T20:30:00Z'), 'America/Bogota')).toBe(15)
+  })
+
+  it('computes the hour in UTC', () => {
+    expect(localHour(new Date('2026-07-14T20:30:00Z'), 'UTC')).toBe(20)
+  })
+
+  it('returns 0 (not 24) at local midnight', () => {
+    expect(localHour(new Date('2026-07-14T00:10:00Z'), 'UTC')).toBe(0)
+  })
+
+  it('falls back to UTC hour for an invalid timezone', () => {
+    const now = new Date('2026-07-14T20:30:00Z')
+    expect(localHour(now, 'Not/AZone')).toBe(now.getUTCHours())
+  })
+})
+
+describe('localDateStr', () => {
+  it('returns YYYY-MM-DD in America/Bogota, rolling back a day near UTC midnight', () => {
+    expect(localDateStr(new Date('2026-07-15T02:00:00Z'), 'America/Bogota')).toBe('2026-07-14')
+  })
+
+  it('returns YYYY-MM-DD in UTC', () => {
+    expect(localDateStr(new Date('2026-07-14T12:00:00Z'), 'UTC')).toBe('2026-07-14')
+  })
+
+  it('falls back to UTC date for an invalid timezone', () => {
+    const now = new Date('2026-07-14T12:00:00Z')
+    expect(localDateStr(now, 'Not/AZone')).toBe(now.toISOString().slice(0, 10))
+  })
+})
+
+describe('utcYesterday + isStreakAtRisk', () => {
+  const now = new Date('2026-07-14T12:00:00Z')
+
+  it('true when last_activity_date is UTC yesterday and streak >= min', () => {
+    expect(isStreakAtRisk('2026-07-13', 7, now, 7)).toBe(true)
+  })
+
+  it('false when last_activity_date is today', () => {
+    expect(isStreakAtRisk('2026-07-14', 7, now, 7)).toBe(false)
+  })
+
+  it('false when last_activity_date is two days ago', () => {
+    expect(isStreakAtRisk('2026-07-12', 7, now, 7)).toBe(false)
+  })
+
+  it('false when streak is below min even if the date matches', () => {
+    expect(isStreakAtRisk('2026-07-13', 2, now, 7)).toBe(false)
+  })
+
+  it('false when last_activity_date is null', () => {
+    expect(isStreakAtRisk(null, 7, now, 7)).toBe(false)
+  })
+
+  it('utcYesterday returns YYYY-MM-DD 24h before now', () => {
+    expect(utcYesterday(now)).toBe('2026-07-13')
+  })
+})
+
+describe('buildSummary', () => {
+  it('en: singular card and singular goal, no streak line (not at risk)', () => {
+    const out = buildSummary({ dueCards: 1, goalsPending: 1, streak: 5, streakAtRisk: false }, 'en')
+    expect(out).toBe('1 card due · 1 study goal left this week')
+  })
+
+  it('en: plural cards and goals', () => {
+    const out = buildSummary({ dueCards: 3, goalsPending: 2, streak: 0, streakAtRisk: false }, 'en')
+    expect(out).toBe('3 cards due · 2 study goals left this week')
+  })
+
+  it('en: includes streak line when streakAtRisk and streak >= 3', () => {
+    const out = buildSummary({ dueCards: 12, goalsPending: 1, streak: 14, streakAtRisk: true }, 'en')
+    expect(out).toBe('12 cards due · 1 study goal left this week · your 14-day streak ends tonight')
+  })
+
+  it('en: omits streak line when streakAtRisk but streak < 3', () => {
+    const out = buildSummary({ dueCards: 1, goalsPending: 0, streak: 2, streakAtRisk: true }, 'en')
+    expect(out).toBe('1 card due')
+  })
+
+  it('en: omits streak line when streak >= 3 but not at risk', () => {
+    const out = buildSummary({ dueCards: 1, goalsPending: 0, streak: 5, streakAtRisk: false }, 'en')
+    expect(out).toBe('1 card due')
+  })
+
+  it('es: singular tarjeta/meta', () => {
+    const out = buildSummary({ dueCards: 1, goalsPending: 1, streak: 5, streakAtRisk: false }, 'es')
+    expect(out).toBe('1 tarjeta pendiente · 1 meta de estudio esta semana')
+  })
+
+  it('es: plural tarjetas/metas + streak line', () => {
+    const out = buildSummary({ dueCards: 4, goalsPending: 3, streak: 9, streakAtRisk: true }, 'es')
+    expect(out).toBe('4 tarjetas pendientes · 3 metas de estudio esta semana · tu racha de 9 días termina esta noche')
+  })
+
+  it('joins parts with " · "', () => {
+    const out = buildSummary({ dueCards: 2, goalsPending: 1, streak: 3, streakAtRisk: true }, 'en')
+    expect(out.split(' · ')).toHaveLength(3)
+  })
+
+  it('returns an empty string when everything is zero / not at risk', () => {
+    expect(buildSummary({ dueCards: 0, goalsPending: 0, streak: 0, streakAtRisk: false }, 'en')).toBe('')
+  })
+})
+
+describe('renderTemplate', () => {
+  it('replaces a {{var}} placeholder', () => {
+    expect(renderTemplate('Hi {{first_name}}!', { first_name: 'Ada' })).toBe('Hi Ada!')
+  })
+
+  it('replaces a repeated variable in all occurrences', () => {
+    expect(renderTemplate('{{streak}} day streak, {{streak}} strong', { streak: '7' })).toBe(
+      '7 day streak, 7 strong'
+    )
+  })
+
+  it('replaces multiple distinct variables', () => {
+    expect(renderTemplate('{{a}} and {{b}}', { a: '1', b: '2' })).toBe('1 and 2')
+  })
+
+  it('leaves a missing variable placeholder as-is', () => {
+    expect(renderTemplate('Hi {{first_name}}, {{unknown}} remains', { first_name: 'Ada' })).toBe(
+      'Hi Ada, {{unknown}} remains'
+    )
+  })
+})
+
+describe('resolveChannels', () => {
+  it('undefined row defaults to both channels on', () => {
+    expect(resolveChannels(undefined)).toEqual({ inApp: true, email: true })
+  })
+
+  it('email_enabled false turns email off', () => {
+    expect(
+      resolveChannels({ user_id: 'u1', in_app_enabled: true, email_enabled: false, email_frequency: 'immediate' })
+    ).toEqual({ inApp: true, email: false })
+  })
+
+  it('email_frequency "never" turns email off even if email_enabled is true', () => {
+    expect(
+      resolveChannels({ user_id: 'u1', in_app_enabled: true, email_enabled: true, email_frequency: 'never' })
+    ).toEqual({ inApp: true, email: false })
+  })
+
+  it('in_app_enabled false turns inApp off', () => {
+    expect(
+      resolveChannels({ user_id: 'u1', in_app_enabled: false, email_enabled: true, email_frequency: 'immediate' })
+    ).toEqual({ inApp: false, email: true })
+  })
+})
+
+describe('firstName', () => {
+  it('takes the first token of a full name', () => {
+    expect(firstName('Ada Lovelace', 'en')).toBe('Ada')
+  })
+
+  it('falls back to "there" for null in en', () => {
+    expect(firstName(null, 'en')).toBe('there')
+  })
+
+  it('falls back to "estudiante" for null in es', () => {
+    expect(firstName(null, 'es')).toBe('estudiante')
+  })
+
+  it('falls back for a whitespace-only name', () => {
+    expect(firstName('  ', 'en')).toBe('there')
+    expect(firstName('  ', 'es')).toBe('estudiante')
+  })
+})
+
+describe('pickTemplate', () => {
+  const tenantId = 'tenant-1'
+  const globalRow = { id: 1, name: 'daily_digest_en', title: 'Global title', content: 'Global content', tenant_id: null }
+  const tenantRow = {
+    id: 2,
+    name: 'daily_digest_en',
+    title: 'Tenant title',
+    content: 'Tenant content',
+    tenant_id: 'tenant-1',
+  }
+  const otherTenantRow = {
+    id: 3,
+    name: 'daily_digest_en',
+    title: 'Other tenant title',
+    content: 'Other tenant content',
+    tenant_id: 'tenant-2',
+  }
+
+  it('prefers the tenant-specific row over the global row', () => {
+    const result = pickTemplate([globalRow, tenantRow], 'daily_digest', 'en', tenantId)
+    expect(result).toEqual({ id: 2, title: 'Tenant title', content: 'Tenant content' })
+  })
+
+  it('uses the global row (tenant_id null) when there is no tenant-specific row', () => {
+    const result = pickTemplate([globalRow, otherTenantRow], 'daily_digest', 'en', tenantId)
+    expect(result).toEqual({ id: 1, title: 'Global title', content: 'Global content' })
+  })
+
+  it('falls back to built-in copy (id null) when no rows match name/tenant/locale', () => {
+    const result = pickTemplate([otherTenantRow], 'daily_digest', 'en', tenantId)
+    expect(result.id).toBeNull()
+    expect(result.title).toBe('Your day at {{school_name}}')
+    expect(result.content).toBe('{{summary}}. A few minutes today keeps you on track.')
+  })
+
+  it('falls back to built-in copy for streak_nudge/es when rows list is empty', () => {
+    const result = pickTemplate([], 'streak_nudge', 'es', tenantId)
+    expect(result.id).toBeNull()
+    expect(result.title).toBe('Tu racha de {{streak}} días termina esta noche')
+  })
+})
+
+describe('tenantBaseUrl', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('uses http for a lvh.me platform domain', () => {
+    vi.stubEnv('NEXT_PUBLIC_PLATFORM_DOMAIN', 'lvh.me:3000')
+    expect(tenantBaseUrl('slug')).toBe('http://slug.lvh.me:3000')
+  })
+
+  it('uses https for a non-local platform domain', () => {
+    vi.stubEnv('NEXT_PUBLIC_PLATFORM_DOMAIN', 'example.com')
+    expect(tenantBaseUrl('slug')).toBe('https://slug.example.com')
+  })
+
+  it('falls back to the "app" subdomain when slug is null', () => {
+    vi.stubEnv('NEXT_PUBLIC_PLATFORM_DOMAIN', 'example.com')
+    expect(tenantBaseUrl(null)).toBe('https://app.example.com')
+  })
+})

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,10 @@
     {
       "path": "/api/cron/expire-subscriptions",
       "schedule": "0 0 * * *"
+    },
+    {
+      "path": "/api/cron/daily-digest",
+      "schedule": "0 * * * *"
     }
   ]
 }


### PR DESCRIPTION
## Description

Closes the return loop from EPIC #388: students now get **one calm, personalized daily digest** ("3 cards due · 2 study goals left this week · your 14-day streak ends tonight") at their school's send hour, and an optional **evening streak-saver nudge** when a streak ≥ 7 days is about to break. Implements the verified Duolingo finding that the retention/return lever had ~5x the impact of any other engagement mechanic (`docs/LEARNING_SCIENCE_RESEARCH_2026.md`) — FSRS (#389), study plans, and streaks only pay off if students come back on the day reviews are due.

### Changes made

- **Migration `20260714150000_daily_digest.sql`** — `get_daily_digest_candidates()` (SECURITY DEFINER, service_role-only): one-round-trip aggregation over `tenant_users` (active students) of due review cards (`suspended = false AND due_at <= now()`), incomplete Monday-anchored weekly `study_goals`, and streak state from `gamification_profiles`; returns only students with something to say and reads `auth.users.email` so the cron never pages the admin API. Also seeds 4 global `notification_templates` rows (`daily_digest_en/es`, `streak_nudge_en/es`) — tenants can override by name with their own `tenant_id`.
- **`lib/notifications/daily-digest.ts`** — the engine, as pure/testable helpers + `runDailyDigest(admin)`:
  - Tenant config via `tenant_settings` key `daily_digest`: `{ send_hour: 17, nudge_hour: 20, timezone: "UTC", locale: "en" }` (all defaulted; no per-tenant timezone column exists, so the issue's "start simple" tenant-level hour lives here).
  - **One notification, not three**: single digest per student per day; the streak line joins the summary only when streak ≥ 3 and at risk (last activity = yesterday, matching `award_xp()`'s `CURRENT_DATE` math).
  - **Nudge rules**: streak ≥ 7 AND still no activity today; structural cap of 2 sends/day (digest + nudge).
  - **Preferences**: first real consumer of `notification_preferences` — missing row = schema defaults; in-app unless `in_app_enabled = false`; email only when `email_enabled` and `email_frequency != 'never'`.
  - **Idempotent** per (user, kind, tenant-local day) via `notifications.metadata` — cron retries and same-day re-runs never double-send.
  - **Tenant hygiene**: the service-role client bypasses RLS, so every query/insert filters/sets `tenant_id` explicitly.
  - Deep link per tenant + locale: `https://{slug}.{platform}/{locale}/dashboard/student?src=digest` (minimal open/click tracking via `user_notifications.in_app_read` + the `src` param).
- **`app/api/cron/daily-digest/route.ts`** — hourly cron, constant-time `CRON_SECRET` compare (same pattern as `solana-pull`). Registered in `vercel.json` (`0 * * * *`) and documented in the `docs/DEPLOYMENT.md` server crontab.
- **`lib/email/templates/daily-digest.ts`** — Mailgun digest + nudge emails (en/es), same pure-function pattern as the other templates; `sendEmail` safely no-ops when Mailgun is unconfigured and `user_notifications.email_sent` records reality.
- **`tests/unit/daily-digest.test.ts`** — 49 unit tests over the pure helpers.

### Notable judgment calls

- The existing `createNotification`/`dispatchNotification` server actions are admin-role-gated and call `revalidatePath`, so the cron writes `notifications` + `user_notifications` directly with the service role.
- `study_goals` is weekly (no per-day granularity), so digest copy says "left this week" rather than the issue's "today's goals".
- In-app `notification_templates` rows are used for the in-app copy (with `{{var}}` interpolation and per-tenant override); email HTML stays in `lib/email/templates/` like every other email.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Database migration (label `db-migration`)

## Relationship

Closes #397. Part of EPIC #388.

## Testing

- [x] `npm run build` — clean (new route compiles, no new type errors).
- [x] `npm run test:unit` — 113/113 passing (49 new).
- [x] Migration applied to local Supabase; `get_daily_digest_candidates()` returns correct per-tenant counts and excludes nothing-due students.
- [x] End-to-end against seeded local data (two tenants), via `curl` on the cron route:
  - Unauthorized request → 401; wrong-hour tick → tenant skipped.
  - Digest at send hour: `student@e2etest.com` (3 due cards, incomplete goals, 14-day at-risk streak) got exactly one digest with correct counts; `alice@student.com` (Code Academy, `locale: es`) got hers **in Spanish** with her tenant's data only.
  - Re-run same hour → `skippedAlreadySent: 2`, zero new rows (idempotency).
  - `email_enabled = false` preference → `delivery_channels = {in_app}` only.
  - Nudge at nudge hour: sent for streak 14 (≥ 7, at risk); **not** sent for streak 5; **not** sent when the student was active today; idempotent on re-run.

### QA verification steps

1. `supabase migration up` (or apply `20260714150000_daily_digest.sql`), then confirm `select * from get_daily_digest_candidates()` runs as service role and errors as `authenticated`.
2. Seed a student with overdue `review_cards`, an incomplete current-week `study_goal`, and `gamification_profiles.current_streak >= 3` with `last_activity_date = yesterday`.
3. Set the tenant's send hour to the current UTC hour: `insert into tenant_settings (tenant_id, setting_key, setting_value) values ('<tenant>', 'daily_digest', '{"send_hour": <utc-hour>}') on conflict (tenant_id, setting_key) do update set setting_value = excluded.setting_value;`
4. `curl -H "Authorization: Bearer $CRON_SECRET" http://localhost:3000/api/cron/daily-digest` → expect `digestsSent: 1`; repeat the call → `skippedAlreadySent: 1`.
5. Log in as that student and open `/dashboard/notifications` — the digest should read "N cards due · M study goals left this week · your K-day streak ends tonight".
6. Repeat with `send_hour` not matching the current hour → nothing sent; with a student who has nothing due → nothing sent.

## Screenshots

Verification GIF (student dashboard → notifications page showing the digest and the streak nudge, seeded local data):

![issue-397 verification](https://raw.githubusercontent.com/guillermoscript/lms-front/master/docs/verification/issue-397-digest.gif?v=1)
