### PR TITLE
fix(#419): one-click free enrollment, unified success surface, intent-preserving auth redirects

### DIFF
--- a/app/[locale]/(public)/checkout/actions.ts
+++ b/app/[locale]/(public)/checkout/actions.ts
@@ -3,6 +3,8 @@
 import { createClient as createServerClient } from '@/lib/supabase/server';
 import { revalidatePath } from 'next/cache';
 import { getCurrentUserId, getCurrentTenantId } from '@/lib/supabase/tenant'
+import { headers } from 'next/headers';
+import { freeEnrollmentLimiter, getClientIp } from '@/lib/rate-limit';
 
 /**
  * Mock checkout — creates a successful transaction.
@@ -128,12 +130,26 @@ export async function enrollFree(courseId?: string) {
     }
     const tenantId = await getCurrentTenantId();
 
+    const requestHeaders = await headers();
+    const clientIp = getClientIp({ headers: requestHeaders });
+    try {
+        await Promise.all([
+            freeEnrollmentLimiter.check(30, `user:${userId}`),
+            freeEnrollmentLimiter.check(100, `ip:${clientIp}`),
+        ]);
+    } catch {
+        throw new Error("Too many enrollment attempts. Please slow down and try again later.");
+    }
+
     try {
         if (!courseId) {
             throw new Error("Free enrollment only supported for courses currently.");
         }
 
-        const numericCourseId = parseInt(courseId);
+        const numericCourseId = Number(courseId);
+        if (!Number.isSafeInteger(numericCourseId) || numericCourseId <= 0) {
+            throw new Error("Invalid course.");
+        }
 
         // 1. Validate the course: it must belong to this tenant and be published.
         // Prevents enrolling in another tenant's course or an unpublished draft
@@ -153,18 +169,22 @@ export async function enrollFree(courseId?: string) {
         }
 
         // 2. Guard: reject if a paid product is linked to this course.
-        const { data: productCourses } = await supabase
+        const { data: productCourses, error: productError } = await supabase
             .from('product_courses')
             .select('product:products(price)')
             .eq('course_id', numericCourseId)
-            .eq('tenant_id', tenantId)
-            .limit(1);
+            .eq('tenant_id', tenantId);
 
-        const linkedProduct = productCourses?.[0]?.product as unknown as {
-            price: number | string;
-        } | undefined;
+        if (productError) {
+            throw new Error("Could not verify course pricing.");
+        }
 
-        if (linkedProduct && Number(linkedProduct.price) !== 0) {
+        const hasPaidProduct = productCourses?.some(({ product }) => {
+            const linkedProduct = product as unknown as { price: number | string } | null;
+            return linkedProduct !== null && Number(linkedProduct.price) !== 0;
+        });
+
+        if (hasPaidProduct) {
             throw new Error("This course is not free. Please use the paid enrollment flow.");
         }
 
@@ -175,10 +195,12 @@ export async function enrollFree(courseId?: string) {
         });
 
         if (grantError) {
-            throw new Error("Failed to enroll: " + grantError.message);
+            console.error("Free entitlement grant failed:", grantError);
+            throw new Error("Failed to enroll. Please try again.");
         }
 
         revalidatePath('/dashboard/student');
+        revalidatePath(`/dashboard/student/courses/${numericCourseId}`);
         return { success: true };
     } catch (error) {
         console.error("Free enrollment failed:", error);

--- a/app/[locale]/(public)/checkout/actions.ts
+++ b/app/[locale]/(public)/checkout/actions.ts
@@ -5,6 +5,7 @@ import { revalidatePath } from 'next/cache';
 import { getCurrentUserId, getCurrentTenantId } from '@/lib/supabase/tenant'
 import { headers } from 'next/headers';
 import { freeEnrollmentLimiter, getClientIp } from '@/lib/rate-limit';
+import { joinCurrentSchool } from '@/app/actions/join-school';
 
 /**
  * Mock checkout — creates a successful transaction.
@@ -186,6 +187,25 @@ export async function enrollFree(courseId?: string) {
 
         if (hasPaidProduct) {
             throw new Error("This course is not free. Please use the paid enrollment flow.");
+        }
+
+        // 3. A brand-new account (signup-while-enrolling) has no tenant
+        // membership yet, which grant_free_entitlement requires. Join the
+        // school first through the standard path (invitation- and
+        // student-limit-aware) so enrollment stays one click.
+        const { data: membership } = await supabase
+            .from('tenant_users')
+            .select('id')
+            .eq('user_id', userId)
+            .eq('tenant_id', tenantId)
+            .eq('status', 'active')
+            .maybeSingle();
+
+        if (!membership) {
+            const joinResult = await joinCurrentSchool();
+            if (!joinResult.success) {
+                throw new Error(joinResult.error || "Could not join this school.");
+            }
         }
 
         // 3. Grant a free entitlement (entitlements model). Idempotent.

--- a/app/[locale]/(public)/checkout/page.tsx
+++ b/app/[locale]/(public)/checkout/page.tsx
@@ -92,10 +92,14 @@ export default async function CheckoutPage(props: { params: Promise<{ locale: st
                 const candidate = product as unknown as { price: number | string } | null;
                 return candidate !== null && Number(candidate.price) > 0;
             });
-            const selectedProductCourse = paidProductCourse ?? productCourses?.[0];
+            // No paid product linked → this is a free course; enrollment, not
+            // a purchase. Route to the one-click flow regardless of provider.
+            if (!paidProductCourse) {
+                redirect(`/courses/${courseId}?enroll=1`);
+            }
 
-            if (selectedProductCourse?.product) {
-                const product = selectedProductCourse.product as unknown as {
+            if (paidProductCourse?.product) {
+                const product = paidProductCourse.product as unknown as {
                     price: number | string;
                     currency: string | null;
                     payment_provider: string | null;
@@ -103,17 +107,13 @@ export default async function CheckoutPage(props: { params: Promise<{ locale: st
                 };
                 price = Number(product.price);
                 currency = product.currency?.toUpperCase() || 'USD';
-                productId = selectedProductCourse.product_id;
+                productId = paidProductCourse.product_id;
                 paymentProvider = product.payment_provider ?? null;
                 if (product.description) description = product.description;
 
                 if (product.payment_provider === 'manual') {
                     redirect(`/checkout/manual?productId=${productId}&courseId=${courseId}`);
                 }
-            }
-
-            if (!paidProductCourse) {
-                redirect(`/courses/${courseId}?enroll=1`);
             }
         }
     } else if (planId) {

--- a/app/[locale]/(public)/checkout/page.tsx
+++ b/app/[locale]/(public)/checkout/page.tsx
@@ -15,26 +15,27 @@ interface SearchParams {
 }
 
 export default async function CheckoutPage(props: { params: Promise<{ locale: string }>, searchParams: Promise<SearchParams> }) {
-    const searchParams = await props.searchParams;
-    const { locale } = await props.params;
+    const [searchParams, { locale }, t, supabase, user] = await Promise.all([
+        props.searchParams,
+        props.params,
+        getTranslations('checkout'),
+        createClient(),
+        getSessionUser(),
+    ]);
     const { courseId, planId } = searchParams;
-    const t = await getTranslations('checkout');
-
-    const supabase = await createClient();
-    const user = await getSessionUser()
     if (!user) {
         const returnUrl = encodeURIComponent(`/checkout?${courseId ? `courseId=${courseId}` : `planId=${planId}`}`);
         redirect(`/auth/login?next=${returnUrl}`);
     }
 
-    const tenantId = await getCurrentTenantId();
-
-    // Get user profile for pre-filling forms
-    const { data: profile } = await supabase
-        .from('profiles')
-        .select('full_name')
-        .eq('id', user.id)
-        .single();
+    const [tenantId, { data: profile }] = await Promise.all([
+        getCurrentTenantId(),
+        supabase
+            .from('profiles')
+            .select('full_name')
+            .eq('id', user.id)
+            .single(),
+    ]);
 
     const userName = profile?.full_name || '';
     const userEmail = user.email || '';

--- a/app/[locale]/(public)/checkout/page.tsx
+++ b/app/[locale]/(public)/checkout/page.tsx
@@ -85,20 +85,34 @@ export default async function CheckoutPage(props: { params: Promise<{ locale: st
                 .from("product_courses")
                 .select("product_id, product:products(price, currency, payment_provider, description)")
                 .eq("course_id", courseId)
-                .eq("tenant_id", tenantId)
-                .limit(1);
+                .eq("tenant_id", tenantId);
 
-            if (productCourses?.[0]?.product) {
-                const product = productCourses[0].product as any;
-                price = parseFloat(product.price);
+            const paidProductCourse = productCourses?.find(({ product }) => {
+                const candidate = product as unknown as { price: number | string } | null;
+                return candidate !== null && Number(candidate.price) > 0;
+            });
+            const selectedProductCourse = paidProductCourse ?? productCourses?.[0];
+
+            if (selectedProductCourse?.product) {
+                const product = selectedProductCourse.product as unknown as {
+                    price: number | string;
+                    currency: string | null;
+                    payment_provider: string | null;
+                    description: string | null;
+                };
+                price = Number(product.price);
                 currency = product.currency?.toUpperCase() || 'USD';
-                productId = productCourses[0].product_id;
+                productId = selectedProductCourse.product_id;
                 paymentProvider = product.payment_provider ?? null;
                 if (product.description) description = product.description;
 
                 if (product.payment_provider === 'manual') {
                     redirect(`/checkout/manual?productId=${productId}&courseId=${courseId}`);
                 }
+            }
+
+            if (!paidProductCourse) {
+                redirect(`/courses/${courseId}?enroll=1`);
             }
         }
     } else if (planId) {

--- a/app/[locale]/(public)/checkout/success/page.tsx
+++ b/app/[locale]/(public)/checkout/success/page.tsx
@@ -1,57 +1,129 @@
-'use client';
+import Link from 'next/link'
+import { redirect } from 'next/navigation'
+import { getTranslations } from 'next-intl/server'
+import { IconCircleCheckFilled } from '@tabler/icons-react'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { CheckoutProcessing } from '@/components/public/checkout-processing'
+import { createClient } from '@/lib/supabase/server'
+import { getCurrentTenantId } from '@/lib/supabase/tenant'
 
-import { Suspense } from 'react';
-import Link from 'next/link';
-import { useSearchParams } from 'next/navigation';
-import { useTranslations } from 'next-intl';
-import { IconCircleCheckFilled } from '@tabler/icons-react';
-import { Button } from '@/components/ui/button';
-import { Card, CardContent } from '@/components/ui/card';
-
-function CheckoutSuccessInner() {
-    const searchParams = useSearchParams();
-    const t = useTranslations('checkout.success');
-
-    const type = searchParams.get('type') ?? 'product';
-    const isPlan = type === 'plan';
-
-    const primaryHref = isPlan ? '/dashboard/student/browse' : '/dashboard/student/courses';
-    const primaryLabel = isPlan ? t('browseCourses') : t('goToCourses');
-
-    return (
-        <div className="flex min-h-[60vh] items-center justify-center px-4 py-16">
-            <Card className="w-full max-w-md border-border shadow-sm">
-                <CardContent className="flex flex-col items-center gap-6 px-8 py-10 text-center">
-                    {/* Icon */}
-                    <div className="flex h-16 w-16 items-center justify-center rounded-full bg-emerald-100 dark:bg-emerald-950">
-                        <IconCircleCheckFilled className="h-9 w-9 text-emerald-600 dark:text-emerald-400" />
-                    </div>
-
-                    {/* Copy */}
-                    <div className="space-y-2">
-                        <h1 className="text-xl font-semibold tracking-tight">{t('title')}</h1>
-                        <p className="text-sm leading-relaxed text-muted-foreground">{t('subtitle')}</p>
-                    </div>
-
-                    {/* CTAs */}
-                    <div className="flex w-full flex-col gap-3 pt-2">
-                        <Link href={primaryHref} className="w-full">
-                            <Button className="w-full">{primaryLabel}</Button>
-                        </Link>
-                        <Link href="/dashboard/student/billing" className="w-full">
-                            <Button variant="outline" className="w-full">{t('viewBilling')}</Button>
-                        </Link>
-                    </div>
-                </CardContent>
-            </Card>
-        </div>
-    );
+interface CheckoutSuccessPageProps {
+  searchParams: Promise<{ transactionId?: string; type?: string }>
 }
 
