### PR TITLE
fix(payments): categorize binance_enabled under Payment settings, not general (#479)

### DIFF
--- a/app/actions/admin/settings.ts
+++ b/app/actions/admin/settings.ts
@@ -35,7 +35,7 @@ export async function getSettings(category?: string): Promise<SettingsResponse> 
       const categoryPrefixes: Record<string, string[]> = {
         general: ['site_name', 'site_description', 'contact_email', 'support_email', 'timezone', 'maintenance_mode'],
         email: ['smtp_', 'email_'],
-        payment: ['stripe_', 'paypal_', 'lemonsqueezy_', 'solana_', 'currency', 'tax_rate', 'invoice_prefix', 'require_payment_approval', 'manual_payment_instructions'],
+        payment: ['stripe_', 'paypal_', 'lemonsqueezy_', 'solana_', 'binance_', 'currency', 'tax_rate', 'invoice_prefix', 'require_payment_approval', 'manual_payment_instructions'],
         enrollment: ['auto_enrollment', 'require_enrollment_approval', 'max_enrollments_per_user', 'allow_self_enrollment', 'enrollment_expiration_days', 'course_capacity_enabled'],
       }
       const keys = categoryPrefixes[category]
@@ -440,7 +440,7 @@ export async function getAllSettingsByCategory(): Promise<SettingsResponse> {
       smtp_host: 'email', smtp_port: 'email', smtp_username: 'email', smtp_password: 'email',
       smtp_from_email: 'email', smtp_from_name: 'email', email_notifications: 'email',
       stripe_enabled: 'payment', paypal_enabled: 'payment',
-      lemonsqueezy_enabled: 'payment', solana_enabled: 'payment', solana_accept_sol: 'payment', currency: 'payment',
+      lemonsqueezy_enabled: 'payment', solana_enabled: 'payment', solana_accept_sol: 'payment', binance_enabled: 'payment', currency: 'payment',
       tax_rate: 'payment', invoice_prefix: 'payment', require_payment_approval: 'payment',
       manual_payment_instructions: 'payment',
       auto_enrollment: 'enrollment', require_enrollment_approval: 'enrollment',

--- a/tests/unit/admin-settings-category-map.test.ts
+++ b/tests/unit/admin-settings-category-map.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+/**
+ * Regression for issue #479: getAllSettingsByCategory()'s categoryMap
+ * previously had no entry for `binance_enabled`, so it fell through to the
+ * `'general'` bucket instead of `'payment'`. The admin Settings > Payment
+ * page reads `settings.payment.binance_enabled` — a missing map entry made
+ * the Binance Pay toggle always render unchecked on reload regardless of the
+ * saved value, even though getEnabledPaymentProviders() (which queries the
+ * key directly) still gated checkout/product forms correctly.
+ */
+
+const state: {
+  role: string
+  rows: { setting_key: string; setting_value: unknown }[]
+} = { role: 'admin', rows: [] }
+
+function makeFakeAdmin() {
+  const b: Record<string, unknown> = {
+    from() { return b },
+    select() { return b },
+    eq() { return b },
+    order() { return Promise.resolve({ data: state.rows, error: null }) },
+  }
+  return b
+}
+
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }))
+vi.mock('@/lib/supabase/tenant', () => ({ getCurrentTenantId: () => Promise.resolve('t1') }))
+vi.mock('@/lib/supabase/get-user-role', () => ({ getUserRole: () => Promise.resolve(state.role) }))
+vi.mock('@/lib/supabase/admin', () => ({
+  createAdminClient: () => makeFakeAdmin(),
+}))
+
+import { getAllSettingsByCategory } from '@/app/actions/admin/settings'
+
+beforeEach(() => { state.role = 'admin'; state.rows = [] })
+
+describe('getAllSettingsByCategory', () => {
+  it('groups binance_enabled under payment, not general', async () => {
+    state.rows = [{ setting_key: 'binance_enabled', setting_value: { enabled: true } }]
+    const r = await getAllSettingsByCategory()
+    expect(r.success).toBe(true)
+    expect(r.data?.payment?.binance_enabled?.value?.enabled).toBe(true)
+    expect(r.data?.general?.binance_enabled).toBeUndefined()
+  })
+
+  it('keeps every other payment toggle categorized alongside it', async () => {
+    state.rows = [
+      { setting_key: 'stripe_enabled', setting_value: { enabled: true } },
+      { setting_key: 'paypal_enabled', setting_value: { enabled: false } },
+      { setting_key: 'lemonsqueezy_enabled', setting_value: { enabled: false } },
+      { setting_key: 'solana_enabled', setting_value: { enabled: false } },
+      { setting_key: 'binance_enabled', setting_value: { enabled: true } },
+    ]
+    const r = await getAllSettingsByCategory()
+    const paymentKeys = Object.keys(r.data?.payment ?? {})
+    expect(paymentKeys.sort()).toEqual(
+      ['binance_enabled', 'lemonsqueezy_enabled', 'paypal_enabled', 'solana_enabled', 'stripe_enabled'].sort()
+    )
+  })
+})


