### PR TITLE
feat(#435): carry selected plan from /platform-pricing into create-school flow

### DIFF
--- a/app/[locale]/(public)/platform-pricing/pricing-display.tsx
+++ b/app/[locale]/(public)/platform-pricing/pricing-display.tsx
@@ -226,7 +226,14 @@ export function PlatformPricingDisplay({ plans }: { plans: PlanData[] }) {
                     </div>
 
                     {/* CTA */}
-                    <Link href="/create-school" className="block mb-7">
+                    <Link
+                      href={
+                        plan.slug === 'free'
+                          ? '/create-school'
+                          : `/create-school?plan=${plan.slug}&interval=${yearly ? 'yearly' : 'monthly'}`
+                      }
+                      className="block mb-7"
+                    >
                       <Button
                         className={cn(
                           'w-full h-12 rounded-xl font-bold text-sm transition-all duration-300',

--- a/app/[locale]/create-school/page.tsx
+++ b/app/[locale]/create-school/page.tsx
@@ -10,14 +10,21 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
   return buildPageMetadata({ title: t('createSchool.title'), description: t('createSchool.description'), path: '/create-school', locale })
 }
 
-export default async function CreateSchoolPage() {
+export default async function CreateSchoolPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ plan?: string; interval?: string }>
+}) {
   const user = await getSessionUser()
+  const { plan, interval } = await searchParams
 
   return (
     <div className="min-h-screen bg-[#0A0A0A] flex items-center justify-center p-4">
       <div className="w-full max-w-lg">
         <CreateSchoolFlow
           user={user ? { id: user.id, email: user.email || '' } : null}
+          plan={plan}
+          interval={interval === 'yearly' ? 'yearly' : interval === 'monthly' ? 'monthly' : undefined}
         />
       </div>
     </div>

--- a/app/[locale]/dashboard/admin/billing/upgrade/page.tsx
+++ b/app/[locale]/dashboard/admin/billing/upgrade/page.tsx
@@ -3,13 +3,27 @@ import { getTranslations } from 'next-intl/server'
 import { AdminBreadcrumb } from '@/components/admin/admin-breadcrumb'
 import { UpgradePageClient } from './upgrade-page-client'
 
-export default async function UpgradePage() {
+export default async function UpgradePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ plan?: string; interval?: string }>
+}) {
   const t = await getTranslations('dashboard.admin')
   const tBreadcrumbs = await getTranslations('dashboard.admin.breadcrumbs')
-  const [plans, status] = await Promise.all([
+  const [plans, status, { plan: planParam, interval: intervalParam }] = await Promise.all([
     getAvailablePlans(),
     getSubscriptionStatus(),
+    searchParams,
   ])
+
+  // Pre-select only a real, paid, non-current plan; ignore anything else.
+  const preselectedPlan = plans.some(
+    (p) => p.slug === planParam && p.slug !== 'free' && p.slug !== status.plan,
+  )
+    ? planParam
+    : undefined
+  const preselectedInterval =
+    intervalParam === 'yearly' || intervalParam === 'monthly' ? intervalParam : undefined
 
   return (
     <div className="space-y-6 p-6 lg:p-8" data-testid="upgrade-page">
@@ -30,6 +44,8 @@ export default async function UpgradePage() {
       <UpgradePageClient
         plans={plans}
         currentPlan={status.plan}
+        preselectedPlan={preselectedPlan}
+        preselectedInterval={preselectedInterval}
       />
     </div>
   )

--- a/app/[locale]/dashboard/admin/billing/upgrade/upgrade-page-client.tsx
+++ b/app/[locale]/dashboard/admin/billing/upgrade/upgrade-page-client.tsx
@@ -22,9 +22,11 @@ interface UpgradePageClientProps {
     limits: { max_courses: number; max_students: number }
   }>
   currentPlan: string
+  preselectedPlan?: string
+  preselectedInterval?: 'monthly' | 'yearly'
 }
 
-export function UpgradePageClient({ plans, currentPlan }: UpgradePageClientProps) {
+export function UpgradePageClient({ plans, currentPlan, preselectedPlan, preselectedInterval }: UpgradePageClientProps) {
   const router = useRouter()
   const locale = useLocale()
   const t = useTranslations('dashboard.admin.billing.upgrade')
@@ -100,6 +102,8 @@ export function UpgradePageClient({ plans, currentPlan }: UpgradePageClientProps
     <PlanComparisonTable
       plans={plans}
       currentPlan={currentPlan}
+      preselectedPlan={preselectedPlan}
+      initialInterval={preselectedInterval}
       onSelectPlan={handleSelectPlan}
       onManualTransfer={handleManualTransfer}
       loading={loading}

--- a/app/[locale]/onboarding/page.tsx
+++ b/app/[locale]/onboarding/page.tsx
@@ -4,8 +4,13 @@ import { redirect } from 'next/navigation'
 import { getTranslations } from 'next-intl/server'
 import OnboardingWizard from '@/components/onboarding/onboarding-wizard'
 
-export default async function OnboardingPage() {
+export default async function OnboardingPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ plan?: string; interval?: string }>
+}) {
   const t = await getTranslations('onboarding')
+  const { plan, interval } = await searchParams
 
   const supabase = await createClient()
   const user = await getSessionUser()
@@ -30,7 +35,17 @@ export default async function OnboardingPage() {
     .single()
 
   const role = tenantUser?.role || 'teacher'
-  const redirectTo = role === 'admin' ? '/dashboard/admin' : '/dashboard/teacher'
+  // Admins arriving from /platform-pricing with a paid plan choice continue to
+  // the upgrade page with that plan pre-selected instead of the plain dashboard.
+  const upgradeQuery = plan && plan !== 'free'
+    ? `?plan=${encodeURIComponent(plan)}${interval === 'yearly' || interval === 'monthly' ? `&interval=${interval}` : ''}`
+    : ''
+  const redirectTo =
+    role === 'admin'
+      ? upgradeQuery
+        ? `/dashboard/admin/billing/upgrade${upgradeQuery}`
+        : '/dashboard/admin'
+      : '/dashboard/teacher'
 
   if (profile?.onboarding_completed) {
     redirect(redirectTo)

--- a/components/admin/plan-comparison-table.tsx
+++ b/components/admin/plan-comparison-table.tsx
@@ -26,6 +26,8 @@ interface PlanComparisonTableProps {
   onManualTransfer?: (planId: string, interval: 'monthly' | 'yearly') => void
   loading?: boolean
   showActions?: boolean
+  preselectedPlan?: string
+  initialInterval?: 'monthly' | 'yearly'
 }
 
 const FEATURE_LABELS: Record<string, string> = {
@@ -74,8 +76,10 @@ export function PlanComparisonTable({
   onManualTransfer,
   loading = false,
   showActions = true,
+  preselectedPlan,
+  initialInterval,
 }: PlanComparisonTableProps) {
-  const [interval, setInterval] = useState<'monthly' | 'yearly'>('monthly')
+  const [interval, setInterval] = useState<'monthly' | 'yearly'>(initialInterval ?? 'monthly')
   const yearly = interval === 'yearly'
   const featureKeys = useMemo(
     () => FEATURE_KEYS.filter((key) => plans.some((plan) => plan.features[key] !== undefined)),
@@ -124,6 +128,7 @@ export function PlanComparisonTable({
       <div className="grid items-stretch gap-4 md:grid-cols-2 xl:grid-cols-3">
         {plans.map((plan) => {
           const isCurrent = plan.slug === currentPlan
+          const isPreselected = !isCurrent && plan.slug === preselectedPlan
           const isPopular = plan.slug === 'pro'
           const price = yearly ? plan.price_yearly : plan.price_monthly
           const monthlyEquivalent = yearly ? Math.round(plan.price_yearly / 12) : plan.price_monthly
@@ -138,8 +143,13 @@ export function PlanComparisonTable({
                 'relative flex flex-col overflow-visible',
                 isPopular && 'border-primary shadow-lg shadow-primary/10',
                 isCurrent && 'bg-muted/30',
+                isPreselected && 'border-primary ring-2 ring-primary shadow-lg shadow-primary/15',
               )}
+              data-preselected={isPreselected || undefined}
             >
+              {isPreselected && (
+                <Badge className="absolute -top-3 right-5 shadow-sm">Your selection</Badge>
+              )}
               {isPopular && (
                 <Badge className="absolute -top-3 left-5 gap-1.5 shadow-sm">
                   <IconSparkles className="size-3" />

--- a/components/tenant/create-school-flow.tsx
+++ b/components/tenant/create-school-flow.tsx
@@ -28,9 +28,15 @@ import {
 
 interface CreateSchoolFlowProps {
   user: { id: string; email: string } | null
+  plan?: string
+  interval?: 'monthly' | 'yearly'
 }
 
-export function CreateSchoolFlow({ user }: CreateSchoolFlowProps) {
+export function CreateSchoolFlow({ user, plan, interval }: CreateSchoolFlowProps) {
+  // Query string carrying the pricing-page plan choice through the flow ('' when no plan / free)
+  const planQuery = plan && plan !== 'free'
+    ? `?plan=${encodeURIComponent(plan)}${interval ? `&interval=${interval}` : ''}`
+    : ''
   const router = useRouter()
   const [step, setStep] = useState<'account' | 'school'>(user ? 'school' : 'account')
   const [loading, setLoading] = useState(false)
@@ -69,7 +75,7 @@ export function CreateSchoolFlow({ user }: CreateSchoolFlowProps) {
     const { error } = await supabase.auth.signInWithOAuth({
       provider: 'google',
       options: {
-        redirectTo: `${window.location.origin}/api/auth/callback?next=/create-school`,
+        redirectTo: `${window.location.origin}/api/auth/callback?next=${encodeURIComponent(`/create-school${planQuery}`)}`,
       },
     })
     if (error) {
@@ -161,13 +167,13 @@ export function CreateSchoolFlow({ user }: CreateSchoolFlowProps) {
 
       toast.success('School created! Setting up your dashboard...')
 
-      // Redirect to subdomain onboarding
+      // Redirect to subdomain onboarding, carrying the chosen plan (if any)
       const platformDomain = process.env.NEXT_PUBLIC_PLATFORM_DOMAIN
       if (platformDomain && platformDomain !== 'localhost') {
         const protocol = window.location.protocol
-        window.location.href = `${protocol}//${slug.trim()}.${platformDomain}/onboarding`
+        window.location.href = `${protocol}//${slug.trim()}.${platformDomain}/onboarding${planQuery}`
       } else {
-        router.push('/onboarding')
+        router.push(`/onboarding${planQuery}`)
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Something went wrong')
@@ -328,7 +334,7 @@ export function CreateSchoolFlow({ user }: CreateSchoolFlowProps) {
 
               <p className="text-center text-sm text-zinc-500">
                 Already have an account?{' '}
-                <Link href="/auth/login?redirectTo=/create-school" className="text-blue-400 hover:text-blue-300 underline underline-offset-4">
+                <Link href={`/auth/login?redirectTo=${encodeURIComponent(`/create-school${planQuery}`)}`} className="text-blue-400 hover:text-blue-300 underline underline-offset-4">
                   Log in
                 </Link>
               </p>
@@ -355,7 +361,7 @@ export function CreateSchoolFlow({ user }: CreateSchoolFlowProps) {
                 </p>
               </div>
               <div className="w-full pt-2 space-y-3">
-                <Link href="/auth/login?redirectTo=/create-school">
+                <Link href={`/auth/login?redirectTo=${encodeURIComponent(`/create-school${planQuery}`)}`}>
                   <Button className="w-full bg-blue-600 hover:bg-blue-500 text-white">
                     Go to Log in
                     <ArrowRight className="ml-2 w-4 h-4" />


### PR DESCRIPTION
## Description

Carries the plan selected on `/platform-pricing` all the way through school creation, so a new owner never has to re-pick their plan.

**Changes:**
- `pricing-display.tsx` — paid-plan CTAs now link `/create-school?plan=<slug>&interval=<monthly|yearly>` (from the card's slug and the pricing toggle). Free CTA and the bottom generic CTA stay plain `/create-school`.
- `create-school/page.tsx` — reads `plan`/`interval` searchParams and passes them to the flow.
- `create-school-flow.tsx` — new optional `plan`/`interval` props. The param survives the Google OAuth round-trip (`next=` param) and the "Log in" links, and rides the post-`create_school` redirect to `/onboarding?plan=...` (both the subdomain and same-host branches).
- `onboarding/page.tsx` — admins with a paid plan param get `redirectTo = /dashboard/admin/billing/upgrade?plan=<slug>&interval=<...>` instead of the plain dashboard (both the already-completed redirect and the wizard's finish target).
- `billing/upgrade/page.tsx` + `upgrade-page-client.tsx` + `plan-comparison-table.tsx` — the upgrade page validates the incoming slug against the fetched plans (must exist, not `free`, not the current plan), pre-sets the billing-interval toggle, and highlights the chosen plan card with a ring + "Your selection" badge (`data-preselected` for tests).

Invalid, `free`, or missing params are ignored everywhere — the default flow is byte-for-byte unchanged.

## Type of change

- [x] New feature

## Relationship

Closes #435 (sub-task of EPIC #432).

## Testing

- [x] `npx tsc --noEmit` — clean (no errors in changed files).
- [x] `npm run build` — passes.
- [x] Live end-to-end in local dev (lvh.me:3005): picked **Pro / Yearly** on `/platform-pricing` → `/create-school?plan=pro&interval=yearly` → created school "Pro Plan Flow Test" → redirect carried the param to `/onboarding?plan=pro&interval=yearly` → landed on `/dashboard/admin/billing/upgrade?plan=pro&interval=yearly` with the Yearly toggle pre-set and the Pro card highlighted "Your selection".
- [x] Verified via DOM inspection that only paid-plan CTAs carry params (free + nav + bottom CTA stay plain).

Note: an unrelated concurrent edit to `app/api/stripe/connect/route.ts` existed in the working tree during verification (another session's work); it is not part of this PR.

### QA verification steps

1. Open `/platform-pricing`, toggle **Yearly**, click **Get Started** on Pro → URL should be `/create-school?plan=pro&interval=yearly`.
2. Sign up (or be signed in) and create a school → after creation you are sent to `/onboarding?plan=pro&interval=yearly` on the new subdomain.
3. Finish (or having already finished) onboarding as the admin → you land on `/dashboard/admin/billing/upgrade?plan=pro&interval=yearly`: Yearly toggle active, Pro card ringed with a "Your selection" badge — no re-choosing needed.
4. Free path: click **Start Free** → plain `/create-school`, flow ends at `/dashboard/admin` as before.
5. Garbage param: visit `/dashboard/admin/billing/upgrade?plan=nonsense` → no card highlighted, defaults unchanged.

## Screenshots

Verification GIF of the full Pro/Yearly path follows in a PR comment.
