### PR TITLE
perf: cache tenant/user-role lookups, trim payloads, lower Sentry sampling (#412)

### DIFF
--- a/app/[locale]/dashboard/admin/enrollments/page.tsx
+++ b/app/[locale]/dashboard/admin/enrollments/page.tsx
@@ -32,7 +32,7 @@ export default async function AdminEnrollmentsPage({
   // Get all enrollments
   const { data: enrollments } = await supabase
     .from('enrollments')
-    .select('*, user_id, course_id')
+    .select('enrollment_id, user_id, course_id, status, enrollment_date')
     .eq('tenant_id', tenantId)
     .order('enrollment_date', { ascending: false })
 

--- a/app/[locale]/dashboard/admin/users/page.tsx
+++ b/app/[locale]/dashboard/admin/users/page.tsx
@@ -38,7 +38,7 @@ export default async function AdminUsersPage() {
   const [{ data: rawProfiles }, { data: enrollments }, joinUrl] = await Promise.all([
     supabase
       .from('profiles')
-      .select('*')
+      .select('id, full_name, created_at, deactivated_at')
       .in('id', memberUserIds.length > 0 ? memberUserIds : ['00000000-0000-0000-0000-000000000000'])
       .order('created_at', { ascending: false }),
     supabase

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -9,6 +9,7 @@ import { TenantCssVars } from "@/components/tenant/tenant-css-vars";
 import { TenantCssVarsServer } from "@/components/tenant/tenant-css-vars-server";
 import { getCurrentTenant } from "@/lib/supabase/tenant";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { unstable_cache } from "next/cache";
 import { NextIntlClientProvider } from 'next-intl';
 import { getMessages, getTranslations, setRequestLocale } from 'next-intl/server';
 import { notFound } from 'next/navigation';
@@ -82,6 +83,26 @@ export function generateStaticParams() {
   return locales.map((locale) => ({ locale }));
 }
 
+// Branding settings are near-static; cache per tenant for 60s so every
+// navigation doesn't re-query tenant_settings before <html> can render.
+// Admin settings updates use revalidatePath, which doesn't consistently
+// cover this root layout across all touched call sites — a short TTL is a
+// safer invalidation strategy than relying on tags being threaded through
+// every settings-write path.
+const getTenantSettings = unstable_cache(
+  async (tenantId: string) => {
+    const sb = createAdminClient();
+    const { data: settings } = await sb
+      .from('tenant_settings')
+      .select('setting_key, setting_value')
+      .eq('tenant_id', tenantId)
+      .in('setting_key', ['site_name', 'logo_url', 'primary_color', 'secondary_color', 'favicon_url', 'theme_preset']);
+    return settings ?? [];
+  },
+  ['tenant-settings-branding'],
+  { revalidate: 60 }
+);
+
 export default async function RootLayout({
   children,
   params
@@ -107,18 +128,11 @@ export default async function RootLayout({
   // setting_value is jsonb: `{ value: string }` for branding keys, a StoredPreset for theme_preset
   let tenantSettings: Record<string, { value?: string } | undefined> = {};
   if (tenant) {
-    const sb = createAdminClient();
-    const { data: settings } = await sb
-      .from('tenant_settings')
-      .select('setting_key, setting_value')
-      .eq('tenant_id', tenant.id)
-      .in('setting_key', ['site_name', 'logo_url', 'primary_color', 'secondary_color', 'favicon_url', 'theme_preset']);
-    if (settings) {
-      tenantSettings = settings.reduce((acc: typeof tenantSettings, s) => {
-        acc[s.setting_key] = s.setting_value;
-        return acc;
-      }, {});
-    }
+    const settings = await getTenantSettings(tenant.id);
+    tenantSettings = settings.reduce((acc: typeof tenantSettings, s) => {
+      acc[s.setting_key] = s.setting_value;
+      return acc;
+    }, {});
   }
 
   const tenantInfo = tenant ? {

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -2,7 +2,6 @@
 
 import * as React from "react"
 import Link from "next/link"
-import { usePathname } from "next/navigation"
 import { useTranslations } from "next-intl"
 import {
     IconBook,
@@ -46,6 +45,7 @@ import {
 } from "@/components/ui/collapsible"
 import { useTenant } from "@/components/tenant/tenant-provider"
 import { useLogout } from "@/hooks/use-logout"
+import { useActiveNav } from "@/hooks/use-active-nav"
 import Image from "next/image"
 
 interface NavSubItem {
@@ -66,25 +66,9 @@ interface AppSidebarProps extends React.ComponentProps<typeof Sidebar> {
     userRole: 'student' | 'teacher' | 'admin' | null
 }
 
-// On hard loads the browser URL carries the locale prefix (/en, /es) while nav
-// hrefs are locale-less; client-side navigations are already locale-less.
-// (i18n.ts can't be imported here — it pulls in next-intl/server.)
-function stripLocale(pathname: string): string {
-    return pathname.replace(/^\/(en|es)(?=\/|$)/, '') || '/'
-}
-
-function isNavActive(href: string, pathname: string): boolean {
-    const hrefPath = href.split('?')[0]
-    if (pathname === hrefPath) return true
-    if (hrefPath !== '/dashboard/admin' && hrefPath !== '/dashboard/teacher' && hrefPath !== '/dashboard/student') {
-        return pathname.startsWith(hrefPath + '/')
-    }
-    return false
-}
-
 function NavEntry({ item }: { item: NavItem }) {
-    const pathname = stripLocale(usePathname())
-    const active = isNavActive(item.href, pathname)
+    const { isActive } = useActiveNav()
+    const active = isActive(item.href)
     const tourProps = item.tourId ? { 'data-tour': item.tourId } : {}
 
     if (!item.items?.length) {
@@ -102,7 +86,7 @@ function NavEntry({ item }: { item: NavItem }) {
         )
     }
 
-    const childActive = item.items.some((sub) => isNavActive(sub.href, pathname))
+    const childActive = item.items.some((sub) => isActive(sub.href))
 
     return (
         <Collapsible
@@ -132,7 +116,7 @@ function NavEntry({ item }: { item: NavItem }) {
                         >
                             <SidebarMenuSubButton
                                 render={<Link href={sub.href} />}
-                                isActive={isNavActive(sub.href, pathname)}
+                                isActive={isActive(sub.href)}
                             >
                                 <span>{sub.title}</span>
                             </SidebarMenuSubButton>

--- a/components/user-nav.tsx
+++ b/components/user-nav.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import Link from "next/link"
+import type { User } from "@supabase/supabase-js"
 import { useTranslations } from "next-intl"
 import { Button } from "@/components/ui/button"
 import {
@@ -15,16 +16,15 @@ import {
 import { IconLogout, IconSettings, IconUser } from "@tabler/icons-react"
 import { GamificationHeaderCard } from "./gamification/gamification-header-card"
 import { CurrentUserAvatar } from "./current-user-avatar"
-import { useCurrentUserName } from "@/hooks/use-current-user-name"
 import { useLogout } from "@/hooks/use-logout"
 
 interface UserNavProps {
-  user: any
+  user: User | null
 }
 
 export function UserNav({ user }: UserNavProps) {
   const t = useTranslations('userNav')
-  const currentName = useCurrentUserName()
+  const currentName = user?.user_metadata?.full_name || user?.email || "User"
   const logout = useLogout()
 
   return (
@@ -41,7 +41,7 @@ export function UserNav({ user }: UserNavProps) {
           <DropdownMenuLabel className="font-normal p-4">
             <div className="flex flex-col space-y-1">
               <p className="text-sm font-semibold leading-none text-foreground">
-                {currentName || user?.user_metadata?.full_name || "User"}
+                {currentName}
               </p>
               <p className="text-xs leading-none text-muted-foreground truncate">
                 {user?.email}

--- a/hooks/use-active-nav.ts
+++ b/hooks/use-active-nav.ts
@@ -1,0 +1,31 @@
+import { usePathname } from "next/navigation"
+
+// On hard loads the browser URL carries the locale prefix (/en, /es) while nav
+// hrefs are locale-less; client-side navigations are already locale-less.
+// (i18n.ts can't be imported here — it pulls in next-intl/server.)
+function stripLocale(pathname: string): string {
+    return pathname.replace(/^\/(en|es)(?=\/|$)/, '') || '/'
+}
+
+function isNavActive(href: string, pathname: string): boolean {
+    const hrefPath = href.split('?')[0]
+    if (pathname === hrefPath) return true
+    if (hrefPath !== '/dashboard/admin' && hrefPath !== '/dashboard/teacher' && hrefPath !== '/dashboard/student') {
+        return pathname.startsWith(hrefPath + '/')
+    }
+    return false
+}
+
+/**
+ * Isolates the active-link comparison logic used for sidebar nav highlighting.
+ * Returns the current (locale-stripped) pathname plus a checker for whether a
+ * given href should be considered "active" against it.
+ */
+export function useActiveNav() {
+    const pathname = stripLocale(usePathname())
+
+    return {
+        pathname,
+        isActive: (href: string) => isNavActive(href, pathname),
+    }
+}

--- a/lib/supabase/get-user-role.ts
+++ b/lib/supabase/get-user-role.ts
@@ -1,3 +1,4 @@
+import { cache } from 'react'
 import { createClient } from '@/lib/supabase/server'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { getCurrentTenantId, getCurrentUserId } from '@/lib/supabase/tenant'
@@ -8,8 +9,10 @@ import { getCurrentTenantId, getCurrentUserId } from '@/lib/supabase/tenant'
  * then falls back to JWT claims.
  *
  * Uses x-user-id header (set by middleware) to avoid redundant getUser() calls.
+ * Wrapped in React.cache() so multiple call sites within one request tree
+ * (e.g. layout + nested page) collapse into a single tenant_users query.
  */
-export async function getUserRole(): Promise<'student' | 'teacher' | 'admin' | null> {
+export const getUserRole = cache(async (): Promise<'student' | 'teacher' | 'admin' | null> => {
   const userId = await getCurrentUserId()
   if (!userId) return null
 
@@ -42,12 +45,12 @@ export async function getUserRole(): Promise<'student' | 'teacher' | 'admin' | n
   } catch {
     return 'student'
   }
-}
+})
 
 /**
  * Get user role from JWT claims (used in middleware)
  */
-export function getRoleFromClaims(claims: any): 'student' | 'teacher' | 'admin' {
+export function getRoleFromClaims(claims: { tenant_role?: string; user_role?: string } | null | undefined): 'student' | 'teacher' | 'admin' {
   const role = (claims?.tenant_role || claims?.user_role) as 'student' | 'teacher' | 'admin' | undefined
   return role || 'student'
 }
@@ -77,8 +80,9 @@ export async function getUserTenantId(): Promise<string | null> {
  * Does NOT trust JWT claims to prevent privilege escalation.
  *
  * Uses x-user-id header (set by middleware) to avoid redundant getUser() calls.
+ * Wrapped in React.cache() to dedupe repeated calls within one request tree.
  */
-export async function isSuperAdmin(): Promise<boolean> {
+export const isSuperAdmin = cache(async (): Promise<boolean> => {
   const userId = await getCurrentUserId()
   if (!userId) return false
 
@@ -90,4 +94,4 @@ export async function isSuperAdmin(): Promise<boolean> {
     .maybeSingle()
 
   return !!data
-}
+})

--- a/next.config.ts
+++ b/next.config.ts
@@ -13,6 +13,11 @@ const nextConfig: NextConfig = {
   // Allow the local tenant domains so the app is interactive under automation.
   allowedDevOrigins: ['lvh.me', '*.lvh.me', 'localhost'],
   transpilePackages: ['@lms/core'],
+  experimental: {
+    // Both are used repo-wide via barrel named imports (672 files each);
+    // this lets Next.js rewrite them to per-icon imports at build time.
+    optimizePackageImports: ['@tabler/icons-react', 'lucide-react'],
+  },
   async rewrites() {
     return {
       beforeFiles: [

--- a/proxy.ts
+++ b/proxy.ts
@@ -29,6 +29,24 @@ async function checkSuperAdmin(userId: string): Promise<boolean> {
 
 const DEFAULT_TENANT_ID = '00000000-0000-0000-0000-000000000001'
 
+// Short-TTL in-memory cache for tenant slug -> {id, status} lookups.
+// Module scope persists for the life of the Edge isolate, so this avoids a
+// DB round trip on every request for a mapping that rarely changes. TTL
+// keeps a deactivated tenant from staying "active" for long after a status
+// flip, without needing external cache infra.
+const TENANT_LOOKUP_TTL_MS = 60_000
+const tenantLookupCache = new Map<string, { tenant: { id: string; status: string } | null; expiresAt: number }>()
+
+function getCachedTenantLookup(slug: string) {
+  const entry = tenantLookupCache.get(slug)
+  if (entry && entry.expiresAt > Date.now()) return entry.tenant
+  return undefined
+}
+
+function setCachedTenantLookup(slug: string, tenant: { id: string; status: string } | null) {
+  tenantLookupCache.set(slug, { tenant, expiresAt: Date.now() + TENANT_LOOKUP_TTL_MS })
+}
+
 // Strip port from domain for hostname comparisons
 const PLATFORM_DOMAIN_RAW = process.env.NEXT_PUBLIC_PLATFORM_DOMAIN || 'lmsplatform.com'
 const PLATFORM_DOMAIN = PLATFORM_DOMAIN_RAW.split(':')[0] // e.g. "lvh.me" from "lvh.me:3000"
@@ -180,23 +198,30 @@ export default async function proxy(request: NextRequest) {
   let tenantId = DEFAULT_TENANT_ID
 
   if (tenantSlug) {
-    // Look up tenant by slug using service client (no auth needed)
-    const supabaseLookup = createServerClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_OR_ANON_KEY!,
-      {
-        cookies: {
-          getAll() { return request.cookies.getAll() },
-          setAll() { /* not needed for lookup */ },
-        },
-      }
-    )
-    const { data: tenant } = await supabaseLookup
-      .from('tenants')
-      .select('id, status')
-      .eq('slug', tenantSlug)
-      .eq('status', 'active')
-      .single()
+    let tenant = getCachedTenantLookup(tenantSlug)
+
+    if (tenant === undefined) {
+      // Look up tenant by slug using service client (no auth needed)
+      const supabaseLookup = createServerClient(
+        process.env.NEXT_PUBLIC_SUPABASE_URL!,
+        process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_OR_ANON_KEY!,
+        {
+          cookies: {
+            getAll() { return request.cookies.getAll() },
+            setAll() { /* not needed for lookup */ },
+          },
+        }
+      )
+      const { data } = await supabaseLookup
+        .from('tenants')
+        .select('id, status')
+        .eq('slug', tenantSlug)
+        .eq('status', 'active')
+        .single()
+
+      tenant = data ?? null
+      setCachedTenantLookup(tenantSlug, tenant)
+    }
 
     if (!tenant) {
       // Invalid tenant slug - redirect to platform root (skip for API routes)

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -8,8 +8,9 @@ import * as Sentry from "@sentry/nextjs";
 Sentry.init({
   dsn: "https://e40fdc0a3e5965c1862e6594a8c2631f@o4507789962706944.ingest.us.sentry.io/4507789965721600",
 
-  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 1,
+  // Define how likely traces are sampled. Full sampling in dev for debugging;
+  // 10% in production to avoid tracing every request.
+  tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1,
 
   // Enable logs to be sent to Sentry
   enableLogs: true,

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -7,8 +7,9 @@ import * as Sentry from "@sentry/nextjs";
 Sentry.init({
   dsn: "https://e40fdc0a3e5965c1862e6594a8c2631f@o4507789962706944.ingest.us.sentry.io/4507789965721600",
 
-  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 1,
+  // Define how likely traces are sampled. Full sampling in dev for debugging;
+  // 10% in production to avoid tracing every request.
+  tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1,
 
   // Enable logs to be sent to Sentry
   enableLogs: true,


### PR DESCRIPTION
## Description

Addresses the highest-impact, lowest-risk items from the #412 page-transition perf audit. The audit listed 8 findings; a code survey done before implementation found two of them had already been partially addressed since the audit was written (documented below), so this PR scopes to what's real and safe to ship together.

### Changes made

1. **`proxy.ts`** — added a 60s in-memory TTL cache for the tenant slug→id lookup, keyed by slug, so it doesn't hit `tenants` on every request. **Survey correction:** the audit's claim of a separate sequential `tenant_users` membership query no longer exists in current code — role is already read from the JWT cookie (added for #282/#287), so no DB round trip for that. Auth/JWT flow is untouched; the cache is additive and read-only.
2. **`app/[locale]/layout.tsx`** — wrapped the `tenant_settings` branding query in `unstable_cache` (60s, per tenant) so it doesn't block every navigation's TTFB.
3. **`lib/supabase/get-user-role.ts`** — wrapped `getUserRole()` and `isSuperAdmin()` in `React.cache()` so multiple call sites in one request tree (layout + nested page) collapse into a single query. Also replaced `getRoleFromClaims(claims: any)` with a proper claims type (pre-existing `any`, fixed because it's in a touched file — lint-staged runs whole-file).
4. **`sentry.server.config.ts` / `sentry.edge.config.ts`** — `tracesSampleRate` now `0.1` in production, `1` in dev.
5. **`components/user-nav.tsx`** — dropped the redundant client-side `getSession()` fetch (`useCurrentUserName()`); derives the display name from the `user` prop `DashboardLayout` already passes. Also typed the prop as Supabase's `User` instead of `any` (same lint-staged reason as above).
6. **`app/[locale]/dashboard/admin/enrollments/page.tsx`** and **`.../admin/users/page.tsx`** — trimmed `select('*')` to the columns actually rendered/used downstream.
7. **`components/app-sidebar.tsx`** — extracted the active-link comparison into a new `useActiveNav()` hook (`hooks/use-active-nav.ts`) for clarity. No behavior change.
8. **`next.config.ts`** — added `experimental.optimizePackageImports` for `@tabler/icons-react` and `lucide-react` (verified both are used via barrel imports across ~670 files each).

### Descoped (documented in the issue, not silently dropped)

- **i18n namespace-splitting** (#412 item 4) — loading the full locale JSON per request is real, but properly namespace-scoping message loading touches every `useTranslations()` call site. Too large and cross-cutting to bundle safely with the above; left for its own PR.
- **Full server conversion of `app-sidebar.tsx`** (#412 item 5) — the file also uses `useTranslations()` and `useTenant()` (client context) throughout, not just `usePathname()`, so it can't be pushed server-side without a larger data-flow change. This PR only isolates the active-link logic (see #7 above).
- **Admin Auth Admin API dedup** (#412 secondary finding) — both `admin/enrollments` and `admin/users` already wrap their `getUserById()` calls in `Promise.all` (contrary to the audit's "sequential" characterization) — the remaining N-call cost would need a `profiles`-side email cache/column to truly dedupe, a bigger schema change out of scope here.

## Type of change

- [x] Performance
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Docs

## Relationship

Closes #412

## Testing

- [x] `npm run build` — passes, no new TypeScript/lint errors on any changed file (pre-existing lint baseline elsewhere untouched).
- [x] `npx tsc --noEmit` — clean.
- [x] Manual QA via Playwright against a local dev server (details below) — logged in as `owner@e2etest.com` (Default School admin), navigated dashboard/admin, courses, users, enrollments; confirmed:
  - Tenant resolution via `x-tenant-slug` dev-override header returns distinct `x-tenant-id` per tenant on repeated requests (cache doesn't leak across tenants).
  - Invalid tenant slug still 307-redirects as before (regression check on the new cache path).
  - Admin `/users` and `/enrollments` pages render all expected columns after the `SELECT *` trim.
  - `user-nav.tsx` dropdown shows the correct name/email from the prop (no client fetch).
  - No new console errors; dev server log clean.

### QA verification steps

1. `npm run dev` (or `PORT=<free-port> npx next dev -p <port>` if 3000 is taken by the MCP server).
2. Log in as `owner@e2etest.com` / `password123` on the default tenant.
3. Navigate `/dashboard/admin` → `/dashboard/admin/users` → `/dashboard/admin/enrollments` → `/dashboard/admin/courses`; confirm all data renders (names, emails, statuses, dates) and the sidebar active-link highlighting still tracks the current page.
4. Click the user avatar (top right) — confirm the name/email shown matches the logged-in user.
5. Repeat login as `creator@codeacademy.com` on `code-academy.lvh.me:3000` (or via `x-tenant-slug: code-academy` header in dev) — confirm branding/data doesn't leak from the Default School tenant.
6. Confirm `/join-school` still redirects correctly for a non-member (regression check near the #282/#287 JWT-role logic, which sits next to the new tenant-lookup cache).

## Notes for reviewers

- `proxy.ts` is the only middleware and is multi-tenant-security critical — the diff there is intentionally minimal and additive (a cache wrapper around the existing lookup, no change to redirect/auth logic). Please give it a close look regardless.
- Two `any` types were fixed in files this PR already touched (`user-nav.tsx`, `get-user-role.ts`) — required by this repo's lint-staged running on the whole file, not scope creep.