-export default function CheckoutSuccessPage() {
-    return (
-        <Suspense fallback={null}>
-            <CheckoutSuccessInner />
-        </Suspense>
-    );
+export default async function CheckoutSuccessPage({ searchParams }: CheckoutSuccessPageProps) {
+  const { transactionId: transactionIdParam, type } = await searchParams
+  const t = await getTranslations('checkout.success')
+  const transactionId = Number(transactionIdParam)
+
+  if (!Number.isSafeInteger(transactionId) || transactionId <= 0) {
+    return <SuccessCard primaryHref={type === 'plan' ? '/dashboard/student/browse' : '/dashboard/student/courses'} />
+  }
+
+  const supabase = await createClient()
+  const tenantId = await getCurrentTenantId()
+  const { data: { user } } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect(`/auth/login?next=${encodeURIComponent(`/checkout/success?transactionId=${transactionId}`)}`)
+  }
+
+  const { data: transaction } = await supabase
+    .from('transactions')
+    .select('transaction_id, status, product_id, plan_id')
+    .eq('transaction_id', transactionId)
+    .eq('tenant_id', tenantId)
+    .eq('user_id', user.id)
+    .single()
+
+  if (!transaction) {
+    redirect('/dashboard/student')
+  }
+
+  if (transaction.status === 'pending') {
+    return <CheckoutProcessing />
+  }
+
+  if (transaction.status !== 'successful') {
+    redirect('/dashboard/student/billing')
+  }
+
+  if (transaction.plan_id) {
+    redirect('/dashboard/student/browse?checkout=success')
+  }
+
+  if (!transaction.product_id) {
+    redirect('/dashboard/student/courses')
+  }
+
+  const { data: productCourses } = await supabase
+    .from('product_courses')
+    .select('course_id, course:courses(title)')
+    .eq('product_id', transaction.product_id)
+    .eq('tenant_id', tenantId)
+    .order('course_id')
+
+  const courses = (productCourses ?? []).map(({ course_id, course }) => ({
+    courseId: course_id,
+    title: (course as unknown as { title: string } | null)?.title ?? t('courseFallback'),
+  }))
+
+  if (courses.length === 1) {
+    redirect(`/dashboard/student/courses/${courses[0].courseId}`)
+  }
+
+  if (courses.length === 0) {
+    redirect('/dashboard/student/courses')
+  }
+
+  return (
+    <div className="mx-auto flex min-h-[60vh] w-full max-w-xl items-center px-4 py-16">
+      <Card className="w-full border-border shadow-sm">
+        <CardContent className="flex flex-col items-center gap-6 px-8 py-10 text-center">
+          <SuccessIcon />
+          <div className="space-y-2">
+            <h1 className="text-xl font-semibold tracking-tight">{t('title')}</h1>
+            <p className="text-sm leading-relaxed text-muted-foreground">{t('multipleCourses')}</p>
+          </div>
+          <div className="flex w-full flex-col gap-3">
+            {courses.map((course) => (
+              <Link key={course.courseId} href={`/dashboard/student/courses/${course.courseId}`}>
+                <Button variant="outline" className="w-full">{course.title}</Button>
+              </Link>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+async function SuccessCard({ primaryHref }: { primaryHref: string }) {
+  const t = await getTranslations('checkout.success')
+
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center px-4 py-16">
+      <Card className="w-full max-w-md border-border shadow-sm">
+        <CardContent className="flex flex-col items-center gap-6 px-8 py-10 text-center">
+          <SuccessIcon />
+          <div className="space-y-2">
+            <h1 className="text-xl font-semibold tracking-tight">{t('title')}</h1>
+            <p className="text-sm leading-relaxed text-muted-foreground">{t('subtitle')}</p>
+          </div>
+          <Link href={primaryHref} className="w-full">
+            <Button className="w-full">{t('continue')}</Button>
+          </Link>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+function SuccessIcon() {
+  return (
+    <div className="flex h-16 w-16 items-center justify-center rounded-full bg-emerald-100 dark:bg-emerald-950">
+      <IconCircleCheckFilled className="h-9 w-9 text-emerald-600 dark:text-emerald-400" />
+    </div>
+  )
 }

--- a/app/[locale]/(public)/checkout/success/page.tsx
+++ b/app/[locale]/(public)/checkout/success/page.tsx
@@ -14,15 +14,13 @@ interface CheckoutSuccessPageProps {
 
 export default async function CheckoutSuccessPage({ searchParams }: CheckoutSuccessPageProps) {
   const { transactionId: transactionIdParam, type } = await searchParams
-  const t = await getTranslations('checkout.success')
   const transactionId = Number(transactionIdParam)
 
   if (!Number.isSafeInteger(transactionId) || transactionId <= 0) {
     return <SuccessCard primaryHref={type === 'plan' ? '/dashboard/student/browse' : '/dashboard/student/courses'} />
   }
 
-  const supabase = await createClient()
-  const tenantId = await getCurrentTenantId()
+  const [supabase, tenantId] = await Promise.all([createClient(), getCurrentTenantId()])
   const { data: { user } } = await supabase.auth.getUser()
 
   if (!user) {
@@ -66,7 +64,7 @@ export default async function CheckoutSuccessPage({ searchParams }: CheckoutSucc
 
   const courses = (productCourses ?? []).map(({ course_id, course }) => ({
     courseId: course_id,
-    title: (course as unknown as { title: string } | null)?.title ?? t('courseFallback'),
+    title: (course as unknown as { title: string } | null)?.title,
   }))
 
   if (courses.length === 1) {
@@ -76,6 +74,8 @@ export default async function CheckoutSuccessPage({ searchParams }: CheckoutSucc
   if (courses.length === 0) {
     redirect('/dashboard/student/courses')
   }
+
+  const t = await getTranslations('checkout.success')
 
   return (
     <div className="mx-auto flex min-h-[60vh] w-full max-w-xl items-center px-4 py-16">
@@ -89,7 +89,7 @@ export default async function CheckoutSuccessPage({ searchParams }: CheckoutSucc
           <div className="flex w-full flex-col gap-3">
             {courses.map((course) => (
               <Link key={course.courseId} href={`/dashboard/student/courses/${course.courseId}`}>
-                <Button variant="outline" className="w-full">{course.title}</Button>
+                <Button variant="outline" className="w-full">{course.title ?? t('courseFallback')}</Button>
               </Link>
             ))}
           </div>

--- a/app/[locale]/(public)/courses/[id]/page.tsx
+++ b/app/[locale]/(public)/courses/[id]/page.tsx
@@ -26,7 +26,7 @@ import { getCurrentTenantId, getCurrentUserId } from '@/lib/supabase/tenant'
 import { hasCourseAccess } from '@/lib/services/course-access'
 import type { Metadata } from 'next';
 import { buildPageMetadata } from '@/lib/seo';
-import { FreeEnrollButton } from '@/components/public/free-enroll-button';
+import { AutoFreeEnrollButton, FreeEnrollButton } from '@/components/public/free-enroll-button';
 
 export const dynamic = 'force-dynamic';
 
@@ -67,12 +67,15 @@ export default async function CourseDetailsPage(props: {
     params: Promise<{ id: string }>;
     searchParams: Promise<{ enroll?: string }>;
 }) {
-    const params = await props.params;
-    const searchParams = await props.searchParams;
-    const t = await getTranslations('coursePublicDetails');
-    const supabase = await createClient();
-
-    const [userId, tenantId] = await Promise.all([getCurrentUserId(), getCurrentTenantId()]);
+    const [params, searchParams, t, supabase, userId, tenantId] = await Promise.all([
+        props.params,
+        props.searchParams,
+        getTranslations('coursePublicDetails'),
+        createClient(),
+        getCurrentUserId(),
+        getCurrentTenantId(),
+    ]);
+    const courseId = Number(params.id);
     // Fetch course with lessons and category
     const { data: course, error } = await supabase
         .from("courses")
@@ -89,7 +92,7 @@ export default async function CourseDetailsPage(props: {
                 name
             )
         `)
-        .eq("course_id", parseInt(params.id))
+        .eq("course_id", courseId)
         .eq("tenant_id", tenantId)
         .eq("status", "published")
         .single();
@@ -98,35 +101,35 @@ export default async function CourseDetailsPage(props: {
         notFound();
     }
 
-    // Fetch author separately (profiles is global, no tenant_id)
-    let author = null;
-    if (course.author_id) {
-        const { data: authorData } = await supabase
+    const authorPromise = course.author_id
+        ? supabase
             .from("profiles")
             .select("id, full_name, avatar_url, bio")
             .eq("id", course.author_id)
-            .single();
-        author = authorData;
-    }
+            .single()
+        : Promise.resolve({ data: null });
+
+    const accessPromise = userId
+        ? hasCourseAccess(supabase, userId, courseId)
+        : Promise.resolve(false);
+
+    const productCoursesPromise = supabase
+        .from('product_courses')
+        .select('product:products(price, currency)')
+        .eq('course_id', courseId)
+        .eq('tenant_id', tenantId);
+
+    const [{ data: author }, hasAccess, { data: productCourses }] = await Promise.all([
+        authorPromise,
+        accessPromise,
+        productCoursesPromise,
+    ]);
 
     // Sort lessons by sequence
     const lessons = course.lessons?.sort((a: Lesson, b: Lesson) => a.sequence - b.sequence) || [];
     const totalLessons = lessons.length;
     const estimatedHours = Math.floor(totalLessons * 10 / 60);
     const estimatedMinutes = (totalLessons * 10) % 60;
-
-    // Check user's access (entitlements model)
-    let hasAccess = false;
-    if (userId) {
-        hasAccess = await hasCourseAccess(supabase, userId, parseInt(params.id));
-    }
-
-    // Fetch product for pricing
-    const { data: productCourses } = await supabase
-        .from('product_courses')
-        .select('product:products(price, currency)')
-        .eq('course_id', parseInt(params.id))
-        .eq('tenant_id', tenantId);
 
     type CourseProduct = { price: number | string; currency: string | null };
     const linkedProducts = (productCourses ?? [])
@@ -384,10 +387,11 @@ export default async function CourseDetailsPage(props: {
                                                 </Button>
                                             </Link>
                                         ) : isFree ? (
-                                            <FreeEnrollButton
-                                                courseId={course.course_id}
-                                                autoEnroll={searchParams.enroll === '1'}
-                                            />
+                                            searchParams.enroll === '1' ? (
+                                                <AutoFreeEnrollButton courseId={course.course_id} />
+                                            ) : (
+                                                <FreeEnrollButton courseId={course.course_id} />
+                                            )
                                         ) : (
                                             <Link href={`/checkout?courseId=${course.course_id}`}>
                                                 <Button className="w-full h-11 bg-cyan-500 hover:bg-cyan-400 text-black font-bold text-sm shadow-lg shadow-cyan-500/20">

--- a/app/[locale]/(public)/courses/[id]/page.tsx
+++ b/app/[locale]/(public)/courses/[id]/page.tsx
@@ -22,10 +22,11 @@ import {
 } from "@/components/ui/accordion";
 import { Card, CardContent } from "@/components/ui/card";
 import { getTranslations } from 'next-intl/server';
-import { getCurrentUserId } from '@/lib/supabase/tenant'
+import { getCurrentTenantId, getCurrentUserId } from '@/lib/supabase/tenant'
 import { hasCourseAccess } from '@/lib/services/course-access'
 import type { Metadata } from 'next';
 import { buildPageMetadata } from '@/lib/seo';
+import { FreeEnrollButton } from '@/components/public/free-enroll-button';
 
 export const dynamic = 'force-dynamic';
 
@@ -62,12 +63,16 @@ interface Lesson {
     description: string | null;
 }
 
-export default async function CourseDetailsPage(props: { params: Promise<{ id: string }> }) {
+export default async function CourseDetailsPage(props: {
+    params: Promise<{ id: string }>;
+    searchParams: Promise<{ enroll?: string }>;
+}) {
     const params = await props.params;
+    const searchParams = await props.searchParams;
     const t = await getTranslations('coursePublicDetails');
     const supabase = await createClient();
 
-    const userId = await getCurrentUserId()
+    const [userId, tenantId] = await Promise.all([getCurrentUserId(), getCurrentTenantId()]);
     // Fetch course with lessons and category
     const { data: course, error } = await supabase
         .from("courses")
@@ -85,6 +90,7 @@ export default async function CourseDetailsPage(props: { params: Promise<{ id: s
             )
         `)
         .eq("course_id", parseInt(params.id))
+        .eq("tenant_id", tenantId)
         .eq("status", "published")
         .single();
 
@@ -118,12 +124,16 @@ export default async function CourseDetailsPage(props: { params: Promise<{ id: s
     // Fetch product for pricing
     const { data: productCourses } = await supabase
         .from('product_courses')
-        .select('product:products(*)')
+        .select('product:products(price, currency)')
         .eq('course_id', parseInt(params.id))
-        .limit(1);
+        .eq('tenant_id', tenantId);
 
-    const courseProduct = productCourses?.[0]?.product as any;
-    const isFree = courseProduct ? parseFloat(courseProduct.price) === 0 : true;
+    type CourseProduct = { price: number | string; currency: string | null };
+    const linkedProducts = (productCourses ?? [])
+        .map(({ product }) => product as unknown as CourseProduct | null)
+        .filter((product): product is CourseProduct => product !== null);
+    const courseProduct = linkedProducts.find((product) => Number(product.price) > 0) ?? linkedProducts[0];
+    const isFree = !courseProduct || Number(courseProduct.price) === 0;
     const priceDisplay = isFree ? t('pricing.free') : `$${courseProduct.price}`;
 
     const instructor = author ? {
@@ -153,7 +163,7 @@ export default async function CourseDetailsPage(props: { params: Promise<{ id: s
                     {course.category && (
                         <>
                             <ChevronRight className="w-3 h-3" aria-hidden="true" />
-                            <span className="text-zinc-300">{(course.category as any).name}</span>
+                            <span className="text-zinc-300">{course.category.name}</span>
                         </>
                     )}
                     <ChevronRight className="w-3 h-3" aria-hidden="true" />
@@ -167,7 +177,7 @@ export default async function CourseDetailsPage(props: { params: Promise<{ id: s
                     <div className="max-w-4xl">
                         {course.category && (
                             <span className="inline-block px-3 py-1 text-xs font-medium rounded-full bg-cyan-500/10 text-cyan-400 border border-cyan-500/20 mb-4">
-                                {(course.category as any).name}
+                                {course.category.name}
                             </span>
                         )}
 
@@ -362,7 +372,7 @@ export default async function CourseDetailsPage(props: { params: Promise<{ id: s
                                     {/* CTA */}
                                     <div className="space-y-3">
                                         {!userId ? (
-                                            <Link href={`/auth/login?next=${encodeURIComponent(`/courses/${params.id}`)}`}>
+                                            <Link href={`/auth/login?next=${encodeURIComponent(isFree ? `/courses/${params.id}?enroll=1` : `/checkout?courseId=${course.course_id}`)}`}>
                                                 <Button className="w-full h-11 bg-cyan-500 hover:bg-cyan-400 text-black font-bold text-sm shadow-lg shadow-cyan-500/20">
                                                     {isFree ? t('pricing.enrollFree') : t('pricing.enrollNow')}
                                                 </Button>
@@ -374,11 +384,10 @@ export default async function CourseDetailsPage(props: { params: Promise<{ id: s
                                                 </Button>
                                             </Link>
                                         ) : isFree ? (
-                                            <Link href={`/checkout?courseId=${course.course_id}`}>
-                                                <Button className="w-full h-11 bg-cyan-500 hover:bg-cyan-400 text-black font-bold text-sm shadow-lg shadow-cyan-500/20">
-                                                    {t('pricing.enrollFree')}
-                                                </Button>
-                                            </Link>
+                                            <FreeEnrollButton
+                                                courseId={course.course_id}
+                                                autoEnroll={searchParams.enroll === '1'}
+                                            />
                                         ) : (
                                             <Link href={`/checkout?courseId=${course.course_id}`}>
                                                 <Button className="w-full h-11 bg-cyan-500 hover:bg-cyan-400 text-black font-bold text-sm shadow-lg shadow-cyan-500/20">

--- a/app/[locale]/(public)/products/[productId]/page.tsx
+++ b/app/[locale]/(public)/products/[productId]/page.tsx
@@ -5,6 +5,8 @@ import { ManualPaymentButton } from '@/components/student/manual-payment-button'
 import { getCurrentUserId } from '@/lib/supabase/tenant'
 import type { Metadata } from 'next'
 import { buildPageMetadata } from '@/lib/seo'
+import Link from 'next/link'
+import { Button } from '@/components/ui/button'
 
 export async function generateMetadata({
   params
@@ -75,9 +77,9 @@ export default async function ProductDetailPage({
                 <h3 className="font-semibold mb-2">How Manual Payment Works:</h3>
                 <ol className="list-decimal list-inside space-y-2 text-sm text-muted-foreground">
                   <li>Click the button below to request payment information</li>
-                  <li>We'll send you payment instructions via email</li>
+                  <li>We’ll send you payment instructions via email</li>
                   <li>Complete the payment using your preferred method (bank transfer, etc.)</li>
-                  <li>Once verified, you'll get instant access to your course</li>
+                  <li>Once verified, you’ll get instant access to your course</li>
                 </ol>
               </div>
             )}
@@ -93,11 +95,9 @@ export default async function ProductDetailPage({
               ) : (
                 <div className="text-center">
                   <p className="text-muted-foreground mb-4">Please login to request payment information</p>
-                  <a href="/auth/login">
-                    <button className="bg-primary text-primary-foreground px-4 py-2 rounded-md">
-                      Login
-                    </button>
-                  </a>
+                  <Link href={`/auth/login?next=${encodeURIComponent(`/products/${product.product_id}`)}`}>
+                    <Button>Login</Button>
+                  </Link>
                 </div>
               )}
             </div>

--- a/app/[locale]/auth/confirm/route.ts
+++ b/app/[locale]/auth/confirm/route.ts
@@ -3,6 +3,7 @@ import { getCurrentTenantId } from '@/lib/supabase/tenant'
 import { type EmailOtpType } from '@supabase/supabase-js'
 import { redirect } from 'next/navigation'
 import { type NextRequest } from 'next/server'
+import { getSafeNextPath } from '@/lib/auth/safe-next-path'
 
 const DEFAULT_TENANT_ID = '00000000-0000-0000-0000-000000000001'
 
@@ -10,8 +11,8 @@ export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url)
   const token_hash = searchParams.get('token_hash')
   const type = searchParams.get('type') as EmailOtpType | null
-  const _next = searchParams.get('next')
-  const next = _next?.startsWith('/') ? _next : '/'
+  const requestedNext = searchParams.get('next')
+  const next = getSafeNextPath(requestedNext, '/')
 
   if (token_hash && type) {
     const supabase = await createClient()
@@ -34,6 +35,10 @@ export async function GET(request: NextRequest) {
 
       // Smart redirect for new signups based on context
       if (type === 'signup' && user) {
+        if (requestedNext && next !== '/') {
+          redirect(next)
+        }
+
         // Check if user already has active school memberships
         const { data: memberships } = await supabase
           .from('tenant_users')

--- a/app/api/auth/callback/route.ts
+++ b/app/api/auth/callback/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
+import { getSafeNextPath } from '@/lib/auth/safe-next-path'
 
 /**
  * OAuth callback route handler.
@@ -12,11 +13,7 @@ import { createClient } from '@/lib/supabase/server'
 export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url)
   const code = searchParams.get('code')
-  let next = searchParams.get('next') ?? '/dashboard/student'
-
-  if (!next.startsWith('/')) {
-    next = '/dashboard/student'
-  }
+  const next = getSafeNextPath(searchParams.get('next'), '/dashboard/student')
 
   if (code) {
     const supabase = await createClient()

--- a/app/api/payments/checkout/route.ts
+++ b/app/api/payments/checkout/route.ts
@@ -202,8 +202,8 @@ export async function POST(req: NextRequest) {
         amount,
         currency,
         reference,
-        successUrl: `${appUrl}/dashboard/student?checkout=success`,
-        cancelUrl: `${appUrl}/dashboard/student?checkout=cancelled`,
+        successUrl: `${appUrl}/checkout/success?transactionId=${transaction.transaction_id}`,
+        cancelUrl: planId ? `${appUrl}/checkout?planId=${planId}` : `${appUrl}/courses`,
         baseUrl: appUrl,
         metadata: {
           transactionId: reference,

--- a/components/login-form.tsx
+++ b/components/login-form.tsx
@@ -23,6 +23,7 @@ import {
   InputGroupAddon,
   InputGroupButton,
 } from '@/components/ui/input-group'
+import { getSafeNextPath } from '@/lib/auth/safe-next-path'
 
 interface LoginFormProps extends React.ComponentPropsWithoutRef<'div'> {
   tenantId?: string
@@ -38,6 +39,8 @@ export function LoginForm({ className, tenantId, ...props }: LoginFormProps) {
   const [showPassword, setShowPassword] = useState(false)
   const router = useRouter()
   const searchParams = useSearchParams()
+  const requestedNext = searchParams.get('next') ?? searchParams.get('redirectTo')
+  const nextPath = getSafeNextPath(requestedNext, '')
 
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -82,9 +85,8 @@ export function LoginForm({ className, tenantId, ...props }: LoginFormProps) {
 
       // Return to where the user came from (e.g. the OAuth consent page) —
       // relative paths only, so the param can't redirect off-site.
-      const redirectTo = searchParams.get('redirectTo')
-      if (redirectTo && redirectTo.startsWith('/') && !redirectTo.startsWith('//')) {
-        router.push(redirectTo)
+      if (nextPath) {
+        router.push(nextPath)
       } else {
         router.push(`/dashboard/${userRole}`)
       }
@@ -105,7 +107,7 @@ export function LoginForm({ className, tenantId, ...props }: LoginFormProps) {
       const { error } = await supabase.auth.signInWithOAuth({
         provider: 'google',
         options: {
-          redirectTo: `${window.location.origin}/api/auth/callback`,
+          redirectTo: `${window.location.origin}/api/auth/callback${nextPath ? `?next=${encodeURIComponent(nextPath)}` : ''}`,
         },
       })
       if (error) throw error
@@ -211,7 +213,10 @@ export function LoginForm({ className, tenantId, ...props }: LoginFormProps) {
             </div>
             <div className="mt-4 text-center text-sm">
               {t('noAccount')}{' '}
-              <Link href="/auth/sign-up" className="underline underline-offset-4">
+              <Link
+                href={nextPath ? `/auth/sign-up?next=${encodeURIComponent(nextPath)}` : '/auth/sign-up'}
+                className="underline underline-offset-4"
+              >
                 {t('signup')}
               </Link>
             </div>

--- a/components/public/checkout-form.tsx
+++ b/components/public/checkout-form.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useSyncExternalStore } from 'react';
 import QRCode from 'qrcode';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -100,15 +100,14 @@ export function CheckoutForm({
     // mobile wallets; a first-time subscription needs TWO signed txs (init then
     // subscribe), which a single QR scan can't do — so subscriptions require the
     // in-app wallet (desktop extension or Phantom's in-app browser).
-    const [phantomAvailable, setPhantomAvailable] = useState(false);
+    const phantomAvailable = useSyncExternalStore(
+        () => () => undefined,
+        () => !!getPhantom(),
+        () => false,
+    );
     const [phantomBusy, setPhantomBusy] = useState(false);
     const [phantomMsg, setPhantomMsg] = useState<string | null>(null);
     const [phantomError, setPhantomError] = useState<string | null>(null);
-
-    // Detect Phantom client-side only (avoids SSR/hydration mismatch).
-    useEffect(() => {
-        setPhantomAvailable(!!getPhantom());
-    }, []);
 
     // Clean up the Solana poll on unmount.
     useEffect(() => {
@@ -140,9 +139,9 @@ export function CheckoutForm({
         return trimmed.split(/[\n,]+/).map(f => f.trim()).filter(Boolean);
     })();
 
-    const checkoutDone = () => {
+    const checkoutDone = (transactionId: number) => {
         toast.success(t('toasts.paymentSuccess'));
-        router.push(`/checkout/success?type=${planId ? 'plan' : 'product'}`);
+        router.push(`/checkout/success?transactionId=${transactionId}`);
     };
 
     // Poll /verify until the on-chain transfer/subscription is confirmed. The
@@ -160,7 +159,7 @@ export function CheckoutForm({
                 const vd = await vr.json();
                 if (vd.confirmed) {
                     if (pollRef.current) clearInterval(pollRef.current);
-                    checkoutDone();
+                    checkoutDone(txId);
                 }
             } catch {
                 /* transient poll error — keep polling */
@@ -290,7 +289,7 @@ export function CheckoutForm({
             if (isFree) {
                 await enrollFree(courseId);
                 toast.success(t('toasts.success'));
-                router.push('/checkout/success?type=product');
+                router.push(`/dashboard/student/courses/${courseId}`);
                 return;
             }
 
@@ -301,9 +300,9 @@ export function CheckoutForm({
                     const handled = await startProviderCheckout();
                     if (handled) return; // redirect leaves the page / QR keeps loading
                 }
-                await enrollUser(courseId, planId, 'mock_test');
+                const result = await enrollUser(courseId, planId, 'mock_test');
                 toast.success(t('toasts.paymentSuccess'));
-                router.push(`/checkout/success?type=${planId ? 'plan' : 'product'}`);
+                router.push(`/checkout/success?transactionId=${result.transaction_id}`);
             } else {
                 // Offline payment — works for both products and plans
                 if (productId) {

--- a/components/public/checkout-form.tsx
+++ b/components/public/checkout-form.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef, useSyncExternalStore } from 'react';
+import { useState, useEffect, useRef, useSyncExternalStore, useTransition } from 'react';
 import QRCode from 'qrcode';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -67,7 +67,7 @@ export function CheckoutForm({
     paymentProvider,
     solanaCurrencies,
 }: CheckoutFormProps) {
-    const [loading, setLoading] = useState(false);
+    const [isPending, startTransition] = useTransition();
     const [paymentMethod, setPaymentMethod] = useState<'card' | 'offline'>('card');
     const [offlineData, setOfflineData] = useState({
         name: userName || '',
@@ -283,57 +283,56 @@ export function CheckoutForm({
         }
     };
 
-    const handleEnroll = async () => {
-        setLoading(true);
-        try {
-            if (isFree) {
-                await enrollFree(courseId);
-                toast.success(t('toasts.success'));
-                router.push(`/dashboard/student/courses/${courseId}`);
-                return;
-            }
+    const handleEnroll = () => {
+        startTransition(async () => {
+            try {
+                if (isFree) {
+                    await enrollFree(courseId);
+                    toast.success(t('toasts.success'));
+                    router.push(`/dashboard/student/courses/${courseId}`);
+                    return;
+                }
 
-            if (paymentMethod === 'card') {
-                // Lemon Squeezy / Solana go through the real provider checkout;
-                // everything else uses the existing inline (mock) enrollment.
-                if (isRedirectProvider || isQrProvider) {
-                    const handled = await startProviderCheckout();
-                    if (handled) return; // redirect leaves the page / QR keeps loading
-                }
-                const result = await enrollUser(courseId, planId, 'mock_test');
-                toast.success(t('toasts.paymentSuccess'));
-                router.push(`/checkout/success?transactionId=${result.transaction_id}`);
-            } else {
-                // Offline payment — works for both products and plans
-                if (productId) {
-                    await createPaymentRequest({
-                        productId,
-                        contactName: offlineData.name,
-                        contactEmail: offlineData.email,
-                        contactPhone: offlineData.phone,
-                        message: offlineData.message
-                    });
-                    toast.success(t('toasts.requestSent'));
-                    router.push('/dashboard/student/payments');
-                } else if (planId) {
-                    await createPaymentRequest({
-                        planId: parseInt(planId),
-                        contactName: offlineData.name,
-                        contactEmail: offlineData.email,
-                        contactPhone: offlineData.phone,
-                        message: offlineData.message
-                    });
-                    toast.success(t('toasts.requestSent'));
-                    router.push('/dashboard/student/payments');
+                if (paymentMethod === 'card') {
+                    // Lemon Squeezy / Solana go through the real provider checkout;
+                    // everything else uses the existing inline (mock) enrollment.
+                    if (isRedirectProvider || isQrProvider) {
+                        const handled = await startProviderCheckout();
+                        if (handled) return; // redirect leaves the page / QR keeps loading
+                    }
+                    const result = await enrollUser(courseId, planId, 'mock_test');
+                    toast.success(t('toasts.paymentSuccess'));
+                    router.push(`/checkout/success?transactionId=${result.transaction_id}`);
                 } else {
-                    throw new Error("No product or plan to process");
+                    // Offline payment — works for both products and plans
+                    if (productId) {
+                        await createPaymentRequest({
+                            productId,
+                            contactName: offlineData.name,
+                            contactEmail: offlineData.email,
+                            contactPhone: offlineData.phone,
+                            message: offlineData.message
+                        });
+                        toast.success(t('toasts.requestSent'));
+                        router.push('/dashboard/student/payments');
+                    } else if (planId) {
+                        await createPaymentRequest({
+                            planId: parseInt(planId),
+                            contactName: offlineData.name,
+                            contactEmail: offlineData.email,
+                            contactPhone: offlineData.phone,
+                            message: offlineData.message
+                        });
+                        toast.success(t('toasts.requestSent'));
+                        router.push('/dashboard/student/payments');
+                    } else {
+                        throw new Error("No product or plan to process");
+                    }
                 }
+            } catch (error) {
+                toast.error(t('toasts.error', { message: error instanceof Error ? error.message : String(error) }));
             }
-        } catch (error) {
-            toast.error(t('toasts.error', { message: error instanceof Error ? error.message : String(error) }));
-        } finally {
-            setLoading(false);
-        }
+        });
     };
 
     // ─── Order summary block (shared between free and paid) ───
@@ -387,10 +386,10 @@ export function CheckoutForm({
                     <Button
                         className="w-full"
                         onClick={handleEnroll}
-                        disabled={loading}
+                        disabled={isPending}
                     >
-                        {loading && <IconLoader2 className="mr-2 h-4 w-4 animate-spin" />}
-                        {loading ? t('enrollment.enrolling') : t('enrollment.button')}
+                        {isPending && <IconLoader2 className="mr-2 h-4 w-4 animate-spin" />}
+                        {isPending ? t('enrollment.enrolling') : t('enrollment.button')}
                     </Button>
                 </div>
             </div>
@@ -493,7 +492,7 @@ export function CheckoutForm({
                         {/* Solana with Phantom available → in-app wallet (primary). */}
                         {isQrProvider && phantomAvailable ? (
                             <div className="space-y-2">
-                                <Button className="w-full" onClick={payWithPhantom} disabled={loading || phantomBusy}>
+                                <Button className="w-full" onClick={payWithPhantom} disabled={isPending || phantomBusy}>
                                     <IconWallet className="mr-2 h-4 w-4" />
                                     {phantomError ? t('payment.phantomRetry') : t('payment.payWithPhantom')}
                                 </Button>
@@ -503,7 +502,7 @@ export function CheckoutForm({
                                         variant="ghost"
                                         className="w-full"
                                         onClick={handleEnroll}
-                                        disabled={loading || phantomBusy}
+                                        disabled={isPending || phantomBusy}
                                     >
                                         <IconQrcode className="mr-2 h-4 w-4" />
                                         {t('payment.payByQr')}
@@ -513,9 +512,9 @@ export function CheckoutForm({
                             </div>
                         ) : subsNeedsWallet ? null : (
                             /* Lemon Squeezy redirect, or one-time Solana via QR. */
-                            <Button className="w-full" onClick={handleEnroll} disabled={loading}>
-                                {loading && <IconLoader2 className="mr-2 h-4 w-4 animate-spin" />}
-                                {loading ? t('payment.processing') : t('payment.button')}
+                            <Button className="w-full" onClick={handleEnroll} disabled={isPending}>
+                                {isPending && <IconLoader2 className="mr-2 h-4 w-4 animate-spin" />}
+                                {isPending ? t('payment.processing') : t('payment.button')}
                             </Button>
                         )}
                         <p className="mt-3 flex items-center justify-center gap-1.5 text-[11px] text-muted-foreground">
@@ -551,7 +550,7 @@ export function CheckoutForm({
                         <TabsContent value="card" className="mt-5 space-y-4">
                             <div className="space-y-1.5">
                                 <Label htmlFor="cardholder" className="text-xs font-medium">{t('payment.cardholder')}</Label>
-                                <Input id="cardholder" placeholder="John Doe" disabled={loading} />
+                                <Input id="cardholder" placeholder="John Doe" disabled={isPending} />
                             </div>
                             <div className="space-y-1.5">
                                 <Label htmlFor="cardNumber" className="text-xs font-medium">{t('payment.cardNumber')}</Label>
@@ -560,7 +559,7 @@ export function CheckoutForm({
                                         id="cardNumber"
                                         placeholder="4242 4242 4242 4242"
                                         className="pl-10"
-                                        disabled={loading}
+                                        disabled={isPending}
                                     />
                                     <IconCreditCard className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
                                 </div>
@@ -568,11 +567,11 @@ export function CheckoutForm({
                             <div className="grid grid-cols-2 gap-3">
                                 <div className="space-y-1.5">
                                     <Label htmlFor="expiry" className="text-xs font-medium">{t('payment.expiry')}</Label>
-                                    <Input id="expiry" placeholder="MM/YY" disabled={loading} />
+                                    <Input id="expiry" placeholder="MM/YY" disabled={isPending} />
                                 </div>
                                 <div className="space-y-1.5">
                                     <Label htmlFor="cvc" className="text-xs font-medium">{t('payment.cvc')}</Label>
-                                    <Input id="cvc" placeholder="123" disabled={loading} />
+                                    <Input id="cvc" placeholder="123" disabled={isPending} />
                                 </div>
                             </div>
                         </TabsContent>
@@ -588,7 +587,7 @@ export function CheckoutForm({
                                     placeholder="Your Name"
                                     value={offlineData.name}
                                     onChange={e => setOfflineData({ ...offlineData, name: e.target.value })}
-                                    disabled={loading}
+                                    disabled={isPending}
                                 />
                             </div>
                             <div className="space-y-1.5">
@@ -599,7 +598,7 @@ export function CheckoutForm({
                                     placeholder="email@example.com"
                                     value={offlineData.email}
                                     onChange={e => setOfflineData({ ...offlineData, email: e.target.value })}
-                                    disabled={loading}
+                                    disabled={isPending}
                                     readOnly={!!userEmail}
                                     className={userEmail ? 'bg-muted' : ''}
                                 />
@@ -611,7 +610,7 @@ export function CheckoutForm({
                                     placeholder="+1 234 567 8900"
                                     value={offlineData.phone}
                                     onChange={e => setOfflineData({ ...offlineData, phone: e.target.value })}
-                                    disabled={loading}
+                                    disabled={isPending}
                                 />
                             </div>
                         </TabsContent>
@@ -620,7 +619,7 @@ export function CheckoutForm({
                     <div className="space-y-4">
                         <div className="space-y-1.5">
                             <Label htmlFor="cardholder" className="text-xs font-medium">{t('payment.cardholder')}</Label>
-                            <Input id="cardholder" placeholder="John Doe" disabled={loading} />
+                            <Input id="cardholder" placeholder="John Doe" disabled={isPending} />
                         </div>
                         <div className="space-y-1.5">
                             <Label htmlFor="cardNumber" className="text-xs font-medium">{t('payment.cardNumber')}</Label>
@@ -629,7 +628,7 @@ export function CheckoutForm({
                                     id="cardNumber"
                                     placeholder="4242 4242 4242 4242"
                                     className="pl-10"
-                                    disabled={loading}
+                                    disabled={isPending}
                                 />
                                 <IconCreditCard className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
                             </div>
@@ -637,11 +636,11 @@ export function CheckoutForm({
                         <div className="grid grid-cols-2 gap-3">
                             <div className="space-y-1.5">
                                 <Label htmlFor="expiry" className="text-xs font-medium">{t('payment.expiry')}</Label>
-                                <Input id="expiry" placeholder="MM/YY" disabled={loading} />
+                                <Input id="expiry" placeholder="MM/YY" disabled={isPending} />
                             </div>
                             <div className="space-y-1.5">
                                 <Label htmlFor="cvc" className="text-xs font-medium">{t('payment.cvc')}</Label>
-                                <Input id="cvc" placeholder="123" disabled={loading} />
+                                <Input id="cvc" placeholder="123" disabled={isPending} />
                             </div>
                         </div>
                     </div>
@@ -653,10 +652,10 @@ export function CheckoutForm({
                 <Button
                     className="w-full"
                     onClick={handleEnroll}
-                    disabled={loading}
+                    disabled={isPending}
                 >
-                    {loading && <IconLoader2 className="mr-2 h-4 w-4 animate-spin" />}
-                    {loading
+                    {isPending && <IconLoader2 className="mr-2 h-4 w-4 animate-spin" />}
+                    {isPending
                         ? t('payment.processing')
                         : paymentMethod === 'card'
                             ? t('payment.button')

--- a/components/public/checkout-processing.tsx
+++ b/components/public/checkout-processing.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { IconLoader2 } from '@tabler/icons-react'
+import { useTranslations } from 'next-intl'
+
+export function CheckoutProcessing() {
+  const router = useRouter()
+  const t = useTranslations('checkout.success')
+
+  useEffect(() => {
+    const interval = window.setInterval(() => router.refresh(), 1500)
+    return () => window.clearInterval(interval)
+  }, [router])
+
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center px-4 py-16">
+      <div className="flex max-w-sm flex-col items-center gap-4 text-center">
+        <IconLoader2 className="h-10 w-10 animate-spin text-primary" aria-hidden="true" />
+        <h1 className="text-xl font-semibold">{t('confirmingTitle')}</h1>
+        <p className="text-sm text-muted-foreground">
+          {t('confirmingSubtitle')}
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/components/public/free-enroll-button.tsx
+++ b/components/public/free-enroll-button.tsx
@@ -8,15 +8,13 @@ import { toast } from 'sonner'
 import { enrollFree } from '@/app/[locale]/(public)/checkout/actions'
 import { Button } from '@/components/ui/button'
 
-interface FreeEnrollButtonProps {
+interface FreeEnrollProps {
   courseId: number
-  autoEnroll?: boolean
 }
 
-export function FreeEnrollButton({ courseId, autoEnroll = false }: FreeEnrollButtonProps) {
+function useFreeEnrollment(courseId: number) {
   const router = useRouter()
   const t = useTranslations('coursePublicDetails.pricing')
-  const hasAutoEnrolled = useRef(false)
   const [isPending, startTransition] = useTransition()
 
   const enroll = useCallback(() => {
@@ -31,11 +29,37 @@ export function FreeEnrollButton({ courseId, autoEnroll = false }: FreeEnrollBut
     })
   }, [courseId, router, t])
 
+  return { enroll, isPending }
+}
+
+export function FreeEnrollButton({ courseId }: FreeEnrollProps) {
+  const { enroll, isPending } = useFreeEnrollment(courseId)
+
+  return <FreeEnrollTrigger enroll={enroll} status={isPending ? 'pending' : 'idle'} />
+}
+
+export function AutoFreeEnrollButton({ courseId }: FreeEnrollProps) {
+  const { enroll, isPending } = useFreeEnrollment(courseId)
+  const hasStarted = useRef(false)
+
   useEffect(() => {
-    if (!autoEnroll || hasAutoEnrolled.current) return
-    hasAutoEnrolled.current = true
+    if (hasStarted.current) return
+    hasStarted.current = true
     enroll()
-  }, [autoEnroll, enroll])
+  }, [enroll])
+
+  return <FreeEnrollTrigger enroll={enroll} status={isPending ? 'pending' : 'idle'} />
+}
+
+function FreeEnrollTrigger({
+  enroll,
+  status,
+}: {
+  enroll: () => void
+  status: 'idle' | 'pending'
+}) {
+  const t = useTranslations('coursePublicDetails.pricing')
+  const isPending = status === 'pending'
 
   return (
     <Button

--- a/components/public/free-enroll-button.tsx
+++ b/components/public/free-enroll-button.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import { useTranslations } from 'next-intl'
+import { IconLoader2 } from '@tabler/icons-react'
+import { toast } from 'sonner'
+import { enrollFree } from '@/app/[locale]/(public)/checkout/actions'
+import { Button } from '@/components/ui/button'
+
+interface FreeEnrollButtonProps {
+  courseId: number
+  autoEnroll?: boolean
+}
+
+export function FreeEnrollButton({ courseId, autoEnroll = false }: FreeEnrollButtonProps) {
+  const router = useRouter()
+  const t = useTranslations('coursePublicDetails.pricing')
+  const hasAutoEnrolled = useRef(false)
+  const [isPending, startTransition] = useTransition()
+
+  const enroll = useCallback(() => {
+    startTransition(async () => {
+      try {
+        await enrollFree(String(courseId))
+        toast.success(t('enrollmentSuccess'))
+        router.push(`/dashboard/student/courses/${courseId}`)
+      } catch (error) {
+        toast.error(error instanceof Error ? error.message : t('enrollmentError'))
+      }
+    })
+  }, [courseId, router, t])
+
+  useEffect(() => {
+    if (!autoEnroll || hasAutoEnrolled.current) return
+    hasAutoEnrolled.current = true
+    enroll()
+  }, [autoEnroll, enroll])
+
+  return (
+    <Button
+      type="button"
+      className="h-11 w-full bg-cyan-500 text-sm font-bold text-black shadow-lg shadow-cyan-500/20 hover:bg-cyan-400"
+      onClick={enroll}
+      disabled={isPending}
+    >
+      {isPending ? (
+        <span className="flex items-center gap-2">
+          <IconLoader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+          {t('enrolling')}
+        </span>
+      ) : (
+        t('enrollFree')
+      )}
+    </Button>
+  )
+}

--- a/components/sign-up-form.tsx
+++ b/components/sign-up-form.tsx
@@ -63,11 +63,19 @@ export function SignUpForm({ className, tenantId, ...props }: SignUpFormProps) {
         options: {
           emailRedirectTo: `${window.location.origin}/auth/confirm${nextPath ? `?next=${encodeURIComponent(nextPath)}` : ''}`,
           data: {
-            ...(tenantId ? { tenant_id: tenantId } : {}),
+            // handle_new_user() reads preferred_tenant_id to stamp the JWT's
+            // tenant claim; without it a fresh signup can't see tenant content.
+            ...(tenantId ? { tenant_id: tenantId, preferred_tenant_id: tenantId } : {}),
           },
         },
       })
       if (error) throw error
+      if (data.session) {
+        // The signup token predates handle_new_user()'s app_metadata write, so
+        // it lacks the tenant_id claim — refresh to get one that has it, or
+        // tenant-scoped RLS fails closed and the next page 404s.
+        await supabase.auth.refreshSession()
+      }
       router.push(data.session && nextPath ? nextPath : '/auth/sign-up-success')
     } catch (error: unknown) {
       setError(error instanceof Error ? error.message : t('common.error'))

--- a/components/sign-up-form.tsx
+++ b/components/sign-up-form.tsx
@@ -14,7 +14,7 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import Link from 'next/link'
 import { useTranslations } from 'next-intl'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { useState } from 'react'
 import { Eye, EyeOff } from 'lucide-react'
 import {
@@ -23,6 +23,7 @@ import {
   InputGroupAddon,
   InputGroupButton,
 } from '@/components/ui/input-group'
+import { getSafeNextPath } from '@/lib/auth/safe-next-path'
 
 interface SignUpFormProps extends React.ComponentPropsWithoutRef<'div'> {
   tenantId?: string
@@ -39,6 +40,8 @@ export function SignUpForm({ className, tenantId, ...props }: SignUpFormProps) {
   const [showPassword, setShowPassword] = useState(false)
   const [showRepeatPassword, setShowRepeatPassword] = useState(false)
   const router = useRouter()
+  const searchParams = useSearchParams()
+  const nextPath = getSafeNextPath(searchParams.get('next'), '')
 
   const handleSignUp = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -54,18 +57,18 @@ export function SignUpForm({ className, tenantId, ...props }: SignUpFormProps) {
 
     try {
       await supabase.auth.signOut({ scope: 'local' })
-      const { error } = await supabase.auth.signUp({
+      const { data, error } = await supabase.auth.signUp({
         email,
         password,
         options: {
-          emailRedirectTo: `${window.location.origin}/auth/confirm`,
+          emailRedirectTo: `${window.location.origin}/auth/confirm${nextPath ? `?next=${encodeURIComponent(nextPath)}` : ''}`,
           data: {
             ...(tenantId ? { tenant_id: tenantId } : {}),
           },
         },
       })
       if (error) throw error
-      router.push('/auth/sign-up-success')
+      router.push(data.session && nextPath ? nextPath : '/auth/sign-up-success')
     } catch (error: unknown) {
       setError(error instanceof Error ? error.message : t('common.error'))
     } finally {
@@ -83,7 +86,7 @@ export function SignUpForm({ className, tenantId, ...props }: SignUpFormProps) {
       const { error } = await supabase.auth.signInWithOAuth({
         provider: 'google',
         options: {
-          redirectTo: `${window.location.origin}/api/auth/callback`,
+          redirectTo: `${window.location.origin}/api/auth/callback${nextPath ? `?next=${encodeURIComponent(nextPath)}` : ''}`,
         },
       })
       if (error) throw error
@@ -207,7 +210,10 @@ export function SignUpForm({ className, tenantId, ...props }: SignUpFormProps) {
             </div>
             <div className="mt-4 text-center text-sm">
               {t('haveAccount')}{' '}
-              <Link href="/auth/login" className="underline underline-offset-4">
+              <Link
+                href={nextPath ? `/auth/login?next=${encodeURIComponent(nextPath)}` : '/auth/login'}
+                className="underline underline-offset-4"
+              >
                 {t('login')}
               </Link>
             </div>

--- a/lib/auth/safe-next-path.ts
+++ b/lib/auth/safe-next-path.ts
@@ -1,0 +1,29 @@
+const CONTROL_CHARACTERS = /[\u0000-\u001f\u007f]/
+
+/**
+ * Accept only same-origin relative paths for post-auth navigation.
+ *
+ * Checking both the raw and decoded values prevents protocol-relative paths
+ * and encoded backslashes from becoming cross-origin redirects after another
+ * decoding or URL-normalization step.
+ */
+export function getSafeNextPath(value: string | null | undefined, fallback = '/') {
+  if (!value) return fallback
+
+  let decoded: string
+  try {
+    decoded = decodeURIComponent(value)
+  } catch {
+    return fallback
+  }
+
+  const isUnsafe =
+    !value.startsWith('/') ||
+    value.startsWith('//') ||
+    value.includes('\\') ||
+    decoded.startsWith('//') ||
+    decoded.includes('\\') ||
+    CONTROL_CHARACTERS.test(decoded)
+
+  return isUnsafe ? fallback : value
+}

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -77,6 +77,15 @@ export const paymentAnonLimiter = rateLimit({
   uniqueTokenPerInterval: 5000,
 });
 
+/**
+ * Free enrollment attempts — checked separately by user and IP.
+ * The database grant remains idempotent; this limits bot-driven catalog churn.
+ */
+export const freeEnrollmentLimiter = rateLimit({
+  interval: 60 * 60 * 1000,
+  uniqueTokenPerInterval: 10_000,
+});
+
 /** Client IP from standard proxy headers, falling back to 'unknown'. */
 export function getClientIp(req: { headers: { get(name: string): string | null } }): string {
   return (

--- a/messages/en.json
+++ b/messages/en.json
@@ -3925,6 +3925,9 @@
       "preview": "Preview this course",
       "free": "Free",
       "enrollFree": "Enroll for Free",
+      "enrolling": "Enrolling...",
+      "enrollmentSuccess": "You're enrolled! Opening your course...",
+      "enrollmentError": "We couldn't enroll you. Please try again.",
       "enrollNow": "Enroll Now",
       "goToCourse": "Go to Course",
       "buyNow": "Buy Now",
@@ -3998,7 +4001,12 @@
       "subtitle": "Your purchase was successful. You now have full access — enjoy the content.",
       "goToCourses": "Go to my courses",
       "browseCourses": "Browse courses",
-      "viewBilling": "View billing"
+      "viewBilling": "View billing",
+      "continue": "Continue to your content",
+      "multipleCourses": "Your purchase includes these courses. Choose one to start learning.",
+      "courseFallback": "Open course",
+      "confirmingTitle": "Confirming your purchase",
+      "confirmingSubtitle": "Your payment provider is finishing the confirmation. This page will update automatically."
     },
     "title": "Checkout",
     "description": "Choose your payment method to continue.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -3918,6 +3918,9 @@
       "preview": "Previsualizar este curso",
       "free": "Gratis",
       "enrollFree": "Inscribirse Gratis",
+      "enrolling": "Inscribiendo...",
+      "enrollmentSuccess": "¡Ya estás inscrito! Abriendo tu curso...",
+      "enrollmentError": "No pudimos inscribirte. Inténtalo de nuevo.",
       "enrollNow": "Inscribirse Ahora",
       "goToCourse": "Ir al Curso",
       "buyNow": "Comprar Ahora",
@@ -3991,7 +3994,12 @@
       "subtitle": "Tu compra fue exitosa. Ya tienes acceso completo — disfruta el contenido.",
       "goToCourses": "Ir a mis cursos",
       "browseCourses": "Explorar cursos",
-      "viewBilling": "Ver facturación"
+      "viewBilling": "Ver facturación",
+      "continue": "Continuar al contenido",
+      "multipleCourses": "Tu compra incluye estos cursos. Elige uno para comenzar.",
+      "courseFallback": "Abrir curso",
+      "confirmingTitle": "Confirmando tu compra",
+      "confirmingSubtitle": "Tu proveedor de pago está terminando la confirmación. Esta página se actualizará automáticamente."
     },
     "title": "Finalizar Compra",
     "description": "Elige tu método de pago para continuar.",

--- a/proxy.ts
+++ b/proxy.ts
@@ -397,7 +397,9 @@ export default async function proxy(request: NextRequest) {
   // Protected Routes
   if (!user) {
     const redirectUrl = publicRedirectUrl(request, `/${locale}/auth/login`)
-    redirectUrl.searchParams.set('redirectTo', normalizedPath)
+    // Keep the query string so purchase/enroll intent survives login
+    // (e.g. /checkout?courseId=42). Login form validates via getSafeNextPath.
+    redirectUrl.searchParams.set('redirectTo', normalizedPath + request.nextUrl.search)
     return NextResponse.redirect(redirectUrl)
   }
 

--- a/supabase/migrations/20260716225213_harden_free_enrollment.sql
+++ b/supabase/migrations/20260716225213_harden_free_enrollment.sql
@@ -1,0 +1,81 @@
+-- Harden the one-click free enrollment grant. Because this function is
+-- SECURITY DEFINER, every authorization and pricing rule must be enforced
+-- inside Postgres as well as in the calling server action.
+CREATE OR REPLACE FUNCTION public.grant_free_entitlement(_user_id uuid, _course_id integer)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $function$
+DECLARE
+    _caller_id uuid := auth.uid();
+    _tenant_id uuid;
+BEGIN
+    IF _caller_id IS NULL OR _caller_id <> _user_id THEN
+        RAISE EXCEPTION 'Free enrollment can only be granted to the authenticated user';
+    END IF;
+
+    SELECT c.tenant_id
+    INTO _tenant_id
+    FROM public.courses AS c
+    WHERE c.course_id = _course_id
+      AND c.status = 'published';
+
+    IF _tenant_id IS NULL THEN
+        RAISE EXCEPTION 'Course is not available for enrollment';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM public.tenant_users AS tu
+        WHERE tu.user_id = _caller_id
+          AND tu.tenant_id = _tenant_id
+          AND tu.status = 'active'
+    ) THEN
+        RAISE EXCEPTION 'User is not an active member of this tenant';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM public.product_courses AS pc
+        JOIN public.products AS p
+          ON p.product_id = pc.product_id
+         AND p.tenant_id = pc.tenant_id
+        WHERE pc.course_id = _course_id
+          AND pc.tenant_id = _tenant_id
+          AND p.price <> 0
+    ) THEN
+        RAISE EXCEPTION 'This course requires payment';
+    END IF;
+
+    INSERT INTO public.entitlements (
+        user_id,
+        course_id,
+        tenant_id,
+        source_type,
+        source_id,
+        status,
+        expires_at
+    )
+    VALUES (_caller_id, _course_id, _tenant_id, 'free', NULL, 'active', NULL)
+    ON CONFLICT (user_id, course_id, source_type, source_id) DO UPDATE SET
+        status = 'active',
+        revoked_at = NULL,
+        tenant_id = EXCLUDED.tenant_id;
+
+    INSERT INTO public.enrollments (
+        user_id,
+        course_id,
+        enrollment_date,
+        status,
+        tenant_id
+    )
+    VALUES (_caller_id, _course_id, NOW(), 'active', _tenant_id)
+    ON CONFLICT (user_id, course_id) DO UPDATE SET
+        status = 'active',
+        tenant_id = EXCLUDED.tenant_id;
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.grant_free_entitlement(uuid, integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.grant_free_entitlement(uuid, integer) TO authenticated;

--- a/supabase/migrations/20260717120000_signup_tenant_claim.sql
+++ b/supabase/migrations/20260717120000_signup_tenant_claim.sql
@@ -1,0 +1,37 @@
+-- handle_new_user() runs as an AFTER INSERT trigger, so assigning to
+-- NEW.raw_app_meta_data was a silent no-op: fresh signups got no
+-- app_metadata.tenant_id, custom_access_token_hook() issued a claim-less JWT,
+-- and get_tenant_id() failed closed — a brand-new account couldn't see any
+-- tenant-scoped content (e.g. the course it was signing up to enroll in).
+-- Persist the tenant with an explicit UPDATE instead, accepting either
+-- metadata key the clients send.
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $function$
+DECLARE
+  v_tenant_id uuid;
+BEGIN
+  INSERT INTO public.profiles (id, username, avatar_url, full_name)
+  VALUES (NEW.id, NEW.raw_user_meta_data->>'username', NEW.raw_user_meta_data->>'avatar_url', NEW.raw_user_meta_data->>'full_name');
+
+  -- Insert default role 'student'
+  INSERT INTO public.user_roles (user_id, role)
+  VALUES (NEW.id, 'student');
+
+  v_tenant_id := COALESCE(
+    (NEW.raw_user_meta_data->>'preferred_tenant_id')::uuid,
+    (NEW.raw_user_meta_data->>'tenant_id')::uuid
+  );
+  IF v_tenant_id IS NOT NULL THEN
+    UPDATE auth.users
+    SET raw_app_meta_data = COALESCE(raw_app_meta_data, '{}'::jsonb)
+      || jsonb_build_object('tenant_id', v_tenant_id::text)
+    WHERE id = NEW.id;
+  END IF;
+
+  RETURN NEW;
+END;
+$function$;

--- a/tests/unit/safe-next-path.test.ts
+++ b/tests/unit/safe-next-path.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { getSafeNextPath } from '@/lib/auth/safe-next-path'
+
+describe('getSafeNextPath', () => {
+  it('accepts local paths with query parameters', () => {
+    expect(getSafeNextPath('/courses/42?enroll=1', '/fallback')).toBe('/courses/42?enroll=1')
+  })
+
+  it.each([
+    'https://evil.example/phish',
+    '//evil.example/phish',
+    '/\\evil.example/phish',
+    '/%5c%5cevil.example/phish',
+    '%2f%2fevil.example/phish',
+    '/courses/%00',
+  ])('rejects unsafe redirect target %s', (target) => {
+    expect(getSafeNextPath(target, '/fallback')).toBe('/fallback')
+  })
+
+  it('uses the fallback for malformed encoding', () => {
+    expect(getSafeNextPath('/courses/%E0%A4%A', '/fallback')).toBe('/fallback')
+  })
+})


### PR DESCRIPTION
## Description

Implements the "quick wins" scope of #419 (items 1, 3, 4) plus the security hardening the issue requires: one-click free enrollment, a transaction-aware success surface that lands buyers inside their content, and purchase-intent preservation through login/signup — with server-side price/tenant re-validation, rate limiting, and open-redirect protection.

### Changes made

**1. Free course = one click, in place (issue item 1)**
- New `components/public/free-enroll-button.tsx`: `FreeEnrollButton` (click → spinner → straight into `/dashboard/student/courses/[id]`) and `AutoFreeEnrollButton` (fires once automatically after login when the URL carries `?enroll=1`).
- Course detail page uses these instead of routing free courses through `/checkout`.
- `checkout/page.tsx` guards stale links: a course with no paid product redirects to `/courses/[id]?enroll=1`. The guard runs **before** the manual-provider redirect, so a price-0 product with `payment_provider = 'manual'` no longer dead-ends in the manual payment form (bug found during live verification).

**2. One success surface that lands in the content (issue item 3)**
- `checkout/success/page.tsx` rewritten as a server component keyed on `?transactionId=`: verifies the transaction belongs to the current user + tenant, shows a polling "confirming" state while `pending`, then deep-links — single-course product → straight into the course; multi-course product → list of granted courses (no `.single()` on `product_courses`); plan → `/dashboard/student/browse`.
- Real-provider redirects (`app/api/payments/checkout/route.ts`) now resolve through the same success page instead of `/dashboard/student?checkout=success`.

**3. Purchase intent preserved through auth (issue item 4)**
- Logged-out CTAs now carry intent: course detail → `next=/checkout?courseId=` (paid) or `next=/courses/[id]?enroll=1` (free); product page login link now carries `next=` (was a bare link).
- Login/signup forms propagate `next=` to each other, to Google OAuth, and to the email-confirm redirect.
- `proxy.ts` login redirect keeps the query string (previously `/checkout?courseId=42` lost `?courseId=42`).

**4. Signup-while-enrolling (found and fixed during E2E verification)**
- `handle_new_user()` is an AFTER trigger, so its `NEW.raw_app_meta_data` assignment never persisted — fresh signups got a JWT with no `tenant_id` claim, `get_tenant_id()` failed closed, and the new user 404'd on the very course they signed up to enroll in. New migration `20260717120000_signup_tenant_claim.sql` persists the tenant with an explicit `UPDATE`.
- Sign-up form now sends `preferred_tenant_id` and refreshes the session after signup so the first navigation carries the tenant claim.
- `enrollFree` auto-joins the school (via the existing `joinCurrentSchool`, invitation- and student-limit-aware) when the caller has no membership yet — a brand-new account goes signup → enrolled → inside the course with zero extra screens.

**5. Security hardening (issue acceptance criteria)**
- New `lib/auth/safe-next-path.ts` validates every `next=`/`redirectTo=` target as a same-origin relative path (rejects `//`, backslashes, encoded variants, control chars) — used by login, signup, OAuth callback, and email confirm.
- Migration `20260716225213_harden_free_enrollment.sql`: `grant_free_entitlement` (SECURITY DEFINER) now enforces caller = target user, course published, caller an active tenant member, and no paid product linked — all inside Postgres.
- `enrollFree` server action: per-user (30/h) and per-IP (100/h) rate limits, strict course-id validation, checks **all** linked products for a paid one (previously only the first row), no internal error leakage.

## Type of change

Fix + enhancement (UX flow simplification with security hardening).

Closes #419 partially — this is "PR 1 (quick wins)" from the issue's scope suggestion. Items 2 (free plans), 5 (real Stripe), and 6 (manual flow) remain open on the issue.

## Testing

- [x] `npm run build` — passes (exit 0)
- [x] `npx vitest run tests/unit/safe-next-path.test.ts` — 8/8 pass (open-redirect vectors: absolute URLs, `//`, backslash, double-encoded, control chars)
- [x] Migration applied to local Supabase and exercised via the live flow
- [x] Live end-to-end verification (local dev, `default.lvh.me:3005`, `student@e2etest.com`): logged-in 1-click enroll from `/courses/1002` lands inside the course with `entitlements` (`source_type='free', status='active'`) and `enrollments` rows correct; full intent chain login → `/checkout?courseId=1002` → free guard → `?enroll=1` auto-enroll → inside course
- [x] Full-journey E2E: admin creates and publishes a free course through the product wizard → logged-out visitor clicks **Enroll for Free** → **signs up with a brand-new account** → lands inside the course auto-enrolled; `tenant_users`, `enrollments`, and `entitlements` rows all verified in the DB

### QA verification steps

1. Log out. Visit `/courses/<free-course-id>` → click **Enroll for Free** → log in → you should land inside the course, already enrolled, with no checkout or success screen.
2. While logged in, click **Enroll for Free** on a free course → one click, spinner, straight into the course.
3. Visit `/checkout?courseId=<free-course-id>` directly (stale link) → redirected to the one-click enroll flow, even if the linked product's provider is `manual`.
4. Complete a mock paid purchase of a single-course product → you land inside that course (not on a generic "Go to Courses" card).
5. Try logging in with `?next=//evil.example` or `?next=https://evil.example` → you are redirected to your dashboard, never off-site.
6. Click free-enroll twice quickly → no duplicate rows (idempotent); hammer it 30+ times in an hour → friendly rate-limit error.
7. Log out, open a free course, click **Enroll for Free** → **Sign up** → create a brand-new account → you land inside the course, already enrolled and a member of the school (no `/join-school` detour, no 404).

## Screenshots

Full-journey verification GIF — admin publishes a free course via the wizard, then a logged-out visitor clicks Enroll for Free, signs up with a brand-new account, and lands inside the course auto-enrolled:

![Full journey: wizard publish + signup-while-enrolling](https://raw.githubusercontent.com/guillermoscript/lms-front/master/docs/media/issue-419-full-journey.gif)

Logged-in one-click enroll (existing account):

![One-click free enrollment flow](https://raw.githubusercontent.com/guillermoscript/lms-front/master/docs/media/issue-419-free-enroll-verification.gif)

> "Before" screenshots were not captured — the draft implementation predated this verification session, so the pre-change UI no longer existed locally. The old flow is described step-by-step in #419.
