### PR TITLE
fix(payments): flip abandoned hosted-checkout tx on payment.failed so retry works (#479)

### DIFF
--- a/lib/payments/webhook-dispatch.ts
+++ b/lib/payments/webhook-dispatch.ts
@@ -248,11 +248,33 @@ export async function dispatchBillingEvent(
       break
     }
 
-    case 'payment.failed':
-      // No transaction state change — the pending row is rolled back by the
-      // checkout route on creation failure, and LS does not deliver a one-time
-      // payment-failed webhook for hosted checkout. Logged for completeness.
-      console.log(`[webhook] payment.failed for ${provider} — no-op in shared dispatcher`)
+    case 'payment.failed': {
+      // A hosted-checkout provider can deliver a terminal failure for an
+      // abandoned order (Binance Pay `PAY_CLOSED` on order expiry). The pending
+      // transaction created at checkout must be cleared, or the partial unique
+      // indexes transactions_unique_product / transactions_unique_plan
+      // (WHERE status IN ('pending','successful')) keep blocking the buyer's
+      // retry purchase forever. Flip the referenced row → failed.
+      //
+      // Idempotent + ordering-safe: the `.eq('status','pending')` guard means a
+      // late PAY_CLOSED that races a PAY_SUCCESS (already flipped → successful)
+      // is a no-op, and a redelivery finds no pending row. Providers that never
+      // send a one-time payment-failed webhook (Lemon Squeezy) never reach here
+      // with a reference, so this is a no-op for them.
+      if (!event.reference) {
+        console.log(`[webhook] payment.failed for ${provider} without reference — no-op`)
+        break
+      }
+      const txnId = Number.parseInt(event.reference, 10)
+      if (Number.isNaN(txnId)) break
+
+      const { error } = await admin
+        .from('transactions')
+        .update({ status: 'failed' })
+        .eq('transaction_id', txnId)
+        .eq('status', 'pending')
+      if (error) throw new Error(`dispatch ${event.type} failed: ${error.message}`)
       break
+    }
   }
 }

--- a/tests/unit/webhook-dispatch.test.ts
+++ b/tests/unit/webhook-dispatch.test.ts
@@ -268,4 +268,27 @@ describe('dispatchBillingEvent', () => {
     expect(calls.updates).toHaveLength(0)
     expect(calls.rpc).toHaveLength(0)
   })
+
+  it('payment.failed with reference → flips the abandoned pending tx to failed (frees retry, #479)', async () => {
+    // Binance PAY_CLOSED on an abandoned checkout: the pending transaction must
+    // be cleared or transactions_unique_product/plan blocks the buyer's retry.
+    const { admin, calls } = makeFakeAdmin('pending')
+    await dispatchBillingEvent(event('payment.failed', { reference: '42', providerPaymentId: 'ord_1' }), {
+      provider: 'binance',
+      admin,
+    })
+    const txUpdate = calls.updates.find((u) => u.table === 'transactions')
+    expect(txUpdate?.values).toMatchObject({ status: 'failed' })
+    expect(calls.rpc).toHaveLength(0)
+  })
+
+  it('payment.failed WITHOUT reference → no write (Lemon Squeezy path)', async () => {
+    const { admin, calls } = makeFakeAdmin()
+    await dispatchBillingEvent(event('payment.failed', { providerPaymentId: 'pi_1' }), {
+      provider: PROVIDER,
+      admin,
+    })
+    expect(calls.updates).toHaveLength(0)
+    expect(calls.rpc).toHaveLength(0)
+  })
 })


### PR DESCRIPTION
## What & why

Closes part of #479 (credentialed-QA follow-up to #466 / PR #478). While doing the **static** portion of that QA — code review + the checklist items that need no live sandbox credentials — I found one real defect and fixed it. The rest of #479 (live PayPal sandbox + Binance Pay merchant runs) still needs credentials and stays open; see my QA record on the issue.

## The bug

Binance Pay delivers a `PAY_CLOSED` webhook when a buyer abandons a checkout and the order expires. `binance-provider.normalizeWebhookEvent` maps it to `payment.failed`, but the shared `dispatchBillingEvent` treated `payment.failed` as a **log-only no-op** — a reasoning that only held for Lemon Squeezy (which never sends a one-time payment-failed webhook).

Consequence: the pending `transactions` row created at checkout was never cleared. The partial unique indexes `transactions_unique_product` / `transactions_unique_plan` (`WHERE status IN ('pending','successful')`) then **blocked the buyer's retry purchase indefinitely** — the checkout route's insert 500s. This directly contradicts #479's own Binance acceptance line:

> Abandon a checkout … `PAY_CLOSED` (order expiry) arrives → normalized `payment.failed`, no state corruption, **retry purchase works (partial unique index allows it)**.

## The fix

In the dispatcher's `payment.failed` case: when the event carries a transaction `reference`, flip that row `pending` → `failed`, freeing the partial unique index so a retry succeeds.

- **Idempotent + ordering-safe** — `.eq('status','pending')` guard: a late `PAY_CLOSED` racing a `PAY_SUCCESS` (already `successful`) is a no-op, and a redelivery finds no pending row.
- **No-op for Lemon Squeezy** — it sends no reference on this path, so behavior is unchanged.

## Test plan

- [x] `npx vitest run tests/unit/webhook-dispatch.test.ts tests/unit/paypal-binance-providers.test.ts` → **33/33 pass** (2 new dispatcher tests: reference → flip to `failed`; no reference → no-op).
- [x] `npx eslint` on changed files → 0 errors.
- [x] Migration `20260719180000_add_binance_payment_provider.sql` applied to local DB; `products_payment_provider_check` and `plans_payment_provider_check` both now include `binance`.
- [ ] Live Binance sandbox abandon → `PAY_CLOSED` → retry succeeds — **needs Binance merchant credentials** (tracked in #479).

## Static-QA results also folded into #479

Verified in code (no credentials): unit suite green; UI polish all-pass (Binance toggle en+es, provider gating in product/plan forms + wizard, checkout hosted-redirect flow, PayPal no longer "Coming Soon"). Full record + the credential-blocked items + live-verify risks are commented on #479.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Khcu1sKtuzosX8w2JAixEv
