### PR TITLE
fix(billing): revert over-limit portal downgrades to keep Stripe and DB plan in sync (#461)

### DIFF
--- a/app/api/stripe/platform-webhook/route.ts
+++ b/app/api/stripe/platform-webhook/route.ts
@@ -4,6 +4,7 @@ import { createAdminClient } from '@/lib/supabase/admin'
 import type Stripe from 'stripe'
 import { sendEmail } from '@/lib/email/send'
 import { paymentFailedTemplate } from '@/lib/email/templates/payment-failed'
+import { applyPortalPlanChange } from '@/lib/payments/platform-plan-change'
 
 function getPlatformWebhookSecret(): string {
   const secret = process.env.STRIPE_PLATFORM_WEBHOOK_SECRET
@@ -137,56 +138,13 @@ export async function POST(req: NextRequest) {
           })
           .eq('id', tenantId)
 
-        // If plan changed via Stripe portal, update plan slug
-        if (subscription.items?.data?.[0]?.price?.id) {
-          const newPriceId = subscription.items.data[0].price.id
-          const { data: newPlan } = await adminClient
-            .from('platform_plans')
-            .select('slug, plan_id, transaction_fee_percent')
-            .or(`stripe_price_id_monthly.eq.${newPriceId},stripe_price_id_yearly.eq.${newPriceId}`)
-            .single()
-
-          if (newPlan) {
-            // Check downgrade limits before applying new plan
-            const limits = (newPlan as any).limits as { max_courses?: number; max_students?: number } | null
-            const maxCourses = limits?.max_courses ?? -1
-            const maxStudents = limits?.max_students ?? -1
-
-            if (maxCourses !== -1 || maxStudents !== -1) {
-              const [coursesRes, studentsRes] = await Promise.all([
-                adminClient.from('courses').select('*', { count: 'exact', head: true }).eq('tenant_id', tenantId).neq('status', 'archived'),
-                adminClient.from('tenant_users').select('*', { count: 'exact', head: true }).eq('tenant_id', tenantId).eq('role', 'student').eq('status', 'active'),
-              ])
-              const overCourses = maxCourses !== -1 && (coursesRes.count ?? 0) > maxCourses
-              const overStudents = maxStudents !== -1 && (studentsRes.count ?? 0) > maxStudents
-
-              if (overCourses || overStudents) {
-                console.error(`Plan downgrade blocked for tenant ${tenantId}: over course or student limits`)
-                // Don't update the plan — leave Stripe subscription active but don't change DB plan
-                break
-              }
-            }
-
-            await adminClient
-              .from('tenants')
-              .update({ plan: newPlan.slug, updated_at: new Date().toISOString() })
-              .eq('id', tenantId)
-
-            await adminClient
-              .from('platform_subscriptions')
-              .update({ plan_id: newPlan.plan_id, updated_at: new Date().toISOString() })
-              .eq('tenant_id', tenantId)
-
-            await adminClient
-              .from('revenue_splits')
-              .upsert({
-                tenant_id: tenantId,
-                platform_percentage: newPlan.transaction_fee_percent,
-                school_percentage: 100 - newPlan.transaction_fee_percent,
-                updated_at: new Date().toISOString(),
-              }, { onConflict: 'tenant_id' })
-          }
-        }
+        // If plan changed via Stripe portal, apply it with downgrade-limit
+        // enforcement (over-limit downgrades are reverted on Stripe and admins
+        // notified — see lib/payments/platform-plan-change.ts).
+        await applyPortalPlanChange(subscription, {
+          admin: adminClient,
+          stripe: getStripe(),
+        })
 
         break
       }

