### PR TITLE
fix(deploy): install with --legacy-peer-deps in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY packages/core/package.json ./packages/core/package.json
 # Remove the lockfile so npm freshly resolves platform-specific optional
 # native binaries (lightningcss/Tailwind v4) for this Linux image — npm has a
 # long-standing bug that skips optional native deps when a lockfile is present.
-RUN rm -f package-lock.json && npm install --include=optional
+RUN rm -f package-lock.json && npm install --include=optional --legacy-peer-deps
 
 # Build
 FROM base AS builder


### PR DESCRIPTION
## The deploy pipeline has been broken since 2026-07-18

Every **Build and deploy to Dokploy** run has failed at the `npm install` step with `ERESOLVE`:

```
peer @stripe/stripe-js@">=9.5.0 <10.0.0" from @stripe/react-stripe-js@6.8.0
Found: @stripe/stripe-js@8.11.0   (root pins ^8.9.0)
```

The repo resolves this everywhere else via `.npmrc` (`legacy-peer-deps=true`), but the Dockerfile **doesn't `COPY .npmrc`** and runs `rm -f package-lock.json && npm install`, so the strict peer check fails **only inside the image build**. Result: no merge since #457 has actually deployed — #459–#467, #465, and #463 all built-and-deploy-failed.

## Fix
One line — add `--legacy-peer-deps` to the in-image install so fresh resolution matches local/CI:

```dockerfile
RUN rm -f package-lock.json && npm install --include=optional --legacy-peer-deps
```

Keeps the intentional lockfile removal (npm's optional-native-deps bug for lightningcss/Tailwind v4).

## Verified
Ran the exact command in a clean dir mirroring the Dockerfile's COPY (package.json + packages/core/package.json, no `.npmrc`): resolves **1473 packages, exit 0, no ERESOLVE**. The next master deploy run should get past `npm install` and reach the Dokploy webhook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LVTsGCEjPyjwtjJs6qSmhR