### PR TITLE
feat(#436): leaner signup — drop confirm-password, async email verification

### DIFF
--- a/app/[locale]/dashboard/layout.tsx
+++ b/app/[locale]/dashboard/layout.tsx
@@ -7,6 +7,7 @@ import { ModeToggle } from "@/components/mode-toggle"
 import { UserNav } from "@/components/user-nav"
 import { LanguageSwitcher } from "@/components/language-switcher"
 import { GamificationHeaderCard } from "@/components/gamification/gamification-header-card"
+import { VerifyEmailBanner } from "@/components/shared/verify-email-banner"
 import type { Metadata } from "next"
 
 export const metadata: Metadata = {
@@ -39,6 +40,9 @@ export default async function DashboardLayout({
                         <UserNav user={user} />
                     </div>
                 </header>
+                {user?.email && !user.email_confirmed_at && (
+                    <VerifyEmailBanner email={user.email} />
+                )}
                 <div className="flex flex-1 flex-col">
                     {children}
                 </div>

--- a/app/actions/admin/invitations.ts
+++ b/app/actions/admin/invitations.ts
@@ -4,6 +4,7 @@ import { createClient } from '@/lib/supabase/server'
 import { createAdminClient } from '@/lib/supabase/admin'
 import {getCurrentTenantId, getCurrentUserId } from '@/lib/supabase/tenant'
 import { getUserRole } from '@/lib/supabase/get-user-role'
+import { isEmailVerified, EMAIL_NOT_VERIFIED_ERROR } from '@/lib/auth/require-verified-email'
 import { sendEmail } from '@/lib/email/send'
 import { invitationTemplate } from '@/lib/email/templates/invitation'
 import { revalidatePath } from 'next/cache'
@@ -24,6 +25,10 @@ export async function createInvitation({
   const userRole = await getUserRole()
   if (userRole !== 'admin') {
     return { success: false, error: 'Unauthorized' }
+  }
+
+  if (!(await isEmailVerified())) {
+    return { success: false, error: EMAIL_NOT_VERIFIED_ERROR }
   }
 
   const supabase = await createClient()

--- a/app/api/stripe/connect/route.ts
+++ b/app/api/stripe/connect/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getStripe } from '@/lib/stripe'
 import { createClient } from '@/lib/supabase/server'
 import { getCurrentTenantId } from '@/lib/supabase/tenant'
+import { EMAIL_NOT_VERIFIED_ERROR } from '@/lib/auth/require-verified-email'
 
 /**
  * POST /api/stripe/connect
@@ -13,6 +14,12 @@ export async function POST(req: NextRequest) {
 
   if (!user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  // Email verification is async at signup (issue #436), but payout setup
+  // requires a verified email.
+  if (!user.email_confirmed_at) {
+    return NextResponse.json({ error: EMAIL_NOT_VERIFIED_ERROR }, { status: 403 })
   }
 
   const tenantId = await getCurrentTenantId()

--- a/components/shared/verify-email-banner.tsx
+++ b/components/shared/verify-email-banner.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { useState } from 'react'
+import { useTranslations } from 'next-intl'
+import { toast } from 'sonner'
+import { IconMailExclamation, IconX } from '@tabler/icons-react'
+import { Button } from '@/components/ui/button'
+import { createClient } from '@/lib/supabase/client'
+
+interface VerifyEmailBannerProps {
+  email: string
+}
+
+export function VerifyEmailBanner({ email }: VerifyEmailBannerProps) {
+  const t = useTranslations('components.verifyEmailBanner')
+  const [dismissed, setDismissed] = useState(false)
+  const [sending, setSending] = useState(false)
+
+  if (dismissed) return null
+
+  const handleResend = async () => {
+    setSending(true)
+    const supabase = createClient()
+    const { error } = await supabase.auth.resend({
+      type: 'signup',
+      email,
+      options: {
+        emailRedirectTo: `${window.location.origin}/auth/confirm?next=/dashboard`,
+      },
+    })
+    setSending(false)
+    if (error) {
+      toast.error(error.message)
+    } else {
+      toast.success(t('resendSuccess'))
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-3 border-b border-yellow-500/50 bg-yellow-50 px-4 py-2.5 text-yellow-800 dark:bg-yellow-950/20 dark:text-yellow-200">
+      <IconMailExclamation className="h-5 w-5 shrink-0" />
+      <p className="flex-1 text-sm">
+        {t('message', { email })}{' '}
+        <span className="text-xs opacity-80">{t('gatedNote')}</span>
+      </p>
+      <Button variant="outline" size="sm" onClick={handleResend} disabled={sending}>
+        {sending ? t('resending') : t('resend')}
+      </Button>
+      <button
+        onClick={() => setDismissed(true)}
+        aria-label={t('dismiss')}
+        className="text-muted-foreground hover:text-foreground"
+      >
+        <IconX className="h-4 w-4" />
+      </button>
+    </div>
+  )
+}

--- a/components/sign-up-form.tsx
+++ b/components/sign-up-form.tsx
@@ -33,12 +33,10 @@ export function SignUpForm({ className, tenantId, ...props }: SignUpFormProps) {
   const t = useTranslations('auth.signup')
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
-  const [repeatPassword, setRepeatPassword] = useState('')
   const [error, setError] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(false)
   const [isSocialLoading, setIsSocialLoading] = useState(false)
   const [showPassword, setShowPassword] = useState(false)
-  const [showRepeatPassword, setShowRepeatPassword] = useState(false)
   const router = useRouter()
   const searchParams = useSearchParams()
   const nextPath = getSafeNextPath(searchParams.get('next'), '')
@@ -48,12 +46,6 @@ export function SignUpForm({ className, tenantId, ...props }: SignUpFormProps) {
     const supabase = createClient()
     setIsLoading(true)
     setError(null)
-
-    if (password !== repeatPassword) {
-      setError(t('errors.passwordsDontMatch'))
-      setIsLoading(false)
-      return
-    }
 
     try {
       await supabase.auth.signOut({ scope: 'local' })
@@ -173,6 +165,7 @@ export function SignUpForm({ className, tenantId, ...props }: SignUpFormProps) {
                     data-testid="signup-password"
                     type={showPassword ? 'text' : 'password'}
                     required
+                    minLength={6}
                     value={password}
                     onChange={(e) => setPassword(e.target.value)}
                   />
@@ -183,30 +176,6 @@ export function SignUpForm({ className, tenantId, ...props }: SignUpFormProps) {
                       aria-label={showPassword ? 'Hide password' : 'Show password'}
                     >
                       {showPassword ? <EyeOff /> : <Eye />}
-                    </InputGroupButton>
-                  </InputGroupAddon>
-                </InputGroup>
-              </div>
-              <div className="grid gap-2">
-                <div className="flex items-center">
-                  <Label htmlFor="repeat-password">{t('repeatPassword')}</Label>
-                </div>
-                <InputGroup>
-                  <InputGroupInput
-                    id="repeat-password"
-                    data-testid="signup-repeat-password"
-                    type={showRepeatPassword ? 'text' : 'password'}
-                    required
-                    value={repeatPassword}
-                    onChange={(e) => setRepeatPassword(e.target.value)}
-                  />
-                  <InputGroupAddon align="inline-end">
-                    <InputGroupButton
-                      size="icon-xs"
-                      onClick={() => setShowRepeatPassword(!showRepeatPassword)}
-                      aria-label={showRepeatPassword ? 'Hide password' : 'Show password'}
-                    >
-                      {showRepeatPassword ? <EyeOff /> : <Eye />}
                     </InputGroupButton>
                   </InputGroupAddon>
                 </InputGroup>

--- a/components/tenant/create-school-flow.tsx
+++ b/components/tenant/create-school-flow.tsx
@@ -41,9 +41,7 @@ export function CreateSchoolFlow({ user }: CreateSchoolFlowProps) {
   // Account state
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
-  const [confirmPassword, setConfirmPassword] = useState('')
   const [showPassword, setShowPassword] = useState(false)
-  const [showConfirmPassword, setShowConfirmPassword] = useState(false)
 
   // School state
   const [schoolName, setSchoolName] = useState('')
@@ -82,10 +80,6 @@ export function CreateSchoolFlow({ user }: CreateSchoolFlowProps) {
     e.preventDefault()
     setError(null)
 
-    if (password !== confirmPassword) {
-      setError('Passwords do not match')
-      return
-    }
     if (password.length < 6) {
       setError('Password must be at least 6 characters')
       return
@@ -94,10 +88,15 @@ export function CreateSchoolFlow({ user }: CreateSchoolFlowProps) {
     setLoading(true)
     const supabase = createClient()
 
-    // Sign up
-    const { error: signUpError } = await supabase.auth.signUp({
+    // Sign up. Email verification is async: if Supabase returns a session
+    // (auto-confirm or confirmation-optional config) we continue immediately
+    // and the dashboard shows a "verify your email" banner until confirmed.
+    const { data: signUpData, error: signUpError } = await supabase.auth.signUp({
       email: email.trim(),
       password,
+      options: {
+        emailRedirectTo: `${window.location.origin}/auth/confirm?next=/create-school`,
+      },
     })
 
     if (signUpError) {
@@ -110,16 +109,21 @@ export function CreateSchoolFlow({ user }: CreateSchoolFlowProps) {
       return
     }
 
-    // Sign in immediately
-    const { error: signInError } = await supabase.auth.signInWithPassword({
-      email: email.trim(),
-      password,
-    })
+    if (!signUpData.session) {
+      // Sign-up may not return a session when the email already exists
+      // (Supabase obfuscation) — a direct sign-in still works there.
+      const { error: signInError } = await supabase.auth.signInWithPassword({
+        email: email.trim(),
+        password,
+      })
 
-    if (signInError) {
-      setEmailConfirmationNeeded(true)
-      setLoading(false)
-      return
+      if (signInError) {
+        // Supabase strictly requires email confirmation before any session
+        // exists — the check-your-email fallback is unavoidable here.
+        setEmailConfirmationNeeded(true)
+        setLoading(false)
+        return
+      }
     }
 
     // Success — advance to school step
@@ -275,32 +279,6 @@ export function CreateSchoolFlow({ user }: CreateSchoolFlowProps) {
                       aria-label={showPassword ? 'Hide password' : 'Show password'}
                     >
                       {showPassword ? <EyeOff /> : <Eye />}
-                    </InputGroupButton>
-                  </InputGroupAddon>
-                </InputGroup>
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="confirm-password" className="text-zinc-300">Confirm Password</Label>
-                <InputGroup>
-                  <InputGroupInput
-                    id="confirm-password"
-                    type={showConfirmPassword ? 'text' : 'password'}
-                    value={confirmPassword}
-                    onChange={(e) => setConfirmPassword(e.target.value)}
-                    placeholder="Repeat your password"
-                    className="bg-zinc-800 border-zinc-700 text-white"
-                    required
-                    disabled={loading}
-                    minLength={6}
-                  />
-                  <InputGroupAddon align="inline-end">
-                    <InputGroupButton
-                      size="icon-xs"
-                      onClick={() => setShowConfirmPassword(!showConfirmPassword)}
-                      aria-label={showConfirmPassword ? 'Hide password' : 'Show password'}
-                    >
-                      {showConfirmPassword ? <EyeOff /> : <Eye />}
                     </InputGroupButton>
                   </InputGroupAddon>
                 </InputGroup>

--- a/lib/auth/require-verified-email.ts
+++ b/lib/auth/require-verified-email.ts
@@ -1,0 +1,15 @@
+import { createClient } from '@/lib/supabase/server'
+
+export const EMAIL_NOT_VERIFIED_ERROR =
+  'Please verify your email address to use this feature. Check your inbox for the confirmation link.'
+
+/**
+ * Whether the current user's email is confirmed. Email verification is async
+ * (issue #436): signup never blocks on it, but sensitive actions — sending
+ * invitations, connecting Stripe payouts — require a verified email.
+ */
+export async function isEmailVerified(): Promise<boolean> {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  return Boolean(user?.email_confirmed_at)
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -3342,6 +3342,14 @@
     "ago": "ago"
   },
   "components": {
+    "verifyEmailBanner": {
+      "message": "Verify your email — we sent a confirmation link to {email}.",
+      "gatedNote": "Sending invitations and payout setup are locked until verified.",
+      "resend": "Resend email",
+      "resending": "Sending...",
+      "resendSuccess": "Confirmation email sent. Check your inbox.",
+      "dismiss": "Dismiss"
+    },
     "connectClaude": {
       "title": "Connect Claude",
       "description": "Add the LMS as a custom connector — no token needed, you sign in with your LMS account.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -3187,6 +3187,14 @@
     "ago": "atrás"
   },
   "components": {
+    "verifyEmailBanner": {
+      "message": "Verifica tu correo — enviamos un enlace de confirmación a {email}.",
+      "gatedNote": "Las invitaciones y la configuración de pagos quedan bloqueadas hasta verificar.",
+      "resend": "Reenviar correo",
+      "resending": "Enviando...",
+      "resendSuccess": "Correo de confirmación enviado. Revisa tu bandeja.",
+      "dismiss": "Descartar"
+    },
     "connectClaude": {
       "title": "Conectar Claude",
       "description": "Agrega el LMS como conector personalizado — sin tokens, inicias sesión con tu cuenta del LMS.",

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Description

Part of EPIC #432. Removes two pieces of signup friction:

1. **Confirm-password fields dropped** from both signup surfaces — the create-school flow (`components/tenant/create-school-flow.tsx`) and the general `/auth/sign-up` page (`components/sign-up-form.tsx`). Min-length validation (6 chars) and the show-password toggle stay.
2. **Email verification is now async** — the create-school flow no longer bounces users to a "Check your email" wall. It uses the session returned by `signUp` directly (dropping the redundant `signInWithPassword` call) and advances straight to the school step. The check-your-email card remains only as an unavoidable fallback when Supabase is configured to withhold sessions entirely until confirmation.

Verification moves to the dashboard:

- New `VerifyEmailBanner` (`components/shared/verify-email-banner.tsx`), rendered from the shared dashboard layout whenever the session's `email_confirmed_at` is null. Persistent (session-dismissible, reappears on reload), with a working "Resend email" button (`supabase.auth.resend`). Localized en/es.
- **Gating**: only sensitive actions require a verified email — sending invitations (`app/actions/admin/invitations.ts`) and Stripe Connect payout onboarding (`app/api/stripe/connect/route.ts`), via the new `lib/auth/require-verified-email.ts` helper. School creation and course building are never gated.
- Google OAuth path untouched.

## Type of change

Feature / UX improvement.

Closes #436

## Testing

- [x] `npm run build` — passes (TypeScript + lint).
- [x] Full create-school flow exercised live (fresh email → account step with single password field → school step → school created → onboarding), no wall, no interstitial.
- [x] `/auth/sign-up` renders with a single password field.
- [x] Banner verified against a real unverified session state: banner shows on the dashboard, "Resend email" fires and toasts success.
- [x] Confirmed no E2E tests reference the removed `signup-repeat-password` test id.

### QA verification steps

1. Sign out, go to `/create-school`. The account step should show Email + one Password field (with eye toggle), no "Confirm Password".
2. Sign up with a fresh email — you should land directly on the "School" step ("Signed in as …" chip), with no "Check your email" screen.
3. Name the school and create it — you should reach onboarding/dashboard without ever leaving the flow.
4. To see the banner locally (local Supabase auto-confirms): the dashboard banner renders whenever the session user has `email_confirmed_at = null`. In a deployment with email confirmation enabled but sessions allowed, it appears automatically after signup and disappears once the link is clicked.
5. As an unverified admin, sending an invitation or hitting `POST /api/stripe/connect` returns "Please verify your email address to use this feature."

Note: with strict "confirm before session" Supabase config, GoTrue refuses to create any session for unconfirmed users (verified live: login returns "Email not confirmed") — in that config the fallback check-email card is shown; this is a Supabase-side limit, not a flow regression.

## Screenshots

Before/after screenshots and a verification GIF follow in a PR comment.