--- a/lib/email/templates/downgrade-blocked.ts
+++ b/lib/email/templates/downgrade-blocked.ts
@@ -1,0 +1,49 @@
+export interface DowngradeBlockedData {
+  schoolName: string
+  oldPlanName: string
+  newPlanName: string
+  reasons: string[]
+  outcome: 'reverted' | 'applied_over_limit'
+  billingUrl: string
+}
+
+export function downgradeBlockedTemplate(data: DowngradeBlockedData): {
+  subject: string
+  html: string
+} {
+  const reverted = data.outcome === 'reverted'
+  const subject = reverted
+    ? `Your downgrade to ${data.newPlanName} could not be completed`
+    : `Action required: ${data.schoolName} is over its ${data.newPlanName} plan limits`
+  const lead = reverted
+    ? `We could not complete the downgrade of <strong>${data.schoolName}</strong> to the <strong>${data.newPlanName}</strong> plan because your school currently exceeds that plan's limits. Your subscription remains on the <strong>${data.oldPlanName}</strong> plan and your billing has not changed.`
+    : `<strong>${data.schoolName}</strong> was downgraded to the <strong>${data.newPlanName}</strong> plan, but your school currently exceeds that plan's limits. Please reduce usage or upgrade your plan.`
+
+  return {
+    subject,
+    html: `<!DOCTYPE html>
+<html>
+<body style="font-family:sans-serif;max-width:600px;margin:0 auto;padding:24px;color:#1a1a1a">
+  <h2 style="color:#d97706">${reverted ? 'Downgrade Not Completed' : 'Over Plan Limits'}</h2>
+  <p>Hi,</p>
+  <p>${lead}</p>
+  <ul style="color:#444">
+    ${data.reasons.map((r) => `<li>${r}</li>`).join('\n    ')}
+  </ul>
+  <p>${
+    reverted
+      ? `To downgrade to ${data.newPlanName}, first reduce your usage below its limits, then change your plan again from the billing page.`
+      : `Until this is resolved, parts of your school may be restricted by the ${data.newPlanName} plan limits.`
+  }</p>
+  <p style="text-align:center;margin:32px 0">
+    <a href="${data.billingUrl}" style="background:#d97706;color:#fff;padding:12px 28px;border-radius:6px;text-decoration:none;font-weight:600">
+      Manage Billing
+    </a>
+  </p>
+  <p style="color:#666;font-size:13px">If you believe this is an error, please contact support.</p>
+  <hr style="border:none;border-top:1px solid #eee;margin:24px 0"/>
+  <p style="color:#999;font-size:12px">LMS Platform Billing</p>
+</body>
+</html>`,
+  }
+}

--- a/lib/payments/platform-plan-change.ts
+++ b/lib/payments/platform-plan-change.ts
@@ -44,7 +44,7 @@ export interface PortalPlanChangeResult {
 }
 
 interface PlanRow {
-  plan_id: number
+  plan_id: string
   slug: string
   name: string | null
   transaction_fee_percent: number
@@ -85,7 +85,7 @@ export async function applyPortalPlanChange(
     .from('platform_subscriptions')
     .select('plan_id, interval')
     .eq('tenant_id', tenantId)
-    .maybeSingle()) as { data: { plan_id: number; interval: string | null } | null }
+    .maybeSingle()) as { data: { plan_id: string; interval: string | null } | null }
 
   // No-op guard: the incoming price maps to the plan already recorded. This is
   // also what terminates the webhook echo triggered by our own revert below.

