### PR TITLE
fix(#459): guard against parallel-subscription double-billing

### DIFF
--- a/app/[locale]/(public)/checkout/actions.ts
+++ b/app/[locale]/(public)/checkout/actions.ts
@@ -6,6 +6,7 @@ import { getCurrentUserId, getCurrentTenantId } from '@/lib/supabase/tenant'
 import { headers } from 'next/headers';
 import { freeEnrollmentLimiter, getClientIp } from '@/lib/rate-limit';
 import { joinCurrentSchool } from '@/app/actions/join-school';
+import { findConflictingSubscription, PARALLEL_SUBSCRIPTION_MESSAGE } from '@/lib/payments/subscription-guard';
 
 /**
  * Mock checkout — creates a successful transaction.
@@ -80,6 +81,16 @@ export async function enrollUser(courseId?: string, planId?: string, paymentMeth
 
             if (planError || !plan) {
                 throw new Error("Plan not found.");
+            }
+
+            // Parallel-subscription guard (#459) — same-plan renewal passes.
+            const conflict = await findConflictingSubscription(supabase, {
+                userId,
+                tenantId,
+                planId: plan.plan_id,
+            });
+            if (conflict) {
+                throw new Error(PARALLEL_SUBSCRIPTION_MESSAGE);
             }
 
             // Create the transaction. The after_transaction_insert trigger
@@ -171,6 +182,18 @@ export async function subscribeFree(planId?: string) {
         }
         if (Number(plan.price) !== 0) {
             throw new Error("This plan is not free. Please use the paid checkout.");
+        }
+
+        // Parallel-subscription guard (#459): even a free plan must not run
+        // alongside a paid one — the paid plan keeps billing while the student
+        // believes they "switched". Same-plan re-activation passes.
+        const conflict = await findConflictingSubscription(supabase, {
+            userId,
+            tenantId,
+            planId: numericPlanId,
+        });
+        if (conflict) {
+            throw new Error(PARALLEL_SUBSCRIPTION_MESSAGE);
         }
 
         // Signup-while-subscribing: join the school first (same as enrollFree).

--- a/app/[locale]/(public)/checkout/page.tsx
+++ b/app/[locale]/(public)/checkout/page.tsx
@@ -8,6 +8,8 @@ import { Button } from "@/components/ui/button";
 import { getCurrentTenantId } from "@/lib/supabase/tenant";
 import { getSessionUser } from '@/lib/supabase/tenant'
 import { getSolanaSettlementOptions } from "@/app/actions/admin/settings";
+import { findConflictingSubscription } from "@/lib/payments/subscription-guard";
+import { SubscriptionConflictNotice } from "@/components/public/subscription-conflict-notice";
 
 interface SearchParams {
     courseId?: string;
@@ -125,6 +127,28 @@ export default async function CheckoutPage(props: { params: Promise<{ locale: st
             .single();
 
         if (dbPlan) {
+            // Parallel-subscription guard (#459): a live subscription to a
+            // different plan means this checkout would double-bill — show the
+            // blocking notice instead of any payment UI. Same-plan renewal
+            // falls through to the normal form.
+            const conflict = await findConflictingSubscription(supabase, {
+                userId: user.id,
+                tenantId,
+                planId: dbPlan.plan_id,
+            });
+            if (conflict) {
+                return (
+                    <div className="min-h-screen bg-background">
+                        <div className="mx-auto max-w-xl px-4 py-12 sm:py-20">
+                            <div className="mb-8 text-center">
+                                <h1 className="text-2xl font-bold tracking-tight">{t('title')}</h1>
+                            </div>
+                            <SubscriptionConflictNotice currentPlanName={conflict.plan_name} />
+                        </div>
+                    </div>
+                );
+            }
+
             title = dbPlan.plan_name;
             description = dbPlan.description;
             price = parseFloat(dbPlan.price);

--- a/app/[locale]/checkout/manual/page.tsx
+++ b/app/[locale]/checkout/manual/page.tsx
@@ -4,6 +4,8 @@ import { createClient } from '@/lib/supabase/server'
 import { getCurrentTenantId, getSessionUser } from '@/lib/supabase/tenant'
 import { PaymentRequestForm } from '@/components/student/payment-request-form'
 import { getManualPaymentInstructions } from '@/app/actions/admin/settings'
+import { findConflictingSubscription } from '@/lib/payments/subscription-guard'
+import { SubscriptionConflictNotice } from '@/components/public/subscription-conflict-notice'
 import { IconShieldCheck, IconLock } from '@tabler/icons-react'
 import type { Metadata } from 'next'
 
@@ -63,6 +65,24 @@ export default async function ManualCheckoutPage(props: {
 
     if (plan.payment_provider !== 'manual') {
       redirect(`/checkout?planId=${planId}`)
+    }
+
+    // Parallel-subscription guard (#459): block the manual request flow the
+    // same way the main checkout blocks — a different live plan would bill
+    // alongside this one. Same-plan renewal falls through.
+    const conflict = await findConflictingSubscription(supabase, {
+      userId: user.id,
+      tenantId,
+      planId: plan.plan_id,
+    })
+    if (conflict) {
+      return (
+        <div className="min-h-screen bg-background">
+          <div className="mx-auto max-w-xl px-4 py-12 sm:py-20">
+            <SubscriptionConflictNotice currentPlanName={conflict.plan_name} />
+          </div>
+        </div>
+      )
     }
 
     itemName = plan.plan_name

--- a/app/actions/payment-requests.ts
+++ b/app/actions/payment-requests.ts
@@ -5,6 +5,7 @@ import { createAdminClient } from '@/lib/supabase/admin'
 import {getCurrentTenantId, getCurrentUserId } from '@/lib/supabase/tenant'
 import { getUserRole, isSuperAdmin } from '@/lib/supabase/get-user-role'
 import { revalidatePath } from 'next/cache'
+import { findConflictingSubscription, PARALLEL_SUBSCRIPTION_MESSAGE } from '@/lib/payments/subscription-guard'
 
 export interface PaymentRequestFormData {
   productId?: number
@@ -141,6 +142,18 @@ export async function createPaymentRequest(data: PaymentRequestFormData) {
 
     if (!plan) {
       throw new Error('Plan not found')
+    }
+
+    // Parallel-subscription guard (#459): block the manual request up front so
+    // the student gets the warning before any admin back-and-forth. Same-plan
+    // renewal requests pass.
+    const conflict = await findConflictingSubscription(supabase, {
+      userId,
+      tenantId,
+      planId: plan.plan_id,
+    })
+    if (conflict) {
+      throw new Error(PARALLEL_SUBSCRIPTION_MESSAGE)
     }
 
     paymentAmount = parseFloat(plan.price)

--- a/app/api/payments/checkout/route.ts
+++ b/app/api/payments/checkout/route.ts
@@ -26,6 +26,11 @@ import type { CreateCheckoutParams, PaymentProvider } from '@/lib/payments/types
 import { getSolUsdPrice, usdToLamports } from '@/lib/payments/sol-price'
 import { getSolanaSettlementOptions } from '@/app/actions/admin/settings'
 import { paymentAuthLimiter } from '@/lib/rate-limit'
+import {
+  findConflictingSubscription,
+  PARALLEL_SUBSCRIPTION_CODE,
+  PARALLEL_SUBSCRIPTION_MESSAGE,
+} from '@/lib/payments/subscription-guard'
 
 // Providers whose checkout this route owns. Stripe + manual have their own paths.
 const HANDLED: PaymentProvider[] = ['lemonsqueezy', 'solana', 'solana_subs']
@@ -51,6 +56,24 @@ export async function POST(req: NextRequest) {
       await paymentAuthLimiter.check(10, user.id)
     } catch {
       return NextResponse.json({ error: 'Too many requests' }, { status: 429 })
+    }
+
+    // Parallel-subscription guard (#459): a different plan would create a
+    // second live subscription billing alongside the current one. Blocked
+    // before any pending transaction / provider session exists. Same-plan
+    // checkout (renewal) passes through.
+    if (planId) {
+      const conflict = await findConflictingSubscription(supabase, {
+        userId: user.id,
+        tenantId,
+        planId: Number(planId),
+      })
+      if (conflict) {
+        return NextResponse.json(
+          { error: PARALLEL_SUBSCRIPTION_MESSAGE, code: PARALLEL_SUBSCRIPTION_CODE },
+          { status: 409 },
+        )
+      }
     }
 
     // Resolve price + provider from the plan / product (tenant-scoped).

--- a/app/api/stripe/create-payment-intent/route.ts
+++ b/app/api/stripe/create-payment-intent/route.ts
@@ -4,6 +4,11 @@ import { createClient } from '@/lib/supabase/server'
 import { getCurrentTenantId } from '@/lib/supabase/tenant'
 import { toCents } from '@/lib/currency'
 import { getPaymentProvider } from '@/lib/payments'
+import {
+  findConflictingSubscription,
+  PARALLEL_SUBSCRIPTION_CODE,
+  PARALLEL_SUBSCRIPTION_MESSAGE,
+} from '@/lib/payments/subscription-guard'
 
 export async function POST(req: NextRequest) {
   try {
@@ -21,6 +26,22 @@ export async function POST(req: NextRequest) {
     const { data: { user }, error: authError } = await supabase.auth.getUser()
     if (authError || !user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    // Parallel-subscription guard (#459): block before any Stripe side effects
+    // (customer creation, subscription, PaymentIntent). Same-plan renewal passes.
+    if (planId) {
+      const conflict = await findConflictingSubscription(supabase, {
+        userId: user.id,
+        tenantId,
+        planId: Number(planId),
+      })
+      if (conflict) {
+        return NextResponse.json(
+          { error: PARALLEL_SUBSCRIPTION_MESSAGE, code: PARALLEL_SUBSCRIPTION_CODE },
+          { status: 409 },
+        )
+      }
     }
 
     // Get or create Stripe customer

--- a/components/public/subscription-conflict-notice.tsx
+++ b/components/public/subscription-conflict-notice.tsx
@@ -1,0 +1,45 @@
+import { getTranslations } from 'next-intl/server'
+import Link from 'next/link'
+import { IconAlertTriangle } from '@tabler/icons-react'
+import { Button } from '@/components/ui/button'
+
+/**
+ * Blocking notice shown in place of the checkout form when the student already
+ * has a live subscription to a different plan in this school (issue #459).
+ * Server component — rendered by the checkout pages before any payment UI.
+ */
+export async function SubscriptionConflictNotice({
+  currentPlanName,
+}: {
+  currentPlanName: string | null
+}) {
+  const t = await getTranslations('checkout.conflict')
+
+  return (
+    <div
+      className="rounded-xl border border-border bg-card px-6 py-10 text-center sm:px-10"
+      data-testid="subscription-conflict-notice"
+    >
+      <div className="mx-auto mb-5 flex h-14 w-14 items-center justify-center rounded-2xl bg-amber-500/10">
+        <IconAlertTriangle className="h-7 w-7 text-amber-600 dark:text-amber-400" />
+      </div>
+      <h2 className="text-lg font-semibold tracking-tight">{t('title')}</h2>
+      <p className="mx-auto mt-2 max-w-md text-sm leading-relaxed text-muted-foreground">
+        {currentPlanName
+          ? t('descriptionWithPlan', { planName: currentPlanName })
+          : t('description')}
+      </p>
+      <p className="mx-auto mt-2 max-w-md text-sm leading-relaxed text-muted-foreground">
+        {t('howToSwitch')}
+      </p>
+      <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
+        <Link href="/dashboard/student/billing">
+          <Button>{t('viewBilling')}</Button>
+        </Link>
+        <Link href="/dashboard/student/browse">
+          <Button variant="outline">{t('browseCourses')}</Button>
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/lib/payments/subscription-guard.ts
+++ b/lib/payments/subscription-guard.ts
@@ -1,0 +1,71 @@
+/**
+ * Parallel-subscription guard (issue #459).
+ *
+ * The `subscriptions` unique constraint is (user_id, plan_id), so checking out
+ * a *different* plan creates a second, parallel subscription — and for native
+ * providers, a second live provider subscription double-billing every cycle.
+ * Until a real plan-change flow exists (#463), every plan checkout entry point
+ * calls this guard before creating any transaction / provider session.
+ *
+ * Renewal-safe: re-purchasing a plan the user already holds is the renewal
+ * path (`handle_new_subscription` ON CONFLICT extends the period) and is never
+ * blocked — including for users who already hold parallel subscriptions from
+ * before this guard existed.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+/** Statuses that mean "this subscription still bills / grants access". */
+export const BLOCKING_SUBSCRIPTION_STATUSES = ['active', 'past_due']
+
+/** English fallback shown when an API path is hit directly; the checkout pages
+ * render a translated notice before the user ever reaches these routes. */
+export const PARALLEL_SUBSCRIPTION_MESSAGE =
+  'You already have an active plan. Contact your school to switch plans — subscribing to another plan would bill you for both.'
+
+export const PARALLEL_SUBSCRIPTION_CODE = 'parallel_subscription'
+
+export interface ConflictingSubscription {
+  subscription_id: number
+  plan_id: number
+  plan_name: string | null
+  end_date: string | null
+}
+
+/**
+ * Returns the subscription that would run in parallel with a checkout of
+ * `planId`, or null when the checkout is safe (no live subscription in this
+ * tenant, or the user already holds this exact plan — a renewal).
+ *
+ * Throws on query failure so callers fail closed (no checkout on unknown
+ * state) — the DB-level backstop in `handle_new_subscription` is the last
+ * line of defense, but it fires after money may have moved.
+ */
+export async function findConflictingSubscription(
+  supabase: SupabaseClient,
+  { userId, tenantId, planId }: { userId: string; tenantId: string; planId: number },
+): Promise<ConflictingSubscription | null> {
+  const { data, error } = await supabase
+    .from('subscriptions')
+    .select('subscription_id, plan_id, end_date, plan:plans(plan_name)')
+    .eq('user_id', userId)
+    .eq('tenant_id', tenantId)
+    .in('subscription_status', BLOCKING_SUBSCRIPTION_STATUSES)
+
+  if (error) {
+    throw new Error(`Could not verify existing subscriptions: ${error.message}`)
+  }
+  if (!data || data.length === 0) return null
+
+  // Holding the requested plan already → renewal, always allowed.
+  if (data.some((sub) => sub.plan_id === planId)) return null
+
+  const conflict = data[0]
+  const plan = conflict.plan as unknown as { plan_name: string | null } | null
+  return {
+    subscription_id: conflict.subscription_id,
+    plan_id: conflict.plan_id,
+    plan_name: plan?.plan_name ?? null,
+    end_date: conflict.end_date,
+  }
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -4116,6 +4116,14 @@
     "issuedBy": "Issued by LMS Platform"
   },
   "checkout": {
+    "conflict": {
+      "title": "You already have an active plan",
+      "descriptionWithPlan": "Your subscription to {planName} is still active. Subscribing to another plan would not replace it — you would be billed for both plans at the same time.",
+      "description": "You already have an active subscription in this school. Subscribing to another plan would not replace it — you would be billed for both plans at the same time.",
+      "howToSwitch": "To switch plans, contact your school and ask them to cancel your current plan first.",
+      "viewBilling": "View my billing",
+      "browseCourses": "Browse courses"
+    },
     "success": {
       "title": "You're all set!",
       "subtitle": "Your purchase was successful. You now have full access — enjoy the content.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -4109,6 +4109,14 @@
     "issuedBy": "Emitido por LMS Platform"
   },
   "checkout": {
+    "conflict": {
+      "title": "Ya tienes un plan activo",
+      "descriptionWithPlan": "Tu suscripción a {planName} sigue activa. Suscribirte a otro plan no la reemplazaría — se te cobrarían ambos planes al mismo tiempo.",
+      "description": "Ya tienes una suscripción activa en esta escuela. Suscribirte a otro plan no la reemplazaría — se te cobrarían ambos planes al mismo tiempo.",
+      "howToSwitch": "Para cambiar de plan, contacta a tu escuela y pide que cancelen tu plan actual primero.",
+      "viewBilling": "Ver mi facturación",
+      "browseCourses": "Explorar cursos"
+    },
     "success": {
       "title": "¡Todo listo!",
       "subtitle": "Tu compra fue exitosa. Ya tienes acceso completo — disfruta el contenido.",

--- a/supabase/migrations/20260719120000_guard_parallel_subscriptions.sql
+++ b/supabase/migrations/20260719120000_guard_parallel_subscriptions.sql
@@ -1,0 +1,106 @@
+-- Parallel-subscription guard, DB backstop (issue #459).
+--
+-- The subscriptions unique key is (user_id, plan_id), so a successful
+-- transaction for a *different* plan silently creates a second live
+-- subscription that bills alongside the first. Every checkout entry point now
+-- guards against this app-side (lib/payments/subscription-guard.ts); this
+-- migration adds the defense-in-depth backstop inside handle_new_subscription
+-- itself, covering any path that reaches the transaction trigger without
+-- passing an app guard.
+--
+-- Semantics (renewal-safe):
+--   * A row already exists for (user_id, plan_id) → renewal. Always allowed,
+--     even if the user holds other live subscriptions (pre-existing parallel
+--     subscribers keep renewing).
+--   * No row for this plan, but another 'active'/'past_due' subscription
+--     exists for the same (user_id, tenant) → RAISE. A loud, recoverable
+--     failure (the webhook/action errors, the transaction stays visible)
+--     beats a silent second billing cycle.
+--
+-- Body otherwise identical to 20260615140000_phase2_native_subscriptions.sql.
+
+CREATE OR REPLACE FUNCTION public.handle_new_subscription(
+  _user_id uuid,
+  _plan_id integer,
+  _transaction_id integer,
+  _start_date timestamp with time zone DEFAULT now()
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+    _duration INTERVAL;
+    _end_date TIMESTAMP WITH TIME ZONE;
+    _existing_end TIMESTAMP WITH TIME ZONE;
+    _is_renewal BOOLEAN;
+    _tenant_id UUID;
+    _subscription_id INTEGER;
+    _provider TEXT;
+    _provider_sub_id TEXT;
+    _rec RECORD;
+BEGIN
+    SELECT make_interval(days => p.duration_in_days), p.tenant_id INTO _duration, _tenant_id
+    FROM plans p WHERE p.plan_id = _plan_id;
+    IF _tenant_id IS NULL THEN
+        RAISE EXCEPTION 'Plan % not found', _plan_id;
+    END IF;
+
+    -- Provider info recorded on the transaction at checkout (native sub id).
+    SELECT t.payment_provider, t.provider_subscription_id
+      INTO _provider, _provider_sub_id
+    FROM transactions t WHERE t.transaction_id = _transaction_id;
+
+    SELECT end_date INTO _existing_end FROM subscriptions WHERE user_id = _user_id AND plan_id = _plan_id;
+    _is_renewal := FOUND;
+
+    -- Parallel-subscription backstop (#459): refuse to CREATE a subscription
+    -- while another live one exists for the same user + tenant. Renewals of an
+    -- existing row are exempt.
+    IF NOT _is_renewal THEN
+        PERFORM 1 FROM subscriptions s
+         WHERE s.user_id = _user_id
+           AND s.tenant_id = _tenant_id
+           AND s.plan_id <> _plan_id
+           AND s.subscription_status IN ('active', 'past_due');
+        IF FOUND THEN
+            RAISE EXCEPTION 'parallel_subscription: user % already has a live subscription in tenant %; refusing to create a second one for plan % (issue #459)',
+                _user_id, _tenant_id, _plan_id;
+        END IF;
+    END IF;
+
+    _end_date := GREATEST(COALESCE(_existing_end, _start_date), _start_date) + _duration;
+
+    INSERT INTO subscriptions (
+        user_id, plan_id, start_date, end_date, current_period_end, transaction_id,
+        subscription_status, tenant_id, payment_provider, provider_subscription_id
+    )
+    VALUES (
+        _user_id, _plan_id, _start_date, _end_date, _end_date, _transaction_id,
+        'active', _tenant_id, COALESCE(_provider, 'manual'), _provider_sub_id
+    )
+    ON CONFLICT (user_id, plan_id) DO UPDATE SET
+        end_date = EXCLUDED.end_date,
+        current_period_end = EXCLUDED.current_period_end,
+        transaction_id = EXCLUDED.transaction_id,
+        subscription_status = 'active',
+        tenant_id = EXCLUDED.tenant_id,
+        ended_at = NULL,
+        -- COALESCE so a manual/legacy transaction with NULL provider info never
+        -- wipes an existing native subscription id.
+        payment_provider = COALESCE(EXCLUDED.payment_provider, subscriptions.payment_provider),
+        provider_subscription_id = COALESCE(EXCLUDED.provider_subscription_id, subscriptions.provider_subscription_id)
+    RETURNING subscription_id INTO _subscription_id;
+
+    -- Grant access only. Enrollment is the student's explicit choice (self-enroll
+    -- via /browse), NOT auto-created here.
+    FOR _rec IN SELECT pc.course_id FROM plan_courses pc WHERE pc.plan_id = _plan_id
+    LOOP
+        INSERT INTO entitlements (user_id, course_id, tenant_id, source_type, source_id, status, expires_at)
+        VALUES (_user_id, _rec.course_id, _tenant_id, 'subscription', _subscription_id, 'active', _end_date)
+        ON CONFLICT (user_id, course_id, source_type, source_id) DO UPDATE SET
+            status = 'active', expires_at = EXCLUDED.expires_at, revoked_at = NULL, tenant_id = EXCLUDED.tenant_id;
+    END LOOP;
+END;
+$function$;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -573,6 +573,19 @@ VALUES
   'usd',
   'stripe',
   '00000000-0000-0000-0000-000000000002'
+),
+-- Second Code Academy plan: exercises the parallel-subscription guard (#459)
+-- in E2E — alice holds plan 2001, so checking out 2002 must be blocked.
+(
+  2002,
+  'Code Academy Pro Annual',
+  190.00,
+  365,
+  'Full access to all Code Academy Pro courses for a year.',
+  '["Unlimited course access","Certificate of completion","Priority support","Offline downloads","2 months free"]',
+  'usd',
+  'stripe',
+  '00000000-0000-0000-0000-000000000002'
 )
 ON CONFLICT (plan_id) DO NOTHING;
 

--- a/tests/playwright/parallel-subscription-guard.spec.ts
+++ b/tests/playwright/parallel-subscription-guard.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from '@playwright/test'
+import { loginAsTenantStudent } from './utils/auth'
+import { TENANT_BASE } from './utils/constants'
+
+/**
+ * P0 — Parallel-subscription double-billing guard (issue #459).
+ *
+ * Seeded state: alice@student.com holds an ACTIVE subscription to plan 2001
+ * (Code Academy Pro Monthly). Plan 2002 (Code Academy Pro Annual) exists in
+ * the same tenant. Checking out 2002 must be blocked everywhere; re-checking
+ * out 2001 (a renewal) must NOT be blocked.
+ */
+
+test.describe('Parallel-subscription guard', () => {
+  test('checkout page blocks a second plan with the conflict notice', async ({ page }) => {
+    await loginAsTenantStudent(page)
+    await page.goto(`${TENANT_BASE}/en/checkout?planId=2002`)
+    await expect(page.getByTestId('subscription-conflict-notice')).toBeVisible()
+    await expect(page.getByText(/Code Academy Pro Monthly/i)).toBeVisible()
+    // No payment UI of any kind behind the notice
+    await expect(page.getByText(/Pay & Enroll/i)).toHaveCount(0)
+  })
+
+  test('same-plan checkout (renewal) is not blocked', async ({ page }) => {
+    await loginAsTenantStudent(page)
+    await page.goto(`${TENANT_BASE}/en/checkout?planId=2001`)
+    await expect(page.getByTestId('subscription-conflict-notice')).toHaveCount(0)
+    // Normal checkout renders the order summary for the plan
+    await expect(page.getByText(/Code Academy Pro Monthly/i)).toBeVisible()
+  })
+
+  test('create-payment-intent API returns 409 for a second plan', async ({ page }) => {
+    await loginAsTenantStudent(page)
+    const res = await page.request.post(`${TENANT_BASE}/api/stripe/create-payment-intent`, {
+      data: { planId: 2002 },
+    })
+    expect(res.status()).toBe(409)
+    const body = await res.json()
+    expect(body.code).toBe('parallel_subscription')
+  })
+
+  test('unified payments checkout API returns 409 for a second plan', async ({ page }) => {
+    await loginAsTenantStudent(page)
+    const res = await page.request.post(`${TENANT_BASE}/api/payments/checkout`, {
+      data: { planId: 2002 },
+    })
+    expect(res.status()).toBe(409)
+    const body = await res.json()
+    expect(body.code).toBe('parallel_subscription')
+  })
+
+  test('same-plan API checkout is not treated as a conflict', async ({ page }) => {
+    await loginAsTenantStudent(page)
+    const res = await page.request.post(`${TENANT_BASE}/api/stripe/create-payment-intent`, {
+      data: { planId: 2001 },
+    })
+    // Locally the school has no Stripe account connected, so the request can
+    // fail further down the route — the guard specifically must not fire.
+    expect(res.status()).not.toBe(409)
+  })
+})


### PR DESCRIPTION
## Description

Part of #458 (Phase 1 — billing correctness). Closes #459.

The `subscriptions` unique key is `(user_id, plan_id)`, so `handle_new_subscription` upserts per-plan (`ON CONFLICT (user_id, plan_id)`). Checking out a **different** plan therefore created a second, parallel subscription row — and for native providers (Stripe, Lemon Squeezy, Solana subs) a second live provider subscription — billing the student for **both** every cycle. No checkout path warned, superseded, or cancelled.

This PR adds a **renewal-safe guard** at every plan-checkout entry point: block when the user already holds an `active`/`past_due` subscription to a *different* plan in the same tenant, and let same-plan checkout through (that's the renewal path, which extends the existing row). Full switch UX — proration, self-cancel — is intentionally out of scope and tracked separately (#463 / #464).

## Changes made

- **`lib/payments/subscription-guard.ts`** — shared `findConflictingSubscription()` (fails closed on query error) + the shared blocking message/code.
- **API routes** — `app/api/stripe/create-payment-intent` and `app/api/payments/checkout` return `409 { code: "parallel_subscription" }` **before** any provider side effect (no Stripe customer, subscription, PaymentIntent, or pending transaction is created). Covers **stripe, lemonsqueezy, solana, solana_subs**.
- **Server actions** — `enrollUser` (mock/sandbox), `subscribeFree` (free plans), and `createPaymentRequest` (manual flow, blocked at request creation so the student sees it before any admin back-and-forth) throw a typed error.
- **Checkout pages** — the main and manual checkout pages render a blocking `SubscriptionConflictNotice` in place of the payment UI, with the current plan named. New `checkout.conflict.*` strings in **en + es**.
- **DB backstop** — migration `20260719120000_guard_parallel_subscriptions.sql` patches `handle_new_subscription` to `RAISE` (rather than silently create a second live subscription) for any path that reaches the transaction trigger without an app guard. Renewals and pre-existing parallel subscribers are exempt.
- **Seed + E2E** — second Code Academy plan (2002) seeded; new `tests/playwright/parallel-subscription-guard.spec.ts`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] `npm run build` — passes (exit 0).
- [x] `npx tsc --noEmit` — passes (exit 0).
- [x] `eslint` on all changed files — no new errors (3 pre-existing warnings in untouched code: unused `result`/`itemName`).
- [x] DB backstop verified against local Postgres:
  - parallel-plan `successful` transaction for a user with a live sub → `RAISE parallel_subscription` (trigger aborts, nothing created).
  - same-plan renewal via `handle_new_subscription` → extends `end_date` by the plan duration (+30d), no raise.
  - a legacy user holding two parallel subs → still renews either plan without raising.
  - a fresh user with no live sub → subscribes normally.
- [x] Browser QA (as `alice@student.com`, Code Academy tenant, who holds plan 2001):
  - checkout for a different plan (2002) → blocking notice, no payment UI.
  - both `/api/stripe/create-payment-intent` and `/api/payments/checkout` with `planId: 2002` → `409 { code: "parallel_subscription" }`.
  - same-plan checkout (2001) → normal form, guard does **not** fire.

### QA verification steps

1. Log in as `alice@student.com` / `password123` on `code-academy.lvh.me:3000` (she has an active subscription to *Code Academy Pro Monthly*, plan 2001).
2. Visit `/en/checkout?planId=2002` → expect the **"You already have an active plan"** notice naming *Code Academy Pro Monthly*, with **View my billing** / **Browse courses** buttons and no payment controls.
3. Visit `/en/checkout?planId=2001` (same plan) → expect the **normal** checkout form to render (renewal is allowed).
4. From the browser console on the checkout page, `POST /api/stripe/create-payment-intent` and `POST /api/payments/checkout` with `{ "planId": 2002 }` → both return HTTP **409** with `code: "parallel_subscription"`.
5. Switch the app locale to `es` and repeat step 2 → the notice renders in Spanish.

## Screenshots

**Before** — checking out a second plan rendered payment UI (double-billing path open):

![before](https://raw.githubusercontent.com/guillermoscript/lms-front/master/docs/verification/issue-459-before-checkout.png?v=1)

**After** — the second-plan checkout is blocked with a clear notice:

![after](https://raw.githubusercontent.com/guillermoscript/lms-front/master/docs/verification/issue-459-after-checkout.png?v=1)

**Flow** — billing (Monthly active) → attempting a second plan → blocked:

![verification](https://raw.githubusercontent.com/guillermoscript/lms-front/master/docs/verification/issue-459-verification.gif?v=1)

## Notes for reviewers

- The DB backstop's `RAISE` is deliberate: if the app guards were ever bypassed, a webhook flipping the transaction fails loudly (transaction stays visible, provider retries) — recoverable by an admin, unlike a silent second billing cycle.
- The migration must be applied to cloud after merge (`supabase db push`).
