### PR TITLE
test(e2e): update product tests for creation wizard, raise local auth rate limit

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -181,9 +181,11 @@ sms_sent = 30
 # Number of anonymous sign-ins that can be made per hour per IP address. Requires enable_anonymous_sign_ins = true.
 anonymous_users = 30
 # Number of sessions that can be refreshed in a 5 minute interval per IP address.
-token_refresh = 150
+token_refresh = 1000
 # Number of sign up and sign-in requests that can be made in a 5 minute interval per IP address (excludes anonymous users).
-sign_in_sign_ups = 30
+# Raised for local E2E: the Playwright suite signs in once per test (~260 logins), which
+# trips the default limit of 30/5min and cascades into auth timeouts under parallel workers.
+sign_in_sign_ups = 1000
 # Number of OTP / Magic link verifications that can be made in a 5 minute interval per IP address.
 token_verifications = 30
 # Number of Web3 logins that can be made in a 5 minute interval per IP address.

--- a/tests/playwright/admin-crud.spec.ts
+++ b/tests/playwright/admin-crud.spec.ts
@@ -37,106 +37,81 @@ test.describe('Admin CRUD Operations', () => {
       await expect(statsCards.first()).toBeVisible()
     })
 
-    test('new product form loads with all required fields', async ({ page }) => {
+    test('new product wizard loads on the course step', async ({ page }) => {
       await page.goto(`${TENANT_BASE}/en/dashboard/admin/products/new`, {
         timeout: 30_000,
       })
 
-      // Name field
-      const nameInput = page.locator('#name')
-      await expect(nameInput).toBeVisible()
+      await expect(page.getByTestId('product-creation-wizard')).toBeVisible({
+        timeout: 10_000,
+      })
 
-      // Description field
-      const descriptionInput = page.locator('#description')
-      await expect(descriptionInput).toBeVisible()
+      // Step 1 offers both course sources.
+      await expect(page.getByTestId('course-source-new')).toBeVisible()
+      await expect(page.getByTestId('course-source-existing')).toBeVisible()
 
-      // Price field (type=number)
-      const priceInput = page.locator('#price')
-      await expect(priceInput).toBeVisible()
-      await expect(priceInput).toHaveAttribute('type', 'number')
-
-      // Image URL field
-      const imageInput = page.locator('#image')
-      await expect(imageInput).toBeVisible()
-      await expect(imageInput).toHaveAttribute('type', 'url')
-
-      // Submit button should be visible
-      const submitButton = page.locator('button[type="submit"]')
-      await expect(submitButton).toBeVisible()
+      // The wizard advances rather than submitting, so a Next control gates the flow.
+      await expect(page.getByTestId('product-creation-next')).toBeVisible()
     })
 
-    test('course selector renders courses in new product form (regression)', async ({
+    test('course selector renders courses in new product wizard (regression)', async ({
       page,
     }) => {
       await page.goto(`${TENANT_BASE}/en/dashboard/admin/products/new`, {
         timeout: 30_000,
       })
+      await expect(page.getByTestId('product-creation-wizard')).toBeVisible({
+        timeout: 10_000,
+      })
 
-      // Course selector section should exist with a search input
-      const courseSelectorSearch = page.locator('input[placeholder*="earch"]').last()
-      await expect(courseSelectorSearch).toBeVisible({ timeout: 10_000 })
+      // The course dropdown only renders once "use existing course" is picked.
+      await page.getByTestId('course-source-existing').click()
 
-      // Selected count text should show "0 ... selected" initially
-      const selectedText = page.getByText(/\d+.*selected/i)
-      await expect(selectedText).toBeVisible({ timeout: 10_000 })
+      const courseSelect = page.getByTestId('existing-course-select')
+      await expect(courseSelect).toBeVisible({ timeout: 10_000 })
 
-      // If there are published courses, checkboxes should render
-      const courseCheckboxes = page.locator('[role="checkbox"]')
-      const checkboxCount = await courseCheckboxes.count()
-      if (checkboxCount > 0) {
-        // At least one checkbox is visible
-        await expect(courseCheckboxes.first()).toBeVisible()
-      } else {
-        // No published courses — the empty state message should show
-        const emptyMsg = page.getByText(/no.*courses|no.*available/i)
-        await expect(emptyMsg).toBeVisible({ timeout: 5_000 })
-      }
+      // Opening it should list the tenant's courses (the regression this guards).
+      await courseSelect.click()
+      await expect(page.locator('[role="option"]').first()).toBeVisible({
+        timeout: 10_000,
+      })
     })
 
-    test('product form fields accept input without submission', async ({
+    test('product wizard fields accept input without submission', async ({
       page,
     }) => {
       await page.goto(`${TENANT_BASE}/en/dashboard/admin/products/new`, {
         timeout: 30_000,
       })
+      await expect(page.getByTestId('product-creation-wizard')).toBeVisible({
+        timeout: 10_000,
+      })
 
-      // Wait for the form to render
-      await expect(page.locator('#name')).toBeVisible({ timeout: 10_000 })
+      // Step 1 — Course: create a new course shell, then advance.
+      await page.getByTestId('course-source-new').click()
+      await page.getByTestId('product-creation-next').click()
 
-      // Fill name
-      const nameInput = page.locator('#name')
-      await nameInput.fill('Test Product E2E')
-      await expect(nameInput).toHaveValue('Test Product E2E')
+      // Step 2 — Basics.
+      const titleInput = page.getByTestId('product-creation-title')
+      await expect(titleInput).toBeVisible({ timeout: 10_000 })
+      await titleInput.fill('Test Product E2E')
+      await expect(titleInput).toHaveValue('Test Product E2E')
 
-      // Fill description (textarea element)
-      const descriptionInput = page.locator('#description')
-      await expect(descriptionInput).toBeVisible({ timeout: 5_000 })
+      const descriptionInput = page.getByTestId('product-creation-description')
       await descriptionInput.fill('A test product description for E2E testing')
       await expect(descriptionInput).toHaveValue(
         'A test product description for E2E testing'
       )
+      await page.getByTestId('product-creation-next').click()
 
-      // Fill price
-      const priceInput = page.locator('#price')
-      await expect(priceInput).toBeVisible({ timeout: 5_000 })
+      // Step 3 — Pricing: the price field only appears in paid mode.
+      await page.getByTestId('pricing-mode-paid').click()
+      const priceInput = page.getByTestId('product-creation-price')
+      await expect(priceInput).toBeVisible({ timeout: 10_000 })
       await priceInput.fill('29.99')
       await expect(priceInput).toHaveValue('29.99')
 
-      // Fill image URL
-      const imageInput = page.locator('#image')
-      await expect(imageInput).toBeVisible({ timeout: 5_000 })
-      await imageInput.fill('https://example.com/image.png')
-      await expect(imageInput).toHaveValue('https://example.com/image.png')
-
-      // Toggle a course checkbox if available
-      const firstCheckbox = page.locator('[role="checkbox"]').first()
-      if (await firstCheckbox.isVisible({ timeout: 3_000 }).catch(() => false)) {
-        await firstCheckbox.click()
-        // Selected count should update to 1
-        await expect(page.getByText(/1.*selected/i)).toBeVisible({ timeout: 5_000 })
-      }
-
-      // DO NOT submit — avoid data pollution
+      // DO NOT save or publish — avoid data pollution
     })
 
     test('existing product edit page loads with pre-filled data', async ({
@@ -156,17 +131,17 @@ test.describe('Admin CRUD Operations', () => {
         // URL should contain /products/.../edit
         expect(page.url()).toMatch(/\/products\/\d+\/edit/)
 
-        // Name input should have a pre-filled value (not empty)
-        const nameInput = page.locator('#name')
-        await expect(nameInput).toBeVisible()
-        const nameValue = await nameInput.inputValue()
-        expect(nameValue.length).toBeGreaterThan(0)
+        // Editing reuses the creation wizard, pre-filled with the product.
+        await expect(page.getByTestId('product-creation-wizard')).toBeVisible({
+          timeout: 10_000,
+        })
 
-        // Price input should have a value
-        const priceInput = page.locator('#price')
-        await expect(priceInput).toBeVisible()
-        const priceValue = await priceInput.inputValue()
-        expect(parseFloat(priceValue)).toBeGreaterThan(0)
+        // Basics lives on step 2 — advance from the course step to reach it.
+        await page.getByTestId('product-creation-next').click()
+
+        const titleInput = page.getByTestId('product-creation-title')
+        await expect(titleInput).toBeVisible({ timeout: 10_000 })
+        expect((await titleInput.inputValue()).length).toBeGreaterThan(0)
       }
     })
   })


### PR DESCRIPTION
## Problem

The four admin product E2E tests had been silently stale since **#339** merged the product **creation wizard**. They still targeted the flat form it replaced:

```
Locator: locator('#name')
Expected: visible
Error: element(s) not found
```

`#name`, `#price`, and `#image` no longer exist anywhere — the wizard uses `product-creation-*` testids and splits those fields across 5 steps (Course → Basics → Pricing → After purchase → Review).

## What changed

`tests/playwright/admin-crud.spec.ts` — retargeted at the wizard's real structure and step flow:

| Test | Now does |
|---|---|
| loads with required fields | Asserts the wizard renders on the course step with both sources + the Next control. There is no submit button anymore — the wizard advances. |
| course selector (regression) | The dropdown only renders after picking *use existing course*, so select that first, then open it and assert real options render. **Regression guard preserved**, just aimed at the new control. |
| fields accept input | Walks the real flow: Course → Basics (title, description) → Pricing, where price only exists in **paid** mode. Still never submits. |
| edit page pre-filled | Edit renders the same wizard, so advance to Basics and assert the title is pre-populated. |

`supabase/config.toml` — raised `sign_in_sign_ups` 30 → 1000 and `token_refresh` 150 → 1000 for local dev. The suite signs in once per test (~260 logins) and tripped the default 30/5min limit; GoTrue logged **106 rate-limit hits**, which cascaded into auth timeouts. Local-dev config only.

## Verification

- **Targeted suite: 63 passed / 5 failed → 67 passed / 1 failed.** `admin-crud` is now **17/17**.
- **Mutation-tested, not a vacuous green:** renaming `product-creation-title` in the wizard makes the test fail; restoring it makes it pass. The assertions are genuinely bound to the UI.
- **No data pollution:** DB still has exactly 4 products and zero `Test Product E2E` rows — the "never submit" contract holds.

## Not included

- **`admin dashboard loads with stats grid`** still fails — unrelated seed drift. `seed.sql` sets `onboarding_completed = false` for all four accounts, so the page renders the onboarding wizard instead of the dashboard. It cannot pass on a fresh `supabase db reset`. Worth its own fix (seed the flag, or have the test complete onboarding first).
- **`.env.local` mismatch:** it points at `localhost:3005` while every test hardcodes `code-academy.lvh.me:3000`. Without an override, the subdomain never resolves, the proxy falls back to Default School, and every authenticated test bounces to `/join-school`. Not committed since `.env.local` is untracked, but it makes the suite unrunnable on a clean checkout until reconciled.

## Note on parallelism

Even with the rate limits raised, local runs should stay at **1 worker**. A 6-worker run produced **159 failed / 97 passed in 28 min**; serial finishes this targeted set in **under 4 min**, correctly. The tests share one local database.

## Test plan

```bash
npx playwright test admin-crud --project=desktop-chromium --workers=1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQVomRZZ9Epr6ben2ti89L
