### PR TITLE
feat(#440): one-screen quick product creation (title + price + publish)

### DIFF
--- a/app/[locale]/dashboard/admin/products/new/page.tsx
+++ b/app/[locale]/dashboard/admin/products/new/page.tsx
@@ -3,19 +3,61 @@ import { createAdminClient } from '@/lib/supabase/admin'
 import { getTranslations } from 'next-intl/server'
 import { AdminBreadcrumb } from '@/components/admin/admin-breadcrumb'
 import { ProductCreationWizard } from '@/components/admin/product-creation-wizard'
+import { QuickProductCreate } from '@/components/admin/quick-product-create'
 import { getEnabledPaymentProviders } from '@/app/actions/admin/settings'
+import { checkCourseLimit } from '@/app/actions/teacher/courses'
 import { getCurrentTenantId, getCurrentUserId } from '@/lib/supabase/tenant'
 
-export default async function NewProductPage() {
+export default async function NewProductPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ advanced?: string }>
+}) {
   const t = await getTranslations('dashboard.admin.products.new')
   const tBreadcrumbs = await getTranslations('dashboard.admin.breadcrumbs')
-  const supabase = createAdminClient()
 
   const userId = await getCurrentUserId()
   if (!userId) {
     redirect('/auth/login')
   }
 
+  const { advanced } = await searchParams
+  const showAdvanced = advanced === '1'
+
+  const breadcrumb = (
+    <AdminBreadcrumb
+      items={[
+        { label: tBreadcrumbs('admin'), href: '/dashboard/admin' },
+        { label: tBreadcrumbs('monetization'), href: '/dashboard/admin/monetization' },
+        { label: tBreadcrumbs('products'), href: '/dashboard/admin/products' },
+        { label: tBreadcrumbs('newProduct') },
+      ]}
+    />
+  )
+
+  if (!showAdvanced) {
+    const limitInfo = await checkCourseLimit()
+
+    return (
+      <div className="min-h-screen bg-background">
+        <header className="border-b bg-card">
+          <div className="mx-auto max-w-6xl px-4 py-6 sm:px-6 lg:px-8">
+            <div className="mb-4">{breadcrumb}</div>
+            <div>
+              <h1 className="text-2xl font-bold md:text-3xl">{t('title')}</h1>
+              <p className="mt-1 text-muted-foreground">{t('description')}</p>
+            </div>
+          </div>
+        </header>
+
+        <main className="mx-auto max-w-6xl px-4 py-8 sm:px-6 lg:px-8">
+          <QuickProductCreate limitInfo={limitInfo} />
+        </main>
+      </div>
+    )
+  }
+
+  const supabase = createAdminClient()
   const tenantId = await getCurrentTenantId()
 
   const [{ data: courses }, { data: categories }] = await Promise.all([
@@ -38,16 +80,7 @@ export default async function NewProductPage() {
       {/* Header */}
       <header className="border-b bg-card">
         <div className="mx-auto max-w-6xl px-4 py-6 sm:px-6 lg:px-8">
-          <div className="mb-4">
-            <AdminBreadcrumb
-              items={[
-                { label: tBreadcrumbs('admin'), href: '/dashboard/admin' },
-                { label: tBreadcrumbs('monetization'), href: '/dashboard/admin/monetization' },
-                { label: tBreadcrumbs('products'), href: '/dashboard/admin/products' },
-                { label: tBreadcrumbs('newProduct') },
-              ]}
-            />
-          </div>
+          <div className="mb-4">{breadcrumb}</div>
           <div>
             <h1 className="text-2xl font-bold md:text-3xl">{t('title')}</h1>
             <p className="mt-1 text-muted-foreground">

--- a/components/admin/quick-product-create.tsx
+++ b/components/admin/quick-product-create.tsx
@@ -1,0 +1,235 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { useTranslations } from 'next-intl'
+import { toast } from 'sonner'
+import { IconAlertTriangle, IconArrowRight } from '@tabler/icons-react'
+import { saveProductCreationWizard } from '@/app/actions/admin/products'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import {
+  Field,
+  FieldContent,
+  FieldGroup,
+  FieldLabel,
+} from '@/components/ui/field'
+import { Input } from '@/components/ui/input'
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
+import { cn } from '@/lib/utils'
+import type { PricingMode, SaveIntent } from '@/lib/admin/product-creation/types'
+
+export interface CourseLimitInfo {
+  canCreate: boolean
+  currentCount: number
+  limit: number
+  plan: string
+  approaching?: boolean
+  nextPlan?: string
+}
+
+interface QuickProductCreateProps {
+  limitInfo: CourseLimitInfo
+  className?: string
+}
+
+/**
+ * One-screen quick-create: title + free/paid + price + publish.
+ * Everything else (category, thumbnail, after-purchase steps, provider choice)
+ * is deferred with defaults — the full wizard stays at ?advanced=1.
+ */
+export function QuickProductCreate({ limitInfo, className }: QuickProductCreateProps) {
+  const t = useTranslations('dashboard.admin.products.new.quick')
+  const router = useRouter()
+  const [title, setTitle] = useState('')
+  const [pricingMode, setPricingMode] = useState<PricingMode>('free')
+  const [price, setPrice] = useState('')
+  const [saving, setSaving] = useState<SaveIntent | null>(null)
+
+  const priceValue = Number.parseFloat(price)
+  const canPublish =
+    title.trim().length > 0 &&
+    (pricingMode === 'free' || (Number.isFinite(priceValue) && priceValue > 0))
+
+  const handleSave = async (intent: SaveIntent) => {
+    if (saving) return
+    setSaving(intent)
+    try {
+      const result = await saveProductCreationWizard({
+        intent,
+        course: {
+          sourceMode: 'new',
+          title: title.trim(),
+          description: '',
+          thumbnailUrl: '',
+          categoryId: null,
+        },
+        pricing:
+          pricingMode === 'free'
+            ? { mode: 'free' }
+            : {
+                mode: 'paid',
+                price: priceValue,
+                currency: 'usd',
+                paymentProvider: 'manual',
+              },
+        postRegistrationSteps: [],
+      })
+
+      if (!result.success) {
+        toast.error(result.error || t('saveError'))
+        return
+      }
+
+      toast.success(intent === 'publish' ? t('published') : t('draftSaved'))
+      router.push('/dashboard/admin/products')
+      router.refresh()
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : t('saveError'))
+    } finally {
+      setSaving(null)
+    }
+  }
+
+  const atLimit = !limitInfo.canCreate
+
+  return (
+    <div className={cn('mx-auto w-full max-w-xl space-y-4', className)}>
+      {atLimit ? (
+        <Alert variant="destructive">
+          <IconAlertTriangle className="size-4" />
+          <AlertTitle>{t('limitReachedTitle')}</AlertTitle>
+          <AlertDescription>
+            {t('limitReachedDescription', {
+              count: limitInfo.currentCount,
+              limit: limitInfo.limit,
+              plan: limitInfo.plan,
+            })}{' '}
+            <Link href="/dashboard/admin/billing" className="font-medium underline">
+              {t('upgradeCta')}
+            </Link>
+          </AlertDescription>
+        </Alert>
+      ) : limitInfo.approaching ? (
+        <Alert>
+          <IconAlertTriangle className="size-4" />
+          <AlertDescription>
+            {t('limitApproaching', {
+              count: limitInfo.currentCount,
+              limit: limitInfo.limit,
+            })}
+          </AlertDescription>
+        </Alert>
+      ) : null}
+
+      <Card>
+        <CardHeader>
+          <CardTitle>{t('title')}</CardTitle>
+          <CardDescription>{t('description')}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <FieldGroup className="space-y-6">
+            <Field>
+              <FieldLabel htmlFor="quick-title">{t('courseTitleLabel')}</FieldLabel>
+              <FieldContent>
+                <Input
+                  id="quick-title"
+                  value={title}
+                  onChange={(e) => setTitle(e.target.value)}
+                  placeholder={t('courseTitlePlaceholder')}
+                  disabled={atLimit}
+                  maxLength={200}
+                />
+              </FieldContent>
+            </Field>
+
+            <Field>
+              <FieldLabel>{t('pricingLabel')}</FieldLabel>
+              <FieldContent>
+                <RadioGroup
+                  value={pricingMode}
+                  onValueChange={(value) => setPricingMode(value as PricingMode)}
+                  className="grid grid-cols-2 gap-3"
+                >
+                  {(['free', 'paid'] as const).map((mode) => (
+                    <label
+                      key={mode}
+                      onClick={() => !atLimit && setPricingMode(mode)}
+                      className={cn(
+                        'flex cursor-pointer items-center gap-2 rounded-lg border p-3 text-sm',
+                        pricingMode === mode && 'border-primary bg-primary/5'
+                      )}
+                    >
+                      <RadioGroupItem value={mode} disabled={atLimit} />
+                      {t(mode)}
+                    </label>
+                  ))}
+                </RadioGroup>
+              </FieldContent>
+            </Field>
+
+            {pricingMode === 'paid' && (
+              <Field>
+                <FieldLabel htmlFor="quick-price">{t('priceLabel')}</FieldLabel>
+                <FieldContent>
+                  <div className="relative">
+                    <span className="absolute inset-y-0 left-3 flex items-center text-sm text-muted-foreground">
+                      $
+                    </span>
+                    <Input
+                      id="quick-price"
+                      type="number"
+                      min="0.5"
+                      step="0.01"
+                      inputMode="decimal"
+                      value={price}
+                      onChange={(e) => setPrice(e.target.value)}
+                      placeholder="19.99"
+                      className="pl-7"
+                      disabled={atLimit}
+                    />
+                  </div>
+                  <p className="mt-1 text-xs text-muted-foreground">{t('priceHint')}</p>
+                </FieldContent>
+              </Field>
+            )}
+          </FieldGroup>
+        </CardContent>
+        <CardFooter className="flex flex-col gap-3">
+          <div className="flex w-full gap-3">
+            <Button
+              className="flex-1"
+              onClick={() => handleSave('publish')}
+              disabled={atLimit || !canPublish || saving !== null}
+            >
+              {saving === 'publish' ? t('publishing') : t('publish')}
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => handleSave('draft')}
+              disabled={atLimit || title.trim().length === 0 || saving !== null}
+            >
+              {saving === 'draft' ? t('savingDraft') : t('saveDraft')}
+            </Button>
+          </div>
+          <Link
+            href="/dashboard/admin/products/new?advanced=1"
+            className="inline-flex items-center gap-1 text-sm text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+          >
+            {t('moreOptions')}
+            <IconArrowRight className="size-3.5" />
+          </Link>
+        </CardFooter>
+      </Card>
+    </div>
+  )
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -2835,6 +2835,29 @@
           "details": {
             "title": "Product Details",
             "description": "Set up a one-time product. How payment is handled depends on the payment method you choose below. Link courses to create bundles."
+          },
+          "quick": {
+            "title": "Quick create",
+            "description": "Name your course, pick a price, publish. You can add details later.",
+            "courseTitleLabel": "Course title",
+            "courseTitlePlaceholder": "e.g. Intro to Photography",
+            "pricingLabel": "Pricing",
+            "free": "Free",
+            "paid": "Paid",
+            "priceLabel": "Price (USD)",
+            "priceHint": "Payments are collected manually by default. Configure other providers in Settings → Payments.",
+            "publish": "Create & publish",
+            "publishing": "Publishing…",
+            "saveDraft": "Save as draft",
+            "savingDraft": "Saving…",
+            "published": "Course published.",
+            "draftSaved": "Draft saved.",
+            "saveError": "Could not create the course. Try again.",
+            "moreOptions": "More options (categories, thumbnail, providers, after-purchase steps)",
+            "limitReachedTitle": "Course limit reached",
+            "limitReachedDescription": "Your {plan} plan allows {limit} courses and you already have {count}.",
+            "upgradeCta": "Upgrade your plan",
+            "limitApproaching": "You are using {count} of {limit} courses on your plan."
           }
         },
         "edit": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -2657,6 +2657,29 @@
           "details": {
             "title": "Detalles del Producto",
             "description": "Configura un producto de pago único. La forma de cobro depende del método de pago que elijas. Vincula cursos para crear paquetes."
+          },
+          "quick": {
+            "title": "Creación rápida",
+            "description": "Nombra tu curso, elige un precio y publica. Puedes agregar detalles después.",
+            "courseTitleLabel": "Título del curso",
+            "courseTitlePlaceholder": "p. ej. Introducción a la fotografía",
+            "pricingLabel": "Precio",
+            "free": "Gratis",
+            "paid": "De pago",
+            "priceLabel": "Precio (USD)",
+            "priceHint": "Los pagos se cobran manualmente por defecto. Configura otros proveedores en Configuración → Pagos.",
+            "publish": "Crear y publicar",
+            "publishing": "Publicando…",
+            "saveDraft": "Guardar borrador",
+            "savingDraft": "Guardando…",
+            "published": "Curso publicado.",
+            "draftSaved": "Borrador guardado.",
+            "saveError": "No se pudo crear el curso. Inténtalo de nuevo.",
+            "moreOptions": "Más opciones (categorías, miniatura, proveedores, pasos post-compra)",
+            "limitReachedTitle": "Límite de cursos alcanzado",
+            "limitReachedDescription": "Tu plan {plan} permite {limit} cursos y ya tienes {count}.",
+            "upgradeCta": "Mejora tu plan",
+            "limitApproaching": "Estás usando {count} de {limit} cursos de tu plan."
           }
         },
         "edit": {


### PR DESCRIPTION
## Description

Adds a one-screen quick-create path for products, closing the gap between the heavy 5-step wizard and the "title + price + publish" flow competitors ship. Part of onboarding EPIC #432.

- **`components/admin/quick-product-create.tsx` (new)** — single card with course title, free/paid toggle, price input (paid only), **Create & publish** primary button and a **Save as draft** secondary. Submits the existing `saveProductCreationWizard` server action with `sourceMode: 'new'`, provider auto-picked as `manual` (per the payments-off-critical-path decision), currency `usd`, and no category/thumbnail/after-purchase steps — all deferred with defaults. No new server action, no schema change.
- **`app/[locale]/dashboard/admin/products/new/page.tsx`** — quick-create is now the default view; the full `ProductCreationWizard` renders unchanged at `?advanced=1`, reachable via the "More options" link on the quick form. The page calls `checkCourseLimit()` server-side and surfaces the limit **above the form before typing**: a warning banner when approaching the plan limit, and a blocking alert with an upgrade link (form disabled) when the limit is reached.
- **i18n** — new `dashboard.admin.products.new.quick` namespace in `messages/en.json` and `messages/es.json`.

## Type of change

- [x] New feature

## Relationship

Closes #440

## Testing

- [x] `npm run build` — passes (TypeScript + lint).
- [x] Manual QA on local dev (`default.lvh.me:3005`, owner@e2etest.com): quick-created a paid course ("Guitarra desde cero", $25) — DB shows course `status='published'`, product `price=25.00 usd`, `payment_provider='manual'`, `status='active'`, and the `product_courses` link row.
- [x] `?advanced=1` renders the full 5-step wizard unchanged.

### QA verification steps

1. Log in as a school admin and go to **Monetization → Products → Create Product**.
2. You should see the **Quick create** card (not the 5-step wizard): course title, Free/Paid toggle, and (when Paid) a price field — 4 fields max.
3. Enter a title, select **Paid**, enter a price, click **Create & publish**. You should land on the products list with a "Course published." toast and see the new product with a MANUAL badge and 1 included course.
4. Repeat with **Free**: a published course is created with no product attached.
5. Click **More options** on the quick form → the original 5-step wizard loads (`?advanced=1`) and behaves exactly as before.
6. On a tenant at its plan's course limit, the quick form shows a "Course limit reached" alert with an upgrade link and disabled inputs — before any typing.

## Screenshots

Before/after screenshots and a verification GIF follow in a PR comment.