--- a/lib/payments/platform-plan-change.ts
+++ b/lib/payments/platform-plan-change.ts
@@ -1,0 +1,292 @@
+/**
+ * Portal plan-change handler for the platform (school → platform) billing
+ * webhook.
+ *
+ * Applies a `customer.subscription.updated` price change from the Stripe
+ * Customer Portal to our plan state (`tenants.plan`,
+ * `platform_subscriptions.plan_id`, `revenue_splits`), enforcing the target
+ * plan's course/student limits on downgrades.
+ *
+ * Invariant this module exists to protect: the Stripe subscription price and
+ * the DB plan may NEVER disagree after the webhook returns. A downgrade that
+ * exceeds the target plan's limits is REVERTED on Stripe (back to the old
+ * plan's price, no proration) and school admins are notified; if the revert
+ * is impossible (old plan has no Stripe price) or fails, the downgrade is
+ * applied to the DB instead — consistency wins over enforcement — and admins
+ * are warned they are over the new plan's limits.
+ *
+ * The revert triggers an echo `customer.subscription.updated` event; it maps
+ * back to the plan already recorded in `platform_subscriptions.plan_id` and
+ * hits the no-op guard, so the loop terminates.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { sendEmail } from '@/lib/email/send'
+import { downgradeBlockedTemplate } from '@/lib/email/templates/downgrade-blocked'
+
+export interface PortalPlanChangeDeps {
+  /** Service-role Supabase client (bypasses RLS). */
+  admin: SupabaseClient
+  /** Platform Stripe client — only `subscriptions.update` is used. */
+  stripe: {
+    subscriptions: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      update: (id: string, params: any) => Promise<any>
+    }
+  }
+  /** Injectable for tests; defaults to the Mailgun sender. */
+  sendEmailFn?: typeof sendEmail
+}
+
+export interface PortalPlanChangeResult {
+  action: 'ignored' | 'noop' | 'applied' | 'reverted' | 'applied_over_limit'
+  reason?: string
+}
+
+interface PlanRow {
+  plan_id: number
+  slug: string
+  name: string | null
+  transaction_fee_percent: number
+  limits: { max_courses?: number; max_students?: number } | null
+  stripe_price_id_monthly: string | null
+  stripe_price_id_yearly: string | null
+}
+
+const PLAN_COLUMNS =
+  'plan_id, slug, name, transaction_fee_percent, limits, stripe_price_id_monthly, stripe_price_id_yearly'
+
+export async function applyPortalPlanChange(
+  // Stripe.Subscription with 2026-02-25.clover typing quirks — treated as any
+  // like the rest of the webhook.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  subscription: any,
+  { admin, stripe, sendEmailFn = sendEmail }: PortalPlanChangeDeps
+): Promise<PortalPlanChangeResult> {
+  const tenantId = subscription?.metadata?.tenant_id as string | undefined
+  const item = subscription?.items?.data?.[0]
+  const newPriceId = item?.price?.id as string | undefined
+
+  if (!tenantId || !newPriceId) {
+    return { action: 'ignored', reason: 'missing tenant_id or price on event' }
+  }
+
+  const { data: newPlan } = (await admin
+    .from('platform_plans')
+    .select(PLAN_COLUMNS)
+    .or(`stripe_price_id_monthly.eq.${newPriceId},stripe_price_id_yearly.eq.${newPriceId}`)
+    .maybeSingle()) as { data: PlanRow | null }
+
+  if (!newPlan) {
+    return { action: 'ignored', reason: `no platform plan matches price ${newPriceId}` }
+  }
+
+  const { data: currentSub } = (await admin
+    .from('platform_subscriptions')
+    .select('plan_id, interval')
+    .eq('tenant_id', tenantId)
+    .maybeSingle()) as { data: { plan_id: number; interval: string | null } | null }
+
+  // No-op guard: the incoming price maps to the plan already recorded. This is
+  // also what terminates the webhook echo triggered by our own revert below.
+  if (currentSub?.plan_id === newPlan.plan_id) {
+    return { action: 'noop' }
+  }
+
+  const maxCourses = newPlan.limits?.max_courses ?? -1
+  const maxStudents = newPlan.limits?.max_students ?? -1
+
+  let overCourses = false
+  let overStudents = false
+  let courseCount = 0
+  let studentCount = 0
+
+  if (maxCourses !== -1 || maxStudents !== -1) {
+    const [coursesRes, studentsRes] = await Promise.all([
+      admin
+        .from('courses')
+        .select('*', { count: 'exact', head: true })
+        .eq('tenant_id', tenantId)
+        .neq('status', 'archived'),
+      admin
+        .from('tenant_users')
+        .select('*', { count: 'exact', head: true })
+        .eq('tenant_id', tenantId)
+        .eq('role', 'student')
+        .eq('status', 'active'),
+    ])
+    courseCount = coursesRes.count ?? 0
+    studentCount = studentsRes.count ?? 0
+    overCourses = maxCourses !== -1 && courseCount > maxCourses
+    overStudents = maxStudents !== -1 && studentCount > maxStudents
+  }
+
+  if (!overCourses && !overStudents) {
+    await applyPlanToDb(admin, tenantId, newPlan)
+    return { action: 'applied' }
+  }
+
+  const reasons: string[] = []
+  if (overCourses) {
+    reasons.push(`${courseCount} active courses exceed the ${newPlan.name || newPlan.slug} limit of ${maxCourses}`)
+  }
+  if (overStudents) {
+    reasons.push(`${studentCount} active students exceed the ${newPlan.name || newPlan.slug} limit of ${maxStudents}`)
+  }
+
+  const { data: oldPlan } = currentSub?.plan_id
+    ? ((await admin
+        .from('platform_plans')
+        .select(PLAN_COLUMNS)
+        .eq('plan_id', currentSub.plan_id)
+        .maybeSingle()) as { data: PlanRow | null })
+    : { data: null }
+
+  // Revert to the old plan's price on the subscription's billing interval,
+  // falling back to whichever price the old plan actually has.
+  const preferYearly =
+    currentSub?.interval === 'yearly' || item?.price?.recurring?.interval === 'year'
+  const oldPriceId = preferYearly
+    ? oldPlan?.stripe_price_id_yearly || oldPlan?.stripe_price_id_monthly
+    : oldPlan?.stripe_price_id_monthly || oldPlan?.stripe_price_id_yearly
+
+  if (oldPriceId && item?.id) {
+    try {
+      await stripe.subscriptions.update(subscription.id, {
+        items: [{ id: item.id, price: oldPriceId }],
+        proration_behavior: 'none',
+      })
+      await notifyAdmins(admin, sendEmailFn, {
+        tenantId,
+        outcome: 'reverted',
+        oldPlanName: oldPlan?.name || oldPlan?.slug || 'your current plan',
+        newPlanName: newPlan.name || newPlan.slug,
+        reasons,
+      })
+      console.error(
+        `Plan downgrade reverted for tenant ${tenantId}: ${reasons.join('; ')}`
+      )
+      return { action: 'reverted' }
+    } catch (err) {
+      console.error(`Failed to revert Stripe subscription for tenant ${tenantId}:`, err)
+      // Fall through: if we cannot put Stripe back, the DB follows Stripe.
+    }
+  }
+
+  await applyPlanToDb(admin, tenantId, newPlan)
+  await notifyAdmins(admin, sendEmailFn, {
+    tenantId,
+    outcome: 'applied_over_limit',
+    oldPlanName: oldPlan?.name || oldPlan?.slug || 'your previous plan',
+    newPlanName: newPlan.name || newPlan.slug,
+    reasons,
+  })
+  console.error(
+    `Plan downgrade applied over limits for tenant ${tenantId}: ${reasons.join('; ')}`
+  )
+  return { action: 'applied_over_limit' }
+}
+
+async function applyPlanToDb(admin: SupabaseClient, tenantId: string, plan: PlanRow) {
+  await admin
+    .from('tenants')
+    .update({ plan: plan.slug, updated_at: new Date().toISOString() })
+    .eq('id', tenantId)
+
+  await admin
+    .from('platform_subscriptions')
+    .update({ plan_id: plan.plan_id, updated_at: new Date().toISOString() })
+    .eq('tenant_id', tenantId)
+
+  await admin.from('revenue_splits').upsert(
+    {
+      tenant_id: tenantId,
+      platform_percentage: plan.transaction_fee_percent,
+      school_percentage: 100 - plan.transaction_fee_percent,
+      updated_at: new Date().toISOString(),
+    },
+    { onConflict: 'tenant_id' }
+  )
+}
+
+/**
+ * Best-effort admin notification: one `notifications` row + `user_notifications`
+ * fan-out to every active tenant admin, plus a Mailgun email per admin. Never
+ * throws — notification failure must not fail the webhook.
+ */
+async function notifyAdmins(
+  admin: SupabaseClient,
+  sendEmailFn: typeof sendEmail,
+  params: {
+    tenantId: string
+    outcome: 'reverted' | 'applied_over_limit'
+    oldPlanName: string
+    newPlanName: string
+    reasons: string[]
+  }
+) {
+  const { tenantId, outcome, oldPlanName, newPlanName, reasons } = params
+  try {
+    const [{ data: tenantRow }, { data: adminUsers }] = await Promise.all([
+      admin.from('tenants').select('name').eq('id', tenantId).maybeSingle(),
+      admin
+        .from('tenant_users')
+        .select('user_id')
+        .eq('tenant_id', tenantId)
+        .eq('role', 'admin')
+        .eq('status', 'active'),
+    ])
+
+    const adminIds: string[] = (adminUsers || []).map((u: { user_id: string }) => u.user_id)
+    if (adminIds.length === 0) return
+
+    const title =
+      outcome === 'reverted' ? 'Plan downgrade could not be completed' : 'School is over plan limits'
+    const content =
+      outcome === 'reverted'
+        ? `Your downgrade to ${newPlanName} was reverted because your school exceeds its limits: ${reasons.join('; ')}. You remain on ${oldPlanName}.`
+        : `Your school was downgraded to ${newPlanName} but exceeds its limits: ${reasons.join('; ')}. Please reduce usage or upgrade.`
+
+    const { data: notification } = await admin
+      .from('notifications')
+      .insert({
+        title,
+        content,
+        notification_type: 'warning',
+        priority: 'high',
+        target_type: 'user',
+        target_user_ids: adminIds,
+        status: 'sent',
+        sent_at: new Date().toISOString(),
+        created_by: adminIds[0],
+        tenant_id: tenantId,
+      })
+      .select('id')
+      .single()
+
+    if (notification) {
+      await admin
+        .from('user_notifications')
+        .insert(adminIds.map((userId) => ({ notification_id: notification.id, user_id: userId })))
+    }
+
+    const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://app.example.com'
+    const template = downgradeBlockedTemplate({
+      schoolName: tenantRow?.name || 'your school',
+      oldPlanName,
+      newPlanName,
+      reasons,
+      outcome,
+      billingUrl: `${appUrl}/dashboard/admin/billing`,
+    })
+
+    for (const userId of adminIds) {
+      const { data: authUser } = await admin.auth.admin.getUserById(userId)
+      if (authUser?.user?.email) {
+        await sendEmailFn({ to: authUser.user.email, ...template })
+      }
+    }
+  } catch (err) {
+    console.error('Failed to notify admins about plan downgrade:', err)
+  }
+}

