### PR TITLE
feat(landing): upgrade built-in templates to live-data widgets (#429)

### DIFF
--- a/lib/puck/templates/business-coaching.ts
+++ b/lib/puck/templates/business-coaching.ts
@@ -60,6 +60,7 @@ const homeTemplate: PuckTemplate = {
         avatarCount: 5,
       }),
       c('StatsCounter', {
+        useLiveStats: true,
         items: [
           { value: '3,500', label: 'Clients Coached', prefix: '', suffix: '+' },
           { value: '40', label: 'Avg. Revenue Growth', prefix: '', suffix: '%' },
@@ -82,6 +83,7 @@ const homeTemplate: PuckTemplate = {
         columns: '3',
       }),
       c('CourseGrid', {
+        courseIds: [],
         title: 'Programs & Courses',
         subtitle: 'Self-paced programs to build skills on your schedule.',
         maxItems: 6, columns: '3', showPrice: true, showDescription: true,
@@ -155,6 +157,7 @@ const aboutTemplate: PuckTemplate = {
         alignment: 'center', color: '', maxWidth: '768px', fontSize: '1.125rem',
       }),
       c('StatsCounter', {
+        useLiveStats: true,
         items: [
           { value: '3,500', label: 'Clients Coached', prefix: '', suffix: '+' },
           { value: '$50M', label: 'Client Revenue Added', prefix: '', suffix: '' },

--- a/lib/puck/templates/design-school.ts
+++ b/lib/puck/templates/design-school.ts
@@ -54,6 +54,7 @@ const homeTemplate: PuckTemplate = {
         backgroundImage: '', alignment: 'center', overlayOpacity: 55, minHeight: '520px',
       }),
       c('StatsCounter', {
+        useLiveStats: true,
         items: [
           { value: '14,000', label: 'Designers Trained', prefix: '', suffix: '+' },
           { value: '120', label: 'Hands-On Projects', prefix: '', suffix: '+' },
@@ -87,6 +88,7 @@ const homeTemplate: PuckTemplate = {
         columns: '4',
       }),
       c('CourseGrid', {
+        courseIds: [],
         title: 'Popular Courses',
         subtitle: 'Start with our most popular courses, chosen by thousands of designers.',
         maxItems: 6, columns: '3', showPrice: true, showDescription: true,
@@ -160,6 +162,7 @@ const aboutTemplate: PuckTemplate = {
         alignment: 'center', color: '', maxWidth: '768px', fontSize: '1.125rem',
       }),
       c('StatsCounter', {
+        useLiveStats: true,
         items: [
           { value: '14,000', label: 'Designers Trained', prefix: '', suffix: '+' },
           { value: '40', label: 'Countries', prefix: '', suffix: '+' },

--- a/lib/puck/templates/fitness-studio.ts
+++ b/lib/puck/templates/fitness-studio.ts
@@ -54,6 +54,7 @@ const homeTemplate: PuckTemplate = {
         backgroundImage: '', alignment: 'center', overlayOpacity: 60, minHeight: '520px',
       }),
       c('StatsCounter', {
+        useLiveStats: true,
         items: [
           { value: '25,000', label: 'Members', prefix: '', suffix: '+' },
           { value: '600', label: 'Workouts', prefix: '', suffix: '+' },
@@ -86,6 +87,7 @@ const homeTemplate: PuckTemplate = {
         columns: '3',
       }),
       c('CourseGrid', {
+        courseIds: [],
         title: 'Popular Programs',
         subtitle: 'Start with our most popular programs, loved by thousands of members.',
         maxItems: 6, columns: '3', showPrice: true, showDescription: true,
@@ -159,6 +161,7 @@ const aboutTemplate: PuckTemplate = {
         alignment: 'center', color: '', maxWidth: '768px', fontSize: '1.125rem',
       }),
       c('StatsCounter', {
+        useLiveStats: true,
         items: [
           { value: '25,000', label: 'Members', prefix: '', suffix: '+' },
           { value: '50', label: 'Countries', prefix: '', suffix: '+' },

--- a/lib/puck/templates/index.ts
+++ b/lib/puck/templates/index.ts
@@ -106,6 +106,7 @@ const modernAcademyTemplate: PuckTemplate = {
         columns: '3',
       }),
       c('CourseGrid', {
+        courseIds: [],
         title: 'Popular Courses',
         subtitle: 'Explore our most popular courses, chosen by students like you.',
         maxItems: 6,
@@ -180,6 +181,7 @@ const minimalTemplate: PuckTemplate = {
         minHeight: '400px',
       }),
       c('CourseGrid', {
+        courseIds: [],
         title: 'Our Courses',
         subtitle: '',
         maxItems: 6,
@@ -255,6 +257,7 @@ const boldCreatorTemplate: PuckTemplate = {
         minHeight: '500px',
       }),
       c('StatsCounter', {
+        useLiveStats: true,
         items: [
           { value: '5,000', label: 'Students', prefix: '', suffix: '+' },
           { value: '200', label: 'Courses', prefix: '', suffix: '+' },
@@ -264,6 +267,7 @@ const boldCreatorTemplate: PuckTemplate = {
         alignment: 'center',
       }),
       c('CourseGrid', {
+        courseIds: [],
         title: 'Featured Courses',
         subtitle: 'Our most popular courses, hand-picked for you.',
         maxItems: 6,
@@ -336,13 +340,13 @@ const courseCatalogTemplate: PuckTemplate = {
         overlayOpacity: 50,
         minHeight: '350px',
       }),
-      c('CourseGrid', {
+      c('CatalogBrowser', {
         title: 'All Courses',
         subtitle: 'Browse our full catalog and find the right fit for your goals.',
-        maxItems: 12,
         columns: '3',
-        showPrice: true,
-        showDescription: true,
+        pageSize: 12,
+        showSearch: true,
+        showPriceFilter: true,
       }),
       c('PricingTable', {
         title: 'Pricing Plans',
@@ -414,6 +418,7 @@ const aboutTemplate: PuckTemplate = {
         fontSize: '1.125rem',
       }),
       c('StatsCounter', {
+        useLiveStats: true,
         items: [
           { value: '10,000', label: 'Students', prefix: '', suffix: '+' },
           { value: '500', label: 'Courses', prefix: '', suffix: '+' },
@@ -632,6 +637,7 @@ const codeSchoolHomeTemplate: PuckTemplate = {
         minHeight: '520px',
       }),
       c('StatsCounter', {
+        useLiveStats: true,
         items: [
           { value: '12,000', label: 'Students Enrolled', prefix: '', suffix: '+' },
           { value: '95', label: 'Completion Rate', prefix: '', suffix: '%' },
@@ -654,6 +660,7 @@ const codeSchoolHomeTemplate: PuckTemplate = {
         columns: '3',
       }),
       c('CourseGrid', {
+        courseIds: [],
         title: 'Popular Courses',
         subtitle: 'Start with our most popular courses, chosen by thousands of students.',
         maxItems: 6,
@@ -764,6 +771,7 @@ const codeSchoolAboutTemplate: PuckTemplate = {
         fontSize: '1.125rem',
       }),
       c('StatsCounter', {
+        useLiveStats: true,
         items: [
           { value: '12,000', label: 'Students Worldwide', prefix: '', suffix: '+' },
           { value: '40', label: 'Countries', prefix: '', suffix: '+' },
@@ -1045,13 +1053,13 @@ const codeSchoolCatalogTemplate: PuckTemplate = {
         ],
         columns: '2',
       }),
-      c('CourseGrid', {
+      c('CatalogBrowser', {
         title: 'All Courses',
         subtitle: 'Browse our complete catalog. New courses added every month.',
-        maxItems: 12,
         columns: '3',
-        showPrice: true,
-        showDescription: true,
+        pageSize: 12,
+        showSearch: true,
+        showPriceFilter: true,
       }),
       c('PricingTable', {
         title: 'Choose Your Plan',

--- a/lib/puck/templates/language-school.ts
+++ b/lib/puck/templates/language-school.ts
@@ -54,6 +54,7 @@ const homeTemplate: PuckTemplate = {
         backgroundImage: '', alignment: 'center', overlayOpacity: 55, minHeight: '500px',
       }),
       c('StatsCounter', {
+        useLiveStats: true,
         items: [
           { value: '8,000', label: 'Active Students', prefix: '', suffix: '+' },
           { value: '6', label: 'Languages', prefix: '', suffix: '' },
@@ -86,6 +87,7 @@ const homeTemplate: PuckTemplate = {
         columns: '3',
       }),
       c('CourseGrid', {
+        courseIds: [],
         title: 'Popular Courses',
         subtitle: 'Start with our most popular language courses, chosen by thousands of learners.',
         maxItems: 6, columns: '3', showPrice: true, showDescription: true,
@@ -159,6 +161,7 @@ const aboutTemplate: PuckTemplate = {
         alignment: 'center', color: '', maxWidth: '768px', fontSize: '1.125rem',
       }),
       c('StatsCounter', {
+        useLiveStats: true,
         items: [
           { value: '8,000', label: 'Students Worldwide', prefix: '', suffix: '+' },
           { value: '6', label: 'Languages Taught', prefix: '', suffix: '' },

--- a/lib/puck/templates/music-academy.ts
+++ b/lib/puck/templates/music-academy.ts
@@ -54,6 +54,7 @@ const homeTemplate: PuckTemplate = {
         backgroundImage: '', alignment: 'center', overlayOpacity: 60, minHeight: '520px',
       }),
       c('StatsCounter', {
+        useLiveStats: true,
         items: [
           { value: '18,000', label: 'Students', prefix: '', suffix: '+' },
           { value: '10', label: 'Instruments', prefix: '', suffix: '+' },
@@ -87,6 +88,7 @@ const homeTemplate: PuckTemplate = {
         columns: '4',
       }),
       c('CourseGrid', {
+        courseIds: [],
         title: 'Popular Courses',
         subtitle: 'Start with our most popular courses, chosen by thousands of students.',
         maxItems: 6, columns: '3', showPrice: true, showDescription: true,
@@ -160,6 +162,7 @@ const aboutTemplate: PuckTemplate = {
         alignment: 'center', color: '', maxWidth: '768px', fontSize: '1.125rem',
       }),
       c('StatsCounter', {
+        useLiveStats: true,
         items: [
           { value: '18,000', label: 'Students', prefix: '', suffix: '+' },
           { value: '10', label: 'Instruments', prefix: '', suffix: '+' },


### PR DESCRIPTION
## Description

Upgrades all 33 static built-in landing templates to the live-data widgets shipped in #430, so a tenant applying any template sees their real courses, plans, and stats instead of fake placeholder numbers.

The survey behind this change found the gap was narrower than the issue assumed: `TestimonialGrid`, `TeamGrid`, and `PricingTable` **already prefer live tenant data** whenever it exists (`live.length > 0 ? live : items`) — their hard-coded arrays only ever render as the no-data fallback, which acceptance criterion 5 wants kept. The real bug was the stats blocks: `StatsCounter` only goes live when `useLiveStats === true`, and Puck's `<Render>` does not backfill `defaultProps` for content stored in `puck_data`, so every applied template rendered fake numbers ("8,000+ students", "Founded 2019") forever.

### Changes made

- **`useLiveStats: true` on all 14 `StatsCounter` instances** (4 in `index.ts`, 2 in each of the 5 vertical packs). Hard-coded `items` stay as the no-data fallback.
- **Explicit `courseIds: []` on all 9 remaining `CourseGrid` instances** — documents the "latest courses" curation contract and matches the `free-course-school` reference template.
- **Catalog pages upgraded to `CatalogBrowser`**: the "Course Catalog" and "Code School — Courses" templates swap their static `maxItems: 12` "All Courses" `CourseGrid` for the live `CatalogBrowser` (search + Free/Paid filter + pagination), keeping each page's title/subtitle.
- **Deliberately unchanged**: static testimonial/team/pricing arrays (they are already pure fallback and preserve each template's branding on empty tenants); `SocialProof` (already per-field live-aware); `EnrollCta` not added — every home template already closes with a CTA block, and `EnrollCta` only adds value once an admin curates a specific course in the editor.

No component, schema, or query changes — template data only. Existing saved `landing_pages` rows are snapshots and are unaffected; only pages created from templates after this change pick it up.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Relationship

Closes #429

## Testing

- [x] `npm run build` — exit 0 (only pre-existing `bigint` binding warnings)
- [x] `npm run gen:puck-fields` — no diff (manifest derives from `lib/puck/config.ts`, not templates; verified anyway)
- [x] Browser spot-check on the seeded Code Academy tenant: "Language School — Home", "Course Catalog", and "Code School — About" re-rendered from the updated templates — stats sections show live counts (1 student / 2 courses / 0 completions), the catalog page shows the searchable `CatalogBrowser`, and testimonial/team/pricing fallbacks still render for data the tenant lacks (reviews/instructors).

### QA verification steps

1. Log in as an admin (`creator@codeacademy.com` / `password123` on `code-academy.lvh.me:3005`).
2. Go to **Dashboard → Website → Landing Pages**, create a new page, and apply the "Language School — Home" template (or any vertical Home template).
3. In the editor preview (or via **Preview** after saving), scroll to the stats band under the hero: it should show the tenant's real counts (students / courses / lessons completed), not "8,000+ / 6 / 120+".
4. Apply the "Course Catalog" template to another page: the "All Courses" section should now be a searchable catalog with Free/Paid filter chips listing the tenant's real courses. Type a course name in the search box and confirm filtering works.
5. Apply any template to a tenant with no courses/reviews (e.g. a fresh school): stats fall back to the template's placeholder numbers and testimonials/team/pricing show the template's placeholder content — no empty sections, no crashes.

## Screenshots

Before/after screenshots and a verification GIF follow in a PR comment (private repo — uploaded as attachments).
