### PR TITLE
fix(#433): add GET handler to /api/stripe/connect (broken Connect entry)

### DIFF
--- a/app/api/stripe/connect/route.ts
+++ b/app/api/stripe/connect/route.ts
@@ -3,21 +3,25 @@ import { getStripe } from '@/lib/stripe'
 import { createClient } from '@/lib/supabase/server'
 import { getCurrentTenantId } from '@/lib/supabase/tenant'
 
+type ConnectLinkResult =
+  | { url: string }
+  | { error: string; status: number }
+
 /**
- * POST /api/stripe/connect
- * Creates a Stripe Connect account link for the current tenant admin.
+ * Shared logic for both handlers: auth → tenant → admin guard →
+ * find-or-create Stripe account → account link.
  */
-export async function POST(req: NextRequest) {
+async function createConnectLink(req: NextRequest): Promise<ConnectLinkResult> {
   const supabase = await createClient()
   const { data: { user } } = await supabase.auth.getUser()
 
   if (!user) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    return { error: 'Unauthorized', status: 401 }
   }
 
   const tenantId = await getCurrentTenantId()
   if (!tenantId) {
-    return NextResponse.json({ error: 'No tenant context' }, { status: 400 })
+    return { error: 'No tenant context', status: 400 }
   }
 
   // Verify user is tenant admin
@@ -29,7 +33,7 @@ export async function POST(req: NextRequest) {
     .single()
 
   if (tenantUser?.role !== 'admin') {
-    return NextResponse.json({ error: 'Only tenant admins can connect Stripe' }, { status: 403 })
+    return { error: 'Only tenant admins can connect Stripe', status: 403 }
   }
 
   // Check if tenant already has a Stripe account
@@ -66,5 +70,45 @@ export async function POST(req: NextRequest) {
     type: 'account_onboarding',
   })
 
-  return NextResponse.json({ url: accountLink.url })
+  return { url: accountLink.url }
+}
+
+/**
+ * POST /api/stripe/connect
+ * Returns the Stripe Connect onboarding link as JSON.
+ */
+export async function POST(req: NextRequest) {
+  const result = await createConnectLink(req)
+  if ('error' in result) {
+    return NextResponse.json({ error: result.error }, { status: result.status })
+  }
+  return NextResponse.json({ url: result.url })
+}
+
+/**
+ * GET /api/stripe/connect
+ * Browser-navigation entry point (used by plain links/window.location):
+ * redirects straight to the Stripe hosted onboarding link, or back to the
+ * monetization page with ?stripe=error on failure.
+ */
+export async function GET(req: NextRequest) {
+  let result: ConnectLinkResult
+  try {
+    result = await createConnectLink(req)
+  } catch (err) {
+    console.error('[stripe/connect] failed to create account link:', err)
+    result = { error: 'stripe_error', status: 500 }
+  }
+  if ('error' in result) {
+    // Build the origin from the Host header — behind the tenant proxy,
+    // req.nextUrl.origin resolves to the internal host (localhost) and the
+    // redirect would drop the tenant subdomain (and with it the session).
+    const host = req.headers.get('x-forwarded-host') ?? req.headers.get('host') ?? req.nextUrl.host
+    const proto = req.headers.get('x-forwarded-proto') ?? req.nextUrl.protocol.replace(':', '')
+    const back = new URL('/dashboard/admin/monetization', `${proto}://${host}`)
+    back.searchParams.set('stripe', 'error')
+    back.searchParams.set('reason', String(result.status))
+    return NextResponse.redirect(back)
+  }
+  return NextResponse.redirect(result.url)
 }


### PR DESCRIPTION
## Description

`/api/stripe/connect` only exported `POST`, but every caller invokes it as a plain GET navigation, so the Stripe Connect entry point returned **405 Method Not Allowed** from all of them:

- `components/onboarding/onboarding-wizard.tsx` — `window.location.href = '/api/stripe/connect'`
- `app/[locale]/dashboard/admin/monetization/page.tsx` — `<a href>` Connect button
- `app/[locale]/dashboard/teacher/revenue/page.tsx` — `<a href>` Connect button (third caller, not listed in the issue)

### Changes made

- Extracted the route logic into a shared `createConnectLink()` helper (auth → tenant → admin-role guard → find-or-create Stripe account → account link). Guard logic unchanged; POST keeps its `{ url }` JSON contract.
- Added a `GET` handler that runs the same helper and redirects the browser straight to the Stripe hosted onboarding link. No caller changes needed.
- On failure (unauthenticated, non-admin, missing tenant, Stripe API error) GET redirects back to `/dashboard/admin/monetization?stripe=error&reason=<status>` instead of dumping JSON into a navigated tab. Stripe errors are also logged server-side.
- The error redirect builds its origin from `x-forwarded-host`/`host` headers — behind the tenant proxy `req.nextUrl.origin` resolves to the internal host (localhost in dev), which dropped the tenant subdomain and the session.

**Type of change:** fix

Closes #433 (part of EPIC #432)

## Testing

- [x] `npm run build` — passes (type + lint check).
- [x] Live-verified on local dev (`default.lvh.me:3005`, admin `owner@e2etest.com`): GET `/api/stripe/connect` no longer 405s; it passes the auth + admin guard and calls the Stripe API. The dev Stripe test account has Connect disabled ("You can only create new accounts if you've signed up for Connect"), so Stripe returns 400 and the new error path correctly redirects back to `/dashboard/admin/monetization?stripe=error&reason=500` with the session intact. Reaching the actual Stripe hosted onboarding page requires a Connect-enabled Stripe account and should be confirmed in staging/production.
- [x] Verified `tenants.stripe_account_id` is only written after a successful Stripe account creation (unchanged logic, shared path).

### QA verification steps

1. Log in as a tenant admin and open **Dashboard → Admin → Monetization**.
2. Click **Connect Stripe**. Expected: browser navigates to Stripe hosted onboarding (no 405). On an account without Connect enabled you land back on the monetization page with `?stripe=error` instead.
3. Repeat from the onboarding wizard payment step — same expected behavior.
4. Complete Stripe onboarding (Connect-enabled account): you should return to `/dashboard/admin/settings?stripe=connected` and `tenants.stripe_account_id` should be set.
5. As a non-admin (e.g. teacher revenue page), clicking Connect should bounce back with `?stripe=error&reason=403` and create no Stripe account.

## Screenshots

**Before — Connect button navigates to a 405:**

![before monetization](https://raw.githubusercontent.com/guillermoscript/lms-front/master/docs/verification/issue-433-before-monetization.png?v=2)
![before 405](https://raw.githubusercontent.com/guillermoscript/lms-front/master/docs/verification/issue-433-before-405.png?v=2)

**After — flow recording (GET passes guards, calls Stripe, error path redirects back with `?stripe=error` because the dev Stripe account lacks Connect):**

![verification gif](https://raw.githubusercontent.com/guillermoscript/lms-front/master/docs/verification/issue-433-verification.gif?v=2)

Reviewer: please visually verify the flow above (and ideally the real Stripe hosted onboarding on a Connect-enabled account) before merging.
