### PR TITLE
fix(#291): seed community feature flags + authoritative plan seed; richer 404 page

### DIFF
--- a/app/[locale]/not-found.tsx
+++ b/app/[locale]/not-found.tsx
@@ -5,28 +5,104 @@ export default async function NotFound() {
   const t = await getTranslations('errors')
 
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center bg-background px-4">
-      <div className="text-center max-w-md">
-        <div className="mb-6">
-          <span className="text-8xl font-bold text-primary">404</span>
+    <main className="relative flex min-h-screen items-center justify-center overflow-hidden bg-background px-6 py-16">
+      {/* Faint notebook grid, fading toward the edges */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 opacity-70"
+        style={{
+          backgroundImage:
+            'radial-gradient(circle, var(--border) 1px, transparent 1.4px)',
+          backgroundSize: '22px 22px',
+          maskImage:
+            'radial-gradient(ellipse 70% 60% at 50% 42%, black 30%, transparent 78%)',
+          WebkitMaskImage:
+            'radial-gradient(ellipse 70% 60% at 50% 42%, black 30%, transparent 78%)',
+        }}
+      />
+      {/* Soft brand glow behind the numerals */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute left-1/2 top-[38%] h-[40rem] w-[40rem] -translate-x-1/2 -translate-y-1/2"
+        style={{
+          background:
+            'radial-gradient(circle, color-mix(in oklch, var(--primary) 16%, transparent), transparent 68%)',
+        }}
+      />
+
+      <div className="relative w-full max-w-xl text-center">
+        <p className="nf-rise [font-family:var(--font-geist-mono)] text-xs font-medium uppercase tracking-[0.4em] text-muted-foreground">
+          {t('notFound.title')}
+        </p>
+
+        {/* The displaced 404: solid, an outlined hole, then muted, each knocked askew */}
+        <div
+          aria-hidden
+          className="my-6 flex select-none items-center justify-center gap-2 [font-family:var(--font-geist-mono)] text-[clamp(6rem,26vw,13rem)] font-bold leading-none tracking-tight sm:gap-4"
+        >
+          <span className="nf-glyph -translate-y-2 -rotate-6 text-primary">4</span>
+          <span
+            className="nf-glyph nf-glyph-2 translate-y-1 rotate-2 text-transparent"
+            style={{ WebkitTextStroke: '2px var(--primary)' }}
+          >
+            0
+          </span>
+          <span className="nf-glyph nf-glyph-3 -translate-y-3 rotate-6 text-foreground/25">
+            4
+          </span>
         </div>
-        <h1 className="text-2xl font-semibold mb-3">{t('notFound.title')}</h1>
-        <p className="text-muted-foreground mb-8">{t('notFound.description')}</p>
-        <div className="flex flex-col sm:flex-row gap-3 justify-center">
+
+        <h1 className="nf-rise nf-rise-2 text-balance text-2xl font-semibold tracking-tight text-foreground sm:text-3xl">
+          {t('notFound.title')}
+        </h1>
+        <p className="nf-rise nf-rise-3 mx-auto mt-3 max-w-sm text-pretty text-sm leading-relaxed text-muted-foreground sm:text-base">
+          {t('notFound.description')}
+        </p>
+
+        <div className="nf-rise nf-rise-4 mt-9 flex flex-col items-center justify-center gap-3 sm:flex-row">
           <Link
             href="/dashboard"
-            className="inline-flex items-center justify-center rounded-md bg-primary px-6 py-2.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+            className="inline-flex h-11 items-center justify-center rounded-full bg-primary px-7 text-sm font-medium text-primary-foreground shadow-sm transition-[transform,background-color] duration-200 hover:-translate-y-0.5 hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
           >
             {t('notFound.backToDashboard')}
           </Link>
           <Link
             href="/"
-            className="inline-flex items-center justify-center rounded-md border px-6 py-2.5 text-sm font-medium hover:bg-muted transition-colors"
+            className="inline-flex h-11 items-center justify-center rounded-full border border-border px-7 text-sm font-medium text-foreground transition-[transform,background-color] duration-200 hover:-translate-y-0.5 hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
           >
             {t('notFound.goHome')}
           </Link>
         </div>
       </div>
-    </div>
+
+      {/* Scoped entrance motion, disabled under reduced-motion */}
+      <style>{`
+        .nf-glyph {
+          opacity: 0;
+          transform-origin: center bottom;
+          animation: nf-drop 0.9s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+        }
+        .nf-glyph-2 { animation-delay: 0.09s; }
+        .nf-glyph-3 { animation-delay: 0.18s; }
+        .nf-rise {
+          opacity: 0;
+          animation: nf-fade 0.7s cubic-bezier(0.16, 1, 0.3, 1) 0.28s forwards;
+        }
+        .nf-rise-2 { animation-delay: 0.36s; }
+        .nf-rise-3 { animation-delay: 0.44s; }
+        .nf-rise-4 { animation-delay: 0.52s; }
+        @keyframes nf-drop {
+          from { opacity: 0; transform: translateY(-1.5rem); }
+          to   { opacity: 1; transform: translateY(0); }
+        }
+        @keyframes nf-fade {
+          from { opacity: 0; transform: translateY(0.5rem); }
+          to   { opacity: 1; transform: translateY(0); }
+        }
+        @media (prefers-reduced-motion: reduce) {
+          .nf-glyph, .nf-rise { opacity: 1; animation: none; }
+        }
+      `}</style>
+    </main>
   )
 }

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -19,42 +19,54 @@
 
 
 -- ---------------------------------------------------------------------------
--- 0. PLATFORM PLANS  (idempotent — already seeded by migration but kept here
---    so `supabase db reset` produces a consistent state)
+-- 0. PLATFORM PLANS  (authoritative for local dev — DO UPDATE so this seed
+--    always wins over whatever the original billing migration inserted;
+--    the migration's INSERT never included a `community` feature flag, which
+--    left the community feature 100% inaccessible on every plan/tenant —
+--    see issue #291. Free = locked w/ upgrade nudge, Starter+ = accessible,
+--    per the #291 spec.)
 -- ---------------------------------------------------------------------------
 INSERT INTO platform_plans (slug, name, description, price_monthly, price_yearly, transaction_fee_percent, sort_order, features, limits)
 VALUES
 (
   'free', 'Free', 'Get started with basic features',
   0, 0, 10.00, 0,
-  '{"leaderboard":false,"achievements":false,"store":false,"certificates":"basic","analytics":false,"ai_grading":false,"custom_branding":false,"custom_domain":false,"api_access":false,"white_label":false,"priority_support":false,"xp":true,"levels":true,"streaks":true}'::jsonb,
+  '{"leaderboard":false,"achievements":false,"store":false,"certificates":"basic","analytics":false,"ai_grading":false,"custom_branding":false,"custom_domain":false,"api_access":false,"white_label":false,"priority_support":false,"community":false,"xp":true,"levels":true,"streaks":true}'::jsonb,
   '{"max_courses":5,"max_students":50}'::jsonb
 ),
 (
   'starter', 'Starter', 'For growing schools that need more capacity',
   9, 90, 5.00, 1,
-  '{"leaderboard":true,"achievements":true,"store":false,"certificates":"custom","analytics":"basic","ai_grading":false,"custom_branding":false,"custom_domain":false,"api_access":false,"white_label":false,"priority_support":false,"xp":true,"levels":true,"streaks":true}'::jsonb,
+  '{"leaderboard":true,"achievements":true,"store":false,"certificates":"custom","analytics":"basic","ai_grading":false,"custom_branding":false,"custom_domain":false,"api_access":false,"white_label":false,"priority_support":false,"community":true,"xp":true,"levels":true,"streaks":true}'::jsonb,
   '{"max_courses":15,"max_students":200}'::jsonb
 ),
 (
   'pro', 'Pro', 'Advanced features for professional educators',
   29, 290, 2.00, 2,
-  '{"leaderboard":true,"achievements":true,"store":true,"certificates":"custom","analytics":"advanced","ai_grading":true,"custom_branding":false,"custom_domain":false,"api_access":false,"white_label":false,"priority_support":false,"xp":true,"levels":true,"streaks":true}'::jsonb,
+  '{"leaderboard":true,"achievements":true,"store":true,"certificates":"custom","analytics":"advanced","ai_grading":true,"custom_branding":false,"custom_domain":false,"api_access":false,"white_label":false,"priority_support":false,"community":true,"xp":true,"levels":true,"streaks":true}'::jsonb,
   '{"max_courses":100,"max_students":1000}'::jsonb
 ),
 (
   'business', 'Business', 'Full platform with custom branding and priority support',
   79, 790, 0, 3,
-  '{"leaderboard":true,"achievements":true,"store":true,"certificates":"custom","analytics":"advanced","ai_grading":true,"custom_branding":true,"custom_domain":true,"api_access":false,"white_label":false,"priority_support":true,"xp":true,"levels":true,"streaks":true}'::jsonb,
+  '{"leaderboard":true,"achievements":true,"store":true,"certificates":"custom","analytics":"advanced","ai_grading":true,"custom_branding":true,"custom_domain":true,"api_access":false,"white_label":false,"priority_support":true,"community":true,"xp":true,"levels":true,"streaks":true}'::jsonb,
   '{"max_courses":-1,"max_students":5000}'::jsonb
 ),
 (
   'enterprise', 'Enterprise', 'Unlimited everything with white-label and API access',
   199, 1990, 0, 4,
-  '{"leaderboard":true,"achievements":true,"store":true,"certificates":"custom","analytics":"advanced","ai_grading":true,"custom_branding":true,"custom_domain":true,"api_access":true,"white_label":true,"priority_support":true,"xp":true,"levels":true,"streaks":true}'::jsonb,
+  '{"leaderboard":true,"achievements":true,"store":true,"certificates":"custom","analytics":"advanced","ai_grading":true,"custom_branding":true,"custom_domain":true,"api_access":true,"white_label":true,"priority_support":true,"community":true,"xp":true,"levels":true,"streaks":true}'::jsonb,
   '{"max_courses":-1,"max_students":-1}'::jsonb
 )
-ON CONFLICT (slug) DO NOTHING;
+ON CONFLICT (slug) DO UPDATE SET
+  name = EXCLUDED.name,
+  description = EXCLUDED.description,
+  price_monthly = EXCLUDED.price_monthly,
+  price_yearly = EXCLUDED.price_yearly,
+  transaction_fee_percent = EXCLUDED.transaction_fee_percent,
+  sort_order = EXCLUDED.sort_order,
+  features = EXCLUDED.features,
+  limits = EXCLUDED.limits;
 
 
 -- ---------------------------------------------------------------------------
@@ -68,9 +80,12 @@ VALUES ('00000000-0000-0000-0000-000000000001', 'default', 'Default School', '#2
 ON CONFLICT (id) DO NOTHING;
 
 -- Code Academy — used for subdomain E2E tests (code-academy.lvh.me:3000)
+-- On 'enterprise' (full plan, all features unlocked) so it's the go-to tenant
+-- for testing gated features; Default School stays on 'free' (all gates
+-- active) so upgrade-nudge / locked-feature UX is also covered. See #291.
 INSERT INTO tenants (id, slug, name, primary_color, secondary_color, plan, status, billing_status)
-VALUES ('00000000-0000-0000-0000-000000000002', 'code-academy', 'Code Academy Pro', '#7c3aed', '#2563eb', 'pro', 'active', 'active')
-ON CONFLICT (id) DO NOTHING;
+VALUES ('00000000-0000-0000-0000-000000000002', 'code-academy', 'Code Academy Pro', '#7c3aed', '#2563eb', 'enterprise', 'active', 'active')
+ON CONFLICT (id) DO UPDATE SET plan = EXCLUDED.plan, billing_status = EXCLUDED.billing_status;
 
 
 -- ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Salvages two never-landed pieces of work from old WIP stashes:

- **Seed (`supabase/seed.sql`)** — per #291:
  - Adds the `community` feature flag to all five platform plans (free = `false`, starter+ = `true`). Without it, the community feature was inaccessible on every plan in a fresh local DB.
  - Switches the `platform_plans` seed to `ON CONFLICT DO UPDATE` so the seed is authoritative over the original billing migration's insert.
  - Bumps the Code Academy tenant `pro` → `enterprise` (all gates open, go-to tenant for testing gated features); Default School stays `free` to cover locked-feature/upgrade-nudge UX.
- **404 page (`app/[locale]/not-found.tsx`)** — redesigned page (animated 404, i18n via existing `errors.notFound.*` keys, Back to Dashboard / Go Home CTAs).

## Verification (local, after `supabase db reset`)
- DB: `platform_plans.features->>'community'` = false/true/true/true/true; tenants = code-academy → enterprise, default → free ✅
- Browser (Chrome): `/en/courses/999999` renders the new 404 with CTAs ✅
- Community gate: Default School student sees lock + "Upgrade to Starter $9/mo" nudge; Code Academy student (enterprise) gets the full community feed ✅

## QA script
1. `supabase db reset`
2. `PORT=3005 npm run dev`
3. Visit `http://default.lvh.me:3005/en/courses/999999` → new 404 page
4. Login `student@e2etest.com` → `/dashboard/student/community` → locked w/ upgrade nudge
5. Login `alice@student.com` on `code-academy.lvh.me:3005` → community feed accessible

## Notes
- Code Academy plan change (pro→enterprise) alters which feature gates E2E sees on that tenant — worth a P0 E2E pass before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012VBFCR4kdNaFd9SChWyT74