### PR TITLE
test(e2e): derive platform-root URL from BASE instead of hardcoding :3000

### DIFF
--- a/tests/playwright/tenant-isolation.spec.ts
+++ b/tests/playwright/tenant-isolation.spec.ts
@@ -84,7 +84,8 @@ test.describe('Tenant Isolation', () => {
 
   test('platform root (lvh.me) loads', async ({ page }) => {
     await page.goto(`${BASE}/en`)
-    await expect(page).toHaveURL(/lvh\.me:3000\/en/)
+    // Derive from BASE rather than hardcoding a port — the dev server may run anywhere.
+    await expect(page).toHaveURL(`${BASE}/en`)
   })
 
   test('subdomain (code-academy.lvh.me) shows Code Academy Pro', async ({ page }) => {

--- a/tests/playwright/utils/auth.ts
+++ b/tests/playwright/utils/auth.ts
@@ -29,22 +29,22 @@ export async function login(
   await dismissTours(page)
 }
 
-/** Login as student on default tenant (lvh.me:3000) */
+/** Login as student on the default tenant */
 export async function loginAsStudent(page: Page, baseUrl = BASE) {
   await login(page, ACCOUNTS.student.email, ACCOUNTS.student.password, baseUrl)
 }
 
-/** Login as teacher/owner on default tenant (lvh.me:3000) */
+/** Login as teacher/owner on the default tenant */
 export async function loginAsTeacher(page: Page, baseUrl = BASE) {
   await login(page, ACCOUNTS.teacher.email, ACCOUNTS.teacher.password, baseUrl)
 }
 
-/** Login as admin on code-academy tenant (code-academy.lvh.me:3000) */
+/** Login as admin on the code-academy tenant */
 export async function loginAsAdmin(page: Page, baseUrl = TENANT_BASE) {
   await login(page, ACCOUNTS.admin.email, ACCOUNTS.admin.password, baseUrl)
 }
 
-/** Login as student on code-academy tenant (code-academy.lvh.me:3000) */
+/** Login as student on the code-academy tenant */
 export async function loginAsTenantStudent(page: Page, baseUrl = TENANT_BASE) {
   await login(
     page,
@@ -55,7 +55,7 @@ export async function loginAsTenantStudent(page: Page, baseUrl = TENANT_BASE) {
 }
 
 /**
- * Login as super admin on the platform domain (lvh.me:3000).
+ * Login as super admin on the platform domain (default tenant).
  * After login, navigates to /en/platform (does NOT wait for dashboard/**).
  */
 export async function loginAsSuperAdmin(page: Page, baseUrl = BASE) {


### PR DESCRIPTION
## Problem

`tenant-isolation.spec.ts` asserted the platform root with a hardcoded port:

```ts
await expect(page).toHaveURL(/lvh\.me:3000\/en/)
```

On any dev server not running on 3000 this fails **regardless of correctness** — it was the sole red test in `tenant-isolation` + `auth-security`.

This is the same drift #417 fixed for the `E2E_*` string constants. It was missed there because the port was buried in a **regex**, which the sweep for hardcoded URLs didn't catch.

## What changed

- Assert against `BASE` (already driven by `E2E_BASE_URL`) instead of a literal port.
- Drop the now-stale `:3000` references from the `utils/auth.ts` helper comments.

## Verification

`tenant-isolation` + `auth-security` on a server running on **port 3005**:

| | Result |
|---|---|
| before | 22 passed / **1 failed** |
| after | **23 / 23** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQVomRZZ9Epr6ben2ti89L
