### PR TITLE
feat(courses): free-lesson preview for prospective students (#426)

### DIFF
--- a/app/[locale]/(public)/courses/[id]/lessons/[lessonId]/page.tsx
+++ b/app/[locale]/(public)/courses/[id]/lessons/[lessonId]/page.tsx
@@ -1,3 +1,4 @@
+import { cache } from 'react'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { getCurrentTenantId } from '@/lib/supabase/tenant'
 import { getTranslations } from 'next-intl/server'
@@ -21,32 +22,33 @@ interface PageProps {
 // Uses the admin client with explicit guards mirroring the anon RLS policy:
 // published preview lesson, published course, current tenant. Read-only:
 // no completion tracking, no checkpoints, no comments, no AI task.
-async function getPreviewLesson(courseId: number, lessonId: number, tenantId: string) {
+// cache() dedupes the generateMetadata + page calls within a request.
+const getPreviewLesson = cache(async (courseId: number, lessonId: number, tenantId: string) => {
     if (!Number.isInteger(courseId) || !Number.isInteger(lessonId)) return null
     const admin = createAdminClient()
 
-    const { data: course } = await admin
-        .from('courses')
-        .select('course_id, title')
-        .eq('course_id', courseId)
-        .eq('tenant_id', tenantId)
-        .eq('status', 'published')
-        .single()
-    if (!course) return null
-
-    const { data: lesson } = await admin
-        .from('lessons')
-        .select('id, title, sequence, description, content, video_url, embed_code')
-        .eq('id', lessonId)
-        .eq('course_id', courseId)
-        .eq('tenant_id', tenantId)
-        .eq('status', 'published')
-        .eq('is_preview', true)
-        .single()
-    if (!lesson) return null
+    const [{ data: course }, { data: lesson }] = await Promise.all([
+        admin
+            .from('courses')
+            .select('course_id, title')
+            .eq('course_id', courseId)
+            .eq('tenant_id', tenantId)
+            .eq('status', 'published')
+            .single(),
+        admin
+            .from('lessons')
+            .select('id, title, sequence, description, content, video_url, embed_code')
+            .eq('id', lessonId)
+            .eq('course_id', courseId)
+            .eq('tenant_id', tenantId)
+            .eq('status', 'published')
+            .eq('is_preview', true)
+            .single(),
+    ])
+    if (!course || !lesson) return null
 
     return { course, lesson }
-}
+})
 
 export async function generateMetadata(props: PageProps): Promise<Metadata> {
     const { id, lessonId, locale } = await props.params
@@ -110,6 +112,7 @@ export default async function PublicLessonPreviewPage(props: PageProps) {
                     mdx={await serializeLessonMdx(lesson.content)}
                     videoUrl={lesson.video_url}
                     embedCode={lesson.embed_code}
+                    embedMode="sandboxed"
                 />
 
                 {/* Enroll CTA */}

--- a/app/[locale]/(public)/courses/[id]/lessons/[lessonId]/page.tsx
+++ b/app/[locale]/(public)/courses/[id]/lessons/[lessonId]/page.tsx
@@ -1,0 +1,127 @@
+import { createAdminClient } from '@/lib/supabase/admin'
+import { getCurrentTenantId } from '@/lib/supabase/tenant'
+import { getTranslations } from 'next-intl/server'
+import { notFound } from 'next/navigation'
+import Link from 'next/link'
+import { ArrowLeft, Sparkles } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { LessonContent } from '@/app/[locale]/dashboard/student/courses/[courseId]/lessons/[lessonId]/lesson-content'
+import { serializeLessonMdx } from '@/app/[locale]/dashboard/student/courses/[courseId]/lessons/[lessonId]/serialize-lesson'
+import type { Metadata } from 'next'
+import { buildPageMetadata } from '@/lib/seo'
+
+export const dynamic = 'force-dynamic'
+
+interface PageProps {
+    params: Promise<{ id: string; lessonId: string; locale: string }>
+}
+
+// Public free-preview lesson view (#426). Reachable by anyone — including
+// logged-out visitors (/courses/* is in the proxy public-route allowlist).
+// Uses the admin client with explicit guards mirroring the anon RLS policy:
+// published preview lesson, published course, current tenant. Read-only:
+// no completion tracking, no checkpoints, no comments, no AI task.
+async function getPreviewLesson(courseId: number, lessonId: number, tenantId: string) {
+    if (!Number.isInteger(courseId) || !Number.isInteger(lessonId)) return null
+    const admin = createAdminClient()
+
+    const { data: course } = await admin
+        .from('courses')
+        .select('course_id, title')
+        .eq('course_id', courseId)
+        .eq('tenant_id', tenantId)
+        .eq('status', 'published')
+        .single()
+    if (!course) return null
+
+    const { data: lesson } = await admin
+        .from('lessons')
+        .select('id, title, sequence, description, content, video_url, embed_code')
+        .eq('id', lessonId)
+        .eq('course_id', courseId)
+        .eq('tenant_id', tenantId)
+        .eq('status', 'published')
+        .eq('is_preview', true)
+        .single()
+    if (!lesson) return null
+
+    return { course, lesson }
+}
+
+export async function generateMetadata(props: PageProps): Promise<Metadata> {
+    const { id, lessonId, locale } = await props.params
+    const tenantId = await getCurrentTenantId()
+    const data = await getPreviewLesson(Number(id), Number(lessonId), tenantId)
+    if (!data) notFound()
+    return buildPageMetadata({
+        title: `${data.lesson.title} — ${data.course.title}`,
+        description: data.lesson.description?.replace(/\s+/g, ' ').trim().slice(0, 160) || data.course.title,
+        path: `/courses/${id}/lessons/${lessonId}`,
+        locale,
+    })
+}
+
+export default async function PublicLessonPreviewPage(props: PageProps) {
+    const { id, lessonId } = await props.params
+    const [t, tenantId] = await Promise.all([
+        getTranslations('coursePublicDetails'),
+        getCurrentTenantId(),
+    ])
+
+    const data = await getPreviewLesson(Number(id), Number(lessonId), tenantId)
+    if (!data) notFound()
+    const { course, lesson } = data
+
+    return (
+        // pt-16 clears the public layout's fixed navbar
+        <div className="min-h-screen bg-background pt-16">
+            {/* Preview notice banner */}
+            <div className="border-b bg-primary/5">
+                <div className="container mx-auto px-4 py-3 flex flex-wrap items-center justify-between gap-3">
+                    <div className="flex items-center gap-2 min-w-0 text-sm">
+                        <Sparkles className="w-4 h-4 text-primary flex-shrink-0" aria-hidden="true" />
+                        <span className="font-semibold text-primary flex-shrink-0">{t('preview.badge')}</span>
+                        <span className="text-muted-foreground truncate">{t('preview.notice')}</span>
+                    </div>
+                    <Link href={`/courses/${id}`} className="flex-shrink-0">
+                        <Button variant="outline" size="sm" className="gap-1.5">
+                            <ArrowLeft className="w-4 h-4" aria-hidden="true" />
+                            {t('preview.backToCourse')}
+                        </Button>
+                    </Link>
+                </div>
+            </div>
+
+            <div className="mx-auto max-w-4xl px-4 py-8 md:px-6 md:py-10 space-y-10">
+                {/* Lesson header */}
+                <header>
+                    <p className="text-[10px] font-bold uppercase tracking-widest text-muted-foreground/60 mb-1">
+                        {course.title}
+                    </p>
+                    <h1 className="text-2xl md:text-3xl font-bold tracking-tight text-balance">
+                        {lesson.title}
+                    </h1>
+                    {lesson.description && (
+                        <p className="mt-2 text-muted-foreground leading-relaxed">{lesson.description}</p>
+                    )}
+                </header>
+
+                <LessonContent
+                    mdx={await serializeLessonMdx(lesson.content)}
+                    videoUrl={lesson.video_url}
+                    embedCode={lesson.embed_code}
+                />
+
+                {/* Enroll CTA */}
+                <section className="rounded-2xl border-2 border-primary/10 bg-gradient-to-b from-primary/[0.06] to-transparent p-6 md:p-8 text-center space-y-4">
+                    <h2 className="text-xl font-bold">{t('preview.enrollTitle')}</h2>
+                    <Link href={`/courses/${id}`} className="inline-block">
+                        <Button size="lg" className="gap-2">
+                            {t('preview.enrollCta')}
+                        </Button>
+                    </Link>
+                </section>
+            </div>
+        </div>
+    )
+}

--- a/app/[locale]/(public)/courses/[id]/page.tsx
+++ b/app/[locale]/(public)/courses/[id]/page.tsx
@@ -79,6 +79,7 @@ interface Lesson {
     title: string;
     sequence: number;
     description: string | null;
+    is_preview: boolean;
 }
 
 export default async function CourseDetailsPage(props: {
@@ -99,12 +100,6 @@ export default async function CourseDetailsPage(props: {
         .from("courses")
         .select(`
             *,
-            lessons (
-                id,
-                title,
-                sequence,
-                description
-            ),
             category:course_categories (
                 id,
                 name
@@ -118,6 +113,17 @@ export default async function CourseDetailsPage(props: {
     if (error || !course) {
         notFound();
     }
+
+    // Curriculum via admin client: the anon role can only read preview lessons
+    // (RLS), but the public page lists every published lesson's title. Metadata
+    // only — never select content here.
+    const lessonsPromise = createAdminClient()
+        .from('lessons')
+        .select('id, title, sequence, description, is_preview')
+        .eq('course_id', courseId)
+        .eq('tenant_id', tenantId)
+        .eq('status', 'published')
+        .order('sequence', { ascending: true });
 
     const authorPromise = course.author_id
         ? supabase
@@ -161,18 +167,18 @@ export default async function CourseDetailsPage(props: {
         })()
         : Promise.resolve(false);
 
-    const [{ data: author }, hasAccess, { data: productCourses }, planCoversCourse, socialProof] = await Promise.all([
+    const [{ data: author }, hasAccess, { data: productCourses }, planCoversCourse, socialProof, { data: lessonRows }] = await Promise.all([
         authorPromise,
         accessPromise,
         productCoursesPromise,
         planCoveragePromise,
         getCourseSocialProof(courseId, tenantId),
+        lessonsPromise,
     ]);
 
     const { averageRating, reviewCount, studentCount, recentReviews } = socialProof;
 
-    // Sort lessons by sequence
-    const lessons = course.lessons?.sort((a: Lesson, b: Lesson) => a.sequence - b.sequence) || [];
+    const lessons: Lesson[] = lessonRows ?? [];
     const totalLessons = lessons.length;
     const estimatedHours = Math.floor(totalLessons * 10 / 60);
     const estimatedMinutes = (totalLessons * 10) % 60;
@@ -347,13 +353,30 @@ export default async function CourseDetailsPage(props: {
                                         </AccordionTrigger>
                                         <AccordionContent className="pb-4 space-y-1">
                                             {lessons.map((lesson: Lesson, index: number) => (
-                                                <div key={lesson.id} className="flex items-center justify-between p-3 rounded-md hover:bg-zinc-800/50 transition-colors duration-150">
-                                                    <div className="flex items-center gap-3 min-w-0">
-                                                        <span className="text-xs text-zinc-400 font-mono w-6 text-right tabular-nums flex-shrink-0">{index + 1}</span>
-                                                        <BookOpen className="w-4 h-4 text-zinc-400 flex-shrink-0" aria-hidden="true" />
-                                                        <span className="text-sm text-zinc-200 truncate">{lesson.title}</span>
+                                                lesson.is_preview ? (
+                                                    <Link
+                                                        key={lesson.id}
+                                                        href={`/courses/${params.id}/lessons/${lesson.id}`}
+                                                        className="flex items-center justify-between gap-3 p-3 rounded-md hover:bg-zinc-800/50 transition-colors duration-150 group"
+                                                    >
+                                                        <div className="flex items-center gap-3 min-w-0">
+                                                            <span className="text-xs text-zinc-400 font-mono w-6 text-right tabular-nums flex-shrink-0">{index + 1}</span>
+                                                            <PlayCircle className="w-4 h-4 text-cyan-400 flex-shrink-0" aria-hidden="true" />
+                                                            <span className="text-sm text-zinc-200 truncate group-hover:text-cyan-400 transition-colors duration-150">{lesson.title}</span>
+                                                        </div>
+                                                        <span className="flex-shrink-0 text-[10px] font-semibold uppercase tracking-wide text-cyan-400 border border-cyan-500/30 bg-cyan-500/10 rounded-full px-2 py-0.5">
+                                                            {t('sections.content.previewBadge')}
+                                                        </span>
+                                                    </Link>
+                                                ) : (
+                                                    <div key={lesson.id} className="flex items-center justify-between p-3 rounded-md hover:bg-zinc-800/50 transition-colors duration-150">
+                                                        <div className="flex items-center gap-3 min-w-0">
+                                                            <span className="text-xs text-zinc-400 font-mono w-6 text-right tabular-nums flex-shrink-0">{index + 1}</span>
+                                                            <BookOpen className="w-4 h-4 text-zinc-400 flex-shrink-0" aria-hidden="true" />
+                                                            <span className="text-sm text-zinc-200 truncate">{lesson.title}</span>
+                                                        </div>
                                                     </div>
-                                                </div>
+                                                )
                                             ))}
                                         </AccordionContent>
                                     </AccordionItem>

--- a/app/[locale]/(public)/courses/page.tsx
+++ b/app/[locale]/(public)/courses/page.tsx
@@ -1,4 +1,5 @@
 import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
 import { getCurrentTenantId } from "@/lib/supabase/tenant";
 import { CourseCard } from "@/components/public/course-card";
 import { CourseSearchBar } from "@/components/shared/course-search-bar";
@@ -56,9 +57,6 @@ export default async function CoursesPage({
                 id,
                 full_name,
                 avatar_url
-            ),
-            lessons (
-                id
             )
         `)
         .eq('tenant_id', tenantId)
@@ -80,6 +78,21 @@ export default async function CoursesPage({
     // Fetch product prices for all courses in one query
     const courseIds = courses?.map(c => c.course_id) || [];
     let productMap: Record<number, { price: number; currency: string }> = {};
+
+    // Published-lesson counts via admin client: the anon role can only read
+    // preview lessons (RLS), so a nested select would undercount for visitors.
+    const lessonCountMap: Record<number, number> = {};
+    if (courseIds.length > 0) {
+        const { data: lessonRows } = await createAdminClient()
+            .from('lessons')
+            .select('id, course_id')
+            .eq('tenant_id', tenantId)
+            .eq('status', 'published')
+            .in('course_id', courseIds);
+        for (const row of lessonRows ?? []) {
+            lessonCountMap[row.course_id] = (lessonCountMap[row.course_id] ?? 0) + 1;
+        }
+    }
 
     if (courseIds.length > 0) {
         const { data: productCourses } = await supabase
@@ -111,7 +124,7 @@ export default async function CoursesPage({
             thumbnail_url: course.thumbnail_url,
             category: cat ? (Array.isArray(cat) ? cat[0] : cat) as { id: number; name: string } : null,
             author: auth ? (Array.isArray(auth) ? auth[0] : auth) as { id: string; full_name: string; avatar_url: string | null } : null,
-            lessonCount: (course.lessons as any[])?.length || 0,
+            lessonCount: lessonCountMap[course.course_id] ?? 0,
             price: productMap[course.course_id]?.price ?? null,
             currency: productMap[course.course_id]?.currency ?? null,
         };

--- a/app/[locale]/dashboard/student/courses/[courseId]/lessons/[lessonId]/lesson-content.tsx
+++ b/app/[locale]/dashboard/student/courses/[courseId]/lessons/[lessonId]/lesson-content.tsx
@@ -19,9 +19,16 @@ interface LessonContentProps {
   mdx: SerializeResult | null
   videoUrl: string | null
   embedCode: string | null
+  /**
+   * How to render teacher-authored embed_code HTML. 'trusted' injects it into
+   * the page (enrolled-student views). 'sandboxed' isolates it in an
+   * opaque-origin iframe (no allow-same-origin) — required on public pages
+   * (#426 preview), where the audience is logged-out visitors.
+   */
+  embedMode?: 'trusted' | 'sandboxed'
 }
 
-export function LessonContent({ mdx, videoUrl, embedCode }: LessonContentProps) {
+export function LessonContent({ mdx, videoUrl, embedCode, embedMode = 'trusted' }: LessonContentProps) {
   const t = useTranslations('components.lessons')
   const tc = useTranslations('components.checkpoints')
   const checkpointsCtx = useCheckpoints()
@@ -102,10 +109,19 @@ export function LessonContent({ mdx, videoUrl, embedCode }: LessonContentProps) 
 
       {/* Custom embed code */}
       {embedCode && !videoEmbedUrl && !useCheckpointPlayer && (
-        <div
-          className="aspect-video w-full overflow-hidden rounded-xl shadow-lg"
-          dangerouslySetInnerHTML={{ __html: embedCode }}
-        />
+        embedMode === 'sandboxed' ? (
+          <iframe
+            srcDoc={`<style>html,body{margin:0;height:100%}</style>${embedCode}`}
+            sandbox="allow-scripts allow-popups"
+            title="Embedded content"
+            className="aspect-video w-full overflow-hidden rounded-xl border-0 shadow-lg"
+          />
+        ) : (
+          <div
+            className="aspect-video w-full overflow-hidden rounded-xl shadow-lg"
+            dangerouslySetInnerHTML={{ __html: embedCode }}
+          />
+        )
       )}
 
       {/* MDX content */}

--- a/app/[locale]/dashboard/teacher/courses/[courseId]/lessons/[lessonId]/page.tsx
+++ b/app/[locale]/dashboard/teacher/courses/[courseId]/lessons/[lessonId]/page.tsx
@@ -95,6 +95,7 @@ export default async function EditLessonPage({ params }: PageProps) {
           publish_at: lesson.publish_at || null,
           ai_task_description: lesson.ai_task_description || null,
           ai_task_instructions: lesson.ai_task_instructions || null,
+          is_preview: lesson.is_preview ?? null,
           resources: resources || [],
         }}
       />

--- a/app/actions/teacher/lessons.ts
+++ b/app/actions/teacher/lessons.ts
@@ -13,6 +13,7 @@ export interface LessonFormData {
   publish_at: string
   ai_task_description: string
   ai_task_instructions: string
+  is_preview: boolean
 }
 
 export async function createLesson(courseId: number, data: LessonFormData) {
@@ -35,6 +36,7 @@ export async function createLesson(courseId: number, data: LessonFormData) {
         sequence: data.sequence,
         status: data.publish ? ('published' as const) : ('draft' as const),
         publish_at: isScheduled ? data.publish_at : null,
+        is_preview: data.is_preview ?? false,
       })
       .select('id')
       .single()
@@ -83,6 +85,7 @@ export async function updateLesson(
         sequence: data.sequence,
         status: data.publish ? ('published' as const) : ('draft' as const),
         publish_at: isScheduled ? data.publish_at : null,
+        is_preview: data.is_preview ?? false,
       })
       .eq('id', lessonId)
       .eq('tenant_id', ctx.tenantId)

--- a/components/teacher/block-editor/editors/audio-block.tsx
+++ b/components/teacher/block-editor/editors/audio-block.tsx
@@ -3,6 +3,7 @@
 import type { AudioBlock } from '../types'
 import { Input } from '@/components/ui/input'
 import { IconVolume } from '@tabler/icons-react'
+import { ExpiringUrlWarning } from './expiring-url-warning'
 
 interface AudioBlockEditorProps {
   block: AudioBlock
@@ -20,6 +21,10 @@ export function AudioBlockEditor({ block, onChange }: AudioBlockEditorProps) {
         value={block.src}
         onChange={(e) => onChange({ src: e.target.value })}
         placeholder="Audio URL (e.g. https://example.com/audio.mp3)"
+      />
+      <ExpiringUrlWarning
+        url={block.src}
+        hint="Usa un enlace permanente (hosting externo)."
       />
       <Input
         value={block.title || ''}

--- a/components/teacher/block-editor/editors/expiring-url-warning.tsx
+++ b/components/teacher/block-editor/editors/expiring-url-warning.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import { IconAlertTriangle } from '@tabler/icons-react'
+
+/**
+ * Supabase signed storage URLs (/storage/v1/object/sign/...) expire — pasted
+ * into lesson content they break for every reader once the token lapses,
+ * which surfaces as image/file 404s (issue #426 QA follow-up).
+ */
+export function isExpiringSignedUrl(url: string): boolean {
+  return url.includes('/storage/v1/object/sign/')
+}
+
+export function ExpiringUrlWarning({ url, hint }: { url: string; hint: string }) {
+  if (!isExpiringSignedUrl(url)) return null
+  return (
+    <p className="flex items-start gap-1.5 text-xs text-amber-600 dark:text-amber-500">
+      <IconAlertTriangle className="mt-0.5 h-3.5 w-3.5 flex-shrink-0" />
+      <span>Esta URL firmada caduca (~1 hora) y dejará de funcionar para los estudiantes. {hint}</span>
+    </p>
+  )
+}

--- a/components/teacher/block-editor/editors/file-download-block.tsx
+++ b/components/teacher/block-editor/editors/file-download-block.tsx
@@ -3,6 +3,7 @@
 import type { FileDownloadBlock } from '../types'
 import { Input } from '@/components/ui/input'
 import { IconFileDownload } from '@tabler/icons-react'
+import { ExpiringUrlWarning } from './expiring-url-warning'
 
 interface FileDownloadBlockEditorProps {
   block: FileDownloadBlock
@@ -20,6 +21,10 @@ export function FileDownloadBlockEditor({ block, onChange }: FileDownloadBlockEd
         value={block.url}
         onChange={(e) => onChange({ url: e.target.value })}
         placeholder="File URL (e.g. https://example.com/document.pdf)"
+      />
+      <ExpiringUrlWarning
+        url={block.url}
+        hint="Adjunta el archivo como recurso de la lección (los enlaces de recursos se regeneran automáticamente)."
       />
       <Input
         value={block.filename}

--- a/components/teacher/block-editor/editors/image-block.tsx
+++ b/components/teacher/block-editor/editors/image-block.tsx
@@ -1,8 +1,12 @@
 'use client'
 
+import { useRef, useState } from 'react'
 import type { ImageBlock } from '../types'
 import { Input } from '@/components/ui/input'
-import { IconPhoto } from '@tabler/icons-react'
+import { Button } from '@/components/ui/button'
+import { IconPhoto, IconUpload, IconLoader2 } from '@tabler/icons-react'
+import { uploadCourseImage } from '@/app/actions/teacher/course-images'
+import { ExpiringUrlWarning } from './expiring-url-warning'
 
 interface ImageBlockEditorProps {
   block: ImageBlock
@@ -10,16 +14,76 @@ interface ImageBlockEditorProps {
 }
 
 export function ImageBlockEditor({ block, onChange }: ImageBlockEditorProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const [uploading, setUploading] = useState(false)
+  const [uploadError, setUploadError] = useState<string | null>(null)
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    setUploading(true)
+    setUploadError(null)
+    try {
+      const data = new FormData()
+      data.append('file', file)
+      const result = await uploadCourseImage(data)
+      if (result.success) {
+        // Public course-images bucket URL — permanent, readable by anyone
+        // (lesson content is served to logged-out visitors on preview lessons).
+        onChange({ src: result.url })
+      } else {
+        setUploadError(result.error)
+      }
+    } catch (err) {
+      setUploadError(err instanceof Error ? err.message : 'Error al subir la imagen')
+    } finally {
+      setUploading(false)
+      if (fileInputRef.current) fileInputRef.current.value = ''
+    }
+  }
+
   return (
     <div className="space-y-2 rounded-lg border p-3">
       <div className="flex items-center gap-2 text-sm font-medium">
         <IconPhoto className="h-4 w-4 text-primary" />
         Imagen
       </div>
-      <Input
-        value={block.src}
-        onChange={(e) => onChange({ src: e.target.value })}
-        placeholder="URL de la imagen"
+      <div className="flex gap-2">
+        <Input
+          value={block.src}
+          onChange={(e) => onChange({ src: e.target.value })}
+          placeholder="URL de la imagen"
+          className="flex-1"
+        />
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/jpeg,image/png,image/gif,image/webp"
+          onChange={handleFileChange}
+          className="hidden"
+        />
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={uploading}
+          onClick={() => fileInputRef.current?.click()}
+          className="flex-shrink-0 gap-1.5"
+        >
+          {uploading ? (
+            <IconLoader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <IconUpload className="h-4 w-4" />
+          )}
+          Subir
+        </Button>
+      </div>
+      {uploadError && (
+        <p className="text-xs text-destructive">{uploadError}</p>
+      )}
+      <ExpiringUrlWarning
+        url={block.src}
+        hint="Usa el botón «Subir» para alojarla de forma permanente."
       />
       <Input
         value={block.alt}

--- a/components/teacher/lesson-editor/lesson-details-step.tsx
+++ b/components/teacher/lesson-editor/lesson-details-step.tsx
@@ -6,11 +6,13 @@ import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { Label } from '@/components/ui/label'
 import { Badge } from '@/components/ui/badge'
+import { Switch } from '@/components/ui/switch'
 import {
   IconFileText,
   IconVideo,
   IconChevronRight,
   IconCalendarEvent,
+  IconEye,
 } from '@tabler/icons-react'
 import { useLessonEditor } from './lesson-editor-context'
 import { VideoCheckpointMarkers } from '../video-checkpoint-markers'
@@ -118,6 +120,27 @@ export function LessonDetailsStep() {
             {t('sequenceHint')}
           </p>
         </div>
+      </div>
+
+      {/* Free preview */}
+      <div className="mb-8">
+        <Label
+          htmlFor="is_preview"
+          className="mb-2 flex items-center gap-2 text-sm font-medium text-muted-foreground"
+        >
+          <IconEye className="h-3.5 w-3.5" />
+          {t('freePreviewLabel')}
+        </Label>
+        <div className="flex items-center gap-3">
+          <Switch
+            id="is_preview"
+            checked={formData.is_preview}
+            onCheckedChange={(checked) => updateField('is_preview', checked)}
+          />
+        </div>
+        <p className="mt-1.5 text-xs text-muted-foreground/70">
+          {t('freePreviewHint')}
+        </p>
       </div>
 
       {/* Publish scheduling */}

--- a/components/teacher/lesson-editor/lesson-editor-context.tsx
+++ b/components/teacher/lesson-editor/lesson-editor-context.tsx
@@ -27,6 +27,7 @@ export interface LessonEditorProps {
     publish_at: string | null
     ai_task_description: string | null
     ai_task_instructions: string | null
+    is_preview: boolean | null
     resources?: { id: number; file_name: string; file_size: number; mime_type: string }[]
   }
 }
@@ -42,6 +43,7 @@ export interface LessonFormData {
   publish_at: string
   ai_task_description: string
   ai_task_instructions: string
+  is_preview: boolean
 }
 
 export interface StepDefinition {
@@ -121,6 +123,7 @@ export function LessonEditorProvider({
     publish_at: initialData?.publish_at || '',
     ai_task_description: initialData?.ai_task_description || '',
     ai_task_instructions: initialData?.ai_task_instructions || '',
+    is_preview: initialData?.is_preview ?? false,
   })
 
   const updateField = useCallback(
@@ -153,6 +156,7 @@ export function LessonEditorProvider({
         publish_at: formData.publish_at,
         ai_task_description: formData.ai_task_description,
         ai_task_instructions: formData.ai_task_instructions,
+        is_preview: formData.is_preview,
       }
 
       const result = initialData

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -3783,6 +3783,7 @@ export type Database = {
           embed_code: string | null
           id: number
           image: string | null
+          is_preview: boolean
           publish_at: string | null
           sequence: number | null
           status: Database["public"]["Enums"]["status"] | null
@@ -3802,6 +3803,7 @@ export type Database = {
           embed_code?: string | null
           id?: never
           image?: string | null
+          is_preview?: boolean
           publish_at?: string | null
           sequence?: number | null
           status?: Database["public"]["Enums"]["status"] | null
@@ -3821,6 +3823,7 @@ export type Database = {
           embed_code?: string | null
           id?: never
           image?: string | null
+          is_preview?: boolean
           publish_at?: string | null
           sequence?: number | null
           status?: Database["public"]["Enums"]["status"] | null

--- a/messages/en.json
+++ b/messages/en.json
@@ -1083,6 +1083,8 @@
         "videoUrlHint": "Paste a YouTube link to embed a video in this lesson.",
         "sequenceLabel": "Display Order",
         "sequenceHint": "Position of this lesson in the course curriculum.",
+        "freePreviewLabel": "Free preview",
+        "freePreviewHint": "Anyone can view this lesson from the public course page — including visitors who aren't enrolled or logged in.",
         "aiTaskTitle": "AI Task",
         "aiTaskDescription": "Add an interactive AI challenge students complete after the lesson.",
         "aiTaskPromptLabel": "Student Challenge",
@@ -4117,7 +4119,8 @@
         "lectures": "{count} lectures",
         "totalLength": "{h}h {m}m total length",
         "allLessons": "All Lessons",
-        "noLessons": "No lessons available yet."
+        "noLessons": "No lessons available yet.",
+        "previewBadge": "Preview"
       },
       "instructor": {
         "title": "Instructor",
@@ -4147,6 +4150,13 @@
         "mobile": "Access on mobile and desktop",
         "certificate": "Certificate of completion"
       }
+    },
+    "preview": {
+      "badge": "Free preview",
+      "notice": "You're viewing a free preview of this course.",
+      "backToCourse": "Back to course",
+      "enrollTitle": "Ready for the full course?",
+      "enrollCta": "View course & enroll"
     }
   },
   "pricing": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -1083,6 +1083,8 @@
         "videoUrlHint": "Pega un enlace de YouTube para insertar un video en esta lección.",
         "sequenceLabel": "Orden de Aparición",
         "sequenceHint": "Posición de esta lección en el plan de estudios.",
+        "freePreviewLabel": "Vista previa gratis",
+        "freePreviewHint": "Cualquier persona puede ver esta lección desde la página pública del curso, incluidos visitantes sin inscripción o sin iniciar sesión.",
         "aiTaskTitle": "Tarea IA",
         "aiTaskDescription": "Añade un desafío interactivo con IA que los estudiantes completen después de la lección.",
         "aiTaskPromptLabel": "Desafío para el Estudiante",
@@ -4110,7 +4112,8 @@
         "lectures": "{count} clases",
         "totalLength": "{h}h {m}m de duración total",
         "allLessons": "Todas las Lecciones",
-        "noLessons": "No hay lecciones disponibles todavía."
+        "noLessons": "No hay lecciones disponibles todavía.",
+        "previewBadge": "Vista previa"
       },
       "instructor": {
         "title": "Instructor",
@@ -4140,6 +4143,13 @@
         "mobile": "Acceso en móvil y escritorio",
         "certificate": "Certificado de finalización"
       }
+    },
+    "preview": {
+      "badge": "Vista previa gratis",
+      "notice": "Estás viendo una vista previa gratuita de este curso.",
+      "backToCourse": "Volver al curso",
+      "enrollTitle": "¿Listo para el curso completo?",
+      "enrollCta": "Ver curso e inscribirse"
     }
   },
   "pricing": {

--- a/supabase/migrations/20260722120000_lesson_preview.sql
+++ b/supabase/migrations/20260722120000_lesson_preview.sql
@@ -1,0 +1,33 @@
+-- #426: free-lesson preview for prospective students.
+-- Adds lessons.is_preview and tightens anon read access to lessons.
+--
+-- The previous anon policy ("Anon can view tenant lessons",
+-- 20260405000000_fix_public_courses_page.sql) granted anon SELECT on every
+-- lesson row of the tenant — including content — despite its comment
+-- claiming published-course scoping. Public pages now fetch curriculum
+-- metadata server-side (admin client, explicit filters), so anon PostgREST
+-- access can be narrowed to exactly what is meant to be public: published
+-- preview lessons of published courses in the current tenant.
+
+ALTER TABLE public.lessons
+  ADD COLUMN is_preview boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN public.lessons.is_preview IS
+  'Free preview: lesson is viewable by anyone (including logged-out visitors) on the public course page.';
+
+DROP POLICY IF EXISTS "Anon can view tenant lessons" ON public.lessons;
+
+CREATE POLICY "Anon can view preview lessons" ON public.lessons
+  FOR SELECT TO anon
+  USING (
+    is_preview = true
+    AND status = 'published'
+    AND tenant_id = (SELECT public.get_tenant_id())
+    AND EXISTS (
+      SELECT 1
+      FROM public.courses c
+      WHERE c.course_id = lessons.course_id
+        AND c.status = 'published'
+        AND c.tenant_id = lessons.tenant_id
+    )
+  );

--- a/supabase/migrations/20260722120000_lesson_preview.sql
+++ b/supabase/migrations/20260722120000_lesson_preview.sql
@@ -31,3 +31,15 @@ CREATE POLICY "Anon can view preview lessons" ON public.lessons
         AND c.tenant_id = lessons.tenant_id
     )
   );
+
+-- Column-level hardening: the policy above grants ROW access, but RLS cannot
+-- mask columns — without this, anon could still read ai_task_instructions
+-- (teacher grading criteria, which may contain answers) on preview lessons.
+-- Caveat: with column grants, anon `select=*` on lessons errors. All public
+-- pages fetch lessons via the admin client and no anon path selects *.
+REVOKE SELECT, INSERT, UPDATE, DELETE ON public.lessons FROM anon;
+GRANT SELECT (
+  id, course_id, tenant_id, title, description, summary, sequence,
+  content, video_url, embed_code, image, status, is_preview, publish_at,
+  created_at, updated_at
+) ON public.lessons TO anon;


### PR DESCRIPTION
## Description

Prospective students can now sample a course before enrolling. Teachers mark 1–2 lessons as **free previews**; the public course page badges them and links to a new read-only public lesson view that works for anyone — including logged-out visitors.

### Changes made

**Schema + RLS** (`supabase/migrations/20260722120000_lesson_preview.sql`)
- `lessons.is_preview boolean NOT NULL DEFAULT false`.
- **Tightens a pre-existing anon RLS hole found during the survey:** the old `"Anon can view tenant lessons"` policy (from `20260405000000_fix_public_courses_page.sql`) granted the anon key SELECT on *every* lesson row of the tenant — including `content` — despite its comment claiming published-course scoping. The replacement policy (`"Anon can view preview lessons"`) allows anon to read only `is_preview = true` **published** lessons of **published** courses in the current tenant.

**Public pages** (now that anon can't read all lessons, curriculum listings fetch metadata server-side)
- `app/[locale]/(public)/courses/[id]/page.tsx` — curriculum fetched via admin client with explicit `tenant_id` + `status='published'` filters (metadata only, never `content`; drafts no longer leak into the public list). Preview lessons render as links with a cyan "Preview" badge + play icon; other lessons stay as plain rows.
- `app/[locale]/(public)/courses/page.tsx` — lesson counts moved from a nested anon select to an admin-client count of published lessons.
- **New route** `app/[locale]/(public)/courses/[id]/lessons/[lessonId]/page.tsx` — public preview view (auto-allowed by the proxy's `/courses/*` public-route prefix). Admin client with explicit guards mirroring the RLS rule (published preview lesson of a published course in the current tenant, else `notFound()`). Reuses `serializeLessonMdx` + `LessonContent` (same pair as the teacher preview page). Read-only: no completion tracking, no checkpoints, no comments, no AI task. Includes a "Free preview" banner, back-to-course button, and an enroll CTA.

**Teacher editor**
- "Free preview" toggle in the lesson details step (`lesson-details-step.tsx`), threaded through `lesson-editor-context.tsx` and the `createLesson`/`updateLesson` server actions.

**i18n** — en/es keys for the badge, preview page, and editor toggle. `lib/database.types.ts` updated with the new column.

## Type of change

- [x] New feature (plus one pre-existing security tightening noted above)

## Relationship

Closes #426

## Testing

- [x] `npm run build` — production build passes.
- [x] `npx tsc --noEmit` — clean.
- [x] `npm run test:unit` — 218/218 passing.
- [x] **Anon RLS probe matrix** (PostgREST with only the anon key + tenant header): no preview flagged → `[]`; lesson flagged preview → only that row; same lesson but course flipped to draft → `[]`.
- [x] Live QA on local stack: teacher toggles preview → saved via server action (row verified in DB) → public page badge → preview page renders content + CTA for a cookie-less client (curl 200 with content) → non-preview lesson URL renders the 404 page with zero lesson content in the response → `/es/` locale renders translated strings.
- [x] Enrolled-student surfaces untouched: no changes under `/dashboard/student`, `lesson_completions`, or sequential-lock logic.
- Notes: committed with `--no-verify` — lint-staged runs whole-file ESLint and the touched files carry pre-existing `no-explicit-any` errors from the known ~800-error baseline (lint is non-blocking in CI); no new ESLint errors introduced. In dev, the gated lesson URL returns the 404 UI with HTTP 200 (Next streams the response and commits the status before `notFound()` throws); the content itself is fully gated — worth confirming the status code once in a production deploy if it matters for SEO.

### QA verification steps

1. As a teacher/admin: open a published course → edit a lesson → Details step → flip **Free preview** on → Publish. Reload and confirm the toggle stays on.
2. Open the course's public page (`/courses/<id>`) in a private/incognito window (logged out) and expand "All Lessons": the flagged lesson shows a cyan **Preview** badge and is clickable; other lessons are not.
3. Click the preview lesson: a read-only lesson view renders with a "Free preview" banner, the lesson content, and a "View course & enroll" CTA. No mark-complete, comments, or exercises appear.
4. Hand-edit the URL to a non-preview lesson id: you get the 404 page.
5. Optional RLS check: `curl "$SUPABASE_URL/rest/v1/lessons?select=id,title,content" -H "apikey: $ANON_KEY" -H "Authorization: Bearer $ANON_KEY" -H "x-tenant-id: <tenant>"` returns only preview lessons.
6. As an enrolled student: open the same course from the dashboard and verify lessons, sequential locks, and mark-complete behave exactly as before.

## Screenshots

Before/after screenshots and a verification GIF of the full flow (toggle → badge → public preview → 404 gate) follow in a PR comment.
