### PR TITLE
fix(billing): real access-cutoff enforcement for over-limit tenants (#494)

### DIFF
--- a/app/[locale]/dashboard/admin/billing/billing-dashboard-client.tsx
+++ b/app/[locale]/dashboard/admin/billing/billing-dashboard-client.tsx
@@ -50,6 +50,7 @@ interface BillingDashboardClientProps {
     }
     features: Record<string, unknown>
     transactionFeePercent: number
+    accessCutoffAt: string | null
   }
   paymentRequests: Array<{
     request_id: string
@@ -59,6 +60,7 @@ interface BillingDashboardClientProps {
     interval: string
     created_at: string
     proof_url?: string | null
+    request_type?: string
     platform_plans: { name: string; slug: string } | null
   }>
 }
@@ -99,8 +101,8 @@ export function BillingDashboardClient({ status, paymentRequests }: BillingDashb
       await requestManualRenewal()
       toast.success('Renewal request submitted')
       router.refresh()
-    } catch (e: any) {
-      toast.error(e.message)
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Failed to submit renewal request')
     } finally {
       setRenewalLoading(false)
     }
@@ -125,8 +127,8 @@ export function BillingDashboardClient({ status, paymentRequests }: BillingDashb
       toast.success(t('cancelSuccess'))
       setCancelOpen(false)
       router.refresh()
-    } catch (e: any) {
-      toast.error(e.message || t('cancelError'))
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : t('cancelError'))
     } finally {
       setCancelLoading(false)
     }
