### PR TITLE
feat(billing): in-app school plan downgrade, cancel & interval switch (#465)

### DIFF
--- a/app/[locale]/dashboard/admin/billing/billing-dashboard-client.tsx
+++ b/app/[locale]/dashboard/admin/billing/billing-dashboard-client.tsx
@@ -8,8 +8,18 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { ProofUpload } from '@/components/shared/proof-upload'
-import { IconExternalLink, IconRefresh, IconCreditCard, IconPhoto, IconClock } from '@tabler/icons-react'
-import { uploadPaymentProof, requestManualRenewal } from '@/app/actions/admin/billing'
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import { IconExternalLink, IconRefresh, IconCreditCard, IconPhoto, IconClock, IconLoader2 } from '@tabler/icons-react'
+import { useTranslations } from 'next-intl'
+import { uploadPaymentProof, requestManualRenewal, cancelSubscription } from '@/app/actions/admin/billing'
 
 interface BillingDashboardClientProps {
   status: {
@@ -55,10 +65,13 @@ interface BillingDashboardClientProps {
 
 export function BillingDashboardClient({ status, paymentRequests }: BillingDashboardClientProps) {
   const router = useRouter()
+  const t = useTranslations('dashboard.admin.billing.overview')
   const [portalLoading, setPortalLoading] = useState(false)
   const [renewalLoading, setRenewalLoading] = useState(false)
   const [switchLoading, setSwitchLoading] = useState(false)
   const [uploadingFor, setUploadingFor] = useState<string | null>(null)
+  const [cancelOpen, setCancelOpen] = useState(false)
+  const [cancelLoading, setCancelLoading] = useState(false)
 
   const handleManageBilling = async () => {
     setPortalLoading(true)
@@ -100,6 +113,20 @@ export function BillingDashboardClient({ status, paymentRequests }: BillingDashb
     }
   }
 
+  const handleCancel = async () => {
+    setCancelLoading(true)
+    try {
+      await cancelSubscription()
+      toast.success(t('cancelSuccess'))
+      setCancelOpen(false)
+      router.refresh()
+    } catch (e: any) {
+      toast.error(e.message || t('cancelError'))
+    } finally {
+      setCancelLoading(false)
+    }
+  }
+
   const handleProofUpload = async (requestId: string, file: File) => {
     setUploadingFor(requestId)
     try {
@@ -128,6 +155,10 @@ export function BillingDashboardClient({ status, paymentRequests }: BillingDashb
   const hasPendingRenewal = paymentRequests.some(
     (r) => (r as any).request_type === 'renewal' && !['confirmed', 'rejected', 'expired'].includes(r.status)
   )
+  const cancelDateStr = (() => {
+    const raw = status.subscription?.currentPeriodEnd || status.billingPeriodEnd
+    return raw ? new Date(raw).toLocaleDateString() : null
+  })()
 
   return (
     <div className="space-y-6">
@@ -141,6 +172,7 @@ export function BillingDashboardClient({ status, paymentRequests }: BillingDashb
         usage={status.usage}
         transactionFeePercent={status.transactionFeePercent}
         onManageClick={status.hasStripeCustomer ? handleManageBilling : undefined}
+        onCancelClick={() => setCancelOpen(true)}
       />
 
       {/* Manual Subscription Renewal Section */}
@@ -263,6 +295,26 @@ export function BillingDashboardClient({ status, paymentRequests }: BillingDashb
           </Button>
         </div>
       )}
+
+      <AlertDialog open={cancelOpen} onOpenChange={setCancelOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t('cancelConfirmTitle')}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {cancelDateStr
+                ? t('cancelConfirmBody', { plan: status.planName, date: cancelDateStr })
+                : t('cancelConfirmBodyNoDate', { plan: status.planName })}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={cancelLoading}>{t('cancelKeep')}</AlertDialogCancel>
+            <Button variant="destructive" onClick={handleCancel} disabled={cancelLoading}>
+              {cancelLoading && <IconLoader2 className="mr-2 h-4 w-4 animate-spin" />}
+              {t('cancelConfirmAction')}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   )
 }

--- a/app/[locale]/dashboard/admin/billing/upgrade/page.tsx
+++ b/app/[locale]/dashboard/admin/billing/upgrade/page.tsx
@@ -25,6 +25,10 @@ export default async function UpgradePage({
   const preselectedInterval =
     intervalParam === 'yearly' || intervalParam === 'monthly' ? intervalParam : undefined
 
+  const sub = status.subscription
+  const activeStripeSub = !!sub && sub.paymentMethod === 'stripe' && sub.status === 'active'
+  const currentInterval: 'monthly' | 'yearly' = sub?.interval === 'yearly' ? 'yearly' : 'monthly'
+
   return (
     <div className="space-y-6 p-6 lg:p-8" data-testid="upgrade-page">
       <AdminBreadcrumb
@@ -46,6 +50,8 @@ export default async function UpgradePage({
         currentPlan={status.plan}
         preselectedPlan={preselectedPlan}
         preselectedInterval={preselectedInterval}
+        activeStripeSub={activeStripeSub}
+        currentInterval={currentInterval}
       />
     </div>
   )

--- a/app/[locale]/dashboard/admin/billing/upgrade/upgrade-page-client.tsx
+++ b/app/[locale]/dashboard/admin/billing/upgrade/upgrade-page-client.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation'
 import { toast } from 'sonner'
 import { PlanComparisonTable } from '@/components/admin/plan-comparison-table'
 import { ManualTransferForm } from '@/components/admin/manual-transfer-form'
+import { PlanChangeDialog, type PlanChangeTarget } from '@/components/admin/plan-change-dialog'
 import { requestManualPlanUpgrade } from '@/app/actions/admin/billing'
 import { useTranslations } from 'next-intl'
 import { useLocale } from 'next-intl'
@@ -24,13 +25,17 @@ interface UpgradePageClientProps {
   currentPlan: string
   preselectedPlan?: string
   preselectedInterval?: 'monthly' | 'yearly'
+  /** Tenant already has an active Stripe subscription → in-app change flow. */
+  activeStripeSub?: boolean
+  currentInterval?: 'monthly' | 'yearly'
 }
 
-export function UpgradePageClient({ plans, currentPlan, preselectedPlan, preselectedInterval }: UpgradePageClientProps) {
+export function UpgradePageClient({ plans, currentPlan, preselectedPlan, preselectedInterval, activeStripeSub = false, currentInterval }: UpgradePageClientProps) {
   const router = useRouter()
   const locale = useLocale()
   const t = useTranslations('dashboard.admin.billing.upgrade')
   const [loading, setLoading] = useState(false)
+  const [planChange, setPlanChange] = useState<PlanChangeTarget | null>(null)
   const [manualTransfer, setManualTransfer] = useState<{
     planId: string
     planName: string
@@ -39,6 +44,23 @@ export function UpgradePageClient({ plans, currentPlan, preselectedPlan, presele
   } | null>(null)
 
   const handleSelectPlan = async (planId: string, interval: 'monthly' | 'yearly') => {
+    // Existing Stripe subscribers change plans in-app (Stripe subscription
+    // update + proration preview) rather than starting a fresh checkout.
+    if (activeStripeSub) {
+      const plan = plans.find((p) => p.plan_id === planId)
+      if (!plan) return
+      const currentIndex = plans.findIndex((p) => p.slug === currentPlan)
+      const targetIndex = plans.findIndex((p) => p.plan_id === planId)
+      const direction =
+        plan.slug === currentPlan
+          ? 'interval'
+          : targetIndex > currentIndex
+            ? 'upgrade'
+            : 'downgrade'
+      setPlanChange({ planId, planName: plan.name, interval, direction })
+      return
+    }
+
     setLoading(true)
     try {
       const response = await fetch('/api/stripe/checkout-session', {
@@ -99,14 +121,26 @@ export function UpgradePageClient({ plans, currentPlan, preselectedPlan, presele
   }
 
   return (
-    <PlanComparisonTable
-      plans={plans}
-      currentPlan={currentPlan}
-      preselectedPlan={preselectedPlan}
-      initialInterval={preselectedInterval}
-      onSelectPlan={handleSelectPlan}
-      onManualTransfer={handleManualTransfer}
-      loading={loading}
-    />
+    <>
+      <PlanComparisonTable
+        plans={plans}
+        currentPlan={currentPlan}
+        preselectedPlan={preselectedPlan}
+        initialInterval={preselectedInterval}
+        onSelectPlan={handleSelectPlan}
+        onManualTransfer={activeStripeSub ? undefined : handleManualTransfer}
+        loading={loading}
+        existingSubscriber={activeStripeSub}
+        currentInterval={currentInterval}
+      />
+      <PlanChangeDialog
+        open={planChange !== null}
+        onOpenChange={(open) => {
+          if (!open) setPlanChange(null)
+        }}
+        target={planChange}
+        onConfirmed={navigateToBilling}
+      />
+    </>
   )
 }

--- a/app/actions/admin/billing.ts
+++ b/app/actions/admin/billing.ts
@@ -3,6 +3,8 @@
 import { createClient } from '@/lib/supabase/server'
 import { createAdminClient } from '@/lib/supabase/admin'
 import {getCurrentTenantId, getCurrentUserId } from '@/lib/supabase/tenant'
+import { checkPlanLimits, formatPlanLimitError } from '@/lib/billing/plan-limits'
+import { classifyPlanChange } from '@/lib/billing/plan-change'
 import { revalidatePath } from 'next/cache'
 
 async function verifyAdminAccess() {
@@ -142,9 +144,41 @@ export async function requestManualPlanUpgrade(planId: string, interval: 'monthl
     .single()
 
   if (!plan) throw new Error('Plan not found')
-  if (plan.slug === 'free') throw new Error('Cannot request upgrade to free plan')
+  if (plan.slug === 'free') throw new Error('Cannot request a change to the free plan')
 
   const amount = interval === 'yearly' ? plan.price_yearly : plan.price_monthly
+
+  // Derive a real request_type (upgrade vs downgrade) by comparing against the
+  // tenant's current plan, instead of the old hardcoded 'upgrade'.
+  const { data: tenant } = await adminClient
+    .from('tenants')
+    .select('plan')
+    .eq('id', tenantId)
+    .single()
+  const currentSlug = tenant?.plan || 'free'
+  const { data: currentPlan } = await adminClient
+    .from('platform_plans')
+    .select('sort_order, price_monthly, price_yearly')
+    .eq('slug', currentSlug)
+    .maybeSingle()
+  const currentAmount = currentPlan
+    ? interval === 'yearly'
+      ? currentPlan.price_yearly
+      : currentPlan.price_monthly
+    : 0
+  const { requestType } = classifyPlanChange({
+    currentSortOrder: currentPlan?.sort_order ?? 0,
+    currentAmount: Number(currentAmount) || 0,
+    targetSortOrder: plan.sort_order ?? 0,
+    targetAmount: Number(amount) || 0,
+  })
+
+  // Pre-flight limit check at request time — block an over-limit downgrade
+  // request now, rather than surfacing it days later at super-admin confirm.
+  const limitCheck = await checkPlanLimits(adminClient, tenantId, { planId })
+  if (!limitCheck.ok) {
+    throw new Error(formatPlanLimitError(limitCheck) || 'Plan limits exceeded')
+  }
 
   // Check for existing pending request
   const { data: existingRequest } = await adminClient
@@ -155,7 +189,7 @@ export async function requestManualPlanUpgrade(planId: string, interval: 'monthl
     .single()
 
   if (existingRequest) {
-    throw new Error('You already have a pending upgrade request. Please wait for it to be processed.')
+    throw new Error('You already have a pending plan change request. Please wait for it to be processed.')
   }
 
   const { data: request, error } = await adminClient
@@ -168,7 +202,7 @@ export async function requestManualPlanUpgrade(planId: string, interval: 'monthl
       amount,
       currency: 'usd',
       status: 'pending',
-      request_type: 'upgrade',
+      request_type: requestType,
       bank_reference: bankReference || null,
       notes: notes || null,
     })
@@ -209,43 +243,8 @@ async function checkDowngradeLimits(
   tenantId: string,
   targetPlanId: string,
 ): Promise<string | null> {
-  const [planResult, coursesResult, studentsResult] = await Promise.all([
-    adminClient
-      .from('platform_plans')
-      .select('name, limits')
-      .eq('plan_id', targetPlanId)
-      .single(),
-    adminClient
-      .from('courses')
-      .select('*', { count: 'exact', head: true })
-      .eq('tenant_id', tenantId)
-      .neq('status', 'archived'),
-    adminClient
-      .from('tenant_users')
-      .select('*', { count: 'exact', head: true })
-      .eq('tenant_id', tenantId)
-      .eq('role', 'student')
-      .eq('status', 'active'),
-  ])
-
-  const plan = planResult.data
-  if (!plan) return null
-
-  const limits = plan.limits as { max_courses?: number; max_students?: number } | null
-  const maxCourses = limits?.max_courses ?? -1
-  const maxStudents = limits?.max_students ?? -1
-  const currentCourses = coursesResult.count ?? 0
-  const currentStudents = studentsResult.count ?? 0
-
-  const errors: string[] = []
-  if (maxCourses !== -1 && currentCourses > maxCourses) {
-    errors.push(`You have ${currentCourses} active courses but the ${plan.name} plan allows ${maxCourses}. Archive ${currentCourses - maxCourses} course(s) before downgrading.`)
-  }
-  if (maxStudents !== -1 && currentStudents > maxStudents) {
-    errors.push(`You have ${currentStudents} students but the ${plan.name} plan allows ${maxStudents}.`)
-  }
-
-  return errors.length > 0 ? errors.join(' ') : null
+  const result = await checkPlanLimits(adminClient, tenantId, { planId: targetPlanId })
+  return formatPlanLimitError(result)
 }
 
 /**
@@ -361,6 +360,180 @@ export async function confirmManualPayment(requestId: string) {
 }
 
 /**
+ * Load the pieces needed to modify an active Stripe platform subscription: the
+ * live Stripe subscription item + the target plan's Stripe price. Throws a
+ * friendly Error for every non-actionable state (no active sub, manual sub,
+ * free target, unconfigured price, unreadable Stripe subscription).
+ */
+async function resolvePlatformPlanChange(
+  adminClient: Awaited<ReturnType<typeof createAdminClient>>,
+  tenantId: string,
+  planId: string,
+  interval: 'monthly' | 'yearly',
+) {
+  const { data: sub } = await adminClient
+    .from('platform_subscriptions')
+    .select('stripe_subscription_id, stripe_customer_id, payment_method, status')
+    .eq('tenant_id', tenantId)
+    .single()
+
+  if (!sub || sub.status !== 'active') {
+    throw new Error('No active subscription to change')
+  }
+  if (sub.payment_method !== 'stripe' || !sub.stripe_subscription_id) {
+    throw new Error('In-app plan change is only available for Stripe subscriptions.')
+  }
+
+  const { data: plan } = await adminClient
+    .from('platform_plans')
+    .select('plan_id, slug, name, transaction_fee_percent, stripe_price_id_monthly, stripe_price_id_yearly')
+    .eq('plan_id', planId)
+    .eq('is_active', true)
+    .single()
+
+  if (!plan) throw new Error('Plan not found')
+  if (plan.slug === 'free') {
+    throw new Error('To move to the Free plan, cancel your subscription instead.')
+  }
+
+  const targetPriceId = interval === 'yearly' ? plan.stripe_price_id_yearly : plan.stripe_price_id_monthly
+  if (!targetPriceId) {
+    throw new Error('Stripe price is not configured for this plan. Please contact support.')
+  }
+
+  const { getStripe } = await import('@/lib/stripe')
+  const stripe = getStripe()
+  const stripeSub = await stripe.subscriptions.retrieve(sub.stripe_subscription_id)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const item = (stripeSub as any).items?.data?.[0]
+  if (!item?.id) {
+    throw new Error('Could not read the current subscription from Stripe.')
+  }
+
+  return {
+    stripe,
+    subId: sub.stripe_subscription_id as string,
+    itemId: item.id as string,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    customerId: (sub.stripe_customer_id as string) || ((stripeSub as any).customer as string),
+    targetPriceId: targetPriceId as string,
+    plan,
+  }
+}
+
+/**
+ * Preview an in-app plan change for an active Stripe subscriber. Returns the
+ * blocking limit violations (computed before any Stripe call) OR a Stripe
+ * proration preview so the admin sees the credit/charge before confirming.
+ */
+export async function previewPlanChange(planId: string, interval: 'monthly' | 'yearly' = 'monthly') {
+  const { tenantId } = await verifyAdminAccess()
+  const adminClient = await createAdminClient()
+
+  // Pre-flight limit check BEFORE any Stripe call.
+  const limitCheck = await checkPlanLimits(adminClient, tenantId, { planId })
+  if (!limitCheck.ok) {
+    return { ok: false as const, violations: limitCheck.violations, planName: limitCheck.planName }
+  }
+
+  const ctx = await resolvePlatformPlanChange(adminClient, tenantId, planId, interval)
+
+  try {
+    const preview = await ctx.stripe.invoices.createPreview({
+      customer: ctx.customerId,
+      subscription: ctx.subId,
+      subscription_details: {
+        items: [{ id: ctx.itemId, price: ctx.targetPriceId }],
+        proration_behavior: 'create_prorations',
+      },
+    })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const p = preview as any
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const lines = (p.lines?.data || []) as any[]
+    const prorationAmount = lines
+      .filter((l) => l?.parent?.subscription_item_details?.proration)
+      .reduce((sum, l) => sum + (l.amount ?? 0), 0)
+    return {
+      ok: true as const,
+      proration: {
+        prorationAmount: prorationAmount / 100,
+        total: (p.amount_due ?? p.total ?? 0) / 100,
+        currency: (p.currency || 'usd').toUpperCase(),
+        planName: ctx.plan.name,
+      },
+    }
+  } catch (err) {
+    console.error('Failed to preview plan change:', err)
+    // Preview is best-effort — allow the change to proceed without one.
+    return { ok: true as const, proration: null }
+  }
+}
+
+/**
+ * Apply an in-app plan change (upgrade / downgrade / interval switch) for an
+ * active Stripe subscriber, replacing the old "use the Stripe portal" punt.
+ *
+ * Order matters: the pre-flight limit check and the Stripe update run BEFORE any
+ * DB write, so an over-limit downgrade is blocked with actionable messaging and
+ * our plan state only ever moves after Stripe confirms (the #461 invariant —
+ * Stripe price and DB plan may never disagree). The subsequent optimistic DB
+ * mirror lets the webhook echo (applyPortalPlanChange) hit its no-op guard.
+ */
+export async function changePlan(planId: string, interval: 'monthly' | 'yearly' = 'monthly') {
+  const { tenantId } = await verifyAdminAccess()
+  const adminClient = await createAdminClient()
+
+  // Pre-flight limit check BEFORE touching Stripe.
+  const limitCheck = await checkPlanLimits(adminClient, tenantId, { planId })
+  if (!limitCheck.ok) {
+    throw new Error(formatPlanLimitError(limitCheck) || 'Plan limits exceeded')
+  }
+
+  const ctx = await resolvePlatformPlanChange(adminClient, tenantId, planId, interval)
+
+  // 1) Update Stripe first — swap the subscription item's price, prorate, and
+  //    keep tenant/plan metadata current so the webhook reconciles correctly.
+  await ctx.stripe.subscriptions.update(ctx.subId, {
+    items: [{ id: ctx.itemId, price: ctx.targetPriceId }],
+    proration_behavior: 'create_prorations',
+    metadata: {
+      tenant_id: tenantId,
+      plan_id: ctx.plan.plan_id,
+      plan_slug: ctx.plan.slug,
+      interval,
+    },
+  })
+
+  // 2) Optimistically mirror into our DB so the UI reflects immediately. The
+  //    customer.subscription.updated echo maps the new price back to this same
+  //    plan_id and hits applyPortalPlanChange's no-op guard.
+  const now = new Date().toISOString()
+  await adminClient
+    .from('platform_subscriptions')
+    .update({ plan_id: ctx.plan.plan_id, interval, updated_at: now })
+    .eq('tenant_id', tenantId)
+  await adminClient
+    .from('tenants')
+    .update({ plan: ctx.plan.slug, updated_at: now })
+    .eq('id', tenantId)
+  await adminClient
+    .from('revenue_splits')
+    .upsert(
+      {
+        tenant_id: tenantId,
+        platform_percentage: ctx.plan.transaction_fee_percent,
+        school_percentage: 100 - ctx.plan.transaction_fee_percent,
+        updated_at: now,
+      },
+      { onConflict: 'tenant_id' }
+    )
+
+  revalidatePath('/dashboard/admin/billing')
+  return { success: true, plan: ctx.plan.slug }
+}
+
+/**
  * Cancel subscription (sets cancel_at_period_end)
  */
 export async function cancelSubscription() {
@@ -378,13 +551,24 @@ export async function cancelSubscription() {
   }
 
   if (subscription.payment_method === 'stripe' && subscription.stripe_subscription_id) {
-    // Cancel via Stripe (at period end)
+    // Cancel via Stripe (at period end).
     const { getStripe } = await import('@/lib/stripe')
     await getStripe().subscriptions.update(subscription.stripe_subscription_id, {
       cancel_at_period_end: true,
     })
+    // Mirror locally so the overview reflects the pending cancellation
+    // immediately; the customer.subscription.updated webhook confirms it with
+    // Stripe's authoritative values.
+    await adminClient
+      .from('platform_subscriptions')
+      .update({
+        cancel_at_period_end: true,
+        canceled_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      })
+      .eq('tenant_id', tenantId)
   } else {
-    // Manual subscription — just mark for cancellation
+    // Manual subscription — just mark for cancellation.
     await adminClient
       .from('platform_subscriptions')
       .update({
@@ -395,6 +579,7 @@ export async function cancelSubscription() {
       .eq('tenant_id', tenantId)
   }
 
+  revalidatePath('/dashboard/admin/billing')
   return { success: true }
 }
 

--- a/app/api/stripe/platform-webhook/route.ts
+++ b/app/api/stripe/platform-webhook/route.ts
@@ -113,6 +113,14 @@ export async function POST(req: NextRequest) {
 
         if (!tenantId) break
 
+        // Derive the billing interval from the subscription item's price so an
+        // interval switch (monthly <-> yearly) is reflected locally — the
+        // plan-mapped reconciler below treats a same-plan interval change as a
+        // no-op and would otherwise leave platform_subscriptions.interval stale.
+        const priceInterval = subscription.items?.data?.[0]?.price?.recurring?.interval
+        const localInterval =
+          priceInterval === 'year' ? 'yearly' : priceInterval === 'month' ? 'monthly' : undefined
+
         // Update subscription period and status
         await adminClient
           .from('platform_subscriptions')
@@ -120,6 +128,7 @@ export async function POST(req: NextRequest) {
             status: subscription.status === 'active' ? 'active'
               : subscription.status === 'past_due' ? 'past_due'
               : subscription.status,
+            ...(localInterval ? { interval: localInterval } : {}),
             current_period_start: new Date(subscription.current_period_start * 1000).toISOString(),
             current_period_end: new Date(subscription.current_period_end * 1000).toISOString(),
             cancel_at_period_end: subscription.cancel_at_period_end,

--- a/components/admin/billing-overview.tsx
+++ b/components/admin/billing-overview.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { UsageMeter } from './usage-meter'
-import { IconCreditCard, IconCalendar, IconAlertTriangle } from '@tabler/icons-react'
+import { IconCreditCard, IconCalendar, IconAlertTriangle, IconX } from '@tabler/icons-react'
 import Link from 'next/link'
 import { useTranslations } from 'next-intl'
 
@@ -34,6 +34,7 @@ interface BillingOverviewProps {
   }
   transactionFeePercent: number
   onManageClick?: () => void
+  onCancelClick?: () => void
 }
 
 export function BillingOverview({
@@ -46,6 +47,7 @@ export function BillingOverview({
   usage,
   transactionFeePercent,
   onManageClick,
+  onCancelClick,
 }: BillingOverviewProps) {
   const t = useTranslations('dashboard.admin.billing.overview')
   const isFree = plan === 'free'
@@ -92,6 +94,17 @@ export function BillingOverview({
                   {isFree ? t('upgrade') : t('changePlan')}
                 </Button>
               </Link>
+              {!isFree && onCancelClick && subscription?.status === 'active' && !subscription?.cancelAtPeriodEnd && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={onCancelClick}
+                  className="text-muted-foreground hover:text-destructive"
+                >
+                  <IconX className="mr-2 h-4 w-4" />
+                  {t('cancelPlan')}
+                </Button>
+              )}
             </div>
           </div>
         </CardHeader>

--- a/components/admin/plan-change-dialog.tsx
+++ b/components/admin/plan-change-dialog.tsx
@@ -1,0 +1,182 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useTranslations } from 'next-intl'
+import { toast } from 'sonner'
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import { Button } from '@/components/ui/button'
+import { IconAlertTriangle, IconLoader2 } from '@tabler/icons-react'
+import { previewPlanChange, changePlan } from '@/app/actions/admin/billing'
+
+export type PlanChangeDirection = 'upgrade' | 'downgrade' | 'interval'
+
+export interface PlanChangeTarget {
+  planId: string
+  planName: string
+  interval: 'monthly' | 'yearly'
+  direction: PlanChangeDirection
+}
+
+interface PlanLimitViolation {
+  resource: 'courses' | 'students'
+  current: number
+  max: number
+  reduceBy: number
+}
+
+type PreviewState =
+  | { kind: 'loading' }
+  | { kind: 'blocked'; violations: PlanLimitViolation[]; planName: string | null }
+  | { kind: 'ready'; proration: { prorationAmount: number; total: number; currency: string } | null }
+  | { kind: 'error' }
+
+interface PlanChangeDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  target: PlanChangeTarget | null
+  /** Called after the change is applied successfully (e.g. to navigate). */
+  onConfirmed: () => void
+}
+
+function money(amount: number, currency: string) {
+  return new Intl.NumberFormat(undefined, { style: 'currency', currency }).format(amount)
+}
+
+export function PlanChangeDialog({ open, onOpenChange, target, onConfirmed }: PlanChangeDialogProps) {
+  const t = useTranslations('dashboard.admin.billing.changePlan')
+  const [preview, setPreview] = useState<PreviewState>({ kind: 'loading' })
+  const [confirming, setConfirming] = useState(false)
+
+  useEffect(() => {
+    if (!open || !target) return
+    let cancelled = false
+    // Loader lives inside the effect (cancelled-flag pattern) so the loading
+    // reset runs in an async context, satisfying react-hooks/set-state-in-effect.
+    const load = async () => {
+      setPreview({ kind: 'loading' })
+      try {
+        const res = await previewPlanChange(target.planId, target.interval)
+        if (cancelled) return
+        if (!res.ok) {
+          setPreview({ kind: 'blocked', violations: res.violations, planName: res.planName })
+        } else {
+          setPreview({ kind: 'ready', proration: res.proration })
+        }
+      } catch {
+        if (!cancelled) setPreview({ kind: 'error' })
+      }
+    }
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [open, target])
+
+  const title =
+    target?.direction === 'upgrade'
+      ? t('upgradeTitle', { plan: target?.planName ?? '' })
+      : target?.direction === 'downgrade'
+        ? t('downgradeTitle', { plan: target?.planName ?? '' })
+        : t('intervalTitle', { plan: target?.planName ?? '' })
+
+  const blocked = preview.kind === 'blocked'
+
+  const handleConfirm = async () => {
+    if (!target) return
+    setConfirming(true)
+    try {
+      await changePlan(target.planId, target.interval)
+      toast.success(t('success'))
+      onOpenChange(false)
+      onConfirmed()
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : t('error'))
+    } finally {
+      setConfirming(false)
+    }
+  }
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{blocked ? t('overLimitTitle', { plan: preview.planName ?? target?.planName ?? '' }) : title}</AlertDialogTitle>
+          <AlertDialogDescription>
+            {blocked ? t('overLimitIntro') : t('previewIntro')}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        <div className="text-sm">
+          {preview.kind === 'loading' && (
+            <p className="flex items-center gap-2 text-muted-foreground">
+              <IconLoader2 className="h-4 w-4 animate-spin" />
+              {t('loadingPreview')}
+            </p>
+          )}
+
+          {preview.kind === 'error' && (
+            <p className="text-muted-foreground">{t('previewUnavailable')}</p>
+          )}
+
+          {preview.kind === 'blocked' && (
+            <ul className="space-y-2">
+              {preview.violations.map((v) => (
+                <li key={v.resource} className="flex items-start gap-2 rounded-md border border-amber-300/50 bg-amber-50 p-3 text-amber-900 dark:border-amber-800/50 dark:bg-amber-950/40 dark:text-amber-200">
+                  <IconAlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                  <span>
+                    {v.resource === 'courses'
+                      ? t('violationCourses', { current: v.current, max: v.max, reduceBy: v.reduceBy })
+                      : t('violationStudents', { current: v.current, max: v.max, reduceBy: v.reduceBy })}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {preview.kind === 'ready' && (
+            preview.proration ? (
+              <dl className="space-y-2 rounded-lg border bg-muted/25 p-3.5">
+                <div className="flex items-center justify-between gap-4">
+                  <dt className="text-muted-foreground">
+                    {preview.proration.prorationAmount < 0 ? t('prorationCredit') : t('prorationDueNow')}
+                  </dt>
+                  <dd className="font-medium tabular-nums">
+                    {money(Math.abs(preview.proration.prorationAmount), preview.proration.currency)}
+                  </dd>
+                </div>
+                <div className="flex items-center justify-between gap-4 border-t pt-2">
+                  <dt className="text-muted-foreground">{t('nextInvoiceTotal')}</dt>
+                  <dd className="font-semibold tabular-nums">
+                    {money(preview.proration.total, preview.proration.currency)}
+                  </dd>
+                </div>
+              </dl>
+            ) : (
+              <p className="text-muted-foreground">{t('previewUnavailable')}</p>
+            )
+          )}
+        </div>
+
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={confirming}>
+            {blocked ? t('close') : t('cancel')}
+          </AlertDialogCancel>
+          {!blocked && (
+            <Button onClick={handleConfirm} disabled={confirming || preview.kind === 'loading'}>
+              {confirming && <IconLoader2 className="mr-2 h-4 w-4 animate-spin" />}
+              {t('confirm')}
+            </Button>
+          )}
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/components/admin/plan-comparison-table.tsx
+++ b/components/admin/plan-comparison-table.tsx
@@ -28,6 +28,14 @@ interface PlanComparisonTableProps {
   showActions?: boolean
   preselectedPlan?: string
   initialInterval?: 'monthly' | 'yearly'
+  /**
+   * When true, the tenant already has an active Stripe subscription. CTAs become
+   * direction-aware (Upgrade / Downgrade / Switch interval) and route through an
+   * in-app Stripe subscription update instead of a fresh checkout / bank transfer.
+   */
+  existingSubscriber?: boolean
+  /** The tenant's current billing interval — enables same-plan interval switches. */
+  currentInterval?: 'monthly' | 'yearly'
 }
 
 const FEATURE_LABELS: Record<string, string> = {
@@ -78,6 +86,8 @@ export function PlanComparisonTable({
   showActions = true,
   preselectedPlan,
   initialInterval,
+  existingSubscriber = false,
+  currentInterval,
 }: PlanComparisonTableProps) {
   const [interval, setInterval] = useState<'monthly' | 'yearly'>(initialInterval ?? 'monthly')
   const yearly = interval === 'yearly'
@@ -85,6 +95,7 @@ export function PlanComparisonTable({
     () => FEATURE_KEYS.filter((key) => plans.some((plan) => plan.features[key] !== undefined)),
     [plans],
   )
+  const currentIndex = plans.findIndex((p) => p.slug === currentPlan)
 
   return (
     <div className="space-y-10">
@@ -126,7 +137,7 @@ export function PlanComparisonTable({
       </div>
 
       <div className="grid items-stretch gap-4 md:grid-cols-2 xl:grid-cols-3">
-        {plans.map((plan) => {
+        {plans.map((plan, planIndex) => {
           const isCurrent = plan.slug === currentPlan
           const isPreselected = !isCurrent && plan.slug === preselectedPlan
           const isPopular = plan.slug === 'pro'
@@ -217,7 +228,23 @@ export function PlanComparisonTable({
 
               {showActions && (
                 <CardFooter className="flex flex-col gap-2 pt-2">
-                  {isCurrent ? (
+                  {existingSubscriber ? (
+                    isCurrent ? (
+                      currentInterval && interval !== currentInterval ? (
+                        <Button className="w-full" onClick={() => onSelectPlan?.(plan.plan_id, interval)} disabled={loading}>
+                          {interval === 'yearly' ? 'Switch to yearly billing' : 'Switch to monthly billing'}
+                        </Button>
+                      ) : (
+                        <Button variant="outline" className="w-full" disabled>Current plan</Button>
+                      )
+                    ) : plan.slug === 'free' ? (
+                      <Button variant="ghost" className="w-full" disabled>Cancel to downgrade</Button>
+                    ) : (
+                      <Button className="w-full" onClick={() => onSelectPlan?.(plan.plan_id, interval)} disabled={loading}>
+                        {planIndex > currentIndex ? 'Upgrade to this plan' : 'Downgrade to this plan'}
+                      </Button>
+                    )
+                  ) : isCurrent ? (
                     <Button variant="outline" className="w-full" disabled>Current plan</Button>
                   ) : plan.slug === 'free' ? (
                     <Button variant="ghost" className="w-full" disabled>Free plan</Button>

--- a/lib/billing/plan-change.ts
+++ b/lib/billing/plan-change.ts
@@ -1,0 +1,44 @@
+/**
+ * Pure classifier for a platform plan change, used by the manual
+ * (bank-transfer) flow to record a real `request_type` instead of the
+ * hardcoded `'upgrade'` it used before #465.
+ *
+ * Tier is compared by `sort_order` (free = 0 … enterprise, as seeded in
+ * `platform_plans`). A move to a higher-order plan is an `'upgrade'`; to a
+ * lower-order plan a `'downgrade'`. When the tier is unchanged — an interval
+ * switch on the same plan — the billed amount breaks the tie: paying more
+ * (monthly → yearly) is treated as an `'upgrade'`, paying less a `'downgrade'`;
+ * equal amounts default to `'upgrade'` (there is no downgrade-limit concern).
+ */
+
+export type PlanChangeType = 'upgrade' | 'downgrade'
+
+export interface PlanChangeInput {
+  currentSortOrder: number
+  currentAmount: number
+  targetSortOrder: number
+  targetAmount: number
+}
+
+export interface PlanChangeClassification {
+  requestType: PlanChangeType
+  /** True when only the billing interval changes (same plan tier). */
+  isIntervalOnly: boolean
+}
+
+export function classifyPlanChange(input: PlanChangeInput): PlanChangeClassification {
+  const { currentSortOrder, currentAmount, targetSortOrder, targetAmount } = input
+
+  const isIntervalOnly = currentSortOrder === targetSortOrder
+
+  let requestType: PlanChangeType
+  if (targetSortOrder > currentSortOrder) {
+    requestType = 'upgrade'
+  } else if (targetSortOrder < currentSortOrder) {
+    requestType = 'downgrade'
+  } else {
+    requestType = targetAmount < currentAmount ? 'downgrade' : 'upgrade'
+  }
+
+  return { requestType, isIntervalOnly }
+}

--- a/lib/billing/plan-limits.ts
+++ b/lib/billing/plan-limits.ts
@@ -1,0 +1,153 @@
+/**
+ * Pre-flight plan-limit check for platform (school → platform) billing.
+ *
+ * Answers one question BEFORE any Stripe mutation: does the tenant's current
+ * usage fit within a TARGET plan's limits? Running this ahead of the Stripe
+ * call lets an over-limit downgrade be blocked with actionable "reduce N"
+ * messaging, instead of the reactive "apply then revert on Stripe" path in
+ * `lib/payments/platform-plan-change.ts` (issue #461) that only kicks in after
+ * a portal-initiated change has already happened.
+ *
+ * Source of truth for limits: `platform_plans.limits` `{max_courses,
+ * max_students}` where `-1` means unlimited. Usage counts match the canonical
+ * queries used everywhere else in the codebase — non-archived courses and
+ * active student memberships.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+export type PlanLimits = { max_courses?: number; max_students?: number } | null
+
+export interface PlanLimitViolation {
+  resource: 'courses' | 'students'
+  current: number
+  max: number
+  /** How many of `resource` must be removed to fit under `max`. */
+  reduceBy: number
+}
+
+export interface TenantUsage {
+  courses: number
+  students: number
+}
+
+export interface PlanLimitCheckResult {
+  ok: boolean
+  planName: string | null
+  usage: TenantUsage
+  violations: PlanLimitViolation[]
+}
+
+/**
+ * Count a tenant's usage against the metrics that plan limits constrain:
+ * non-archived courses and active student memberships. Kept separate from the
+ * comparison so callers that already hold a plan's limits in memory (e.g. the
+ * webhook reconciler) can reuse the counts without re-fetching the plan.
+ */
+export async function countTenantUsage(
+  admin: SupabaseClient,
+  tenantId: string
+): Promise<TenantUsage> {
+  const [coursesResult, studentsResult] = await Promise.all([
+    admin
+      .from('courses')
+      .select('*', { count: 'exact', head: true })
+      .eq('tenant_id', tenantId)
+      .neq('status', 'archived'),
+    admin
+      .from('tenant_users')
+      .select('*', { count: 'exact', head: true })
+      .eq('tenant_id', tenantId)
+      .eq('role', 'student')
+      .eq('status', 'active'),
+  ])
+
+  return {
+    courses: coursesResult.count ?? 0,
+    students: studentsResult.count ?? 0,
+  }
+}
+
+/**
+ * Pure comparison of usage against a plan's limits. `-1` (or a missing key)
+ * means unlimited and never produces a violation.
+ */
+export function computePlanLimitViolations(
+  usage: TenantUsage,
+  limits: PlanLimits
+): PlanLimitViolation[] {
+  const maxCourses = limits?.max_courses ?? -1
+  const maxStudents = limits?.max_students ?? -1
+
+  const violations: PlanLimitViolation[] = []
+  if (maxCourses !== -1 && usage.courses > maxCourses) {
+    violations.push({
+      resource: 'courses',
+      current: usage.courses,
+      max: maxCourses,
+      reduceBy: usage.courses - maxCourses,
+    })
+  }
+  if (maxStudents !== -1 && usage.students > maxStudents) {
+    violations.push({
+      resource: 'students',
+      current: usage.students,
+      max: maxStudents,
+      reduceBy: usage.students - maxStudents,
+    })
+  }
+  return violations
+}
+
+/**
+ * Resolve a target plan (by `plan_id` or `slug`), count the tenant's usage, and
+ * report whether the tenant fits within that plan's limits.
+ *
+ * Fail-open on an unknown target plan (returns `ok: true` with no plan name),
+ * matching the long-standing behavior of the manual-confirmation limit check —
+ * a missing plan row must not silently block a legitimate change.
+ */
+export async function checkPlanLimits(
+  admin: SupabaseClient,
+  tenantId: string,
+  target: { planId?: string; slug?: string }
+): Promise<PlanLimitCheckResult> {
+  if (!target.planId && !target.slug) {
+    const usage = await countTenantUsage(admin, tenantId)
+    return { ok: true, planName: null, usage, violations: [] }
+  }
+
+  let planQuery = admin.from('platform_plans').select('name, limits')
+  planQuery = target.planId
+    ? planQuery.eq('plan_id', target.planId)
+    : planQuery.eq('slug', target.slug as string)
+
+  const [planResult, usage] = await Promise.all([
+    planQuery.maybeSingle(),
+    countTenantUsage(admin, tenantId),
+  ])
+
+  const plan = planResult.data as { name: string; limits: PlanLimits } | null
+  if (!plan) {
+    return { ok: true, planName: null, usage, violations: [] }
+  }
+
+  const violations = computePlanLimitViolations(usage, plan.limits)
+  return { ok: violations.length === 0, planName: plan.name, usage, violations }
+}
+
+/**
+ * Human-readable one-line summary of violations, preserving the exact wording
+ * the manual-confirmation path has always thrown so existing UX is unchanged.
+ * Returns `null` when there are no violations.
+ */
+export function formatPlanLimitError(result: PlanLimitCheckResult): string | null {
+  if (result.ok || result.violations.length === 0) return null
+  const planName = result.planName ?? 'target'
+  const parts = result.violations.map((v) =>
+    v.resource === 'courses'
+      ? `You have ${v.current} active courses but the ${planName} plan allows ${v.max}. Archive ${v.reduceBy} course(s) before downgrading.`
+      : `You have ${v.current} students but the ${planName} plan allows ${v.max}.`
+  )
+  return parts.join(' ')
+}

--- a/lib/payments/platform-plan-change.ts
+++ b/lib/payments/platform-plan-change.ts
@@ -23,6 +23,7 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 import { sendEmail } from '@/lib/email/send'
 import { downgradeBlockedTemplate } from '@/lib/email/templates/downgrade-blocked'
+import { countTenantUsage, computePlanLimitViolations } from '@/lib/billing/plan-limits'
 
 export interface PortalPlanChangeDeps {
   /** Service-role Supabase client (bypasses RLS). */
@@ -96,43 +97,23 @@ export async function applyPortalPlanChange(
   const maxCourses = newPlan.limits?.max_courses ?? -1
   const maxStudents = newPlan.limits?.max_students ?? -1
 
-  let overCourses = false
-  let overStudents = false
-  let courseCount = 0
-  let studentCount = 0
+  // Shared with the pre-flight in-app check (lib/billing/plan-limits.ts) so the
+  // reactive webhook path and the proactive path enforce identical limits.
+  const violations =
+    maxCourses !== -1 || maxStudents !== -1
+      ? computePlanLimitViolations(await countTenantUsage(admin, tenantId), newPlan.limits)
+      : []
 
-  if (maxCourses !== -1 || maxStudents !== -1) {
-    const [coursesRes, studentsRes] = await Promise.all([
-      admin
-        .from('courses')
-        .select('*', { count: 'exact', head: true })
-        .eq('tenant_id', tenantId)
-        .neq('status', 'archived'),
-      admin
-        .from('tenant_users')
-        .select('*', { count: 'exact', head: true })
-        .eq('tenant_id', tenantId)
-        .eq('role', 'student')
-        .eq('status', 'active'),
-    ])
-    courseCount = coursesRes.count ?? 0
-    studentCount = studentsRes.count ?? 0
-    overCourses = maxCourses !== -1 && courseCount > maxCourses
-    overStudents = maxStudents !== -1 && studentCount > maxStudents
-  }
-
-  if (!overCourses && !overStudents) {
+  if (violations.length === 0) {
     await applyPlanToDb(admin, tenantId, newPlan)
     return { action: 'applied' }
   }
 
-  const reasons: string[] = []
-  if (overCourses) {
-    reasons.push(`${courseCount} active courses exceed the ${newPlan.name || newPlan.slug} limit of ${maxCourses}`)
-  }
-  if (overStudents) {
-    reasons.push(`${studentCount} active students exceed the ${newPlan.name || newPlan.slug} limit of ${maxStudents}`)
-  }
+  const reasons = violations.map((v) =>
+    v.resource === 'courses'
+      ? `${v.current} active courses exceed the ${newPlan.name || newPlan.slug} limit of ${v.max}`
+      : `${v.current} active students exceed the ${newPlan.name || newPlan.slug} limit of ${v.max}`
+  )
 
   const { data: oldPlan } = currentSub?.plan_id
     ? ((await admin

--- a/messages/en.json
+++ b/messages/en.json
@@ -1770,11 +1770,39 @@
           "upcomingPayment": "Upcoming payment",
           "dueOn": "Due {date}",
           "bankTransfer": "Bank transfer",
-          "cardPayment": "Card payment"
+          "cardPayment": "Card payment",
+          "cancelPlan": "Cancel plan",
+          "cancelConfirmTitle": "Cancel subscription?",
+          "cancelConfirmBody": "Your school keeps {plan} access until {date}, then moves to the Free plan. You can resubscribe anytime.",
+          "cancelConfirmBodyNoDate": "Your school will move to the Free plan at the end of your billing period. You can resubscribe anytime.",
+          "cancelConfirmAction": "Cancel subscription",
+          "cancelKeep": "Keep subscription",
+          "cancelSuccess": "Your subscription will cancel at the end of your billing period",
+          "cancelError": "Failed to cancel subscription"
         },
         "upgrade": {
           "checkoutError": "Failed to create checkout session",
           "checkoutFailed": "Failed to start checkout. Please try again."
+        },
+        "changePlan": {
+          "upgradeTitle": "Upgrade to {plan}",
+          "downgradeTitle": "Downgrade to {plan}",
+          "intervalTitle": "Change {plan} billing",
+          "previewIntro": "Review the proration before confirming. Your card on file is charged automatically.",
+          "loadingPreview": "Calculating proration…",
+          "previewUnavailable": "We couldn't load a price preview, but you can still switch — your next invoice will reflect the change.",
+          "prorationDueNow": "Proration on your next invoice",
+          "prorationCredit": "Credit on your next invoice",
+          "nextInvoiceTotal": "Next invoice total",
+          "overLimitTitle": "Over the {plan} plan limits",
+          "overLimitIntro": "Reduce your usage before downgrading:",
+          "violationCourses": "You have {current} active courses — the plan allows {max}. Archive {reduceBy} to continue.",
+          "violationStudents": "You have {current} students — the plan allows {max}. Remove {reduceBy} to continue.",
+          "confirm": "Confirm change",
+          "cancel": "Cancel",
+          "close": "Close",
+          "success": "Plan updated",
+          "error": "Failed to change plan"
         }
       },
       "users": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -1770,11 +1770,39 @@
           "upcomingPayment": "Próximo pago",
           "dueOn": "Vence el {date}",
           "bankTransfer": "Transferencia bancaria",
-          "cardPayment": "Pago con tarjeta"
+          "cardPayment": "Pago con tarjeta",
+          "cancelPlan": "Cancelar plan",
+          "cancelConfirmTitle": "¿Cancelar suscripción?",
+          "cancelConfirmBody": "Tu escuela conserva el acceso a {plan} hasta el {date}, y luego pasa al plan Gratis. Puedes volver a suscribirte cuando quieras.",
+          "cancelConfirmBodyNoDate": "Tu escuela pasará al plan Gratis al final de tu período de facturación. Puedes volver a suscribirte cuando quieras.",
+          "cancelConfirmAction": "Cancelar suscripción",
+          "cancelKeep": "Mantener suscripción",
+          "cancelSuccess": "Tu suscripción se cancelará al final de tu período de facturación",
+          "cancelError": "Error al cancelar la suscripción"
         },
         "upgrade": {
           "checkoutError": "Error al crear la sesión de pago",
           "checkoutFailed": "Error al iniciar el pago. Por favor, inténtalo de nuevo."
+        },
+        "changePlan": {
+          "upgradeTitle": "Mejorar a {plan}",
+          "downgradeTitle": "Bajar a {plan}",
+          "intervalTitle": "Cambiar facturación de {plan}",
+          "previewIntro": "Revisa el prorrateo antes de confirmar. Se cobrará automáticamente a tu tarjeta registrada.",
+          "loadingPreview": "Calculando prorrateo…",
+          "previewUnavailable": "No pudimos cargar una vista previa del precio, pero aún puedes cambiar: tu próxima factura reflejará el cambio.",
+          "prorationDueNow": "Prorrateo en tu próxima factura",
+          "prorationCredit": "Crédito en tu próxima factura",
+          "nextInvoiceTotal": "Total de la próxima factura",
+          "overLimitTitle": "Superas los límites del plan {plan}",
+          "overLimitIntro": "Reduce tu uso antes de bajar de plan:",
+          "violationCourses": "Tienes {current} cursos activos — el plan permite {max}. Archiva {reduceBy} para continuar.",
+          "violationStudents": "Tienes {current} estudiantes — el plan permite {max}. Elimina {reduceBy} para continuar.",
+          "confirm": "Confirmar cambio",
+          "cancel": "Cancelar",
+          "close": "Cerrar",
+          "success": "Plan actualizado",
+          "error": "Error al cambiar de plan"
         }
       },
       "users": {

--- a/supabase/migrations/20260719160000_platform_payment_requests_downgrade_type.sql
+++ b/supabase/migrations/20260719160000_platform_payment_requests_downgrade_type.sql
@@ -1,0 +1,17 @@
+-- Allow 'downgrade' as a platform payment request type.
+--
+-- Part of #465 (in-app school plan change). The manual (bank-transfer) flow
+-- previously hardcoded request_type = 'upgrade' regardless of tier, so manual
+-- downgrades were indistinguishable from upgrades. The request-creation action
+-- now derives a real 'upgrade' | 'downgrade' via classifyPlanChange(), which
+-- needs the CHECK constraint to permit 'downgrade'.
+--
+-- The original constraint was added in 20260221010000_billing_proof_upload.sql
+-- as: CHECK (request_type IN ('upgrade', 'renewal')).
+
+ALTER TABLE platform_payment_requests
+  DROP CONSTRAINT IF EXISTS platform_payment_requests_request_type_check;
+
+ALTER TABLE platform_payment_requests
+  ADD CONSTRAINT platform_payment_requests_request_type_check
+  CHECK (request_type IN ('upgrade', 'downgrade', 'renewal'));

--- a/tests/unit/plan-change.test.ts
+++ b/tests/unit/plan-change.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import { classifyPlanChange } from '@/lib/billing/plan-change'
+
+/**
+ * Pins the pure plan-change classifier contract (issue #465): tier moves are
+ * decided by sort_order; equal sort_order is an interval-only change decided
+ * by amount, with equal amounts defaulting to 'upgrade'.
+ */
+
+describe('classifyPlanChange', () => {
+  it('tier upgrade — target sort_order higher than current', () => {
+    const result = classifyPlanChange({
+      currentSortOrder: 1,
+      currentAmount: 900,
+      targetSortOrder: 2,
+      targetAmount: 2900,
+    })
+    expect(result).toEqual({ requestType: 'upgrade', isIntervalOnly: false })
+  })
+
+  it('tier downgrade — target sort_order lower than current', () => {
+    const result = classifyPlanChange({
+      currentSortOrder: 2,
+      currentAmount: 2900,
+      targetSortOrder: 1,
+      targetAmount: 900,
+    })
+    expect(result).toEqual({ requestType: 'downgrade', isIntervalOnly: false })
+  })
+
+  it('interval-only upgrade — equal sort_order, target amount higher (monthly → yearly)', () => {
+    const result = classifyPlanChange({
+      currentSortOrder: 2,
+      currentAmount: 2900,
+      targetSortOrder: 2,
+      targetAmount: 29000,
+    })
+    expect(result).toEqual({ requestType: 'upgrade', isIntervalOnly: true })
+  })
+
+  it('interval-only downgrade — equal sort_order, target amount lower (yearly → monthly)', () => {
+    const result = classifyPlanChange({
+      currentSortOrder: 2,
+      currentAmount: 29000,
+      targetSortOrder: 2,
+      targetAmount: 2900,
+    })
+    expect(result).toEqual({ requestType: 'downgrade', isIntervalOnly: true })
+  })
+
+  it('equal sort_order and equal amount defaults to upgrade', () => {
+    const result = classifyPlanChange({
+      currentSortOrder: 2,
+      currentAmount: 2900,
+      targetSortOrder: 2,
+      targetAmount: 2900,
+    })
+    expect(result).toEqual({ requestType: 'upgrade', isIntervalOnly: true })
+  })
+})

--- a/tests/unit/plan-limits.test.ts
+++ b/tests/unit/plan-limits.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect } from 'vitest'
+import {
+  computePlanLimitViolations,
+  checkPlanLimits,
+  formatPlanLimitError,
+  type PlanLimitCheckResult,
+} from '@/lib/billing/plan-limits'
+
+/**
+ * Pins the plan-limit pre-flight check contract (issue #465): pure violation
+ * comparison, the async usage/plan lookup (fail-open on no target / unknown
+ * plan), and the human-readable error wording. Fluent fake Supabase client
+ * modeled on tests/unit/platform-plan-change.test.ts.
+ */
+
+interface FakeConfig {
+  plan?: { name: string; limits: { max_courses?: number; max_students?: number } | null } | null
+  courseCount?: number
+  studentCount?: number
+}
+
+interface Recorder {
+  planEq: { col: string; val: unknown }[]
+}
+
+function makeFakeAdmin(cfg: FakeConfig) {
+  const calls: Recorder = { planEq: [] }
+
+  function makeBuilder(table: string) {
+    const builder: Record<string, unknown> = {
+      select() {
+        return builder
+      },
+      eq(col: string, val: unknown) {
+        if (table === 'platform_plans') calls.planEq.push({ col, val })
+        return builder
+      },
+      neq() {
+        return builder
+      },
+      maybeSingle() {
+        if (table === 'platform_plans') {
+          return Promise.resolve({ data: cfg.plan ?? null, error: null })
+        }
+        return Promise.resolve({ data: null, error: null })
+      },
+      then(resolve: (v: unknown) => unknown) {
+        if (table === 'courses') {
+          return Promise.resolve({ count: cfg.courseCount ?? 0, error: null }).then(resolve)
+        }
+        if (table === 'tenant_users') {
+          return Promise.resolve({ count: cfg.studentCount ?? 0, error: null }).then(resolve)
+        }
+        return Promise.resolve({ data: null, error: null }).then(resolve)
+      },
+    }
+    return builder
+  }
+
+  const admin = {
+    from(table: string) {
+      return makeBuilder(table)
+    },
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return { admin: admin as any, calls }
+}
+
+describe('computePlanLimitViolations (pure)', () => {
+  it('usage under both limits → no violations', () => {
+    const violations = computePlanLimitViolations(
+      { courses: 5, students: 50 },
+      { max_courses: 15, max_students: 200 }
+    )
+    expect(violations).toEqual([])
+  })
+
+  it('over courses only', () => {
+    const violations = computePlanLimitViolations(
+      { courses: 20, students: 50 },
+      { max_courses: 15, max_students: 200 }
+    )
+    expect(violations).toEqual([{ resource: 'courses', current: 20, max: 15, reduceBy: 5 }])
+  })
+
+  it('over students only', () => {
+    const violations = computePlanLimitViolations(
+      { courses: 5, students: 250 },
+      { max_courses: 15, max_students: 200 }
+    )
+    expect(violations).toEqual([{ resource: 'students', current: 250, max: 200, reduceBy: 50 }])
+  })
+
+  it('over both courses and students', () => {
+    const violations = computePlanLimitViolations(
+      { courses: 20, students: 250 },
+      { max_courses: 15, max_students: 200 }
+    )
+    expect(violations).toEqual([
+      { resource: 'courses', current: 20, max: 15, reduceBy: 5 },
+      { resource: 'students', current: 250, max: 200, reduceBy: 50 },
+    ])
+  })
+
+  it('-1 (unlimited) never violates even with high usage', () => {
+    const violations = computePlanLimitViolations(
+      { courses: 100000, students: 100000 },
+      { max_courses: -1, max_students: -1 }
+    )
+    expect(violations).toEqual([])
+  })
+
+  it('null limits → no violations', () => {
+    const violations = computePlanLimitViolations({ courses: 100000, students: 100000 }, null)
+    expect(violations).toEqual([])
+  })
+
+  it('missing max_students key → students treated as unlimited', () => {
+    const violations = computePlanLimitViolations(
+      { courses: 5, students: 100000 },
+      { max_courses: 15 }
+    )
+    expect(violations).toEqual([])
+  })
+})
+
+describe('checkPlanLimits (async)', () => {
+  it('usage fits target plan → ok:true, no violations', async () => {
+    const { admin } = makeFakeAdmin({
+      plan: { name: 'Starter', limits: { max_courses: 15, max_students: 200 } },
+      courseCount: 10,
+      studentCount: 100,
+    })
+    const result = await checkPlanLimits(admin, 'tenant-1', { planId: 'starter-id' })
+    expect(result.ok).toBe(true)
+    expect(result.planName).toBe('Starter')
+    expect(result.usage).toEqual({ courses: 10, students: 100 })
+    expect(result.violations).toEqual([])
+  })
+
+  it('usage over target plan → ok:false with correct violations', async () => {
+    const { admin } = makeFakeAdmin({
+      plan: { name: 'Starter', limits: { max_courses: 15, max_students: 200 } },
+      courseCount: 50,
+      studentCount: 100,
+    })
+    const result = await checkPlanLimits(admin, 'tenant-1', { slug: 'starter' })
+    expect(result.ok).toBe(false)
+    expect(result.planName).toBe('Starter')
+    expect(result.violations).toEqual([
+      { resource: 'courses', current: 50, max: 15, reduceBy: 35 },
+    ])
+  })
+
+  it('unknown plan (maybeSingle returns null) → fail-open ok:true, planName null', async () => {
+    const { admin } = makeFakeAdmin({ plan: null, courseCount: 500, studentCount: 500 })
+    const result = await checkPlanLimits(admin, 'tenant-1', { planId: 'unknown-id' })
+    expect(result.ok).toBe(true)
+    expect(result.planName).toBeNull()
+    expect(result.violations).toEqual([])
+  })
+
+  it('neither planId nor slug provided → fail-open ok:true', async () => {
+    const { admin } = makeFakeAdmin({ courseCount: 500, studentCount: 500 })
+    const result = await checkPlanLimits(admin, 'tenant-1', {})
+    expect(result.ok).toBe(true)
+    expect(result.planName).toBeNull()
+    expect(result.violations).toEqual([])
+    expect(result.usage).toEqual({ courses: 500, students: 500 })
+  })
+})
+
+describe('formatPlanLimitError', () => {
+  it('returns null when ok', () => {
+    const result: PlanLimitCheckResult = {
+      ok: true,
+      planName: 'Starter',
+      usage: { courses: 10, students: 100 },
+      violations: [],
+    }
+    expect(formatPlanLimitError(result)).toBeNull()
+  })
+
+  it('produces exact wording for both courses and students violations', () => {
+    const result: PlanLimitCheckResult = {
+      ok: false,
+      planName: 'Starter',
+      usage: { courses: 50, students: 250 },
+      violations: [
+        { resource: 'courses', current: 50, max: 15, reduceBy: 35 },
+        { resource: 'students', current: 250, max: 200, reduceBy: 50 },
+      ],
+    }
+    expect(formatPlanLimitError(result)).toBe(
+      'You have 50 active courses but the Starter plan allows 15. Archive 35 course(s) before downgrading. ' +
+        'You have 250 students but the Starter plan allows 200.'
+    )
+  })
+
+  it('falls back to "target" when planName is null', () => {
+    const result: PlanLimitCheckResult = {
+      ok: false,
+      planName: null,
+      usage: { courses: 50, students: 100 },
+      violations: [{ resource: 'courses', current: 50, max: 15, reduceBy: 35 }],
+    }
+    expect(formatPlanLimitError(result)).toBe(
+      'You have 50 active courses but the target plan allows 15. Archive 35 course(s) before downgrading.'
+    )
+  })
+})


### PR DESCRIPTION
Closes #465. Part of the Phase 3 plan-change epic (#458).

## What & why
School admins could only **upgrade** in-app; downgrade, cancel, and monthly↔yearly switch were punted to Stripe's hosted Customer Portal, where proration is invisible to the app and over-limit downgrades reconcile *reactively* (apply-then-revert, #461). This wires those flows in-app with a **pre-flight limit check** that blocks over-limit downgrades *before* touching Stripe.

## Changes
- **`lib/billing/plan-limits.ts`** — shared pre-flight limit helper (single source of truth: non-archived courses + active students vs a target plan's `limits`). `applyPortalPlanChange` (#461) and the manual-confirm check now delegate to it — behavior identical, existing tests stay green.
- **`lib/billing/plan-change.ts`** — pure `classifyPlanChange` (tier by `sort_order`, interval amount as tiebreak) → real `upgrade`/`downgrade` for the manual flow.
- **`app/actions/admin/billing.ts`**
  - `previewPlanChange` → limit violations **or** a Stripe `invoices.createPreview` proration.
  - `changePlan` → pre-flight check → `stripe.subscriptions.update` → **then** optimistic DB mirror (strict ordering so Stripe price & DB plan never disagree — the #461 invariant; the webhook echo hits its no-op guard).
  - Revived the previously-dead `cancelSubscription` (period-end) and made it persist `cancel_at_period_end` locally.
  - Manual path now records a real `request_type` and runs the limit check at request time.
- **`platform-webhook`** — reconcile `interval` on `customer.subscription.updated` so portal interval switches persist.
- **UI** — `plan-change-dialog` (proration delta / over-limit "reduce N" block), direction-aware CTAs (Upgrade / Downgrade / Switch interval) in the comparison table, Cancel confirm dialog in the billing dashboard. en/es copy added.
- **Migration** — `20260719160000_platform_payment_requests_downgrade_type.sql` extends the `request_type` CHECK with `'downgrade'`.

## Acceptance
- [x] Existing Stripe subscriber can upgrade / downgrade / switch interval in-app with a proration preview; over-limit downgrade blocked with a clear "reduce N" explanation.
- [x] Cancel button works (period-end); overview card shows "cancels on <date>".
- [x] Customer Portal remains available but is no longer the only path.

## Test plan / QA
- `npm run test:unit` — **184 passing**, incl. new `plan-limits` (14) + `plan-change` (5); existing `platform-plan-change` (7) unchanged & green.
- `npm run typecheck` clean · `npm run build` passes.
- Migration applied locally (verified constraint now allows `downgrade`).
- Only new lint warning/error introduced was a `set-state-in-effect` in the new dialog — fixed. Remaining lint items on changed files are pre-existing baseline `any`/unused-vars on untouched lines.

## ⚠️ Follow-up for maintainer
The cloud DB migration was **not** applied by me (the production-DB write was blocked by the safety classifier). Apply `supabase/migrations/20260719160000_platform_payment_requests_downgrade_type.sql` to cloud before/at deploy — until then, manual **downgrade** requests will violate the old CHECK constraint.

## Not covered locally
Stripe Connect / Platform billing may not be fully enabled in the local env, so the live end-to-end `subscriptions.update` against a real platform sub wasn't exercised here; all Stripe calls are error-guarded with friendly messages, pure logic is unit-tested, and the over-limit/preview UI states render off the seeded data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)