### PR TITLE
fix(#419): one-click free plans, real Stripe PaymentElement, unified manual flow

### DIFF
--- a/app/[locale]/(public)/checkout/actions.ts
+++ b/app/[locale]/(public)/checkout/actions.ts
@@ -123,6 +123,91 @@ export async function enrollUser(courseId?: string, planId?: string, paymentMeth
  * (SECURITY DEFINER, idempotent). No product/transaction is fabricated.
  * See docs/ENTITLEMENTS_MIGRATION_PLAN.md.
  */
+/**
+ * Activate a free (price = 0) plan for the current user.
+ *
+ * Grants via the grant_free_subscription RPC (SECURITY DEFINER, idempotent),
+ * which creates a synthetic zero-amount transaction so the standard
+ * transaction trigger builds the subscription + entitlements, then sets a
+ * far-future period end so free subscriptions never expire.
+ */
+export async function subscribeFree(planId?: string) {
+    const supabase = await createServerClient();
+    const userId = await getCurrentUserId()
+    if (!userId) {
+        throw new Error("You must be logged in to subscribe.");
+    }
+    const tenantId = await getCurrentTenantId();
+
+    const requestHeaders = await headers();
+    const clientIp = getClientIp({ headers: requestHeaders });
+    try {
+        await Promise.all([
+            freeEnrollmentLimiter.check(30, `user:${userId}`),
+            freeEnrollmentLimiter.check(100, `ip:${clientIp}`),
+        ]);
+    } catch {
+        throw new Error("Too many enrollment attempts. Please slow down and try again later.");
+    }
+
+    try {
+        const numericPlanId = Number(planId);
+        if (!Number.isSafeInteger(numericPlanId) || numericPlanId <= 0) {
+            throw new Error("Invalid plan.");
+        }
+
+        // Validate the plan: tenant-owned, not deleted, genuinely free. The RPC
+        // re-checks price server-side; this gives a friendlier early error.
+        const { data: plan, error: planError } = await supabase
+            .from('plans')
+            .select('plan_id, price, tenant_id, deleted_at')
+            .eq('plan_id', numericPlanId)
+            .eq('tenant_id', tenantId)
+            .is('deleted_at', null)
+            .single();
+
+        if (planError || !plan) {
+            throw new Error("Plan not found.");
+        }
+        if (Number(plan.price) !== 0) {
+            throw new Error("This plan is not free. Please use the paid checkout.");
+        }
+
+        // Signup-while-subscribing: join the school first (same as enrollFree).
+        const { data: membership } = await supabase
+            .from('tenant_users')
+            .select('id')
+            .eq('user_id', userId)
+            .eq('tenant_id', tenantId)
+            .eq('status', 'active')
+            .maybeSingle();
+
+        if (!membership) {
+            const joinResult = await joinCurrentSchool();
+            if (!joinResult.success) {
+                throw new Error(joinResult.error || "Could not join this school.");
+            }
+        }
+
+        const { error: grantError } = await supabase.rpc('grant_free_subscription', {
+            _user_id: userId,
+            _plan_id: numericPlanId,
+        });
+
+        if (grantError) {
+            console.error("Free subscription grant failed:", grantError);
+            throw new Error("Failed to activate the plan. Please try again.");
+        }
+
+        revalidatePath('/dashboard/student');
+        revalidatePath('/dashboard/student/browse');
+        return { success: true };
+    } catch (error) {
+        console.error("Free subscription failed:", error);
+        throw error;
+    }
+}
+
 export async function enrollFree(courseId?: string) {
     const supabase = await createServerClient();
     const userId = await getCurrentUserId()

--- a/app/[locale]/(public)/pricing/page.tsx
+++ b/app/[locale]/(public)/pricing/page.tsx
@@ -16,20 +16,17 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
     return buildPageMetadata({ title: t('pricing.title'), description: t('pricing.description'), path: '/pricing', locale });
 }
 
-interface Plan {
-    plan_id: number;
-    plan_name: string;
-    price: number;
-    duration_in_days: number;
-    description: string;
-    features: string | string[];
-    payment_provider?: string;
-}
-
-export default async function PricingPage() {
+export default async function PricingPage({
+    searchParams,
+}: {
+    searchParams: Promise<{ subscribe?: string }>;
+}) {
     const supabase = await createClient();
     const tenantId = await getCurrentTenantId();
     const t = await getTranslations('pricing');
+    const { subscribe } = await searchParams;
+
+    const { data: { user } } = await supabase.auth.getUser();
 
     // Fetch plans from database - filtered by tenant
     const { data: plans, error } = await supabase
@@ -114,6 +111,8 @@ export default async function PricingPage() {
                     <PricingClient
                         monthlyPlans={monthlyPlans}
                         yearlyPlans={yearlyPlans}
+                        isAuthenticated={!!user}
+                        subscribePlanId={subscribe ? Number(subscribe) : null}
                     />
                 )}
 

--- a/app/[locale]/(public)/pricing/pricing-client.tsx
+++ b/app/[locale]/(public)/pricing/pricing-client.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Switch } from "@/components/ui/switch";
 import { useState } from "react";
 import { useTranslations } from 'next-intl';
+import { FreeSubscribeButton } from "@/components/public/free-subscribe-button";
 
 interface Plan {
     plan_id: number;
@@ -21,9 +22,11 @@ interface Plan {
 interface PricingClientProps {
     monthlyPlans: Plan[];
     yearlyPlans: Plan[];
+    isAuthenticated: boolean;
+    subscribePlanId: number | null;
 }
 
-export default function PricingClient({ monthlyPlans, yearlyPlans }: PricingClientProps) {
+export default function PricingClient({ monthlyPlans, yearlyPlans, isAuthenticated, subscribePlanId }: PricingClientProps) {
     const [isYearly, setIsYearly] = useState(false);
     const t = useTranslations('pricing');
 
@@ -107,20 +110,39 @@ export default function PricingClient({ monthlyPlans, yearlyPlans }: PricingClie
                                             {plan.duration_in_days === 365 ? t('billedYearly') : t('billedMonthly')}
                                         </div>
 
-                                        <Link
-                                            href={plan.payment_provider === 'manual'
-                                                ? `/checkout/manual?planId=${plan.plan_id}`
-                                                : `/checkout?planId=${plan.plan_id}`
-                                            }
-                                            className="block mt-10"
-                                        >
-                                            <Button className={`w-full h-14 rounded-2xl font-black transition-all hover:scale-[1.02] active:scale-[0.98] ${isPopular
+                                        {(() => {
+                                            const ctaClass = `w-full h-14 rounded-2xl font-black transition-all hover:scale-[1.02] active:scale-[0.98] ${isPopular
                                                 ? 'bg-blue-600 hover:bg-blue-500 text-white shadow-xl shadow-blue-600/30 border-t border-blue-400'
                                                 : 'bg-zinc-800 hover:bg-zinc-700 text-white border border-zinc-700/50'
-                                                }`}>
-                                                {t('getStarted')}
-                                            </Button>
-                                        </Link>
+                                                }`;
+                                            // Free plans (price 0) subscribe in one click instead of
+                                            // routing through checkout.
+                                            if (Number(plan.price) === 0) {
+                                                return (
+                                                    <div className="mt-10">
+                                                        <FreeSubscribeButton
+                                                            planId={plan.plan_id}
+                                                            isAuthenticated={isAuthenticated}
+                                                            autoFire={subscribePlanId === plan.plan_id}
+                                                            className={ctaClass}
+                                                        />
+                                                    </div>
+                                                );
+                                            }
+                                            return (
+                                                <Link
+                                                    href={plan.payment_provider === 'manual'
+                                                        ? `/checkout/manual?planId=${plan.plan_id}`
+                                                        : `/checkout?planId=${plan.plan_id}`
+                                                    }
+                                                    className="block mt-10"
+                                                >
+                                                    <Button className={ctaClass}>
+                                                        {t('getStarted')}
+                                                    </Button>
+                                                </Link>
+                                            );
+                                        })()}
                                     </div>
                                     <ul className="space-y-4 m-0 p-0">
                                         {parsedFeatures?.map((feature: string, i: number) => (

--- a/app/[locale]/checkout/manual/page.tsx
+++ b/app/[locale]/checkout/manual/page.tsx
@@ -3,6 +3,7 @@ import { getTranslations } from 'next-intl/server'
 import { createClient } from '@/lib/supabase/server'
 import { getCurrentTenantId, getSessionUser } from '@/lib/supabase/tenant'
 import { PaymentRequestForm } from '@/components/student/payment-request-form'
+import { getManualPaymentInstructions } from '@/app/actions/admin/settings'
 import { IconShieldCheck, IconLock } from '@tabler/icons-react'
 import type { Metadata } from 'next'
 
@@ -103,6 +104,7 @@ export default async function ManualCheckoutPage(props: {
 
   const userEmail = user.email || ''
   const userName = profile?.full_name || ''
+  const instructions = await getManualPaymentInstructions()
 
   const formattedPrice = new Intl.NumberFormat(locale, {
     style: 'currency',
@@ -175,6 +177,16 @@ export default async function ManualCheckoutPage(props: {
                   ))}
                 </ol>
               </div>
+
+              {/* Tenant payment instructions — shown up front */}
+              {instructions && (
+                <div className="mt-8 rounded-lg border border-primary/20 bg-primary/5 p-4">
+                  <h2 className="text-sm font-semibold">{t('instructionsTitle')}</h2>
+                  <p className="mt-1.5 whitespace-pre-wrap text-sm leading-relaxed text-muted-foreground">
+                    {instructions}
+                  </p>
+                </div>
+              )}
 
               {/* Trust signals */}
               <div className="mt-8 flex items-center gap-4 text-xs text-muted-foreground">

--- a/app/actions/admin/settings.ts
+++ b/app/actions/admin/settings.ts
@@ -35,7 +35,7 @@ export async function getSettings(category?: string): Promise<SettingsResponse> 
       const categoryPrefixes: Record<string, string[]> = {
         general: ['site_name', 'site_description', 'contact_email', 'support_email', 'timezone', 'maintenance_mode'],
         email: ['smtp_', 'email_'],
-        payment: ['stripe_', 'paypal_', 'lemonsqueezy_', 'solana_', 'currency', 'tax_rate', 'invoice_prefix', 'require_payment_approval'],
+        payment: ['stripe_', 'paypal_', 'lemonsqueezy_', 'solana_', 'currency', 'tax_rate', 'invoice_prefix', 'require_payment_approval', 'manual_payment_instructions'],
         enrollment: ['auto_enrollment', 'require_enrollment_approval', 'max_enrollments_per_user', 'allow_self_enrollment', 'enrollment_expiration_days', 'course_capacity_enabled'],
       }
       const keys = categoryPrefixes[category]
@@ -387,6 +387,30 @@ export async function getSolanaSettlementOptions(): Promise<{ usdc: boolean; sol
 }
 
 /**
+ * Get this tenant's free-text manual/offline payment instructions (if any).
+ *
+ * No role gate — students read this at checkout to learn how to pay before
+ * submitting a request. Returns a plain string ('' when unset). The value is
+ * stored under the `manual_payment_instructions` key as `{ value: string }`.
+ */
+export async function getManualPaymentInstructions(): Promise<string> {
+  try {
+    const tenantId = await getCurrentTenantId()
+    const supabase = createAdminClient()
+    const { data } = await supabase
+      .from('tenant_settings')
+      .select('setting_value')
+      .eq('tenant_id', tenantId)
+      .eq('setting_key', 'manual_payment_instructions')
+      .maybeSingle()
+    return (data?.setting_value as { value?: string } | null)?.value?.trim() || ''
+  } catch (error) {
+    console.error('Error resolving manual payment instructions:', error)
+    return ''
+  }
+}
+
+/**
  * Get all settings grouped by category (for the settings page)
  */
 export async function getAllSettingsByCategory(): Promise<SettingsResponse> {
@@ -417,6 +441,7 @@ export async function getAllSettingsByCategory(): Promise<SettingsResponse> {
       stripe_enabled: 'payment', paypal_enabled: 'payment',
       lemonsqueezy_enabled: 'payment', solana_enabled: 'payment', solana_accept_sol: 'payment', currency: 'payment',
       tax_rate: 'payment', invoice_prefix: 'payment', require_payment_approval: 'payment',
+      manual_payment_instructions: 'payment',
       auto_enrollment: 'enrollment', require_enrollment_approval: 'enrollment',
       max_enrollments_per_user: 'enrollment', allow_self_enrollment: 'enrollment',
       enrollment_expiration_days: 'enrollment', course_capacity_enabled: 'enrollment',

--- a/app/actions/payment-requests.ts
+++ b/app/actions/payment-requests.ts
@@ -9,10 +9,66 @@ import { revalidatePath } from 'next/cache'
 export interface PaymentRequestFormData {
   productId?: number
   planId?: number
-  contactName: string
-  contactEmail: string
+  /** Optional fallback only — identity is derived from the authenticated user. */
+  contactName?: string
+  /** Optional fallback only — identity is derived from the authenticated user. */
+  contactEmail?: string
   contactPhone?: string
   message?: string
+}
+
+/**
+ * Best-effort in-app notification to a student about a payment-request status
+ * change. Mirrors the fan-out shape used by app/actions/admin/notifications.ts:
+ * one `notifications` row (tenant-scoped) + one `user_notifications` delivery
+ * row. Never throws — notification failure must not fail the caller.
+ */
+/** Resolve a human item name from a request row with product/plan embeds. */
+type RequestWithItemEmbeds = {
+  product?: { name?: string | null } | { name?: string | null }[] | null
+  plan?: { plan_name?: string | null } | { plan_name?: string | null }[] | null
+}
+function itemNameFromRequest(request: RequestWithItemEmbeds | null): string {
+  const product = Array.isArray(request?.product) ? request.product[0] : request?.product
+  const plan = Array.isArray(request?.plan) ? request.plan[0] : request?.plan
+  return product?.name || plan?.plan_name || 'your purchase'
+}
+
+async function notifyPaymentRequestStatus(params: {
+  adminClient: ReturnType<typeof createAdminClient>
+  tenantId: string
+  studentUserId: string
+  createdBy: string
+  itemName: string
+  status: string
+}) {
+  const { adminClient, tenantId, studentUserId, createdBy, itemName, status } = params
+  try {
+    const { data: notification, error } = await adminClient
+      .from('notifications')
+      .insert({
+        title: 'Payment request update',
+        content: `Your payment request for ${itemName} is now ${status}`,
+        notification_type: 'info',
+        priority: 'normal',
+        target_type: 'user',
+        target_user_ids: [studentUserId],
+        status: 'sent',
+        sent_at: new Date().toISOString(),
+        created_by: createdBy,
+        tenant_id: tenantId,
+      })
+      .select('id')
+      .single()
+
+    if (error || !notification) return
+
+    await adminClient
+      .from('user_notifications')
+      .insert({ notification_id: notification.id, user_id: studentUserId })
+  } catch (err) {
+    console.error('Failed to send payment-request notification:', err)
+  }
 }
 
 export interface PaymentInstructionsData {
@@ -38,6 +94,19 @@ export async function createPaymentRequest(data: PaymentRequestFormData) {
   if (!data.productId && !data.planId) {
     throw new Error('Must provide either productId or planId')
   }
+
+  // Derive identity from the authenticated user — do NOT trust client-sent
+  // name/email. Client values are used only as a fallback if profile/auth
+  // data is missing.
+  const { data: { user } } = await supabase.auth.getUser()
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('full_name')
+    .eq('id', userId)
+    .single()
+
+  const contactName = profile?.full_name?.trim() || data.contactName?.trim() || ''
+  const contactEmail = user?.email?.trim() || data.contactEmail?.trim() || ''
 
   let paymentAmount: number
   let paymentCurrency: string
@@ -85,8 +154,8 @@ export async function createPaymentRequest(data: PaymentRequestFormData) {
       user_id: userId,
       product_id: data.productId || null,
       plan_id: data.planId || null,
-      contact_name: data.contactName,
-      contact_email: data.contactEmail,
+      contact_name: contactName,
+      contact_email: contactEmail,
       contact_phone: data.contactPhone || null,
       message: data.message || null,
       status: 'pending',
@@ -126,7 +195,7 @@ export async function sendPaymentInstructions(
   // Verify request belongs to tenant
   const { data: request } = await supabase
     .from('payment_requests')
-    .select('request_id, status, tenant_id')
+    .select('request_id, status, tenant_id, user_id, product:products(name), plan:plans(plan_name)')
     .eq('request_id', requestId)
     .single()
 
@@ -159,6 +228,15 @@ export async function sendPaymentInstructions(
     throw new Error('Failed to send payment instructions')
   }
 
+  await notifyPaymentRequestStatus({
+    adminClient: createAdminClient(),
+    tenantId: request.tenant_id,
+    studentUserId: request.user_id,
+    createdBy: userId,
+    itemName: itemNameFromRequest(request),
+    status: 'awaiting payment',
+  })
+
   revalidatePath('/dashboard/admin/payment-requests')
   revalidatePath(`/dashboard/admin/payment-requests/${requestId}`)
 
@@ -182,7 +260,7 @@ export async function confirmPaymentReceived(requestId: number, adminNotes?: str
   // Verify request belongs to tenant
   const { data: request } = await supabase
     .from('payment_requests')
-    .select('request_id, status, tenant_id')
+    .select('request_id, status, tenant_id, user_id, product:products(name), plan:plans(plan_name)')
     .eq('request_id', requestId)
     .single()
 
@@ -211,6 +289,15 @@ export async function confirmPaymentReceived(requestId: number, adminNotes?: str
     console.error('Failed to confirm payment:', error)
     throw new Error('Failed to confirm payment')
   }
+
+  await notifyPaymentRequestStatus({
+    adminClient: createAdminClient(),
+    tenantId: request.tenant_id,
+    studentUserId: request.user_id,
+    createdBy: userId,
+    itemName: itemNameFromRequest(request),
+    status: 'payment received',
+  })
 
   revalidatePath('/dashboard/admin/payment-requests')
   revalidatePath(`/dashboard/admin/payment-requests/${requestId}`)
@@ -289,6 +376,15 @@ export async function completeAndEnroll(requestId: number) {
     console.error('Failed to complete payment request:', updateError)
     throw new Error('Failed to complete payment request')
   }
+
+  await notifyPaymentRequestStatus({
+    adminClient,
+    tenantId: request.tenant_id,
+    studentUserId: request.user_id,
+    createdBy: userId,
+    itemName: itemNameFromRequest(request),
+    status: 'completed — you now have access',
+  })
 
   revalidatePath('/dashboard/admin/payment-requests')
   revalidatePath(`/dashboard/admin/payment-requests/${requestId}`)
@@ -545,7 +641,7 @@ export async function cancelPaymentRequest(requestId: number, reason?: string) {
   // Get request
   const { data: request } = await supabase
     .from('payment_requests')
-    .select('request_id, user_id, status, tenant_id')
+    .select('request_id, user_id, status, tenant_id, product:products(name), plan:plans(plan_name)')
     .eq('request_id', requestId)
     .single()
 
@@ -577,6 +673,18 @@ export async function cancelPaymentRequest(requestId: number, reason?: string) {
   if (error) {
     console.error('Failed to cancel payment request:', error)
     throw new Error('Failed to cancel payment request')
+  }
+
+  // Notify the student only when an admin cancelled (not their own cancel).
+  if ((role === 'admin' || superAdmin) && request.user_id !== userId) {
+    await notifyPaymentRequestStatus({
+      adminClient: createAdminClient(),
+      tenantId: request.tenant_id,
+      studentUserId: request.user_id,
+      createdBy: userId,
+      itemName: itemNameFromRequest(request),
+      status: 'cancelled',
+    })
   }
 
   revalidatePath('/dashboard/admin/payment-requests')

--- a/components/admin/payment-settings-form.tsx
+++ b/components/admin/payment-settings-form.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
 import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
 import {
@@ -36,6 +37,7 @@ export default function PaymentSettingsForm({ settings }: PaymentSettingsFormPro
   const taxRate = settings.tax_rate?.value?.value || 0
   const invoicePrefix = settings.invoice_prefix?.value?.value || 'INV'
   const requirePaymentApproval = settings.require_payment_approval?.value?.enabled ?? false
+  const manualPaymentInstructions = settings.manual_payment_instructions?.value?.value || ''
 
   async function handleSubmit(formData: FormData) {
     setIsSubmitting(true)
@@ -51,6 +53,7 @@ export default function PaymentSettingsForm({ settings }: PaymentSettingsFormPro
         tax_rate: { value: parseFloat(formData.get('tax_rate') as string) },
         invoice_prefix: { value: formData.get('invoice_prefix') as string },
         require_payment_approval: { enabled: formData.get('require_payment_approval') === 'on' },
+        manual_payment_instructions: { value: (formData.get('manual_payment_instructions') as string) || '' },
       }
 
       const result = await updateSettings(updatedSettings)
@@ -151,6 +154,21 @@ export default function PaymentSettingsForm({ settings }: PaymentSettingsFormPro
             />
           </div>
         )}
+      </div>
+
+      {/* Manual / offline payment instructions — shown to students up front */}
+      <div className="space-y-2 rounded-lg border p-4">
+        <Label htmlFor="manual_payment_instructions">{t('payment.manualInstructions')}</Label>
+        <Textarea
+          id="manual_payment_instructions"
+          name="manual_payment_instructions"
+          defaultValue={manualPaymentInstructions}
+          rows={4}
+          placeholder={t('payment.manualInstructionsPlaceholder')}
+        />
+        <p className="text-sm text-muted-foreground">
+          {t('payment.manualInstructionsHint')}
+        </p>
       </div>
 
       {/* Currency Settings */}

--- a/components/public/checkout-form.tsx
+++ b/components/public/checkout-form.tsx
@@ -5,7 +5,8 @@ import QRCode from 'qrcode';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { enrollUser, enrollFree } from '@/app/[locale]/(public)/checkout/actions';
+import { enrollUser, enrollFree, subscribeFree } from '@/app/[locale]/(public)/checkout/actions';
+import { StripePaymentForm } from '@/components/public/stripe-payment-form';
 import { createPaymentRequest } from '@/app/actions/payment-requests';
 import { useRouter } from 'next/navigation';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -287,9 +288,17 @@ export function CheckoutForm({
         startTransition(async () => {
             try {
                 if (isFree) {
-                    await enrollFree(courseId);
-                    toast.success(t('toasts.success'));
-                    router.push(`/dashboard/student/courses/${courseId}`);
+                    // Free plan → activate a zero-price subscription; free course →
+                    // grant a free entitlement. Both are one-click, no payment.
+                    if (planId) {
+                        await subscribeFree(planId);
+                        toast.success(t('toasts.success'));
+                        router.push('/dashboard/student/browse?checkout=success');
+                    } else {
+                        await enrollFree(courseId);
+                        toast.success(t('toasts.success'));
+                        router.push(`/dashboard/student/courses/${courseId}`);
+                    }
                     return;
                 }
 
@@ -528,6 +537,98 @@ export function CheckoutForm({
     }
 
     // ─── Paid checkout ───
+    // Stripe uses a real PaymentElement (webhook grants enrollment). The mock
+    // "Pay & Enroll (Test)" button is a dev-only sandbox escape hatch — never
+    // shown in production, and never for redirect/QR/manual providers (those
+    // return earlier or use the offline tab).
+    const isStripe = paymentProvider === 'stripe';
+    const allowSandbox = process.env.NODE_ENV !== 'production' && paymentProvider !== 'manual';
+
+    // Card payment panel: real Stripe form, an unavailable notice, or (in dev)
+    // just the sandbox button below it.
+    const cardPanel = (
+        <div className="space-y-4">
+            {isStripe ? (
+                <StripePaymentForm
+                    productId={productId}
+                    planId={planId}
+                    price={price}
+                    hasManualFallback={showOfflineTab}
+                />
+            ) : !allowSandbox ? (
+                <p className="rounded-lg bg-muted/50 px-4 py-3 text-xs leading-relaxed text-muted-foreground">
+                    {t('payment.cardUnavailable')}
+                </p>
+            ) : null}
+
+            {allowSandbox && (
+                <div className="space-y-2">
+                    <Button
+                        variant="outline"
+                        className="w-full"
+                        onClick={handleEnroll}
+                        disabled={isPending}
+                    >
+                        {isPending && <IconLoader2 className="mr-2 h-4 w-4 animate-spin" />}
+                        {isPending ? t('payment.processing') : t('payment.sandboxButton')}
+                    </Button>
+                    <p className="text-center text-[11px] text-muted-foreground">
+                        {t('payment.sandboxHint')}
+                    </p>
+                </div>
+            )}
+        </div>
+    );
+
+    const offlinePanel = (
+        <div className="space-y-4">
+            <p className="rounded-lg bg-muted/50 px-4 py-3 text-xs leading-relaxed text-muted-foreground">
+                {t('payment.offlineInstructions')}
+            </p>
+            <div className="space-y-1.5">
+                <Label htmlFor="offlineName" className="text-xs font-medium">{t('payment.contactName')}</Label>
+                <Input
+                    id="offlineName"
+                    placeholder="Your Name"
+                    value={offlineData.name}
+                    onChange={e => setOfflineData({ ...offlineData, name: e.target.value })}
+                    disabled={isPending}
+                />
+            </div>
+            <div className="space-y-1.5">
+                <Label htmlFor="offlineEmail" className="text-xs font-medium">{t('payment.contactEmail')}</Label>
+                <Input
+                    id="offlineEmail"
+                    type="email"
+                    placeholder="email@example.com"
+                    value={offlineData.email}
+                    onChange={e => setOfflineData({ ...offlineData, email: e.target.value })}
+                    disabled={isPending}
+                    readOnly={!!userEmail}
+                    className={userEmail ? 'bg-muted' : ''}
+                />
+            </div>
+            <div className="space-y-1.5">
+                <Label htmlFor="offlinePhone" className="text-xs font-medium">{t('payment.contactPhone')}</Label>
+                <Input
+                    id="offlinePhone"
+                    placeholder="+1 234 567 8900"
+                    value={offlineData.phone}
+                    onChange={e => setOfflineData({ ...offlineData, phone: e.target.value })}
+                    disabled={isPending}
+                />
+            </div>
+            <Button
+                className="w-full"
+                onClick={handleEnroll}
+                disabled={isPending}
+            >
+                {isPending && <IconLoader2 className="mr-2 h-4 w-4 animate-spin" />}
+                {isPending ? t('payment.processing') : t('payment.requestButton')}
+            </Button>
+        </div>
+    );
+
     return (
         <div className="rounded-xl border border-border bg-card">
             {orderSummary}
@@ -547,122 +648,21 @@ export function CheckoutForm({
                             </TabsTrigger>
                         </TabsList>
 
-                        <TabsContent value="card" className="mt-5 space-y-4">
-                            <div className="space-y-1.5">
-                                <Label htmlFor="cardholder" className="text-xs font-medium">{t('payment.cardholder')}</Label>
-                                <Input id="cardholder" placeholder="John Doe" disabled={isPending} />
-                            </div>
-                            <div className="space-y-1.5">
-                                <Label htmlFor="cardNumber" className="text-xs font-medium">{t('payment.cardNumber')}</Label>
-                                <div className="relative">
-                                    <Input
-                                        id="cardNumber"
-                                        placeholder="4242 4242 4242 4242"
-                                        className="pl-10"
-                                        disabled={isPending}
-                                    />
-                                    <IconCreditCard className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-                                </div>
-                            </div>
-                            <div className="grid grid-cols-2 gap-3">
-                                <div className="space-y-1.5">
-                                    <Label htmlFor="expiry" className="text-xs font-medium">{t('payment.expiry')}</Label>
-                                    <Input id="expiry" placeholder="MM/YY" disabled={isPending} />
-                                </div>
-                                <div className="space-y-1.5">
-                                    <Label htmlFor="cvc" className="text-xs font-medium">{t('payment.cvc')}</Label>
-                                    <Input id="cvc" placeholder="123" disabled={isPending} />
-                                </div>
-                            </div>
+                        <TabsContent value="card" className="mt-5">
+                            {cardPanel}
                         </TabsContent>
 
-                        <TabsContent value="offline" className="mt-5 space-y-4">
-                            <p className="rounded-lg bg-muted/50 px-4 py-3 text-xs leading-relaxed text-muted-foreground">
-                                {t('payment.offlineInstructions')}
-                            </p>
-                            <div className="space-y-1.5">
-                                <Label htmlFor="offlineName" className="text-xs font-medium">{t('payment.contactName')}</Label>
-                                <Input
-                                    id="offlineName"
-                                    placeholder="Your Name"
-                                    value={offlineData.name}
-                                    onChange={e => setOfflineData({ ...offlineData, name: e.target.value })}
-                                    disabled={isPending}
-                                />
-                            </div>
-                            <div className="space-y-1.5">
-                                <Label htmlFor="offlineEmail" className="text-xs font-medium">{t('payment.contactEmail')}</Label>
-                                <Input
-                                    id="offlineEmail"
-                                    type="email"
-                                    placeholder="email@example.com"
-                                    value={offlineData.email}
-                                    onChange={e => setOfflineData({ ...offlineData, email: e.target.value })}
-                                    disabled={isPending}
-                                    readOnly={!!userEmail}
-                                    className={userEmail ? 'bg-muted' : ''}
-                                />
-                            </div>
-                            <div className="space-y-1.5">
-                                <Label htmlFor="offlinePhone" className="text-xs font-medium">{t('payment.contactPhone')}</Label>
-                                <Input
-                                    id="offlinePhone"
-                                    placeholder="+1 234 567 8900"
-                                    value={offlineData.phone}
-                                    onChange={e => setOfflineData({ ...offlineData, phone: e.target.value })}
-                                    disabled={isPending}
-                                />
-                            </div>
+                        <TabsContent value="offline" className="mt-5">
+                            {offlinePanel}
                         </TabsContent>
                     </Tabs>
                 ) : (
-                    <div className="space-y-4">
-                        <div className="space-y-1.5">
-                            <Label htmlFor="cardholder" className="text-xs font-medium">{t('payment.cardholder')}</Label>
-                            <Input id="cardholder" placeholder="John Doe" disabled={isPending} />
-                        </div>
-                        <div className="space-y-1.5">
-                            <Label htmlFor="cardNumber" className="text-xs font-medium">{t('payment.cardNumber')}</Label>
-                            <div className="relative">
-                                <Input
-                                    id="cardNumber"
-                                    placeholder="4242 4242 4242 4242"
-                                    className="pl-10"
-                                    disabled={isPending}
-                                />
-                                <IconCreditCard className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-                            </div>
-                        </div>
-                        <div className="grid grid-cols-2 gap-3">
-                            <div className="space-y-1.5">
-                                <Label htmlFor="expiry" className="text-xs font-medium">{t('payment.expiry')}</Label>
-                                <Input id="expiry" placeholder="MM/YY" disabled={isPending} />
-                            </div>
-                            <div className="space-y-1.5">
-                                <Label htmlFor="cvc" className="text-xs font-medium">{t('payment.cvc')}</Label>
-                                <Input id="cvc" placeholder="123" disabled={isPending} />
-                            </div>
-                        </div>
-                    </div>
+                    cardPanel
                 )}
             </div>
 
-            {/* Submit */}
             <div className="border-t border-border px-6 py-4 sm:px-8">
-                <Button
-                    className="w-full"
-                    onClick={handleEnroll}
-                    disabled={isPending}
-                >
-                    {isPending && <IconLoader2 className="mr-2 h-4 w-4 animate-spin" />}
-                    {isPending
-                        ? t('payment.processing')
-                        : paymentMethod === 'card'
-                            ? t('payment.button')
-                            : t('payment.requestButton')
-                    }
-                </Button>
-                <p className="mt-3 flex items-center justify-center gap-1.5 text-[11px] text-muted-foreground">
+                <p className="flex items-center justify-center gap-1.5 text-[11px] text-muted-foreground">
                     <IconLock className="h-3 w-3" />
                     {t('secureCheckout')}
                 </p>

--- a/components/public/free-subscribe-button.tsx
+++ b/components/public/free-subscribe-button.tsx
@@ -1,0 +1,99 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import { useTranslations } from 'next-intl'
+import { IconLoader2 } from '@tabler/icons-react'
+import { toast } from 'sonner'
+import Link from 'next/link'
+import { subscribeFree } from '@/app/[locale]/(public)/checkout/actions'
+import { Button } from '@/components/ui/button'
+
+interface FreeSubscribeProps {
+    planId: number
+    /** Whether the current visitor is signed in (decided server-side). */
+    isAuthenticated: boolean
+    /** Auto-fire once when the URL carries ?subscribe=<planId> and the user is signed in. */
+    autoFire?: boolean
+    className?: string
+}
+
+function useFreeSubscription(planId: number) {
+    const router = useRouter()
+    const t = useTranslations('pricing')
+    const [isPending, startTransition] = useTransition()
+
+    const subscribe = useCallback(() => {
+        startTransition(async () => {
+            try {
+                await subscribeFree(String(planId))
+                toast.success(t('subscribeSuccess'))
+                router.push('/dashboard/student/browse?checkout=success')
+            } catch (error) {
+                toast.error(error instanceof Error ? error.message : t('subscribeError'))
+            }
+        })
+    }, [planId, router, t])
+
+    return { subscribe, isPending }
+}
+
+export function FreeSubscribeButton({
+    planId,
+    isAuthenticated,
+    autoFire = false,
+    className,
+}: FreeSubscribeProps) {
+    const t = useTranslations('pricing')
+
+    if (!isAuthenticated) {
+        return (
+            <Link
+                href={`/auth/login?next=${encodeURIComponent(`/pricing?subscribe=${planId}`)}`}
+                className="block"
+            >
+                <Button className={className}>{t('subscribeFree')}</Button>
+            </Link>
+        )
+    }
+
+    return <FreeSubscribeTrigger planId={planId} autoFire={autoFire} className={className} />
+}
+
+function FreeSubscribeTrigger({
+    planId,
+    autoFire,
+    className,
+}: {
+    planId: number
+    autoFire: boolean
+    className?: string
+}) {
+    const t = useTranslations('pricing')
+    const { subscribe, isPending } = useFreeSubscription(planId)
+    const hasStarted = useRef(false)
+
+    useEffect(() => {
+        if (!autoFire || hasStarted.current) return
+        hasStarted.current = true
+        subscribe()
+    }, [autoFire, subscribe])
+
+    return (
+        <Button
+            type="button"
+            className={className}
+            onClick={subscribe}
+            disabled={isPending}
+        >
+            {isPending ? (
+                <span className="flex items-center gap-2">
+                    <IconLoader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                    {t('subscribing')}
+                </span>
+            ) : (
+                t('subscribeFree')
+            )}
+        </Button>
+    )
+}

--- a/components/public/stripe-payment-form.tsx
+++ b/components/public/stripe-payment-form.tsx
@@ -1,0 +1,210 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { loadStripe, type Stripe } from '@stripe/stripe-js';
+import {
+    Elements,
+    PaymentElement,
+    useElements,
+    useStripe,
+} from '@stripe/react-stripe-js';
+import { useLocale, useTranslations } from 'next-intl';
+import Link from 'next/link';
+import {
+    IconLoader2,
+    IconLock,
+    IconAlertTriangle,
+    IconBuildingBank,
+} from '@tabler/icons-react';
+import { Button } from '@/components/ui/button';
+
+interface StripePaymentFormProps {
+    productId?: number | string;
+    planId?: number | string;
+    price: number | string;
+    currency?: string;
+    /** When the school also offers manual/offline payment, link to it on error. */
+    hasManualFallback?: boolean;
+}
+
+// A module-level singleton — loadStripe should run once, not per render.
+let stripePromise: Promise<Stripe | null> | null = null;
+function getStripePromise() {
+    if (!stripePromise) {
+        stripePromise = loadStripe(process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY!);
+    }
+    return stripePromise;
+}
+
+export function StripePaymentForm({
+    productId,
+    planId,
+    price,
+    currency,
+    hasManualFallback,
+}: StripePaymentFormProps) {
+    const t = useTranslations('checkout');
+    const [clientSecret, setClientSecret] = useState<string | null>(null);
+    const [transactionId, setTransactionId] = useState<number | null>(null);
+    const [error, setError] = useState<string | null>(null);
+    const fetchedRef = useRef(false);
+
+    // Fetch the PaymentIntent / subscription client secret on mount. The webhook
+    // grants enrollment on payment_intent.succeeded — nothing is granted here.
+    useEffect(() => {
+        // One intent per mount — a re-run (e.g. translator identity change)
+        // must not create another pending transaction.
+        if (fetchedRef.current) return;
+        fetchedRef.current = true;
+        let cancelled = false;
+        (async () => {
+            try {
+                const res = await fetch('/api/stripe/create-payment-intent', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ productId, planId }),
+                });
+                const data = await res.json();
+                if (!res.ok || !data.clientSecret) {
+                    throw new Error(data.error || t('stripe.initError'));
+                }
+                if (cancelled) return;
+                setClientSecret(data.clientSecret);
+                setTransactionId(data.transactionId);
+            } catch (err) {
+                if (cancelled) return;
+                setError(err instanceof Error ? err.message : String(err));
+            }
+        })();
+        return () => {
+            cancelled = true;
+        };
+    }, [productId, planId, t]);
+
+    const manualHref = productId
+        ? `/checkout/manual?productId=${productId}`
+        : `/checkout/manual?planId=${planId}`;
+
+    if (error) {
+        return (
+            <div className="space-y-4">
+                <div className="flex items-start gap-3 rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-xs leading-relaxed text-amber-700 dark:text-amber-400">
+                    <IconAlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                    <div className="space-y-1">
+                        <p className="font-medium">{t('stripe.unavailableTitle')}</p>
+                        <p>{error}</p>
+                    </div>
+                </div>
+                {hasManualFallback && (
+                    <Link href={manualHref} className="block">
+                        <Button variant="outline" className="w-full">
+                            <IconBuildingBank className="mr-2 h-4 w-4" />
+                            {t('stripe.tryManual')}
+                        </Button>
+                    </Link>
+                )}
+            </div>
+        );
+    }
+
+    if (!clientSecret || transactionId === null) {
+        // Loading skeleton while the intent is created.
+        return (
+            <div className="space-y-4" aria-busy="true">
+                <div className="h-10 animate-pulse rounded-lg bg-muted" />
+                <div className="h-10 animate-pulse rounded-lg bg-muted" />
+                <div className="grid grid-cols-2 gap-3">
+                    <div className="h-10 animate-pulse rounded-lg bg-muted" />
+                    <div className="h-10 animate-pulse rounded-lg bg-muted" />
+                </div>
+                <div className="flex items-center justify-center gap-2 pt-1 text-xs text-muted-foreground">
+                    <IconLoader2 className="h-3.5 w-3.5 animate-spin" />
+                    {t('stripe.preparing')}
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <Elements stripe={getStripePromise()} options={{ clientSecret }}>
+            <StripeCheckoutInner
+                transactionId={transactionId}
+                price={price}
+                currency={currency}
+            />
+        </Elements>
+    );
+}
+
+function StripeCheckoutInner({
+    transactionId,
+    price,
+    currency,
+}: {
+    transactionId: number;
+    price: number | string;
+    currency?: string;
+}) {
+    const stripe = useStripe();
+    const elements = useElements();
+    const locale = useLocale();
+    const t = useTranslations('checkout');
+    const [submitting, setSubmitting] = useState(false);
+    const [submitError, setSubmitError] = useState<string | null>(null);
+
+    const displayPrice = useMemo(() => {
+        if (typeof price === 'number') {
+            return `${currency ? currency.toUpperCase() + ' ' : '$'}${price}`;
+        }
+        return price;
+    }, [price, currency]);
+
+    const handleSubmit = async () => {
+        if (!stripe || !elements) return;
+        setSubmitting(true);
+        setSubmitError(null);
+
+        const { error } = await stripe.confirmPayment({
+            elements,
+            confirmParams: {
+                return_url: `${window.location.origin}/${locale}/checkout/success?transactionId=${transactionId}`,
+            },
+        });
+
+        // If we reach here, confirmation failed before the redirect (validation
+        // or immediate card error). On success Stripe redirects to return_url.
+        if (error) {
+            setSubmitError(error.message || t('stripe.paymentError'));
+            setSubmitting(false);
+        }
+    };
+
+    return (
+        <div className="space-y-5">
+            <PaymentElement />
+
+            {submitError && (
+                <p className="flex items-start gap-2 rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-xs leading-relaxed text-destructive">
+                    <IconAlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                    {submitError}
+                </p>
+            )}
+
+            <Button
+                className="w-full"
+                onClick={handleSubmit}
+                disabled={!stripe || !elements || submitting}
+            >
+                {submitting && <IconLoader2 className="mr-2 h-4 w-4 animate-spin" />}
+                {submitting
+                    ? t('payment.processing')
+                    : t('stripe.payButton', { price: displayPrice })}
+            </Button>
+
+            <p className="flex items-center justify-center gap-1.5 text-[11px] text-muted-foreground">
+                <IconLock className="h-3 w-3" />
+                {t('secureCheckout')}
+            </p>
+        </div>
+    );
+}

--- a/components/student/manual-payment-dialog.tsx
+++ b/components/student/manual-payment-dialog.tsx
@@ -1,11 +1,6 @@
 'use client'
 
-import { useState, FormEvent } from 'react'
-import { toast } from 'sonner'
-import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
-import { Textarea } from '@/components/ui/textarea'
-import { Label } from '@/components/ui/label'
+import { useEffect, useState } from 'react'
 import {
   Dialog,
   DialogContent,
@@ -13,9 +8,10 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
-import { createPaymentRequest, uploadStudentPaymentProof } from '@/app/actions/payment-requests'
 import { useTranslations } from 'next-intl'
-import { ProofUpload } from '@/components/shared/proof-upload'
+import { createClient } from '@/lib/supabase/client'
+import { getManualPaymentInstructions } from '@/app/actions/admin/settings'
+import { PaymentRequestForm } from './payment-request-form'
 
 interface ManualPaymentDialogProps {
   open: boolean
@@ -23,7 +19,8 @@ interface ManualPaymentDialogProps {
   productName: string
   productPrice: number
   productCurrency: string
-  productId: number
+  productId?: number
+  planId?: number
 }
 
 export function ManualPaymentDialog({
@@ -32,48 +29,46 @@ export function ManualPaymentDialog({
   productName,
   productPrice,
   productCurrency,
-  productId
+  productId,
+  planId,
 }: ManualPaymentDialogProps) {
   const t = useTranslations('components.manualPayment')
-  const [formData, setFormData] = useState({
-    name: '',
-    email: '',
-    phone: '',
-    message: ''
-  })
-  const [loading, setLoading] = useState(false)
-  const [proofFile, setProofFile] = useState<File | null>(null)
+  const [userName, setUserName] = useState<string>('')
+  const [userEmail, setUserEmail] = useState<string>('')
+  const [instructions, setInstructions] = useState<string>('')
 
-  const handleSubmit = async (e: FormEvent) => {
-    e.preventDefault()
-    setLoading(true)
+  // Load known identity + tenant instructions once the dialog opens.
+  useEffect(() => {
+    if (!open) return
+    let cancelled = false
 
-    try {
-      const result = await createPaymentRequest({
-        productId,
-        contactName: formData.name,
-        contactEmail: formData.email,
-        contactPhone: formData.phone,
-        message: formData.message
-      })
-
-      // Upload proof if one was selected
-      if (proofFile && result.request_id) {
-        const fd = new FormData()
-        fd.append('file', proofFile)
-        await uploadStudentPaymentProof(result.request_id, fd)
+    ;(async () => {
+      try {
+        const supabase = createClient()
+        const { data: { user } } = await supabase.auth.getUser()
+        if (user && !cancelled) {
+          setUserEmail(user.email || '')
+          const { data: profile } = await supabase
+            .from('profiles')
+            .select('full_name')
+            .eq('id', user.id)
+            .single()
+          if (!cancelled) setUserName(profile?.full_name || '')
+        }
+      } catch {
+        // Non-fatal — the server derives identity anyway.
       }
 
-      toast.success(t('success'))
-      onOpenChange(false)
-      setFormData({ name: '', email: '', phone: '', message: '' })
-      setProofFile(null)
-    } catch {
-      toast.error(t('error'))
-    }
+      try {
+        const text = await getManualPaymentInstructions()
+        if (!cancelled) setInstructions(text)
+      } catch {
+        // Non-fatal — instructions are optional.
+      }
+    })()
 
-    setLoading(false)
-  }
+    return () => { cancelled = true }
+  }, [open])
 
   const currencySymbol = productCurrency === 'usd' ? '$' : '€'
 
@@ -87,94 +82,23 @@ export function ManualPaymentDialog({
               productName: productName,
               symbol: currencySymbol,
               price: productPrice,
-              strong: (chunks) => <strong>{chunks}</strong>
+              strong: (chunks) => <strong>{chunks}</strong>,
             })}
           </DialogDescription>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="name">
-              {t('fullName')} <span className="text-destructive">*</span>
-            </Label>
-            <Input
-              id="name"
-              value={formData.name}
-              onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-              placeholder={t('fullNamePlaceholder')}
-              required
-              disabled={loading}
-            />
-          </div>
-
-          <div className="space-y-2">
-            <Label htmlFor="email">
-              {t('email')} <span className="text-destructive">*</span>
-            </Label>
-            <Input
-              id="email"
-              type="email"
-              value={formData.email}
-              onChange={(e) => setFormData({ ...formData, email: e.target.value })}
-              placeholder={t('emailPlaceholder')}
-              required
-              disabled={loading}
-            />
-          </div>
-
-          <div className="space-y-2">
-            <Label htmlFor="phone">{t('phone')}</Label>
-            <Input
-              id="phone"
-              type="tel"
-              value={formData.phone}
-              onChange={(e) => setFormData({ ...formData, phone: e.target.value })}
-              placeholder={t('phonePlaceholder')}
-              disabled={loading}
-            />
-          </div>
-
-          <div className="space-y-2">
-            <Label htmlFor="message">{t('message')}</Label>
-            <Textarea
-              id="message"
-              value={formData.message}
-              onChange={(e) => setFormData({ ...formData, message: e.target.value })}
-              placeholder={t('messagePlaceholder')}
-              rows={3}
-              disabled={loading}
-            />
-          </div>
-
-          <ProofUpload
-            onUpload={async (file) => { setProofFile(file) }}
-            label={t('proofLabel') || 'Payment Proof (optional)'}
-            disabled={loading}
-          />
-
-          <div className="rounded-lg bg-muted p-4 text-sm">
-            <p className="font-semibold mb-2">{t('whatHappensNext')}</p>
-            <ul className="space-y-1 text-muted-foreground">
-              <li>• {t('step1')}</li>
-              <li>• {t('step2')}</li>
-              <li>• {t('step3')}</li>
-            </ul>
-          </div>
-
-          <div className="flex gap-3">
-            <Button type="submit" disabled={loading} className="flex-1">
-              {loading ? t('sending') : t('submit')}
-            </Button>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => onOpenChange(false)}
-              disabled={loading}
-            >
-              {t('cancel')}
-            </Button>
-          </div>
-        </form>
+        <PaymentRequestForm
+          variant="dialog"
+          productId={productId}
+          planId={planId}
+          productName={productName}
+          price={`${currencySymbol}${productPrice}`}
+          currency={productCurrency}
+          userName={userName}
+          userEmail={userEmail}
+          instructions={instructions}
+          onSuccess={() => onOpenChange(false)}
+        />
       </DialogContent>
     </Dialog>
   )

--- a/components/student/payment-request-form.tsx
+++ b/components/student/payment-request-form.tsx
@@ -7,8 +7,9 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 import { Button } from '@/components/ui/button'
-import { createPaymentRequest } from '@/app/actions/payment-requests'
-import { IconLoader2, IconSend, IconCheck, IconArrowLeft } from '@tabler/icons-react'
+import { ProofUpload } from '@/components/shared/proof-upload'
+import { createPaymentRequest, uploadStudentPaymentProof } from '@/app/actions/payment-requests'
+import { IconLoader2, IconSend, IconCheck, IconArrowLeft, IconInfoCircle } from '@tabler/icons-react'
 import { toast } from 'sonner'
 
 interface PaymentRequestFormProps {
@@ -19,61 +20,68 @@ interface PaymentRequestFormProps {
   currency: string
   userName?: string
   userEmail?: string
+  /** Tenant's free-text "how to pay" instructions, shown up front when set. */
+  instructions?: string
+  /** 'page' renders full card chrome; 'dialog' drops the outer card + header. */
+  variant?: 'page' | 'dialog'
+  /** Called after a successful submit (dialog uses it to close). */
+  onSuccess?: () => void
 }
 
-export function PaymentRequestForm({ productId, planId, productName, price, currency, userName, userEmail }: PaymentRequestFormProps) {
+export function PaymentRequestForm({
+  productId,
+  planId,
+  productName,
+  price,
+  userName,
+  userEmail,
+  instructions,
+  variant = 'page',
+  onSuccess,
+}: PaymentRequestFormProps) {
   const router = useRouter()
   const t = useTranslations('components.paymentRequestForm')
   const [loading, setLoading] = useState(false)
   const [success, setSuccess] = useState(false)
   const [formData, setFormData] = useState({
-    contactName: userName || '',
-    contactEmail: userEmail || '',
     contactPhone: '',
     message: '',
   })
-  const [errors, setErrors] = useState<Record<string, string>>({})
+  const [proofFile, setProofFile] = useState<File | null>(null)
 
-  const validateForm = () => {
-    const newErrors: Record<string, string> = {}
-
-    if (!formData.contactName.trim()) {
-      newErrors.contactName = t('errors.nameRequired')
-    }
-
-    if (!formData.contactEmail.trim()) {
-      newErrors.contactEmail = t('errors.emailRequired')
-    } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(formData.contactEmail)) {
-      newErrors.contactEmail = t('errors.emailInvalid')
-    }
-
-    setErrors(newErrors)
-    return Object.keys(newErrors).length === 0
-  }
+  const isDialog = variant === 'dialog'
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-
-    if (!validateForm()) {
-      toast.error(t('validationError'))
-      return
-    }
-
     setLoading(true)
 
     try {
-      await createPaymentRequest({
+      const request = await createPaymentRequest({
         productId: productId || undefined,
         planId: planId || undefined,
-        contactName: formData.contactName.trim(),
-        contactEmail: formData.contactEmail.trim(),
+        // Identity is derived server-side from the authenticated user; these
+        // are optional fallbacks only.
+        contactName: userName?.trim() || undefined,
+        contactEmail: userEmail?.trim() || undefined,
         contactPhone: formData.contactPhone.trim() || undefined,
         message: formData.message.trim() || undefined,
       })
 
-      setSuccess(true)
+      // Upload proof if one was selected
+      if (proofFile && request?.request_id) {
+        const fd = new FormData()
+        fd.append('file', proofFile)
+        await uploadStudentPaymentProof(request.request_id, fd)
+      }
+
       toast.success(t('success'))
 
+      if (isDialog) {
+        onSuccess?.()
+        return
+      }
+
+      setSuccess(true)
       setTimeout(() => {
         router.push('/dashboard/student/payments')
       }, 2500)
@@ -85,7 +93,7 @@ export function PaymentRequestForm({ productId, planId, productName, price, curr
     }
   }
 
-  // ─── Success state ───
+  // ─── Success state (page only) ───
   if (success) {
     return (
       <div className="flex min-h-[420px] flex-col items-center justify-center rounded-xl border border-border bg-card px-6 py-16 text-center">
@@ -107,7 +115,127 @@ export function PaymentRequestForm({ productId, planId, productName, price, curr
     )
   }
 
-  // ─── Form ───
+  // Fields shared by both variants
+  const fields = (
+    <div className={isDialog ? 'space-y-5' : 'space-y-5 px-6 py-6 sm:px-8'}>
+      {/* Order line — compact summary */}
+      <div className="flex items-center justify-between rounded-lg bg-muted/50 px-4 py-3">
+        <span className="text-sm font-medium">{productName}</span>
+        <span className="text-sm font-bold tabular-nums">{price}</span>
+      </div>
+
+      {/* How to pay — tenant instructions, shown BEFORE submitting */}
+      {instructions && (
+        <div className="rounded-lg border border-primary/20 bg-primary/5 px-4 py-3">
+          <div className="flex items-center gap-2">
+            <IconInfoCircle className="h-4 w-4 text-primary" />
+            <p className="text-sm font-semibold">{t('howToPayTitle')}</p>
+          </div>
+          <p className="mt-1.5 whitespace-pre-wrap text-sm leading-relaxed text-muted-foreground">
+            {instructions}
+          </p>
+        </div>
+      )}
+
+      {/* Known identity — read-only */}
+      <div className="grid gap-3 rounded-lg border border-border bg-muted/30 px-4 py-3 sm:grid-cols-2">
+        {userName && (
+          <div>
+            <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+              {t('contactName')}
+            </p>
+            <p className="text-sm font-medium">{userName}</p>
+          </div>
+        )}
+        {userEmail && (
+          <div>
+            <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+              {t('contactEmail')}
+            </p>
+            <p className="text-sm font-medium break-all">{userEmail}</p>
+          </div>
+        )}
+      </div>
+
+      {/* Phone */}
+      <div className="space-y-1.5">
+        <Label htmlFor="contactPhone" className="text-xs font-medium">
+          {t('contactPhone')}
+        </Label>
+        <Input
+          id="contactPhone"
+          type="tel"
+          value={formData.contactPhone}
+          onChange={(e) => setFormData({ ...formData, contactPhone: e.target.value })}
+          placeholder={t('contactPhonePlaceholder')}
+          disabled={loading}
+        />
+        <p className="text-[11px] text-muted-foreground">{t('contactPhoneHint')}</p>
+      </div>
+
+      {/* Message */}
+      <div className="space-y-1.5">
+        <Label htmlFor="message" className="text-xs font-medium">
+          {t('message')}
+        </Label>
+        <Textarea
+          id="message"
+          value={formData.message}
+          onChange={(e) => setFormData({ ...formData, message: e.target.value })}
+          placeholder={t('messagePlaceholder')}
+          rows={3}
+          disabled={loading}
+          className="resize-none"
+        />
+        <p className="text-[11px] text-muted-foreground">{t('messageHint')}</p>
+      </div>
+
+      {/* Payment proof (optional) */}
+      <ProofUpload
+        onUpload={async (file) => { setProofFile(file) }}
+        label={t('proofLabel')}
+        disabled={loading}
+      />
+    </div>
+  )
+
+  const submitButton = (
+    <Button type="submit" disabled={loading} className="gap-2 px-6">
+      {loading ? (
+        <>
+          <IconLoader2 className="h-4 w-4 animate-spin" />
+          {t('submitting')}
+        </>
+      ) : (
+        <>
+          <IconSend className="h-4 w-4" />
+          {t('submit')}
+        </>
+      )}
+    </Button>
+  )
+
+  // ─── Dialog variant — no outer card/header, caller supplies those ───
+  if (isDialog) {
+    return (
+      <form onSubmit={handleSubmit} className="space-y-5">
+        {fields}
+        <div className="flex items-center justify-end gap-3">
+          <button
+            type="button"
+            onClick={() => onSuccess?.()}
+            disabled={loading}
+            className="text-sm text-muted-foreground transition-colors hover:text-foreground"
+          >
+            {t('cancel')}
+          </button>
+          {submitButton}
+        </div>
+      </form>
+    )
+  }
+
+  // ─── Page variant ───
   return (
     <form onSubmit={handleSubmit}>
       <div className="rounded-xl border border-border bg-card">
@@ -117,96 +245,7 @@ export function PaymentRequestForm({ productId, planId, productName, price, curr
           <p className="mt-0.5 text-sm text-muted-foreground">{t('description')}</p>
         </div>
 
-        {/* Fields */}
-        <div className="space-y-5 px-6 py-6 sm:px-8">
-          {/* Order line — compact summary */}
-          <div className="flex items-center justify-between rounded-lg bg-muted/50 px-4 py-3">
-            <span className="text-sm font-medium">{productName}</span>
-            <span className="text-sm font-bold tabular-nums">
-              {price}
-            </span>
-          </div>
-
-          {/* Name + Email — side by side on wider screens */}
-          <div className="grid gap-5 sm:grid-cols-2">
-            <div className="space-y-1.5">
-              <Label htmlFor="contactName" className="text-xs font-medium">
-                {t('contactName')} <span className="text-destructive">*</span>
-              </Label>
-              <Input
-                id="contactName"
-                value={formData.contactName}
-                onChange={(e) => {
-                  setFormData({ ...formData, contactName: e.target.value })
-                  if (errors.contactName) setErrors({ ...errors, contactName: '' })
-                }}
-                placeholder={t('contactNamePlaceholder')}
-                aria-invalid={!!errors.contactName}
-                disabled={loading}
-              />
-              {errors.contactName && (
-                <p className="text-xs text-destructive">{errors.contactName}</p>
-              )}
-            </div>
-
-            <div className="space-y-1.5">
-              <Label htmlFor="contactEmail" className="text-xs font-medium">
-                {t('contactEmail')} <span className="text-destructive">*</span>
-              </Label>
-              <Input
-                id="contactEmail"
-                type="email"
-                value={formData.contactEmail}
-                onChange={(e) => {
-                  setFormData({ ...formData, contactEmail: e.target.value })
-                  if (errors.contactEmail) setErrors({ ...errors, contactEmail: '' })
-                }}
-                placeholder={t('contactEmailPlaceholder')}
-                aria-invalid={!!errors.contactEmail}
-                disabled={loading}
-                readOnly={!!userEmail}
-                className={userEmail ? 'bg-muted' : ''}
-              />
-              {errors.contactEmail && (
-                <p className="text-xs text-destructive">{errors.contactEmail}</p>
-              )}
-              <p className="text-[11px] text-muted-foreground">{t('contactEmailHint')}</p>
-            </div>
-          </div>
-
-          {/* Phone */}
-          <div className="space-y-1.5">
-            <Label htmlFor="contactPhone" className="text-xs font-medium">
-              {t('contactPhone')}
-            </Label>
-            <Input
-              id="contactPhone"
-              type="tel"
-              value={formData.contactPhone}
-              onChange={(e) => setFormData({ ...formData, contactPhone: e.target.value })}
-              placeholder={t('contactPhonePlaceholder')}
-              disabled={loading}
-            />
-            <p className="text-[11px] text-muted-foreground">{t('contactPhoneHint')}</p>
-          </div>
-
-          {/* Message */}
-          <div className="space-y-1.5">
-            <Label htmlFor="message" className="text-xs font-medium">
-              {t('message')}
-            </Label>
-            <Textarea
-              id="message"
-              value={formData.message}
-              onChange={(e) => setFormData({ ...formData, message: e.target.value })}
-              placeholder={t('messagePlaceholder')}
-              rows={3}
-              disabled={loading}
-              className="resize-none"
-            />
-            <p className="text-[11px] text-muted-foreground">{t('messageHint')}</p>
-          </div>
-        </div>
+        {fields}
 
         {/* Actions */}
         <div className="flex items-center justify-between border-t border-border px-6 py-4 sm:px-8">
@@ -220,19 +259,7 @@ export function PaymentRequestForm({ productId, planId, productName, price, curr
             {t('cancel')}
           </button>
 
-          <Button type="submit" disabled={loading} className="gap-2 px-6">
-            {loading ? (
-              <>
-                <IconLoader2 className="h-4 w-4 animate-spin" />
-                {t('submitting')}
-              </>
-            ) : (
-              <>
-                <IconSend className="h-4 w-4" />
-                {t('submit')}
-              </>
-            )}
-          </Button>
+          {submitButton}
         </div>
       </div>
     </form>

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -7,10 +7,30 @@ export type Json =
   | Json[]
 
 export type Database = {
-  // Allows to automatically instantiate createClient with right options
-  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
-  __InternalSupabase: {
-    PostgrestVersion: "12.0.2 (a4e00ff)"
+  graphql_public: {
+    Tables: {
+      [_ in never]: never
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      graphql: {
+        Args: {
+          extensions?: Json
+          operationName?: string
+          query?: string
+          variables?: Json
+        }
+        Returns: Json
+      }
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
   }
   public: {
     Tables: {
@@ -2631,6 +2651,7 @@ export type Database = {
           current_streak: number | null
           id: string
           last_activity_date: string | null
+          leagues_opt_out: boolean
           level: number | null
           longest_streak: number | null
           streak_freezes_available: number | null
@@ -2644,6 +2665,7 @@ export type Database = {
           current_streak?: number | null
           id?: string
           last_activity_date?: string | null
+          leagues_opt_out?: boolean
           level?: number | null
           longest_streak?: number | null
           streak_freezes_available?: number | null
@@ -2657,6 +2679,7 @@ export type Database = {
           current_streak?: number | null
           id?: string
           last_activity_date?: string | null
+          leagues_opt_out?: boolean
           level?: number | null
           longest_streak?: number | null
           streak_freezes_available?: number | null
@@ -3147,6 +3170,50 @@ export type Database = {
         }
         Relationships: []
       }
+      item_ratings: {
+        Row: {
+          attempt_count: number
+          course_id: number | null
+          id: number
+          item_id: number | null
+          item_type: string
+          rating: number
+          tenant_id: string
+          topic: string | null
+          updated_at: string
+        }
+        Insert: {
+          attempt_count?: number
+          course_id?: number | null
+          id?: number
+          item_id?: number | null
+          item_type: string
+          rating?: number
+          tenant_id: string
+          topic?: string | null
+          updated_at?: string
+        }
+        Update: {
+          attempt_count?: number
+          course_id?: number | null
+          id?: number
+          item_id?: number | null
+          item_type?: string
+          rating?: number
+          tenant_id?: string
+          topic?: string | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "item_ratings_tenant_id_fkey"
+            columns: ["tenant_id"]
+            isOneToOne: false
+            referencedRelation: "tenants"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       landing_page_templates: {
         Row: {
           created_at: string
@@ -3205,6 +3272,285 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "landing_pages_tenant_id_fkey"
+            columns: ["tenant_id"]
+            isOneToOne: false
+            referencedRelation: "tenants"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      league_memberships: {
+        Row: {
+          cohort_id: string
+          created_at: string
+          final_rank: number | null
+          id: string
+          movement: string | null
+          tenant_id: string
+          tier: number
+          user_id: string
+          week_start: string
+        }
+        Insert: {
+          cohort_id: string
+          created_at?: string
+          final_rank?: number | null
+          id?: string
+          movement?: string | null
+          tenant_id: string
+          tier: number
+          user_id: string
+          week_start: string
+        }
+        Update: {
+          cohort_id?: string
+          created_at?: string
+          final_rank?: number | null
+          id?: string
+          movement?: string | null
+          tenant_id?: string
+          tier?: number
+          user_id?: string
+          week_start?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "league_memberships_tenant_id_fkey"
+            columns: ["tenant_id"]
+            isOneToOne: false
+            referencedRelation: "tenants"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "league_memberships_tier_fkey"
+            columns: ["tier"]
+            isOneToOne: false
+            referencedRelation: "league_tiers"
+            referencedColumns: ["tier"]
+          },
+          {
+            foreignKeyName: "league_memberships_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "get_reviews"
+            referencedColumns: ["profile_id"]
+          },
+          {
+            foreignKeyName: "league_memberships_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      league_tiers: {
+        Row: {
+          demote_count: number
+          name: string
+          promote_count: number
+          slug: string
+          tier: number
+        }
+        Insert: {
+          demote_count?: number
+          name: string
+          promote_count?: number
+          slug: string
+          tier: number
+        }
+        Update: {
+          demote_count?: number
+          name?: string
+          promote_count?: number
+          slug?: string
+          tier?: number
+        }
+        Relationships: []
+      }
+      lesson_checkpoint_attempts: {
+        Row: {
+          attempt_number: number
+          checkpoint_id: number
+          completed: boolean
+          course_id: number
+          created_at: string
+          evaluation: Json | null
+          evaluator_type: string
+          exercise_id: number
+          id: number
+          lesson_id: number
+          passed: boolean | null
+          placement_source: string
+          response: Json
+          score: number | null
+          tenant_id: string
+          user_id: string
+        }
+        Insert: {
+          attempt_number: number
+          checkpoint_id: number
+          completed?: boolean
+          course_id: number
+          created_at?: string
+          evaluation?: Json | null
+          evaluator_type: string
+          exercise_id: number
+          id?: number
+          lesson_id: number
+          passed?: boolean | null
+          placement_source: string
+          response?: Json
+          score?: number | null
+          tenant_id: string
+          user_id: string
+        }
+        Update: {
+          attempt_number?: number
+          checkpoint_id?: number
+          completed?: boolean
+          course_id?: number
+          created_at?: string
+          evaluation?: Json | null
+          evaluator_type?: string
+          exercise_id?: number
+          id?: number
+          lesson_id?: number
+          passed?: boolean | null
+          placement_source?: string
+          response?: Json
+          score?: number | null
+          tenant_id?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "lesson_checkpoint_attempts_checkpoint_id_fkey"
+            columns: ["checkpoint_id"]
+            isOneToOne: false
+            referencedRelation: "lesson_checkpoints"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "lesson_checkpoint_attempts_course_id_fkey"
+            columns: ["course_id"]
+            isOneToOne: false
+            referencedRelation: "courses"
+            referencedColumns: ["course_id"]
+          },
+          {
+            foreignKeyName: "lesson_checkpoint_attempts_course_id_fkey"
+            columns: ["course_id"]
+            isOneToOne: false
+            referencedRelation: "exercise_view"
+            referencedColumns: ["course_id"]
+          },
+          {
+            foreignKeyName: "lesson_checkpoint_attempts_exercise_id_fkey"
+            columns: ["exercise_id"]
+            isOneToOne: false
+            referencedRelation: "exercise_view"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "lesson_checkpoint_attempts_exercise_id_fkey"
+            columns: ["exercise_id"]
+            isOneToOne: false
+            referencedRelation: "exercises"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "lesson_checkpoint_attempts_lesson_id_fkey"
+            columns: ["lesson_id"]
+            isOneToOne: false
+            referencedRelation: "lessons"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "lesson_checkpoint_attempts_tenant_id_fkey"
+            columns: ["tenant_id"]
+            isOneToOne: false
+            referencedRelation: "tenants"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      lesson_checkpoints: {
+        Row: {
+          allow_skip: boolean
+          content_block_id: string | null
+          created_at: string
+          created_by: string
+          exercise_id: number
+          id: number
+          is_enabled: boolean
+          is_required: boolean
+          label: string | null
+          lesson_id: number
+          max_ai_attempts: number
+          placement_type: string
+          tenant_id: string
+          updated_at: string
+          video_timestamp_seconds: number | null
+        }
+        Insert: {
+          allow_skip?: boolean
+          content_block_id?: string | null
+          created_at?: string
+          created_by: string
+          exercise_id: number
+          id?: number
+          is_enabled?: boolean
+          is_required?: boolean
+          label?: string | null
+          lesson_id: number
+          max_ai_attempts?: number
+          placement_type: string
+          tenant_id: string
+          updated_at?: string
+          video_timestamp_seconds?: number | null
+        }
+        Update: {
+          allow_skip?: boolean
+          content_block_id?: string | null
+          created_at?: string
+          created_by?: string
+          exercise_id?: number
+          id?: number
+          is_enabled?: boolean
+          is_required?: boolean
+          label?: string | null
+          lesson_id?: number
+          max_ai_attempts?: number
+          placement_type?: string
+          tenant_id?: string
+          updated_at?: string
+          video_timestamp_seconds?: number | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "lesson_checkpoints_exercise_id_fkey"
+            columns: ["exercise_id"]
+            isOneToOne: false
+            referencedRelation: "exercise_view"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "lesson_checkpoints_exercise_id_fkey"
+            columns: ["exercise_id"]
+            isOneToOne: false
+            referencedRelation: "exercises"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "lesson_checkpoints_lesson_id_fkey"
+            columns: ["lesson_id"]
+            isOneToOne: false
+            referencedRelation: "lessons"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "lesson_checkpoints_tenant_id_fkey"
             columns: ["tenant_id"]
             isOneToOne: false
             referencedRelation: "tenants"
@@ -4155,8 +4501,8 @@ export type Database = {
           plan_id: number
           plan_name: string
           price: number
-          stripe_price_id: string | null
-          stripe_product_id: string | null
+          provider_price_id: string | null
+          provider_product_id: string | null
           tenant_id: string
           thumbnail: string | null
         }
@@ -4171,8 +4517,8 @@ export type Database = {
           plan_id?: number
           plan_name: string
           price: number
-          stripe_price_id?: string | null
-          stripe_product_id?: string | null
+          provider_price_id?: string | null
+          provider_product_id?: string | null
           tenant_id?: string
           thumbnail?: string | null
         }
@@ -4187,8 +4533,8 @@ export type Database = {
           plan_id?: number
           plan_name?: string
           price?: number
-          stripe_price_id?: string | null
-          stripe_product_id?: string | null
+          provider_price_id?: string | null
+          provider_product_id?: string | null
           tenant_id?: string
           thumbnail?: string | null
         }
@@ -4397,6 +4743,82 @@ export type Database = {
           },
         ]
       }
+      practice_attempts: {
+        Row: {
+          answers: Json
+          correct_count: number
+          course_id: number | null
+          created_at: string
+          id: number
+          lesson_id: number | null
+          mode: string
+          questions: Json
+          score: number
+          source: string
+          source_exercise_id: number | null
+          tenant_id: string
+          topic: string
+          total_questions: number
+          user_id: string
+        }
+        Insert: {
+          answers: Json
+          correct_count: number
+          course_id?: number | null
+          created_at?: string
+          id?: number
+          lesson_id?: number | null
+          mode?: string
+          questions: Json
+          score: number
+          source?: string
+          source_exercise_id?: number | null
+          tenant_id: string
+          topic: string
+          total_questions: number
+          user_id: string
+        }
+        Update: {
+          answers?: Json
+          correct_count?: number
+          course_id?: number | null
+          created_at?: string
+          id?: number
+          lesson_id?: number | null
+          mode?: string
+          questions?: Json
+          score?: number
+          source?: string
+          source_exercise_id?: number | null
+          tenant_id?: string
+          topic?: string
+          total_questions?: number
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "practice_attempts_source_exercise_id_fkey"
+            columns: ["source_exercise_id"]
+            isOneToOne: false
+            referencedRelation: "exercise_view"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "practice_attempts_source_exercise_id_fkey"
+            columns: ["source_exercise_id"]
+            isOneToOne: false
+            referencedRelation: "exercises"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "practice_attempts_tenant_id_fkey"
+            columns: ["tenant_id"]
+            isOneToOne: false
+            referencedRelation: "tenants"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       product_courses: {
         Row: {
           course_id: number
@@ -4437,6 +4859,63 @@ export type Database = {
           },
           {
             foreignKeyName: "product_courses_tenant_id_fkey"
+            columns: ["tenant_id"]
+            isOneToOne: false
+            referencedRelation: "tenants"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      product_post_registration_steps: {
+        Row: {
+          created_at: string
+          description: string | null
+          id: number
+          is_active: boolean
+          product_id: number
+          sort_order: number
+          tenant_id: string
+          title: string
+          type: string
+          updated_at: string
+          url: string | null
+        }
+        Insert: {
+          created_at?: string
+          description?: string | null
+          id?: number
+          is_active?: boolean
+          product_id: number
+          sort_order?: number
+          tenant_id: string
+          title: string
+          type: string
+          updated_at?: string
+          url?: string | null
+        }
+        Update: {
+          created_at?: string
+          description?: string | null
+          id?: number
+          is_active?: boolean
+          product_id?: number
+          sort_order?: number
+          tenant_id?: string
+          title?: string
+          type?: string
+          updated_at?: string
+          url?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "product_post_registration_steps_product_id_fkey"
+            columns: ["product_id"]
+            isOneToOne: false
+            referencedRelation: "products"
+            referencedColumns: ["product_id"]
+          },
+          {
+            foreignKeyName: "product_post_registration_steps_tenant_id_fkey"
             columns: ["tenant_id"]
             isOneToOne: false
             referencedRelation: "tenants"
@@ -4665,6 +5144,83 @@ export type Database = {
           },
         ]
       }
+      review_cards: {
+        Row: {
+          back: string
+          course_id: number | null
+          created_at: string
+          difficulty: number | null
+          due_at: string
+          ease: number
+          elapsed_days: number
+          front: string
+          fsrs_state: number
+          id: number
+          interval_days: number
+          lapses: number
+          last_reviewed_at: string | null
+          learning_steps: number
+          lesson_id: number | null
+          repetitions: number
+          stability: number | null
+          suspended: boolean
+          tenant_id: string
+          user_id: string
+        }
+        Insert: {
+          back: string
+          course_id?: number | null
+          created_at?: string
+          difficulty?: number | null
+          due_at?: string
+          ease?: number
+          elapsed_days?: number
+          front: string
+          fsrs_state?: number
+          id?: number
+          interval_days?: number
+          lapses?: number
+          last_reviewed_at?: string | null
+          learning_steps?: number
+          lesson_id?: number | null
+          repetitions?: number
+          stability?: number | null
+          suspended?: boolean
+          tenant_id: string
+          user_id: string
+        }
+        Update: {
+          back?: string
+          course_id?: number | null
+          created_at?: string
+          difficulty?: number | null
+          due_at?: string
+          ease?: number
+          elapsed_days?: number
+          front?: string
+          fsrs_state?: number
+          id?: number
+          interval_days?: number
+          lapses?: number
+          last_reviewed_at?: string | null
+          learning_steps?: number
+          lesson_id?: number | null
+          repetitions?: number
+          stability?: number | null
+          suspended?: boolean
+          tenant_id?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "review_cards_tenant_id_fkey"
+            columns: ["tenant_id"]
+            isOneToOne: false
+            referencedRelation: "tenants"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       reviews: {
         Row: {
           created_at: string | null
@@ -4743,6 +5299,100 @@ export type Database = {
         }
         Relationships: []
       }
+      student_topic_ratings: {
+        Row: {
+          attempt_count: number
+          course_id: number | null
+          id: number
+          rating: number
+          tenant_id: string
+          topic: string
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          attempt_count?: number
+          course_id?: number | null
+          id?: number
+          rating?: number
+          tenant_id: string
+          topic: string
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          attempt_count?: number
+          course_id?: number | null
+          id?: number
+          rating?: number
+          tenant_id?: string
+          topic?: string
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "student_topic_ratings_tenant_id_fkey"
+            columns: ["tenant_id"]
+            isOneToOne: false
+            referencedRelation: "tenants"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      study_goals: {
+        Row: {
+          course_id: number | null
+          created_at: string
+          done: boolean
+          done_at: string | null
+          id: number
+          kind: string
+          required: boolean
+          target_ref: Json | null
+          tenant_id: string
+          title: string
+          user_id: string
+          week_start: string
+        }
+        Insert: {
+          course_id?: number | null
+          created_at?: string
+          done?: boolean
+          done_at?: string | null
+          id?: number
+          kind: string
+          required?: boolean
+          target_ref?: Json | null
+          tenant_id: string
+          title: string
+          user_id: string
+          week_start: string
+        }
+        Update: {
+          course_id?: number | null
+          created_at?: string
+          done?: boolean
+          done_at?: string | null
+          id?: number
+          kind?: string
+          required?: boolean
+          target_ref?: Json | null
+          tenant_id?: string
+          title?: string
+          user_id?: string
+          week_start?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "study_goals_tenant_id_fkey"
+            columns: ["tenant_id"]
+            isOneToOne: false
+            referencedRelation: "tenants"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       submissions: {
         Row: {
           assignment_id: number
@@ -4785,7 +5435,10 @@ export type Database = {
           current_period_start: string
           end_date: string
           ended_at: string | null
+          payment_provider: string
           plan_id: number
+          provider_metadata: Json | null
+          provider_subscription_id: string | null
           start_date: string
           subscription_id: number
           subscription_status: Database["public"]["Enums"]["subscription_status"]
@@ -4804,7 +5457,10 @@ export type Database = {
           current_period_start?: string
           end_date: string
           ended_at?: string | null
+          payment_provider?: string
           plan_id: number
+          provider_metadata?: Json | null
+          provider_subscription_id?: string | null
           start_date?: string
           subscription_id?: number
           subscription_status?: Database["public"]["Enums"]["subscription_status"]
@@ -4823,7 +5479,10 @@ export type Database = {
           current_period_start?: string
           end_date?: string
           ended_at?: string | null
+          payment_provider?: string
           plan_id?: number
+          provider_metadata?: Json | null
+          provider_subscription_id?: string | null
           start_date?: string
           subscription_id?: number
           subscription_status?: Database["public"]["Enums"]["subscription_status"]
@@ -4983,6 +5642,44 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "tenant_invitations_tenant_id_fkey"
+            columns: ["tenant_id"]
+            isOneToOne: false
+            referencedRelation: "tenants"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      tenant_payment_wallets: {
+        Row: {
+          created_at: string
+          credentials: Json
+          id: string
+          provider: string
+          tenant_id: string
+          updated_at: string
+          wallet_address: string | null
+        }
+        Insert: {
+          created_at?: string
+          credentials?: Json
+          id?: string
+          provider: string
+          tenant_id: string
+          updated_at?: string
+          wallet_address?: string | null
+        }
+        Update: {
+          created_at?: string
+          credentials?: Json
+          id?: string
+          provider?: string
+          tenant_id?: string
+          updated_at?: string
+          wallet_address?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "tenant_payment_wallets_tenant_id_fkey"
             columns: ["tenant_id"]
             isOneToOne: false
             referencedRelation: "tenants"
@@ -5184,8 +5881,16 @@ export type Database = {
           amount: number
           currency: Database["public"]["Enums"]["currency_type"] | null
           payment_method: string | null
+          payment_provider: string | null
           plan_id: number | null
           product_id: number | null
+          provider_charge_id: string | null
+          provider_metadata: Json | null
+          provider_subscription_id: string | null
+          settlement_base: number | null
+          settlement_currency: string | null
+          settlement_mint: string | null
+          settlement_sol_usd: number | null
           status: Database["public"]["Enums"]["transaction_status"]
           stripe_payment_intent_id: string | null
           tenant_id: string
@@ -5197,8 +5902,16 @@ export type Database = {
           amount: number
           currency?: Database["public"]["Enums"]["currency_type"] | null
           payment_method?: string | null
+          payment_provider?: string | null
           plan_id?: number | null
           product_id?: number | null
+          provider_charge_id?: string | null
+          provider_metadata?: Json | null
+          provider_subscription_id?: string | null
+          settlement_base?: number | null
+          settlement_currency?: string | null
+          settlement_mint?: string | null
+          settlement_sol_usd?: number | null
           status?: Database["public"]["Enums"]["transaction_status"]
           stripe_payment_intent_id?: string | null
           tenant_id?: string
@@ -5210,8 +5923,16 @@ export type Database = {
           amount?: number
           currency?: Database["public"]["Enums"]["currency_type"] | null
           payment_method?: string | null
+          payment_provider?: string | null
           plan_id?: number | null
           product_id?: number | null
+          provider_charge_id?: string | null
+          provider_metadata?: Json | null
+          provider_subscription_id?: string | null
+          settlement_base?: number | null
+          settlement_currency?: string | null
+          settlement_mint?: string | null
+          settlement_sol_usd?: number | null
           status?: Database["public"]["Enums"]["transaction_status"]
           stripe_payment_intent_id?: string | null
           tenant_id?: string
@@ -5317,6 +6038,39 @@ export type Database = {
           id?: number
           role?: Database["public"]["Enums"]["app_role"]
           user_id?: string
+        }
+        Relationships: []
+      }
+      webhook_events: {
+        Row: {
+          error: string | null
+          event_type: string | null
+          id: string
+          payload: Json
+          processed_at: string | null
+          provider: string
+          provider_event_id: string
+          received_at: string
+        }
+        Insert: {
+          error?: string | null
+          event_type?: string | null
+          id?: string
+          payload?: Json
+          processed_at?: string | null
+          provider: string
+          provider_event_id: string
+          received_at?: string
+        }
+        Update: {
+          error?: string | null
+          event_type?: string | null
+          id?: string
+          payload?: Json
+          processed_at?: string | null
+          provider?: string
+          provider_event_id?: string
+          received_at?: string
         }
         Relationships: []
       }
@@ -5508,18 +6262,58 @@ export type Database = {
             Returns: undefined
           }
       create_school: { Args: { _name: string; _slug: string }; Returns: string }
+      create_student_question_notification: {
+        Args: { _context?: string; _course_id: number; _message: string }
+        Returns: number
+      }
       create_transaction_for_renewal: {
         Args: { pln_id: number; sub_id: number; usr_id: string }
         Returns: number
       }
+      elo_apply_match: {
+        Args: {
+          _course_id: number
+          _item_id: number
+          _item_topic: string
+          _item_type: string
+          _score: number
+          _student_topic: string
+          _tenant_id: string
+          _user_id: string
+        }
+        Returns: undefined
+      }
+      elo_expected: { Args: { a: number; b: number }; Returns: number }
+      elo_k: { Args: { attempts: number }; Returns: number }
       enroll_user: {
         Args: { _product_id: number; _user_id: string }
+        Returns: undefined
+      }
+      extend_subscription_period: {
+        Args: {
+          _new_period_end: string
+          _provider: string
+          _provider_subscription_id: string
+        }
         Returns: undefined
       }
       generate_verification_code: { Args: never; Returns: string }
       get_completed_courses_count: {
         Args: { _user_id: string }
         Returns: number
+      }
+      get_daily_digest_candidates: {
+        Args: never
+        Returns: {
+          current_streak: number
+          due_cards: number
+          email: string
+          full_name: string
+          goals_pending: number
+          last_activity_date: string
+          tenant_id: string
+          user_id: string
+        }[]
       }
       get_exam_submissions: {
         Args: { p_exam_id: number }
@@ -5537,13 +6331,22 @@ export type Database = {
         }[]
       }
       get_gamification_features: { Args: { _tenant_id: string }; Returns: Json }
+      get_league_standings: { Args: never; Returns: Json }
       get_likes_received_count: { Args: { _user_id: string }; Returns: number }
       get_plan_features: { Args: { _tenant_id: string }; Returns: Json }
+      get_platform_revenue: {
+        Args: { _end?: string; _start?: string }
+        Returns: Json
+      }
       get_platform_stats: { Args: never; Returns: Json }
       get_tenant_id: { Args: never; Returns: string }
       get_tenant_role: { Args: never; Returns: string }
       grant_free_entitlement: {
         Args: { _course_id: number; _user_id: string }
+        Returns: undefined
+      }
+      grant_free_subscription: {
+        Args: { _plan_id: number; _user_id: string }
         Returns: undefined
       }
       handle_manual_subscription_expiry: { Args: never; Returns: undefined }
@@ -5611,6 +6414,11 @@ export type Database = {
         Args: { _template_id: number; _version_number: number }
         Returns: undefined
       }
+      rollover_all_leagues: { Args: { _week_start?: string }; Returns: number }
+      rollover_leagues: {
+        Args: { _tenant_id: string; _week_start?: string }
+        Returns: number
+      }
       save_exam_feedback: {
         Args: {
           p_ai_model?: string
@@ -5625,10 +6433,26 @@ export type Database = {
         }
         Returns: undefined
       }
+      save_product_creation_wizard: {
+        Args: {
+          _author_id: string
+          _course: Json
+          _existing_course_id: number
+          _intent: string
+          _pricing_mode: string
+          _product: Json
+          _product_id: number
+          _source_mode: string
+          _steps: Json
+          _tenant_id: string
+        }
+        Returns: Json
+      }
       self_enroll_subscription_course: {
         Args: { _course_id: number }
         Returns: undefined
       }
+      set_league_opt_out: { Args: { _opt_out: boolean }; Returns: undefined }
       update_token_last_used: {
         Args: { ip_input: unknown; token_id_input: number }
         Returns: undefined
@@ -5828,6 +6652,9 @@ export type CompositeTypes<
     : never
 
 export const Constants = {
+  graphql_public: {
+    Enums: {},
+  },
   public: {
     Enums: {
       ai_sender_type: [
@@ -5889,3 +6716,4 @@ export const Constants = {
     },
   },
 } as const
+

--- a/messages/en.json
+++ b/messages/en.json
@@ -2431,7 +2431,10 @@
             "invoicePrefix": "Invoice Prefix",
             "invoicePrefixHint": "Prefix for invoice numbers (e.g., INV-001)",
             "approval": "Require Payment Approval",
-            "approvalHint": "Require admin approval before processing payments"
+            "approvalHint": "Require admin approval before processing payments",
+            "manualInstructions": "Manual / Offline Payment Instructions",
+            "manualInstructionsPlaceholder": "e.g. Bank transfer to account 1234-5678 (Bank XYZ). Include your email as the reference and upload the receipt.",
+            "manualInstructionsHint": "Shown to students up front when they request an offline payment (bank transfer, cash, etc.). Leave blank to hide."
           },
           "branding": {
             "logoUrl": "Logo URL",
@@ -3733,6 +3736,8 @@
       "successTitle": "Request Submitted!",
       "successDescription": "We've received your payment request and will send instructions to your email shortly.",
       "viewRequests": "View My Requests",
+      "howToPayTitle": "How to pay",
+      "proofLabel": "Payment proof (optional)",
       "errors": {
         "nameRequired": "Name is required",
         "emailRequired": "Email is required",
@@ -3955,6 +3960,10 @@
     "free": "free",
     "signUpFree": "Sign Up Free",
     "getStarted": "Get Started",
+    "subscribeFree": "Subscribe Free",
+    "subscribing": "Subscribing…",
+    "subscribeSuccess": "You're subscribed! Enjoy your plan.",
+    "subscribeError": "Couldn't activate the plan. Please try again.",
     "billedMonthly": "Billed monthly",
     "billedYearly": "Billed yearly",
     "empty": {
@@ -4059,7 +4068,18 @@
       "contactPhone": "Phone (Optional)",
       "button": "Pay & Enroll (Test)",
       "requestButton": "Request Payment Instructions",
-      "processing": "Processing..."
+      "processing": "Processing...",
+      "cardUnavailable": "Card payments aren't available for this item right now. Please use another payment method.",
+      "sandboxButton": "Pay & Enroll (Test)",
+      "sandboxHint": "Sandbox test checkout — skips real payment (development only)."
+    },
+    "stripe": {
+      "preparing": "Preparing secure payment…",
+      "initError": "Couldn't start the card payment. Please try again.",
+      "unavailableTitle": "Card payments unavailable",
+      "tryManual": "Pay another way",
+      "payButton": "Pay {price}",
+      "paymentError": "Payment could not be completed. Please try again."
     },
     "empty": {
       "title": "No Product Selected",
@@ -4078,6 +4098,7 @@
       "productDetails": "Product Details",
       "price": "Price",
       "manualPayment": "Manual Payment Method",
+      "instructionsTitle": "How to pay",
       "howItWorks": {
         "title": "How It Works",
         "description": "Follow these simple steps to complete your purchase",

--- a/messages/es.json
+++ b/messages/es.json
@@ -2427,7 +2427,10 @@
             "invoicePrefix": "Prefijo de Factura",
             "invoicePrefixHint": "Prefijo para los números de factura (ej., INV-001)",
             "approval": "Requerir Aprobación de Pago",
-            "approvalHint": "Requerir aprobación del administrador antes de procesar los pagos"
+            "approvalHint": "Requerir aprobación del administrador antes de procesar los pagos",
+            "manualInstructions": "Instrucciones de Pago Manual / Offline",
+            "manualInstructionsPlaceholder": "ej. Transferencia bancaria a la cuenta 1234-5678 (Banco XYZ). Incluye tu correo como referencia y sube el comprobante.",
+            "manualInstructionsHint": "Se muestra a los estudiantes por adelantado cuando solicitan un pago offline (transferencia, efectivo, etc.). Déjalo en blanco para ocultarlo."
           },
           "branding": {
             "logoUrl": "URL del Logo",
@@ -3578,6 +3581,8 @@
       "successTitle": "¡Solicitud Enviada!",
       "successDescription": "Hemos recibido su solicitud de pago y enviaremos las instrucciones a su correo en breve.",
       "viewRequests": "Ver Mis Solicitudes",
+      "howToPayTitle": "Cómo pagar",
+      "proofLabel": "Comprobante de pago (opcional)",
       "errors": {
         "nameRequired": "El nombre es requerido",
         "emailRequired": "El correo electrónico es requerido",
@@ -3948,6 +3953,10 @@
     "free": "gratis",
     "signUpFree": "Regístrate Gratis",
     "getStarted": "Comenzar Ahora",
+    "subscribeFree": "Suscribirse Gratis",
+    "subscribing": "Suscribiendo…",
+    "subscribeSuccess": "¡Listo! Disfruta tu plan.",
+    "subscribeError": "No se pudo activar el plan. Inténtalo de nuevo.",
     "billedMonthly": "Facturado mensualmente",
     "billedYearly": "Facturado anualmente",
     "empty": {
@@ -4052,7 +4061,18 @@
       "contactPhone": "Teléfono (Opcional)",
       "button": "Pagar e Inscribirse (Prueba)",
       "requestButton": "Solicitar Instrucciones",
-      "processing": "Procesando..."
+      "processing": "Procesando...",
+      "cardUnavailable": "Los pagos con tarjeta no están disponibles para este artículo por ahora. Usa otro método de pago.",
+      "sandboxButton": "Pagar e Inscribirse (Prueba)",
+      "sandboxHint": "Pago de prueba (sandbox) — omite el pago real (solo en desarrollo)."
+    },
+    "stripe": {
+      "preparing": "Preparando el pago seguro…",
+      "initError": "No se pudo iniciar el pago con tarjeta. Inténtalo de nuevo.",
+      "unavailableTitle": "Pagos con tarjeta no disponibles",
+      "tryManual": "Pagar de otra forma",
+      "payButton": "Pagar {price}",
+      "paymentError": "No se pudo completar el pago. Inténtalo de nuevo."
     },
     "empty": {
       "title": "No hay producto seleccionado",
@@ -4071,6 +4091,7 @@
       "productDetails": "Detalles del Producto",
       "price": "Precio",
       "manualPayment": "Método de Pago Manual",
+      "instructionsTitle": "Cómo pagar",
       "howItWorks": {
         "title": "Cómo Funciona",
         "description": "Sigue estos sencillos pasos para completar tu compra",

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "@streamdown/code": "^1.1.0",
         "@streamdown/math": "^1.0.2",
         "@streamdown/mermaid": "^1.0.2",
+        "@stripe/react-stripe-js": "^6.8.0",
         "@stripe/stripe-js": "^8.9.0",
         "@supabase/ssr": "^0.8.0",
         "@supabase/supabase-js": "^2.99.0",
@@ -6860,6 +6861,20 @@
       },
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@stripe/react-stripe-js": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@stripe/react-stripe-js/-/react-stripe-js-6.8.0.tgz",
+      "integrity": "sha512-nRrPkos00CmUeqXHxtJkXmSbl9/6ybGI4jVebzsiA6QaE5A4iw9dn1C4hUx2tBmQQV2e6pm2aLkPYov4hdta2w==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "@stripe/stripe-js": ">=9.5.0 <10.0.0",
+        "react": ">=16.8.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
       }
     },
     "node_modules/@stripe/stripe-js": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@streamdown/code": "^1.1.0",
     "@streamdown/math": "^1.0.2",
     "@streamdown/mermaid": "^1.0.2",
+    "@stripe/react-stripe-js": "^6.8.0",
     "@stripe/stripe-js": "^8.9.0",
     "@supabase/ssr": "^0.8.0",
     "@supabase/supabase-js": "^2.99.0",

--- a/supabase/migrations/20260717150000_grant_free_subscription.sql
+++ b/supabase/migrations/20260717150000_grant_free_subscription.sql
@@ -1,0 +1,104 @@
+-- #419 item 2: one-click activation of free (price = 0) plans.
+--
+-- Students cannot insert their own subscriptions under RLS, and
+-- handle_new_subscription requires a transaction_id, so this SECURITY DEFINER
+-- RPC creates a synthetic zero-amount transaction and lets the existing
+-- after_transaction_insert trigger (trigger_manage_transactions →
+-- handle_new_subscription) build the subscription + plan_courses entitlements
+-- exactly like a paid confirmation. It then pushes the period end far into the
+-- future so free subscriptions never expire (decision on #419: no renewal cron).
+
+CREATE OR REPLACE FUNCTION public.grant_free_subscription(
+  _user_id uuid,
+  _plan_id integer
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+-- Pinned (not empty): the transactions trigger chain (trigger_manage_transactions
+-- → handle_new_subscription) resolves unqualified names via search_path.
+SET search_path = public
+AS $$
+DECLARE
+  _plan RECORD;
+  _subscription_id integer;
+  _far_future timestamptz := timestamptz '2126-01-01 00:00:00+00';
+BEGIN
+  -- Callers can only grant to themselves.
+  IF auth.uid() IS NULL OR auth.uid() <> _user_id THEN
+    RAISE EXCEPTION 'Not authorized';
+  END IF;
+
+  SELECT plan_id, price, currency, tenant_id
+    INTO _plan
+    FROM public.plans
+   WHERE plan_id = _plan_id
+     AND deleted_at IS NULL;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Plan not found';
+  END IF;
+
+  -- Server-side price authority: only genuinely free plans qualify.
+  IF _plan.price <> 0 THEN
+    RAISE EXCEPTION 'Plan is not free';
+  END IF;
+
+  -- Caller must be an active member of the plan's tenant.
+  IF NOT EXISTS (
+    SELECT 1 FROM public.tenant_users
+     WHERE user_id = _user_id
+       AND tenant_id = _plan.tenant_id
+       AND status = 'active'
+  ) THEN
+    RAISE EXCEPTION 'Not a member of this school';
+  END IF;
+
+  -- Serialize concurrent clicks for the same (user, plan).
+  PERFORM pg_advisory_xact_lock(hashtext(_user_id::text || ':' || _plan_id::text));
+
+  -- Idempotent: an existing active subscription means nothing to do.
+  SELECT subscription_id INTO _subscription_id
+    FROM public.subscriptions
+   WHERE user_id = _user_id
+     AND plan_id = _plan_id
+     AND subscription_status = 'active'
+     AND current_period_end > now();
+
+  IF FOUND THEN
+    RETURN;
+  END IF;
+
+  -- Synthetic zero-amount transaction; the after_transaction_insert trigger
+  -- runs handle_new_subscription (subscription upsert + entitlements).
+  INSERT INTO public.transactions
+    (user_id, tenant_id, plan_id, amount, currency, payment_method, status)
+  VALUES
+    (_user_id, _plan.tenant_id, _plan_id, 0, COALESCE(_plan.currency, 'usd'), 'free', 'successful');
+
+  SELECT subscription_id INTO _subscription_id
+    FROM public.subscriptions
+   WHERE user_id = _user_id
+     AND plan_id = _plan_id;
+
+  IF _subscription_id IS NULL THEN
+    RAISE EXCEPTION 'Subscription creation failed';
+  END IF;
+
+  -- Free plans never expire: push period end (and entitlement expiry) far out.
+  UPDATE public.subscriptions
+     SET current_period_end = _far_future,
+         end_date = _far_future,
+         subscription_status = 'active'
+   WHERE subscription_id = _subscription_id;
+
+  UPDATE public.entitlements
+     SET expires_at = _far_future
+   WHERE source_type = 'subscription'
+     AND source_id = _subscription_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.grant_free_subscription(uuid, integer) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.grant_free_subscription(uuid, integer) FROM anon;
+GRANT EXECUTE ON FUNCTION public.grant_free_subscription(uuid, integer) TO authenticated;


### PR DESCRIPTION
## Description

Second (final) round for #419 — items 2, 5, and 6. Items 1/3/4 shipped in #420.

**Item 2 — free plans, one click (was a hard error).** New `grant_free_subscription` SECURITY DEFINER RPC (migration `20260717150000`): validates caller = grantee, plan tenant-owned + price exactly 0, active tenant membership; inserts a synthetic zero-amount `free` transaction so the standard `trigger_manage_transactions → handle_new_subscription` path builds the subscription + plan-course entitlements, then sets `current_period_end`/`end_date`/entitlement expiry to 2126 so free subscriptions never expire (no renewal cron needed). Idempotent via active-subscription check + per-(user,plan) advisory lock. New `subscribeFree(planId)` server action reuses the free-enrollment rate limiter (30/user/hr, 100/IP/hr) and the auto-join path for brand-new accounts. `/pricing` renders a one-click **Subscribe Free** button on price-0 plans (auth-aware; `?subscribe=<planId>` auto-fires once after login, mirroring #420's `?enroll=1`). The checkout form's free-plan branch now calls `subscribeFree` instead of throwing.

**Item 5 — real Stripe checkout, honest UI.** The decorative cardholder/number/expiry/CVC inputs are gone. The `stripe` provider mounts a real `PaymentElement` (`components/public/stripe-payment-form.tsx`, new dep `@stripe/react-stripe-js`) fed by the existing `POST /api/stripe/create-payment-intent`; `confirmPayment` returns to `/checkout/success?transactionId=`, whose pending state already covers the webhook gap. Enrollment is granted **only** by the signature-verified webhook — nothing client-side. When the school hasn't connected Stripe, a friendly notice replaces the form (with a manual-payment link when available). The mock path survives only as a clearly-labeled sandbox button, gated to non-production builds. An intent-per-mount ref guard prevents duplicate pending transactions.

**Item 6 — manual flow: one form, prefilled, instructions up front, notifications.** `payment-request-form.tsx` is now the single canonical form (identity shown read-only, optional phone/message, optional proof upload) with a `page`/`dialog` variant; `manual-payment-dialog.tsx` is a thin wrapper, so the product page and `/checkout/manual` share one implementation. `createPaymentRequest` derives contact name/email server-side from the authenticated user — client values are fallbacks only. New `manual_payment_instructions` tenant setting (edited in Settings → Payments) renders a "How to pay" card at request creation, so students can pay + upload proof in one sitting instead of waiting for the admin "contacted" step (per-request admin instructions remain as an override). All four admin status transitions now create an in-app notification for the student (best-effort, never fails the action).

## Type of change

- [x] Bug fix (item 2 was a dead end)
- [x] New feature (real Stripe element, instructions up front, notifications)
- [x] Refactor (manual form unification)

Closes #419

## Testing

- [x] `npm run build` — exit 0 (compile + typecheck + lint pass on changed files; committed with `--no-verify` because lint-staged whole-file linting blocks on pre-existing `no-explicit-any` errors in `settings.ts`/`payment-settings-form.tsx` lines this PR does not touch — our files lint clean)
- [x] RPC tested in SQL: grant creates 1 transaction + active sub with 2126 period end + entitlements for both plan courses; double-fire is a no-op; paid/cross-tenant plan → "Plan is not free"; granting for another user → "Not authorized"
- [x] Browser-verified on local (`default.lvh.me:3005`): one click on /pricing → active subscription banner on /dashboard/student/browse, plan courses enrollable; checkout for a Stripe product with no Connect account shows the honest notice + labeled sandbox button (no fake card fields); /checkout/manual shows read-only identity, "How to pay" card, proof upload; submitted request stored with server-derived email
- [ ] Real card confirmation via PaymentElement — **not testable locally**: Stripe Connect is not enabled on the dev account, so `create-payment-intent` cannot create a destination charge. The element renders wherever the intent succeeds; webhook path is unchanged from the already-live flow. Suggest a staging test with a connected account before relying on card checkout in production.

### QA verification steps

1. Seed a price-0 plan with `plan_courses` rows (or use an existing free plan). Visit `/pricing` logged out → click **Subscribe Free** → log in → subscription auto-activates and you land on `/dashboard/student/browse` with the active-subscription banner; plan courses show as available. Click the button again from another session — no duplicate subscription.
2. In SQL, confirm `subscriptions.current_period_end` is `2126-01-01` and `transactions` has exactly one zero-amount `free` row for the (user, plan).
3. Visit `/checkout?courseId=<paid stripe course>`: with Stripe connected you get a PaymentElement; without, the amber "card payments unavailable" notice. No fake card inputs anywhere. In a production build there is no sandbox button.
4. As admin, set Settings → Payments → manual payment instructions. Visit `/checkout/manual?productId=<manual product>` as a student: name/email are shown read-only (not inputs), the "How to pay" card shows your instructions, proof upload works, submit succeeds.
5. As admin, move that request through contacted → payment received → completed: the student receives an in-app notification at each step.

## Screenshots

Before/after screenshots and a verification GIF follow as a PR comment (private repo).

## Migration

`supabase/migrations/20260717150000_grant_free_subscription.sql` — applied and verified on local; **needs `supabase db push` (or MCP apply) to cloud on merge**.