### PR DESCRIPTION
## What & why

Closes part of #479 (credentialed-QA follow-up to #466 / PR #478). While setting up the live PayPal sandbox portion of that QA, a survey of `app/actions/admin/settings.ts` and `components/admin/payment-settings-form.tsx` — needed to enable PayPal for a test tenant — turned up a second, credential-independent bug in the same admin Settings > Payment surface #479's "UI polish check" covers. The live PayPal/Binance sandbox runs are tracked separately; see the QA record comment on #479.

## The bug

`getAllSettingsByCategory()` hardcodes a `categoryMap` that assigns each `tenant_settings` row to a tab (`general`/`email`/`payment`/`enrollment`) for the admin Settings page. It listed `stripe_enabled`, `paypal_enabled`, `lemonsqueezy_enabled`, and `solana_enabled` under `'payment'` — but not `binance_enabled`. Any key missing from the map falls through to `'general'`.

`PaymentSettingsForm` reads `settings.binance_enabled?.value?.enabled ?? false` from the `payment` bucket to set the Binance Pay switch's initial state. Since the row never landed there, **the Binance Pay toggle always rendered unchecked on page load, regardless of the saved DB value.** An admin who enabled it, navigated away, and came back would see it off — and because the form resubmits every field from its current checkbox state, hitting Save from that stale view would silently flip `binance_enabled` back to `false` in the database.

This is a display/round-trip bug only: `getEnabledPaymentProviders()` (used by checkout, product creation, and plan creation to decide which providers to show) queries `binance_enabled` directly and was unaffected — actual provider gating elsewhere in the app kept working correctly throughout.

Verified live in a local Code Academy Pro tenant: enabling the toggle persisted `binance_enabled: {"enabled": true}` to `tenant_settings`, but reloading the Payment tab with the bug present showed the switch unchecked; with the fix, it correctly shows checked after reload.

## The fix

Add `binance_enabled: 'payment'` to the `categoryMap` in `getAllSettingsByCategory()`, and `binance_` to the equivalent prefix list in the sibling `getSettings(category)` helper (same root cause, same file — currently unused elsewhere in the app, but left consistent rather than leaving an identical latent bug behind).

## Test plan

- [x] New regression test `tests/unit/admin-settings-category-map.test.ts` — asserts a `binance_enabled` row lands under `payment`, not `general`, and stays grouped alongside the other payment toggles.
- [x] `npx vitest run tests/unit/admin-settings-category-map.test.ts tests/unit/admin-enabled-providers.test.ts tests/unit/admin-provider-actions.test.ts tests/unit/paypal-binance-providers.test.ts` → 33/33 pass.
- [x] `npx tsc --noEmit` → clean.
- [x] `npx eslint` on changed files → only the 8 pre-existing `no-explicit-any` errors already present on `app/actions/admin/settings.ts` before this change (same lines, unrelated to this diff) — no new errors introduced.
- [x] Live-verified in the browser against a local Code Academy Pro tenant: reproduced the bug (toggle shows unchecked after reload despite `binance_enabled: true` in the DB), applied the fix, confirmed the toggle now shows checked after reload. Screenshots attached below.

## Screenshots

Before (bug): Binance Pay switch unchecked after reload, despite `tenant_settings.binance_enabled = {"enabled": true}` in the DB.
After (fixed): Binance Pay switch correctly shows checked after reload.

(attached as a PR comment)