--- a/tests/unit/platform-plan-change.test.ts
+++ b/tests/unit/platform-plan-change.test.ts
@@ -10,7 +10,7 @@ import { applyPortalPlanChange } from '@/lib/payments/platform-plan-change'
  */
 
 interface PlanRow {
-  plan_id: number
+  plan_id: string
   slug: string
   name: string | null
   transaction_fee_percent: number
@@ -22,7 +22,7 @@ interface PlanRow {
 interface FakeConfig {
   newPlan?: PlanRow | null
   oldPlan?: PlanRow | null
-  currentSub?: { plan_id: number; interval: string | null } | null
+  currentSub?: { plan_id: string; interval: string | null } | null
   courseCount?: number
   studentCount?: number
   adminUsers?: string[]
@@ -146,8 +146,13 @@ function makeFakeAdmin(cfg: FakeConfig) {
   return { admin: admin as any, calls, sendEmailFn: sendEmailFn as any, makeStripe }
 }
 
+// plan_id is a uuid in the real schema (platform_plans.plan_id) — fixtures
+// use uuid strings so the no-op guard's key equality is exercised as strings.
+const PRO_ID = 'f9318c3a-815d-448d-802e-cf356c2791a4'
+const STARTER_ID = '205e06a0-611f-49b1-b916-5d9be6dcf5ca'
+
 const PRO: PlanRow = {
-  plan_id: 3,
+  plan_id: PRO_ID,
   slug: 'pro',
   name: 'Pro',
   transaction_fee_percent: 2,
@@ -157,7 +162,7 @@ const PRO: PlanRow = {
 }
 
 const STARTER: PlanRow = {
-  plan_id: 2,
+  plan_id: STARTER_ID,
   slug: 'starter',
   name: 'Starter',
   transaction_fee_percent: 5,
@@ -190,7 +195,7 @@ describe('applyPortalPlanChange', () => {
     })
     expect(result.action).toBe('applied')
     expect(calls.updates.find((u) => u.table === 'tenants')?.values.plan).toBe('starter')
-    expect(calls.updates.find((u) => u.table === 'platform_subscriptions')?.values.plan_id).toBe(2)
+    expect(calls.updates.find((u) => u.table === 'platform_subscriptions')?.values.plan_id).toBe(STARTER_ID)
     expect(calls.upserts.find((u) => u.table === 'revenue_splits')?.values.platform_percentage).toBe(5)
     expect(calls.stripeUpdates).toHaveLength(0)
     expect(calls.emails).toHaveLength(0)

--- a/tests/unit/platform-plan-change.test.ts
+++ b/tests/unit/platform-plan-change.test.ts
@@ -1,0 +1,313 @@
+import { describe, it, expect } from 'vitest'
+import { applyPortalPlanChange } from '@/lib/payments/platform-plan-change'
+
+/**
+ * Pins the portal plan-change CONTRACT (issue #461): Stripe price and DB plan
+ * may never disagree after the webhook. Over-limit downgrades revert Stripe and
+ * leave the DB alone; if revert is impossible/fails, the DB follows Stripe;
+ * the echo event of a revert is a no-op (loop terminates). Fluent fake records
+ * writes, same approach as webhook-dispatch.test.ts.
+ */
+
+interface PlanRow {
+  plan_id: number
+  slug: string
+  name: string | null
+  transaction_fee_percent: number
+  limits: { max_courses?: number; max_students?: number } | null
+  stripe_price_id_monthly: string | null
+  stripe_price_id_yearly: string | null
+}
+
+interface FakeConfig {
+  newPlan?: PlanRow | null
+  oldPlan?: PlanRow | null
+  currentSub?: { plan_id: number; interval: string | null } | null
+  courseCount?: number
+  studentCount?: number
+  adminUsers?: string[]
+}
+
+interface Recorder {
+  updates: { table: string; values: Record<string, unknown> }[]
+  upserts: { table: string; values: Record<string, unknown> }[]
+  inserts: { table: string; values: unknown }[]
+  planSelects: string[]
+  emails: { to: string; subject: string }[]
+  stripeUpdates: { id: string; params: Record<string, unknown> }[]
+}
+
+function makeFakeAdmin(cfg: FakeConfig) {
+  const calls: Recorder = {
+    updates: [],
+    upserts: [],
+    inserts: [],
+    planSelects: [],
+    emails: [],
+    stripeUpdates: [],
+  }
+
+  function makeBuilder(table: string) {
+    let usedOr = false
+    let lastInsert: unknown = null
+    const builder: Record<string, unknown> = {
+      select(cols: string) {
+        if (table === 'platform_plans') calls.planSelects.push(cols)
+        return builder
+      },
+      update(values: Record<string, unknown>) {
+        calls.updates.push({ table, values })
+        return builder
+      },
+      upsert(values: Record<string, unknown>) {
+        calls.upserts.push({ table, values })
+        return builder
+      },
+      insert(values: unknown) {
+        lastInsert = values
+        calls.inserts.push({ table, values })
+        return builder
+      },
+      or() {
+        usedOr = true
+        return builder
+      },
+      eq() {
+        return builder
+      },
+      neq() {
+        return builder
+      },
+      maybeSingle() {
+        if (table === 'platform_plans') {
+          return Promise.resolve({ data: usedOr ? (cfg.newPlan ?? null) : (cfg.oldPlan ?? null), error: null })
+        }
+        if (table === 'platform_subscriptions') {
+          return Promise.resolve({ data: cfg.currentSub ?? null, error: null })
+        }
+        if (table === 'tenants') {
+          return Promise.resolve({ data: { name: 'Test School' }, error: null })
+        }
+        return Promise.resolve({ data: null, error: null })
+      },
+      single() {
+        if (table === 'notifications' && lastInsert) {
+          return Promise.resolve({ data: { id: 42 }, error: null })
+        }
+        return Promise.resolve({ data: null, error: null })
+      },
+      then(resolve: (v: unknown) => unknown) {
+        if (table === 'courses') {
+          return Promise.resolve({ count: cfg.courseCount ?? 0, error: null }).then(resolve)
+        }
+        if (table === 'tenant_users') {
+          const admins = (cfg.adminUsers ?? []).map((user_id) => ({ user_id }))
+          // Head-count student query and admin-list query both land here; the
+          // count matters for the former, data for the latter.
+          return Promise.resolve({ count: cfg.studentCount ?? 0, data: admins, error: null }).then(resolve)
+        }
+        return Promise.resolve({ data: null, error: null }).then(resolve)
+      },
+    }
+    return builder
+  }
+
+  const admin = {
+    from(table: string) {
+      return makeBuilder(table)
+    },
+    auth: {
+      admin: {
+        getUserById(id: string) {
+          return Promise.resolve({ data: { user: { email: `${id}@example.com` } }, error: null })
+        },
+      },
+    },
+  }
+
+  const sendEmailFn = (options: { to: string; subject: string }) => {
+    calls.emails.push({ to: options.to, subject: options.subject })
+    return Promise.resolve(true)
+  }
+
+  function makeStripe(shouldThrow = false) {
+    return {
+      subscriptions: {
+        update(id: string, params: Record<string, unknown>) {
+          if (shouldThrow) return Promise.reject(new Error('stripe down'))
+          calls.stripeUpdates.push({ id, params })
+          return Promise.resolve({})
+        },
+      },
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return { admin: admin as any, calls, sendEmailFn: sendEmailFn as any, makeStripe }
+}
+
+const PRO: PlanRow = {
+  plan_id: 3,
+  slug: 'pro',
+  name: 'Pro',
+  transaction_fee_percent: 2,
+  limits: { max_courses: 100, max_students: 1000 },
+  stripe_price_id_monthly: 'price_pro_m',
+  stripe_price_id_yearly: 'price_pro_y',
+}
+
+const STARTER: PlanRow = {
+  plan_id: 2,
+  slug: 'starter',
+  name: 'Starter',
+  transaction_fee_percent: 5,
+  limits: { max_courses: 15, max_students: 200 },
+  stripe_price_id_monthly: 'price_starter_m',
+  stripe_price_id_yearly: 'price_starter_y',
+}
+
+function subscriptionEvent(priceId = 'price_starter_m') {
+  return {
+    id: 'sub_123',
+    metadata: { tenant_id: 'tenant-1' },
+    items: { data: [{ id: 'si_1', price: { id: priceId, recurring: { interval: 'month' } } }] },
+  }
+}
+
+describe('applyPortalPlanChange', () => {
+  it('under-limit downgrade → applied: tenants.plan + platform_subscriptions.plan_id + revenue_splits updated, no Stripe call', async () => {
+    const { admin, calls, sendEmailFn, makeStripe } = makeFakeAdmin({
+      newPlan: STARTER,
+      oldPlan: PRO,
+      currentSub: { plan_id: PRO.plan_id, interval: 'monthly' },
+      courseCount: 10,
+      studentCount: 100,
+    })
+    const result = await applyPortalPlanChange(subscriptionEvent(), {
+      admin,
+      stripe: makeStripe(),
+      sendEmailFn,
+    })
+    expect(result.action).toBe('applied')
+    expect(calls.updates.find((u) => u.table === 'tenants')?.values.plan).toBe('starter')
+    expect(calls.updates.find((u) => u.table === 'platform_subscriptions')?.values.plan_id).toBe(2)
+    expect(calls.upserts.find((u) => u.table === 'revenue_splits')?.values.platform_percentage).toBe(5)
+    expect(calls.stripeUpdates).toHaveLength(0)
+    expect(calls.emails).toHaveLength(0)
+  })
+
+  it('over-limit downgrade → reverted: Stripe pushed back to old price, DB plan untouched, admins notified', async () => {
+    const { admin, calls, sendEmailFn, makeStripe } = makeFakeAdmin({
+      newPlan: STARTER,
+      oldPlan: PRO,
+      currentSub: { plan_id: PRO.plan_id, interval: 'monthly' },
+      courseCount: 50, // over starter's 15
+      studentCount: 100,
+      adminUsers: ['admin-a', 'admin-b'],
+    })
+    const result = await applyPortalPlanChange(subscriptionEvent(), {
+      admin,
+      stripe: makeStripe(),
+      sendEmailFn,
+    })
+    expect(result.action).toBe('reverted')
+    expect(calls.stripeUpdates).toHaveLength(1)
+    expect(calls.stripeUpdates[0].id).toBe('sub_123')
+    expect(calls.stripeUpdates[0].params).toMatchObject({
+      items: [{ id: 'si_1', price: 'price_pro_m' }],
+      proration_behavior: 'none',
+    })
+    // DB plan must NOT change
+    expect(calls.updates.find((u) => u.table === 'tenants')).toBeUndefined()
+    expect(calls.updates.find((u) => u.table === 'platform_subscriptions')).toBeUndefined()
+    expect(calls.upserts).toHaveLength(0)
+    // Recorded + notified
+    expect(calls.inserts.find((i) => i.table === 'notifications')).toBeDefined()
+    expect(calls.inserts.find((i) => i.table === 'user_notifications')).toBeDefined()
+    expect(calls.emails.map((e) => e.to).sort()).toEqual([
+      'admin-a@example.com',
+      'admin-b@example.com',
+    ])
+  })
+
+  it('echo event after revert (price maps to current plan) → complete no-op', async () => {
+    const { admin, calls, sendEmailFn, makeStripe } = makeFakeAdmin({
+      newPlan: PRO,
+      currentSub: { plan_id: PRO.plan_id, interval: 'monthly' },
+      courseCount: 50,
+    })
+    const result = await applyPortalPlanChange(subscriptionEvent('price_pro_m'), {
+      admin,
+      stripe: makeStripe(),
+      sendEmailFn,
+    })
+    expect(result.action).toBe('noop')
+    expect(calls.updates).toHaveLength(0)
+    expect(calls.upserts).toHaveLength(0)
+    expect(calls.stripeUpdates).toHaveLength(0)
+    expect(calls.emails).toHaveLength(0)
+  })
+
+  it('regression: the plan lookup selects `limits` (the old inline guard never did, so it was dead)', async () => {
+    const { admin, calls, sendEmailFn, makeStripe } = makeFakeAdmin({
+      newPlan: STARTER,
+      oldPlan: PRO,
+      currentSub: { plan_id: PRO.plan_id, interval: 'monthly' },
+    })
+    await applyPortalPlanChange(subscriptionEvent(), { admin, stripe: makeStripe(), sendEmailFn })
+    expect(calls.planSelects.length).toBeGreaterThan(0)
+    for (const cols of calls.planSelects) {
+      expect(cols).toContain('limits')
+    }
+  })
+
+  it('revert impossible (old plan has no Stripe prices) → downgrade applied to DB + admins warned', async () => {
+    const { admin, calls, sendEmailFn, makeStripe } = makeFakeAdmin({
+      newPlan: STARTER,
+      oldPlan: { ...PRO, stripe_price_id_monthly: null, stripe_price_id_yearly: null },
+      currentSub: { plan_id: PRO.plan_id, interval: 'monthly' },
+      courseCount: 50,
+      adminUsers: ['admin-a'],
+    })
+    const result = await applyPortalPlanChange(subscriptionEvent(), {
+      admin,
+      stripe: makeStripe(),
+      sendEmailFn,
+    })
+    expect(result.action).toBe('applied_over_limit')
+    expect(calls.stripeUpdates).toHaveLength(0)
+    expect(calls.updates.find((u) => u.table === 'tenants')?.values.plan).toBe('starter')
+    expect(calls.inserts.find((i) => i.table === 'notifications')).toBeDefined()
+    expect(calls.emails).toHaveLength(1)
+  })
+
+  it('Stripe revert fails → falls through: DB follows Stripe (applied_over_limit)', async () => {
+    const { admin, calls, sendEmailFn, makeStripe } = makeFakeAdmin({
+      newPlan: STARTER,
+      oldPlan: PRO,
+      currentSub: { plan_id: PRO.plan_id, interval: 'monthly' },
+      courseCount: 50,
+      adminUsers: ['admin-a'],
+    })
+    const result = await applyPortalPlanChange(subscriptionEvent(), {
+      admin,
+      stripe: makeStripe(true),
+      sendEmailFn,
+    })
+    expect(result.action).toBe('applied_over_limit')
+    expect(calls.updates.find((u) => u.table === 'tenants')?.values.plan).toBe('starter')
+    expect(calls.emails).toHaveLength(1)
+  })
+
+  it('unknown price → ignored, nothing written', async () => {
+    const { admin, calls, sendEmailFn, makeStripe } = makeFakeAdmin({ newPlan: null })
+    const result = await applyPortalPlanChange(subscriptionEvent('price_unknown'), {
+      admin,
+      stripe: makeStripe(),
+      sendEmailFn,
+    })
+    expect(result.action).toBe('ignored')
+    expect(calls.updates).toHaveLength(0)
+    expect(calls.stripeUpdates).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## Description

Part of epic #458 (Phase 1 — billing correctness). Fixes the platform downgrade path where a school could end up paying for a cheaper Stripe plan while the database still recorded the more expensive one.

### Root cause

`app/api/stripe/platform-webhook/route.ts` (`customer.subscription.updated`) applied Stripe Customer Portal plan changes behind a downgrade-limit guard that read `newPlan.limits` — but the plan lookup selected only `slug, plan_id, transaction_fee_percent` and **never fetched `limits`**. The guard therefore always saw `undefined`, defaulted to unlimited, and never fired: every portal downgrade was applied to the DB regardless of course/student limits. In the case the guard was *meant* to handle, it would `break` without touching the DB while the Stripe subscription stayed on the new cheaper price — school pays `starter`, DB keeps `pro`, nobody is notified. Either way the invariant "Stripe price and `tenants.plan` / `platform_subscriptions.plan_id` agree" was not enforced.

### Approach — Revert behavior

Chosen over "apply + grace state": smallest blast radius, keeps limit enforcement meaningful, and is pre-empted by the #458 Phase 3 in-app downgrade flow that will check limits *before* touching Stripe.

The plan-change logic is extracted into **`lib/payments/platform-plan-change.ts`** with injectable deps (admin client, Stripe, email sender) so the contract is unit-testable; the webhook route delegates to it. Behavior:

- **Dead guard fixed** — the plan lookup now selects `limits`.
- **No-op guard** — if the incoming price maps to the plan already recorded in `platform_subscriptions.plan_id`, return early. This also terminates the webhook echo triggered by our own revert (see below), so there is no revert loop.
- **Over-limit downgrade** — revert the Stripe subscription back to the old plan's price (`proration_behavior: 'none'`, interval taken from `platform_subscriptions.interval` with a fallback to the event's recurring interval) and notify school admins both in-app (one `notifications` row + `user_notifications` fan-out) and by email (new `lib/email/templates/downgrade-blocked.ts`). DB plan stays as-is, so Stripe and DB agree again.
- **Revert impossible or Stripe call fails** — if the old plan has no Stripe price id (legacy/manual rows) or the `subscriptions.update` throws, apply the downgrade to the DB instead (consistency wins over enforcement) and warn admins they are over the new plan's limits. Stripe and DB still agree.
- **Under-limit downgrade** — unchanged (`tenants.plan`, `platform_subscriptions.plan_id`, `revenue_splits` updated).

**Invariant guaranteed:** after this webhook returns, the Stripe price and `tenants.plan` / `platform_subscriptions.plan_id` can never disagree.

No schema changes, no migration.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Relationship

Closes #461

## Testing

- [x] `npx vitest run tests/unit/platform-plan-change.test.ts` — 7/7 pass
- [x] `npm run test:unit` — full suite 156/156 pass
- [x] `npx eslint` on the four changed files — clean (one pre-existing `no-explicit-any` error at `route.ts:238` in the untouched `invoice.payment_failed` handler, not part of this change)
- [x] `npm run build` — exit 0, `/api/stripe/platform-webhook` route compiled

The 7 new unit tests cover: over-limit downgrade → revert (Stripe pushed to old price, DB untouched, admins notified); under-limit downgrade → applied (no Stripe call); echo event after revert → complete no-op (loop terminates); regression that the plan lookup now selects `limits`; revert impossible (old plan has no Stripe price) → DB applied + warned; Stripe revert throws → DB follows Stripe; unknown price → ignored.

### QA verification steps

A full portal round-trip needs a Stripe test clock + Customer Portal config, so the paths are pinned by the unit fixtures above. To exercise manually against a Stripe test environment:

1. Put a test tenant on `pro` with more courses/students than `starter`'s limits (e.g. 50 courses).
2. From the Stripe Customer Portal, downgrade that subscription to `starter`.
3. Confirm the `customer.subscription.updated` webhook reverts the Stripe subscription back to the `pro` price (Stripe dashboard shows `pro` again), and that `tenants.plan` / `platform_subscriptions.plan_id` still read `pro`.
4. Confirm the school's admins receive an in-app notification and an email stating the downgrade could not be completed.
5. Repeat with a tenant *under* `starter`'s limits and confirm the downgrade applies normally (DB + revenue split updated, no revert).

## Notes for reviewer

- `route.ts:238` (`(planRow?.platform_plans as any)?.name`) already tripped `no-explicit-any` before this PR — it is in the `invoice.payment_failed` handler, untouched here.
- The revert's own echo `customer.subscription.updated` event is handled by the no-op guard; verified terminating in unit test 3.