@@ -140,8 +142,8 @@ export function BillingDashboardClient({ status, paymentRequests }: BillingDashb
       await uploadPaymentProof(requestId, formData)
       toast.success('Proof uploaded successfully')
       router.refresh()
-    } catch (e: any) {
-      toast.error(e.message)
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Failed to upload proof')
       throw e // re-throw so ProofUpload shows error state
     } finally {
       setUploadingFor(null)
@@ -158,7 +160,7 @@ export function BillingDashboardClient({ status, paymentRequests }: BillingDashb
   const daysUntilEnd = periodEnd ? Math.ceil((periodEnd.getTime() - now.getTime()) / (1000 * 60 * 60 * 24)) : null
   const showRenewalSection = isManualSub && daysUntilEnd !== null && daysUntilEnd <= 30
   const hasPendingRenewal = paymentRequests.some(
-    (r) => (r as any).request_type === 'renewal' && !['confirmed', 'rejected', 'expired'].includes(r.status)
+    (r) => r.request_type === 'renewal' && !['confirmed', 'rejected', 'expired'].includes(r.status)
   )
   const cancelDateStr = (() => {
     const raw = status.subscription?.currentPeriodEnd || status.billingPeriodEnd
@@ -176,6 +178,7 @@ export function BillingDashboardClient({ status, paymentRequests }: BillingDashb
         upcomingPayment={status.upcomingPayment}
         usage={status.usage}
         transactionFeePercent={status.transactionFeePercent}
+        accessCutoffAt={status.accessCutoffAt}
         onManageClick={status.hasStripeCustomer ? handleManageBilling : undefined}
         onCancelClick={() => setCancelOpen(true)}
       />

--- a/app/actions/admin/billing.ts
+++ b/app/actions/admin/billing.ts
@@ -5,6 +5,7 @@ import { createAdminClient } from '@/lib/supabase/admin'
 import {getCurrentTenantId, getCurrentUserId } from '@/lib/supabase/tenant'
 import { checkPlanLimits, formatPlanLimitError } from '@/lib/billing/plan-limits'
 import { classifyPlanChange } from '@/lib/billing/plan-change'
+import { reconcileAccessCutoff } from '@/lib/billing/access-cutoff'
 import { revalidatePath } from 'next/cache'
 
 async function verifyAdminAccess() {
@@ -39,7 +40,7 @@ export async function getSubscriptionStatus() {
   const [tenantResult, subscriptionResult, coursesCount, studentsCount] = await Promise.all([
     adminClient
       .from('tenants')
-      .select('plan, billing_status, billing_period_end, billing_email, stripe_customer_id')
+      .select('plan, billing_status, billing_period_end, billing_email, stripe_customer_id, access_cutoff_at')
       .eq('id', tenantId)
       .single(),
     adminClient
@@ -83,6 +84,7 @@ export async function getSubscriptionStatus() {
     billingPeriodEnd: tenant?.billing_period_end,
     billingEmail: tenant?.billing_email,
     hasStripeCustomer: !!tenant?.stripe_customer_id,
+    accessCutoffAt: tenant?.access_cutoff_at ?? null,
     subscription: subscription ? {
       status: subscription.status,
       paymentMethod: subscription.payment_method,
@@ -356,6 +358,10 @@ export async function confirmManualPayment(requestId: string) {
       updated_at: now.toISOString(),
     }, { onConflict: 'tenant_id' })
 
+  // Activation already passed the pre-flight limit check above, so this
+  // clears any cutoff scheduled from a prior over-limit period.
+  await reconcileAccessCutoff(adminClient, request.tenant_id)
+
   return { success: true }
 }
 
@@ -528,6 +534,10 @@ export async function changePlan(planId: string, interval: 'monthly' | 'yearly' 
       },
       { onConflict: 'tenant_id' }
     )
+
+  // Pre-flight check above already confirmed the new plan's limits are met,
+  // so this clears any cutoff scheduled from a prior over-limit period.
+  await reconcileAccessCutoff(adminClient, tenantId)
 
   revalidatePath('/dashboard/admin/billing')
   return { success: true, plan: ctx.plan.slug }

--- a/app/api/cron/enforce-plan-limits/route.ts
+++ b/app/api/cron/enforce-plan-limits/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+import { reconcileAccessCutoff } from '@/lib/billing/access-cutoff'
+
+export const runtime = 'nodejs'
+
+/**
+ * Cron job: daily sweep reconciling access-cutoff state for every tenant (issue #494).
+ *
+ * `reconcileAccessCutoff()` is already called from event-driven sites —
+ * `downgradeTenantToFree()`, `changePlan()`, `confirmManualPayment()`, and
+ * `applyPortalPlanChange()` — but none of those fire for a tenant that simply
+ * grows over its own plan's limits organically (e.g. a free-plan school that
+ * accumulates students with no plan-change event at all). This cron closes
+ * that gap by walking every tenant once a day and reconciling
+ * `tenants.access_cutoff_at` against its current plan/usage, regardless of
+ * plan (a free-plan tenant needs this as much as a paid one).
+ *
+ * Secured by CRON_SECRET env var (set the same value in the cron scheduler).
+ */
+
+function getSupabaseAdmin(): SupabaseClient {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (!url || !serviceKey) throw new Error('Supabase env vars not set')
+  return createClient(url, serviceKey)
+}
+
+export async function GET(req: NextRequest) {
+  const cronSecret = process.env.CRON_SECRET
+  const provided = req.headers.get('authorization')?.replace('Bearer ', '')
+  if (!cronSecret || provided !== cronSecret) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const supabase = getSupabaseAdmin()
+
+  const { data: tenants } = await supabase.from('tenants').select('id')
+
+  const result = { scheduled: 0, cleared: 0, none: 0, errors: 0 }
+
+  for (const tenant of tenants || []) {
+    try {
+      const decision = await reconcileAccessCutoff(supabase, tenant.id)
+      if (decision.action === 'schedule') result.scheduled++
+      else if (decision.action === 'clear') result.cleared++
+      else result.none++
+    } catch (err) {
+      console.error('enforce-plan-limits: reconcile failed for tenant', tenant.id, err)
+      result.errors++
+    }
+  }
+
+  return NextResponse.json({ success: true, ...result })
+}

--- a/app/api/cron/expire-platform-subscriptions/route.ts
+++ b/app/api/cron/expire-platform-subscriptions/route.ts
@@ -4,6 +4,7 @@ import { sendEmail } from '@/lib/email/send'
 import { renewalReminderTemplate } from '@/lib/email/templates/renewal-reminder'
 import { planDowngradedTemplate } from '@/lib/email/templates/plan-downgraded'
 import { downgradeTenantToFree } from '@/lib/billing/downgrade-tenant'
+import { getTenantAdminEmails } from '@/lib/billing/tenant-admins'
 
 export const runtime = 'nodejs'
 
@@ -39,26 +40,6 @@ function getSupabaseAdmin(): SupabaseClient {
   const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
   if (!url || !serviceKey) throw new Error('Supabase env vars not set')
   return createClient(url, serviceKey)
-}
-
-/**
- * Resolve the active admin emails for a tenant. profiles has no email column,
- * so emails come from the auth admin API keyed by tenant_users membership.
- */
-async function getTenantAdminEmails(supabase: SupabaseClient, tenantId: string): Promise<string[]> {
-  const { data: adminUsers } = await supabase
-    .from('tenant_users')
-    .select('user_id')
-    .eq('tenant_id', tenantId)
-    .eq('role', 'admin')
-    .eq('status', 'active')
-
-  const emails: string[] = []
-  for (const admin of adminUsers || []) {
-    const { data: authUser } = await supabase.auth.admin.getUserById(admin.user_id)
-    if (authUser?.user?.email) emails.push(authUser.user.email)
-  }
-  return emails
 }
 
 // Email sends must never abort a transition; failures are logged and swallowed.

--- a/components/admin/billing-overview.tsx
+++ b/components/admin/billing-overview.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { UsageMeter } from './usage-meter'
+import { LimitReachedBanner } from '@/components/shared/limit-reached-banner'
 import { IconCreditCard, IconCalendar, IconAlertTriangle, IconX } from '@tabler/icons-react'
 import Link from 'next/link'
 import { useTranslations } from 'next-intl'
@@ -33,6 +34,7 @@ interface BillingOverviewProps {
     students: { current: number; limit: number }
   }
   transactionFeePercent: number
+  accessCutoffAt: string | null
   onManageClick?: () => void
   onCancelClick?: () => void
 }
@@ -46,6 +48,7 @@ export function BillingOverview({
   upcomingPayment,
   usage,
   transactionFeePercent,
+  accessCutoffAt,
   onManageClick,
   onCancelClick,
 }: BillingOverviewProps) {
@@ -202,16 +205,32 @@ export function BillingOverview({
 
           <section aria-label={`${t('currentPlan')} usage`} className="border-t pt-5">
             <div className="grid gap-5 md:grid-cols-2">
-            <UsageMeter
-              label={t('courses')}
-              current={usage.courses.current}
-              limit={usage.courses.limit}
-            />
-            <UsageMeter
-              label={t('students')}
-              current={usage.students.current}
-              limit={usage.students.limit}
-            />
+            <div className="space-y-3">
+              <UsageMeter
+                label={t('courses')}
+                current={usage.courses.current}
+                limit={usage.courses.limit}
+              />
+              <LimitReachedBanner
+                resource="courses"
+                current={usage.courses.current}
+                limit={usage.courses.limit}
+                cutoffAt={accessCutoffAt}
+              />
+            </div>
+            <div className="space-y-3">
+              <UsageMeter
+                label={t('students')}
+                current={usage.students.current}
+                limit={usage.students.limit}
+              />
+              <LimitReachedBanner
+                resource="students"
+                current={usage.students.current}
+                limit={usage.students.limit}
+                cutoffAt={accessCutoffAt}
+              />
+            </div>
             </div>
           </section>
         </CardContent>

--- a/components/shared/limit-reached-banner.tsx
+++ b/components/shared/limit-reached-banner.tsx
@@ -11,9 +11,10 @@ interface LimitReachedBannerProps {
   current: number
   limit: number          // -1 = unlimited
   className?: string
+  cutoffAt?: string | null
 }
 
-export function LimitReachedBanner({ resource, current, limit, className }: LimitReachedBannerProps) {
+export function LimitReachedBanner({ resource, current, limit, className, cutoffAt }: LimitReachedBannerProps) {
   const [dismissed, setDismissed] = useState(false)
 
   if (dismissed || limit === -1) return null
@@ -33,12 +34,19 @@ export function LimitReachedBanner({ resource, current, limit, className }: Limi
       className
     )}>
       <IconAlertTriangle className="h-5 w-5 shrink-0" />
-      <p className="flex-1 text-sm">
-        {isAtLimit
-          ? `You've reached your ${resource} limit (${limit}). Upgrade your plan to add more.`
-          : `You're using ${current} of ${limit} ${resource}. Consider upgrading for more capacity.`
-        }
-      </p>
+      <div className="flex-1 text-sm">
+        <p>
+          {isAtLimit
+            ? `You've reached your ${resource} limit (${limit}). Upgrade your plan to add more.`
+            : `You're using ${current} of ${limit} ${resource}. Consider upgrading for more capacity.`
+          }
+        </p>
+        {cutoffAt && (
+          <p className="font-semibold">
+            If this is not resolved by {new Date(cutoffAt).toLocaleDateString(undefined, { dateStyle: 'long' })}, all students will lose access to all courses.
+          </p>
+        )}
+      </div>
       <Link href="/dashboard/admin/billing/upgrade">
         <Button variant={isAtLimit ? 'destructive' : 'outline'} size="sm">
           Upgrade

--- a/docs/MONETIZATION.md
+++ b/docs/MONETIZATION.md
@@ -232,6 +232,17 @@ function MyComponent() {
 
 `app/actions/teacher/courses.ts` reads `platform_plans.limits.max_courses` from the database (not hardcoded). Returns `approaching: true` with `nextPlan` and `nextPlanPrice` when at 80%+ usage.
 
+The two sections above are **creation-time soft caps only** — they block a *new* student from joining or a *new* course from being created once a tenant is at its limit. Neither one does anything about students/courses that already exist when a tenant ends up over its plan's limit (e.g. after a downgrade, or by organically outgrowing its plan with no plan-change event). That gap was issue #494; it's closed by the mechanism below.
+
+### Post-Downgrade Access Enforcement (issue #494)
+
+`lib/billing/access-cutoff.ts` is the single place that decides and schedules `tenants.access_cutoff_at`:
+
+- Whenever a tenant's usage is checked, `countTenantUsage`/`computePlanLimitViolations` (`lib/billing/plan-limits.ts`) compare current course/active-student counts against the tenant's **current** plan limits. If either is over limit and no cutoff is already scheduled, `reconcileAccessCutoff()` schedules `access_cutoff_at` `ACCESS_CUTOFF_GRACE_DAYS` (14 days) out and emails the tenant's admins immediately via `accessCutoffWarningTemplate` (`lib/email/templates/access-cutoff-warning.ts`), naming the exact cutoff date and which limit(s) are exceeded. If usage drops back under the limit, the next reconciliation clears the scheduled cutoff automatically.
+- `reconcileAccessCutoff()` is called from every plan-state transition: `downgradeTenantToFree()` (both the Stripe `customer.subscription.deleted` webhook and the manual-transfer expiry cron), `changePlan()` and `confirmManualPayment()` in `app/actions/admin/billing.ts`, `applyPortalPlanChange()` (`lib/payments/platform-plan-change.ts`), and a daily cron `app/api/cron/enforce-plan-limits/route.ts` that sweeps every tenant to catch organic over-limit growth with no associated plan-change event.
+- Enforcement itself is in the database: once `access_cutoff_at` passes while the tenant is still over its plan's limits, `has_course_access()` (SQL function, migration `supabase/migrations/20260724130000_access_cutoff_enforcement.sql`) starts returning `false` for every student in that tenant — cutting off access tenant-wide, everywhere that function (or its TS counterpart `hasCourseAccess()`) gates access: lessons, exams, exercises, certificates, AI tutor chat. Access is restored automatically as soon as usage is back under the limit or the tenant upgrades.
+- This is a deliberate decision, not an oversight: with no production users yet, real enforcement was shipped directly rather than grandfathering pre-existing over-limit usage.
+
 ---
 
 ## Currency Support

--- a/lib/billing/access-cutoff.ts
+++ b/lib/billing/access-cutoff.ts
@@ -1,0 +1,134 @@
+/**
+ * Real access enforcement for over-limit tenants (issue #494).
+ *
+ * `has_course_access()` never considered a tenant's plan/billing state — a
+ * tenant downgraded (or that simply outgrew its plan) kept full access to
+ * every course indefinitely. This module is the single place that decides
+ * and schedules `tenants.access_cutoff_at`, the timestamp
+ * `has_course_access()` checks (see migration 20260724130000).
+ *
+ * Split mirrors `plan-limits.ts`: a pure decision function (unit-testable,
+ * no DB) plus an impure reconciler that every plan-state transition calls —
+ * the webhook-driven downgrade, both admin plan-change actions, the portal
+ * change handler, and a daily cron sweep for organic growth over a limit
+ * with no plan-change event. All of them can call `reconcileAccessCutoff`
+ * freely; the decision function's null-check on `currentCutoffAt` makes
+ * repeated calls idempotent (no double-scheduling, no duplicate emails).
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { sendEmail } from '@/lib/email/send'
+import { accessCutoffWarningTemplate } from '@/lib/email/templates/access-cutoff-warning'
+import { countTenantUsage, computePlanLimitViolations, type PlanLimitViolation } from '@/lib/billing/plan-limits'
+import { getTenantAdminEmails } from '@/lib/billing/tenant-admins'
+
+export const ACCESS_CUTOFF_GRACE_DAYS = 14
+const DAY_MS = 24 * 60 * 60 * 1000
+
+export interface AccessCutoffDecision {
+  action: 'schedule' | 'clear' | 'none'
+  cutoffAt?: string
+}
+
+/**
+ * Pure decision: should a cutoff be scheduled, cleared, or left alone.
+ * `now` is injectable so callers/tests don't depend on wall-clock time.
+ */
+export function decideAccessCutoffAction(input: {
+  violations: PlanLimitViolation[]
+  currentCutoffAt: string | null
+  now: Date
+}): AccessCutoffDecision {
+  const { violations, currentCutoffAt, now } = input
+
+  if (violations.length > 0 && !currentCutoffAt) {
+    const cutoffAt = new Date(now.getTime() + ACCESS_CUTOFF_GRACE_DAYS * DAY_MS).toISOString()
+    return { action: 'schedule', cutoffAt }
+  }
+
+  if (violations.length === 0 && currentCutoffAt) {
+    return { action: 'clear' }
+  }
+
+  return { action: 'none' }
+}
+
+function formatViolationReasons(violations: PlanLimitViolation[], planName: string): string[] {
+  return violations.map((v) =>
+    v.resource === 'courses'
+      ? `${v.current} active courses exceed the ${planName} plan's limit of ${v.max}`
+      : `${v.current} active students exceed the ${planName} plan's limit of ${v.max}`
+  )
+}
+
+/**
+ * Fetch a tenant's current plan/usage, decide, and apply: write
+ * `access_cutoff_at` and (on `schedule`) email the tenant's admins with the
+ * exact date and reasons. Safe to call from any plan-state transition —
+ * a no-op when nothing needs to change.
+ */
+export async function reconcileAccessCutoff(
+  admin: SupabaseClient,
+  tenantId: string,
+  opts?: { sendEmailFn?: typeof sendEmail; now?: Date }
+): Promise<AccessCutoffDecision> {
+  const sendEmailFn = opts?.sendEmailFn ?? sendEmail
+  const now = opts?.now ?? new Date()
+
+  const { data: tenant } = await admin
+    .from('tenants')
+    .select('name, plan, access_cutoff_at')
+    .eq('id', tenantId)
+    .maybeSingle()
+
+  if (!tenant) return { action: 'none' }
+
+  const [{ data: plan }, usage] = await Promise.all([
+    admin
+      .from('platform_plans')
+      .select('name, limits')
+      .eq('slug', tenant.plan || 'free')
+      .maybeSingle(),
+    countTenantUsage(admin, tenantId),
+  ])
+
+  const violations = computePlanLimitViolations(
+    usage,
+    (plan?.limits as { max_courses?: number; max_students?: number } | null) ?? null
+  )
+
+  const decision = decideAccessCutoffAction({
+    violations,
+    currentCutoffAt: tenant.access_cutoff_at,
+    now,
+  })
+
+  if (decision.action === 'none') return decision
+
+  await admin
+    .from('tenants')
+    .update({ access_cutoff_at: decision.cutoffAt ?? null, updated_at: now.toISOString() })
+    .eq('id', tenantId)
+
+  if (decision.action === 'schedule' && decision.cutoffAt) {
+    const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://app.example.com'
+    const template = accessCutoffWarningTemplate({
+      schoolName: tenant.name || 'your school',
+      planName: plan?.name || tenant.plan || 'Free',
+      reasons: formatViolationReasons(violations, plan?.name || tenant.plan || 'Free'),
+      cutoffDate: new Date(decision.cutoffAt).toLocaleDateString('en-US', { dateStyle: 'long' }),
+      billingUrl: `${appUrl}/dashboard/admin/billing`,
+    })
+
+    const emails = await getTenantAdminEmails(admin, tenantId)
+    for (const to of emails) {
+      try {
+        await sendEmailFn({ to, ...template })
+      } catch (err) {
+        console.error('reconcileAccessCutoff: email send failed', err)
+      }
+    }
+  }
+
+  return decision
+}

--- a/lib/billing/downgrade-tenant.ts
+++ b/lib/billing/downgrade-tenant.ts
@@ -1,4 +1,5 @@
 import type { createAdminClient } from '@/lib/supabase/admin'
+import { reconcileAccessCutoff } from '@/lib/billing/access-cutoff'
 
 type AdminClient = ReturnType<typeof createAdminClient>
 
@@ -57,6 +58,10 @@ export async function downgradeTenantToFree(
       school_percentage: 100 - platformFee,
       updated_at: now,
     }, { onConflict: 'tenant_id' })
+
+  // Schedule (or leave alone) an access cutoff if the tenant now exceeds the
+  // free plan's limits — see lib/billing/access-cutoff.ts (issue #494).
+  await reconcileAccessCutoff(adminClient, tenantId)
 
   return platformFee
 }

--- a/lib/billing/tenant-admins.ts
+++ b/lib/billing/tenant-admins.ts
@@ -1,0 +1,26 @@
+/**
+ * Resolve the active admin emails for a tenant. `profiles` has no email
+ * column, so emails come from the auth admin API keyed by tenant_users
+ * membership. Shared by the platform-subscription cron and the
+ * access-cutoff reconciler so both notify the same audience the same way.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+export async function getTenantAdminEmails(
+  supabase: SupabaseClient,
+  tenantId: string
+): Promise<string[]> {
+  const { data: adminUsers } = await supabase
+    .from('tenant_users')
+    .select('user_id')
+    .eq('tenant_id', tenantId)
+    .eq('role', 'admin')
+    .eq('status', 'active')
+
+  const emails: string[] = []
+  for (const admin of adminUsers || []) {
+    const { data: authUser } = await supabase.auth.admin.getUserById(admin.user_id)
+    if (authUser?.user?.email) emails.push(authUser.user.email)
+  }
+  return emails
+}

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -5771,6 +5771,7 @@ export type Database = {
       }
       tenants: {
         Row: {
+          access_cutoff_at: string | null
           billing_email: string | null
           billing_period_end: string | null
           billing_status: string | null
@@ -5792,6 +5793,7 @@ export type Database = {
           updated_at: string | null
         }
         Insert: {
+          access_cutoff_at?: string | null
           billing_email?: string | null
           billing_period_end?: string | null
           billing_status?: string | null
@@ -5813,6 +5815,7 @@ export type Database = {
           updated_at?: string | null
         }
         Update: {
+          access_cutoff_at?: string | null
           billing_email?: string | null
           billing_period_end?: string | null
           billing_status?: string | null

--- a/lib/email/templates/access-cutoff-warning.ts
+++ b/lib/email/templates/access-cutoff-warning.ts
@@ -1,0 +1,37 @@
+export interface AccessCutoffWarningData {
+  schoolName: string
+  planName: string
+  reasons: string[]
+  cutoffDate: string
+  billingUrl: string
+}
+
+export function accessCutoffWarningTemplate(data: AccessCutoffWarningData): {
+  subject: string
+  html: string
+} {
+  return {
+    subject: `Action required: student access to ${data.schoolName} will be cut off on ${data.cutoffDate}`,
+    html: `<!DOCTYPE html>
+<html>
+<body style="font-family:sans-serif;max-width:600px;margin:0 auto;padding:24px;color:#1a1a1a">
+  <h2 style="color:#dc2626">Course Access Will Be Restricted</h2>
+  <p>Hi,</p>
+  <p><strong>${data.schoolName}</strong> is on the <strong>${data.planName}</strong> plan and currently exceeds its limits:</p>
+  <ul style="color:#444">
+    ${data.reasons.map((r) => `<li>${r}</li>`).join('\n    ')}
+  </ul>
+  <p>If this isn't resolved by <strong>${data.cutoffDate}</strong>, every student at your school will lose access to all courses — lessons, exams, exercises, and certificates — until usage is brought back within the plan's limits or you upgrade.</p>
+  <p>To keep access uninterrupted, upgrade your plan or reduce usage (archive courses / remove students) before the date above.</p>
+  <p style="text-align:center;margin:32px 0">
+    <a href="${data.billingUrl}" style="background:#dc2626;color:#fff;padding:12px 28px;border-radius:6px;text-decoration:none;font-weight:600">
+      Manage Billing
+    </a>
+  </p>
+  <p style="color:#666;font-size:13px">If you believe this is an error, please contact support.</p>
+  <hr style="border:none;border-top:1px solid #eee;margin:24px 0"/>
+  <p style="color:#999;font-size:12px">LMS Platform Billing</p>
+</body>
+</html>`,
+  }
+}

--- a/lib/email/templates/downgrade-blocked.ts
+++ b/lib/email/templates/downgrade-blocked.ts
@@ -33,7 +33,7 @@ export function downgradeBlockedTemplate(data: DowngradeBlockedData): {
   <p>${
     reverted
       ? `To downgrade to ${data.newPlanName}, first reduce your usage below its limits, then change your plan again from the billing page.`
-      : `Until this is resolved, parts of your school may be restricted by the ${data.newPlanName} plan limits.`
+      : `If this isn't resolved within 14 days, all students at your school will lose access to all courses until usage is brought back within the ${data.newPlanName} plan's limits or you upgrade.`
   }</p>
   <p style="text-align:center;margin:32px 0">
     <a href="${data.billingUrl}" style="background:#d97706;color:#fff;padding:12px 28px;border-radius:6px;text-decoration:none;font-weight:600">

--- a/lib/email/templates/plan-downgraded.ts
+++ b/lib/email/templates/plan-downgraded.ts
@@ -13,7 +13,7 @@ export function planDowngradedTemplate(data: PlanDowngradedData): { subject: str
   <h2 style="color:#dc2626">Plan Downgraded</h2>
   <p>Hi,</p>
   <p>We didn't receive a renewal payment for the <strong>${data.planName}</strong> plan on ${data.schoolName} before the grace period ended, so your school has been moved to the <strong>free</strong> plan.</p>
-  <p>Your courses and data are safe, but free-plan limits now apply and your platform transaction fee has changed accordingly.</p>
+  <p>Your courses and data are unaffected immediately, but free-plan limits now apply and your platform transaction fee has changed accordingly. If your current usage exceeds the free plan's limits, you'll receive a separate notice with a firm deadline before student access is restricted.</p>
   <p>You can upgrade again at any time from the billing dashboard.</p>
   <p style="text-align:center;margin:32px 0">
     <a href="${data.billingUrl}" style="background:#7c3aed;color:#fff;padding:12px 28px;border-radius:6px;text-decoration:none;font-weight:600">

--- a/lib/payments/platform-plan-change.ts
+++ b/lib/payments/platform-plan-change.ts
@@ -24,6 +24,7 @@ import type { SupabaseClient } from '@supabase/supabase-js'
 import { sendEmail } from '@/lib/email/send'
 import { downgradeBlockedTemplate } from '@/lib/email/templates/downgrade-blocked'
 import { countTenantUsage, computePlanLimitViolations } from '@/lib/billing/plan-limits'
+import { reconcileAccessCutoff } from '@/lib/billing/access-cutoff'
 
 export interface PortalPlanChangeDeps {
   /** Service-role Supabase client (bypasses RLS). */
@@ -106,6 +107,8 @@ export async function applyPortalPlanChange(
 
   if (violations.length === 0) {
     await applyPlanToDb(admin, tenantId, newPlan)
+    // Clears any cutoff scheduled from a prior over-limit period.
+    await reconcileAccessCutoff(admin, tenantId)
     return { action: 'applied' }
   }
 
@@ -155,6 +158,8 @@ export async function applyPortalPlanChange(
   }
 
   await applyPlanToDb(admin, tenantId, newPlan)
+  // Schedules a cutoff if the tenant is still over the new plan's limits.
+  await reconcileAccessCutoff(admin, tenantId, { sendEmailFn })
   await notifyAdmins(admin, sendEmailFn, {
     tenantId,
     outcome: 'applied_over_limit',

--- a/supabase/migrations/20260724130000_access_cutoff_enforcement.sql
+++ b/supabase/migrations/20260724130000_access_cutoff_enforcement.sql
@@ -1,0 +1,35 @@
+-- Issue #494 — real access enforcement for over-limit tenants.
+--
+-- Adds tenants.access_cutoff_at: a scheduled/active tenant-wide access cutoff
+-- timestamp, set by the app layer (lib/billing/access-cutoff.ts) when a
+-- tenant's usage exceeds its current plan's limits, and cleared once
+-- resolved (upgrade or reduced usage). NULL = no cutoff scheduled or active.
+--
+-- has_course_access() is the single source of truth for student course
+-- access (see docs/DATABASE_SCHEMA.md); this migration adds one additive
+-- condition so a cutoff denies access tenant-wide without touching any other
+-- entitlement semantics.
+
+ALTER TABLE tenants ADD COLUMN IF NOT EXISTS access_cutoff_at timestamptz;
+
+CREATE INDEX IF NOT EXISTS idx_tenants_access_cutoff_at
+  ON tenants (access_cutoff_at)
+  WHERE access_cutoff_at IS NOT NULL;
+
+CREATE OR REPLACE FUNCTION public.has_course_access(_user_id uuid, _course_id integer)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+  SELECT EXISTS (
+    SELECT 1 FROM entitlements e
+    JOIN tenants t ON t.id = e.tenant_id
+    WHERE e.user_id = _user_id
+      AND e.course_id = _course_id
+      AND e.status = 'active'
+      AND (e.expires_at IS NULL OR e.expires_at > now())
+      AND (t.access_cutoff_at IS NULL OR t.access_cutoff_at > now())
+  );
+$function$;

--- a/tests/unit/access-cutoff.test.ts
+++ b/tests/unit/access-cutoff.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest'
+import { decideAccessCutoffAction, ACCESS_CUTOFF_GRACE_DAYS } from '@/lib/billing/access-cutoff'
+import type { PlanLimitViolation } from '@/lib/billing/plan-limits'
+
+describe('decideAccessCutoffAction', () => {
+  it('issue #494 scenario: 10,000 students on a 50-student-max plan schedules a cutoff', () => {
+    const now = new Date('2026-07-24T00:00:00.000Z')
+    const violations: PlanLimitViolation[] = [
+      { resource: 'students', current: 10000, max: 50, reduceBy: 9950 },
+    ]
+    const result = decideAccessCutoffAction({
+      violations,
+      currentCutoffAt: null,
+      now,
+    })
+    expect(result.action).toBe('schedule')
+    expect(result.cutoffAt).toBe(new Date('2026-08-07T00:00:00.000Z').toISOString())
+  })
+
+  it('no violations and no existing cutoff → none', () => {
+    const result = decideAccessCutoffAction({
+      violations: [],
+      currentCutoffAt: null,
+      now: new Date('2026-07-24T00:00:00.000Z'),
+    })
+    expect(result.action).toBe('none')
+    expect(result.cutoffAt).toBeUndefined()
+  })
+
+  it('already scheduled and still over limit does not reschedule (idempotent)', () => {
+    const violations: PlanLimitViolation[] = [
+      { resource: 'students', current: 10000, max: 50, reduceBy: 9950 },
+    ]
+    const result = decideAccessCutoffAction({
+      violations,
+      currentCutoffAt: '2026-07-20T00:00:00.000Z',
+      now: new Date('2026-07-24T00:00:00.000Z'),
+    })
+    expect(result.action).toBe('none')
+    expect(result.cutoffAt).toBeUndefined()
+  })
+
+  it('resolved usage clears an active cutoff', () => {
+    const result = decideAccessCutoffAction({
+      violations: [],
+      currentCutoffAt: '2026-07-20T00:00:00.000Z',
+      now: new Date('2026-07-24T00:00:00.000Z'),
+    })
+    expect(result.action).toBe('clear')
+  })
+
+  it('a courses-only violation also triggers schedule (not student-specific)', () => {
+    const violations: PlanLimitViolation[] = [
+      { resource: 'courses', current: 20, max: 15, reduceBy: 5 },
+    ]
+    const now = new Date('2026-07-24T00:00:00.000Z')
+    const result = decideAccessCutoffAction({
+      violations,
+      currentCutoffAt: null,
+      now,
+    })
+    expect(result.action).toBe('schedule')
+    expect(result.cutoffAt).toBe(
+      new Date(now.getTime() + ACCESS_CUTOFF_GRACE_DAYS * 24 * 60 * 60 * 1000).toISOString()
+    )
+  })
+
+  it('multiple simultaneous violations still yield a single schedule action', () => {
+    const violations: PlanLimitViolation[] = [
+      { resource: 'courses', current: 20, max: 15, reduceBy: 5 },
+      { resource: 'students', current: 10000, max: 50, reduceBy: 9950 },
+    ]
+    const now = new Date('2026-07-24T00:00:00.000Z')
+    const result = decideAccessCutoffAction({
+      violations,
+      currentCutoffAt: null,
+      now,
+    })
+    expect(result.action).toBe('schedule')
+    expect(result.cutoffAt).toBe(new Date('2026-08-07T00:00:00.000Z').toISOString())
+  })
+})

--- a/vercel.json
+++ b/vercel.json
@@ -17,6 +17,10 @@
       "schedule": "0 2 * * *"
     },
     {
+      "path": "/api/cron/enforce-plan-limits",
+      "schedule": "0 3 * * *"
+    },
+    {
       "path": "/api/cron/solana-reconcile",
       "schedule": "*/10 * * * *"
     },


### PR DESCRIPTION
## Description

Non-payment previously produced no consequence: `downgradeTenantToFree()` only ever wrote `platform_subscriptions.status`, `tenants.plan/billing_status/billing_period_end`, and `revenue_splits` — it never touched `courses`, `entitlements`, or `tenant_users`. `has_course_access()`, the single source of truth for course access, checked only `entitlements.status`/expiry with no reference to a tenant's plan or limits. A school that stopped paying (or simply outgrew its plan with no plan-change event at all) kept every student's full course access forever, while the downgrade email claimed "your courses and data are safe" and a fully-built `LimitReachedBanner` component sat unused, never rendered anywhere in the app.

Per explicit product direction, this ships **real enforcement**, not grandfathering (this repo has no production users yet, so there's no legacy-data safety net to design around):

- `tenants.access_cutoff_at` (new column) is scheduled 14 days out (`ACCESS_CUTOFF_GRACE_DAYS`) the moment a tenant's course/student usage exceeds its **current** plan's limits, and the admin is emailed immediately with the exact date and which limits are exceeded (`accessCutoffWarningTemplate`).
- If the tenant is still over its limits when that deadline passes, `has_course_access()` starts returning `false` for every student in the tenant — cutting off lessons, exams, exercises, certificates, and AI tutor chat tenant-wide — until usage drops back under the limit or the tenant upgrades, at which point the cutoff clears automatically.
- `reconcileAccessCutoff()` (the single decide-and-apply function, `lib/billing/access-cutoff.ts`) is wired into every plan-state transition: the Stripe `customer.subscription.deleted` webhook and manual-transfer expiry cron (both via `downgradeTenantToFree()`), in-app plan change and manual-payment confirmation (`app/actions/admin/billing.ts`), and the Stripe-portal change handler (`applyPortalPlanChange()`). A new daily cron (`app/api/cron/enforce-plan-limits`) sweeps every tenant to catch organic over-limit growth with no associated plan-change event.
- Misleading copy fixed: `plan-downgraded.ts` no longer unconditionally claims safety, `downgrade-blocked.ts`'s "may be restricted" is now a concrete, accurate statement, and the previously-dead `LimitReachedBanner` is now wired into the admin billing page and shows the cutoff deadline when one is scheduled.
- Decision documented in `docs/MONETIZATION.md` under a new "Post-Downgrade Access Enforcement" section.

## Type of change

- [x] Bug fix (real enforcement was entirely absent — this closes the gap)

Closes #494 (Phase 1 sub-task of epic #493).

## Testing

- [x] `npm run typecheck` — clean, no errors.
- [x] `npm run lint` — no new errors in any changed file (the tree has pre-existing unrelated lint debt elsewhere, unaffected by this change); fixed 4 pre-existing `any`-type lint errors in `billing-dashboard-client.tsx` that lint-staged surfaced because the file was touched.
- [x] `npm run test:unit` — 263/263 passing, including a new `tests/unit/access-cutoff.test.ts` (6 tests) covering the issue's literal 10,000-students-vs-50-limit scenario, idempotency (no double-scheduling/double-emailing), clearing on resolution, and both violation types.
- [x] `npm run build` — succeeds.
- [x] Manual SQL verification of `has_course_access()` against a throwaway tenant/course/entitlement inside a rolled-back transaction: no cutoff → access `true`; cutoff scheduled in the future → access still `true` (grace respected); cutoff in the past → access `false` (enforced); cutoff cleared → access `true` again. All four cases behaved exactly as designed.
- [ ] **Browser/visual verification not completed** — the Claude-in-Chrome browser extension was not connected in this environment, so I could not capture live screenshots/GIF of the `LimitReachedBanner` cutoff messaging on `/dashboard/admin/billing`. The banner logic was reviewed by hand and is lint/typecheck-clean; a human reviewer should sanity-check it visually before merge (see QA steps below).

### QA verification steps

1. In a local Supabase shell, temporarily lower a tenant's effective course/student limit below its current usage (e.g. `UPDATE platform_plans SET limits = jsonb_set(limits, '{max_courses}', '1') WHERE slug = 'free'` for a free-plan tenant with 2+ courses), then load that tenant admin's `/dashboard/admin/billing` — confirm the courses `LimitReachedBanner` now renders with the "at limit" copy.
2. `UPDATE tenants SET access_cutoff_at = now() + interval '14 days' WHERE id = '<tenant>'` and reload the page — confirm the banner shows the additional bold cutoff-date line.
3. Revert both temporary updates (limit back to original, `access_cutoff_at` back to `NULL`).
4. As a student enrolled in that tenant, confirm course access is unaffected while `access_cutoff_at` is still in the future.
5. Set `access_cutoff_at` to a past timestamp on that tenant and confirm the student's course page now denies access; clear it again and confirm access returns.
