### PR TITLE
feat(platform): billing health dashboard for past-due schools (#495)

### DIFF
--- a/app/[locale]/platform/billing-health/page.tsx
+++ b/app/[locale]/platform/billing-health/page.tsx
@@ -1,0 +1,140 @@
+import { getAtRiskTenants } from '@/app/actions/platform/billing-health'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { format } from 'date-fns'
+import {
+  IconAlertTriangle,
+  IconClockPause,
+  IconCreditCardOff,
+} from '@tabler/icons-react'
+
+export default async function PlatformBillingHealthPage() {
+  const atRisk = await getAtRiskTenants()
+
+  const manualTransfer = atRisk.filter((t) => t.paymentMethod === 'manual_transfer')
+  const stripeDunning = atRisk.filter((t) => t.paymentMethod !== 'manual_transfer')
+  const urgent = manualTransfer.filter((t) => t.daysUntilDowngrade !== null && t.daysUntilDowngrade <= 3)
+
+  const metricCards = [
+    {
+      title: 'Past-Due Schools',
+      value: String(atRisk.length),
+      sub: 'Total schools currently behind on payment',
+      icon: IconAlertTriangle,
+      bg: 'bg-red-50 dark:bg-red-950/40',
+      iconColor: 'text-red-600 dark:text-red-400',
+    },
+    {
+      title: 'Manual-Transfer Grace Running',
+      value: String(manualTransfer.length),
+      sub: urgent.length > 0 ? `${urgent.length} downgrading within 3 days` : 'None expiring imminently',
+      icon: IconClockPause,
+      bg: 'bg-amber-50 dark:bg-amber-950/40',
+      iconColor: 'text-amber-600 dark:text-amber-400',
+    },
+    {
+      title: 'Stripe Dunning In Progress',
+      value: String(stripeDunning.length),
+      sub: 'Downgrade timing controlled by Stripe, not this app',
+      icon: IconCreditCardOff,
+      bg: 'bg-blue-50 dark:bg-blue-950/40',
+      iconColor: 'text-blue-600 dark:text-blue-400',
+    },
+  ]
+
+  return (
+    <main className="flex-1 px-4 py-6 sm:px-6 lg:px-8" data-testid="platform-billing-health">
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold tracking-tight">Billing Health</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Schools currently past-due, with their grace-period countdown to automatic downgrade.
+        </p>
+      </div>
+
+      <div className="mb-8 grid gap-3 sm:grid-cols-3" data-testid="billing-health-metrics">
+        {metricCards.map((card) => (
+          <Card key={card.title} className="relative overflow-hidden">
+            <CardContent className="p-5">
+              <div className="flex items-start justify-between">
+                <div className="min-w-0 flex-1">
+                  <p className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+                    {card.title}
+                  </p>
+                  <p className="mt-2 text-2xl font-bold tracking-tight tabular-nums" data-testid="metric-value">
+                    {card.value}
+                  </p>
+                  <p className="mt-1 text-[11px] text-muted-foreground/70">{card.sub}</p>
+                </div>
+                <div className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-lg ${card.bg}`}>
+                  <card.icon className={`h-[18px] w-[18px] ${card.iconColor}`} strokeWidth={1.75} />
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      <Card data-testid="billing-health-by-tenant">
+        <CardHeader>
+          <CardTitle>At-risk schools</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {atRisk.length === 0 ? (
+            <p className="text-muted-foreground text-sm">No schools currently past-due.</p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b text-left text-[11px] uppercase tracking-wider text-muted-foreground">
+                    <th className="pb-2 font-medium">School</th>
+                    <th className="pb-2 font-medium">Plan</th>
+                    <th className="pb-2 font-medium">Payment method</th>
+                    <th className="pb-2 font-medium">Past due since</th>
+                    <th className="pb-2 font-medium">Downgrades in</th>
+                    <th className="pb-2 font-medium">Access cutoff</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {atRisk.map((t) => (
+                    <tr key={t.tenantId} className="border-b last:border-0" data-testid="at-risk-row" data-tenant-id={t.tenantId}>
+                      <td className="py-2.5 font-medium">{t.tenantName}</td>
+                      <td className="py-2.5 capitalize text-muted-foreground">{t.plan || '—'}</td>
+                      <td className="py-2.5 text-muted-foreground">
+                        {t.paymentMethod === 'manual_transfer' ? 'Manual transfer' : t.paymentMethod === 'stripe' ? 'Stripe' : '—'}
+                      </td>
+                      <td className="py-2.5 text-muted-foreground">
+                        {t.pastDueSince ? format(new Date(t.pastDueSince), 'MMM d, yyyy') : '—'}
+                      </td>
+                      <td className="py-2.5">
+                        {t.isEstimate ? (
+                          <Badge variant="outline" className="text-[10px]">Stripe-managed</Badge>
+                        ) : t.daysUntilDowngrade !== null ? (
+                          <span
+                            className={`font-medium tabular-nums ${
+                              t.daysUntilDowngrade <= 3
+                                ? 'text-red-600 dark:text-red-400'
+                                : t.daysUntilDowngrade <= 7
+                                  ? 'text-amber-600 dark:text-amber-400'
+                                  : 'text-muted-foreground'
+                            }`}
+                          >
+                            {t.daysUntilDowngrade <= 0 ? 'Overdue' : `${t.daysUntilDowngrade} day${t.daysUntilDowngrade === 1 ? '' : 's'}`}
+                          </span>
+                        ) : (
+                          <span className="text-muted-foreground">—</span>
+                        )}
+                      </td>
+                      <td className="py-2.5 text-muted-foreground">
+                        {t.accessCutoffAt ? format(new Date(t.accessCutoffAt), 'MMM d, yyyy') : '—'}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </main>
+  )
+}

--- a/app/[locale]/platform/layout.tsx
+++ b/app/[locale]/platform/layout.tsx
@@ -16,12 +16,18 @@ export const metadata: Metadata = {
 
 async function PlatformSidebarWithCount() {
   const adminClient = createAdminClient()
-  const { count: pendingCount } = await adminClient
-    .from('platform_payment_requests')
-    .select('*', { count: 'exact', head: true })
-    .eq('status', 'pending')
+  const [{ count: pendingCount }, { count: atRiskCount }] = await Promise.all([
+    adminClient
+      .from('platform_payment_requests')
+      .select('*', { count: 'exact', head: true })
+      .eq('status', 'pending'),
+    adminClient
+      .from('tenants')
+      .select('*', { count: 'exact', head: true })
+      .eq('billing_status', 'past_due'),
+  ])
 
-  return <PlatformSidebar pendingBillingCount={pendingCount ?? 0} />
+  return <PlatformSidebar pendingBillingCount={pendingCount ?? 0} atRiskCount={atRiskCount ?? 0} />
 }
 
 export default async function PlatformLayout({

--- a/app/actions/platform/billing-health.ts
+++ b/app/actions/platform/billing-health.ts
@@ -1,0 +1,48 @@
+'use server'
+
+import { createAdminClient } from '@/lib/supabase/admin'
+import { isSuperAdmin } from '@/lib/supabase/get-user-role'
+import { getCurrentUserId } from '@/lib/supabase/tenant'
+import { computeBillingHealth, type AtRiskTenant } from '@/lib/billing/billing-health'
+
+async function verifySuperAdmin() {
+  const userId = await getCurrentUserId()
+  if (!userId) throw new Error('Not authenticated')
+  if (!(await isSuperAdmin())) throw new Error('Super admin only')
+  return userId
+}
+
+export async function getAtRiskTenants(): Promise<AtRiskTenant[]> {
+  await verifySuperAdmin()
+  const admin = createAdminClient()
+
+  const { data: tenants } = await admin
+    .from('tenants')
+    .select('id, name, plan, access_cutoff_at')
+    .eq('billing_status', 'past_due')
+
+  const tenantIds = (tenants || []).map((t) => t.id)
+
+  const { data: subscriptions } = tenantIds.length
+    ? await admin
+        .from('platform_subscriptions')
+        .select('tenant_id, payment_method, current_period_end, grace_period_end')
+        .in('tenant_id', tenantIds)
+    : { data: [] }
+
+  return computeBillingHealth(
+    (tenants || []).map((t) => ({
+      tenantId: t.id,
+      tenantName: t.name,
+      plan: t.plan,
+      accessCutoffAt: t.access_cutoff_at,
+    })),
+    (subscriptions || []).map((s) => ({
+      tenantId: s.tenant_id,
+      paymentMethod: s.payment_method,
+      currentPeriodEnd: s.current_period_end,
+      gracePeriodEnd: s.grace_period_end,
+    })),
+    new Date(),
+  )
+}

--- a/components/platform-sidebar.tsx
+++ b/components/platform-sidebar.tsx
@@ -4,6 +4,7 @@ import * as React from "react"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 import {
+  IconAlertTriangle,
   IconBuildingStore,
   IconChartBar,
   IconCreditCard,
@@ -32,9 +33,10 @@ import { createClient } from "@/lib/supabase/client"
 
 interface PlatformSidebarProps extends React.ComponentProps<typeof Sidebar> {
   pendingBillingCount?: number
+  atRiskCount?: number
 }
 
-export function PlatformSidebar({ pendingBillingCount = 0, ...props }: PlatformSidebarProps) {
+export function PlatformSidebar({ pendingBillingCount = 0, atRiskCount = 0, ...props }: PlatformSidebarProps) {
   const pathname = usePathname()
   const supabase = createClient()
 
@@ -48,6 +50,7 @@ export function PlatformSidebar({ pendingBillingCount = 0, ...props }: PlatformS
     { title: "Tenants", href: "/platform/tenants", icon: IconSchool },
     { title: "Revenue", href: "/platform/revenue", icon: IconReportMoney },
     { title: "Billing", href: "/platform/billing", icon: IconCreditCard, badge: pendingBillingCount },
+    { title: "Billing Health", href: "/platform/billing-health", icon: IconAlertTriangle, badge: atRiskCount },
     { title: "Plans", href: "/platform/plans", icon: IconBuildingStore },
     // Referrals hidden until the backing schema is built — see issue tracking it.
   ]

--- a/lib/billing/billing-health.ts
+++ b/lib/billing/billing-health.ts
@@ -1,0 +1,91 @@
+/**
+ * Computes the "billing health" view for super admins: which tenants are
+ * currently `past_due` and how much runway they have before an automatic
+ * downgrade to free.
+ *
+ * Two past-due paths write `tenants.billing_status = 'past_due'`, and they
+ * carry different amounts of information:
+ *  - manual_transfer (app/api/cron/expire-platform-subscriptions/route.ts)
+ *    stamps a real `platform_subscriptions.grace_period_end` deadline —
+ *    downgrade date is exact.
+ *  - stripe (app/api/stripe/platform-webhook/route.ts) has no local grace
+ *    deadline — Stripe's own dunning/retry schedule decides when
+ *    `customer.subscription.deleted` eventually fires. There is no column
+ *    anywhere that stores that date, so this module reports `isEstimate:
+ *    true` with a null countdown instead of fabricating one.
+ *
+ * Pure/no I/O: callers pass `now` explicitly so this stays deterministic
+ * for tests (mirrors lib/payments/payouts-owed.ts).
+ */
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+export interface AtRiskTenantInput {
+  tenantId: string
+  tenantName: string
+  plan: string | null
+  accessCutoffAt: string | null
+}
+
+export interface PastDueSubscriptionInput {
+  tenantId: string
+  paymentMethod: string | null
+  currentPeriodEnd: string | null
+  gracePeriodEnd: string | null
+}
+
+export interface AtRiskTenant {
+  tenantId: string
+  tenantName: string
+  plan: string | null
+  paymentMethod: string | null
+  pastDueSince: string | null
+  graceEndsAt: string | null
+  /** Ceil'd days remaining before auto-downgrade; null when not computable (Stripe, or no grace data). */
+  daysUntilDowngrade: number | null
+  /** True when there is no fixed downgrade date to report (Stripe-managed dunning). */
+  isEstimate: boolean
+  accessCutoffAt: string | null
+}
+
+export function computeBillingHealth(
+  tenants: AtRiskTenantInput[],
+  subscriptions: PastDueSubscriptionInput[],
+  now: Date,
+): AtRiskTenant[] {
+  const subByTenant = new Map<string, PastDueSubscriptionInput>()
+  for (const sub of subscriptions) {
+    subByTenant.set(sub.tenantId, sub)
+  }
+
+  const results = tenants.map((tenant) => {
+    const sub = subByTenant.get(tenant.tenantId) ?? null
+    const paymentMethod = sub?.paymentMethod ?? null
+    const isManualTransfer = paymentMethod === 'manual_transfer'
+
+    const graceEndsAt = isManualTransfer ? sub?.gracePeriodEnd ?? null : null
+    const daysUntilDowngrade =
+      isManualTransfer && graceEndsAt
+        ? Math.ceil((new Date(graceEndsAt).getTime() - now.getTime()) / DAY_MS)
+        : null
+
+    return {
+      tenantId: tenant.tenantId,
+      tenantName: tenant.tenantName,
+      plan: tenant.plan,
+      paymentMethod,
+      pastDueSince: sub?.currentPeriodEnd ?? null,
+      graceEndsAt,
+      daysUntilDowngrade,
+      isEstimate: !isManualTransfer,
+      accessCutoffAt: tenant.accessCutoffAt,
+    }
+  })
+
+  return results.sort((a, b) => {
+    if (a.daysUntilDowngrade === null && b.daysUntilDowngrade === null) return 0
+    if (a.daysUntilDowngrade === null) return 1
+    if (b.daysUntilDowngrade === null) return -1
+    return a.daysUntilDowngrade - b.daysUntilDowngrade
+  })
+}

--- a/tests/unit/billing-health.test.ts
+++ b/tests/unit/billing-health.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest'
+import { computeBillingHealth } from '@/lib/billing/billing-health'
+
+const NOW = new Date('2026-07-24T00:00:00.000Z')
+
+describe('computeBillingHealth', () => {
+  it('manual_transfer with grace time remaining computes a positive countdown', () => {
+    const result = computeBillingHealth(
+      [{ tenantId: 't1', tenantName: 'School A', plan: 'starter', accessCutoffAt: null }],
+      [{
+        tenantId: 't1',
+        paymentMethod: 'manual_transfer',
+        currentPeriodEnd: '2026-07-17T00:00:00.000Z',
+        gracePeriodEnd: '2026-07-27T00:00:00.000Z',
+      }],
+      NOW,
+    )
+    expect(result[0].daysUntilDowngrade).toBe(3)
+    expect(result[0].isEstimate).toBe(false)
+    expect(result[0].graceEndsAt).toBe('2026-07-27T00:00:00.000Z')
+    expect(result[0].pastDueSince).toBe('2026-07-17T00:00:00.000Z')
+  })
+
+  it('manual_transfer with grace already expired still reports a (negative/zero) countdown, not a crash', () => {
+    const result = computeBillingHealth(
+      [{ tenantId: 't1', tenantName: 'School A', plan: 'starter', accessCutoffAt: null }],
+      [{
+        tenantId: 't1',
+        paymentMethod: 'manual_transfer',
+        currentPeriodEnd: '2026-07-01T00:00:00.000Z',
+        gracePeriodEnd: '2026-07-08T00:00:00.000Z',
+      }],
+      NOW,
+    )
+    expect(result[0].daysUntilDowngrade).toBeLessThanOrEqual(0)
+    expect(result[0].isEstimate).toBe(false)
+  })
+
+  it('stripe past_due reports an estimate with no fabricated countdown', () => {
+    const result = computeBillingHealth(
+      [{ tenantId: 't2', tenantName: 'School B', plan: 'pro', accessCutoffAt: null }],
+      [{
+        tenantId: 't2',
+        paymentMethod: 'stripe',
+        currentPeriodEnd: '2026-07-20T00:00:00.000Z',
+        gracePeriodEnd: null,
+      }],
+      NOW,
+    )
+    expect(result[0].isEstimate).toBe(true)
+    expect(result[0].daysUntilDowngrade).toBeNull()
+    expect(result[0].graceEndsAt).toBeNull()
+    expect(result[0].pastDueSince).toBe('2026-07-20T00:00:00.000Z')
+  })
+
+  it('past_due tenant with no subscription row surfaces with nulls, not a throw', () => {
+    const result = computeBillingHealth(
+      [{ tenantId: 't3', tenantName: 'School C', plan: 'free', accessCutoffAt: null }],
+      [],
+      NOW,
+    )
+    expect(result).toHaveLength(1)
+    expect(result[0].paymentMethod).toBeNull()
+    expect(result[0].daysUntilDowngrade).toBeNull()
+    expect(result[0].isEstimate).toBe(true)
+  })
+
+  it('sorts soonest downgrade first, with estimates/nulls last', () => {
+    const result = computeBillingHealth(
+      [
+        { tenantId: 'stripe-tenant', tenantName: 'Stripe School', plan: 'pro', accessCutoffAt: null },
+        { tenantId: 'far', tenantName: 'Far School', plan: 'starter', accessCutoffAt: null },
+        { tenantId: 'soon', tenantName: 'Soon School', plan: 'starter', accessCutoffAt: null },
+      ],
+      [
+        { tenantId: 'stripe-tenant', paymentMethod: 'stripe', currentPeriodEnd: null, gracePeriodEnd: null },
+        { tenantId: 'far', paymentMethod: 'manual_transfer', currentPeriodEnd: null, gracePeriodEnd: '2026-08-10T00:00:00.000Z' },
+        { tenantId: 'soon', paymentMethod: 'manual_transfer', currentPeriodEnd: null, gracePeriodEnd: '2026-07-25T00:00:00.000Z' },
+      ],
+      NOW,
+    )
+    expect(result.map((r) => r.tenantId)).toEqual(['soon', 'far', 'stripe-tenant'])
+  })
+
+  it('passes through access_cutoff_at unchanged', () => {
+    const result = computeBillingHealth(
+      [{ tenantId: 't1', tenantName: 'School A', plan: 'free', accessCutoffAt: '2026-08-01T00:00:00.000Z' }],
+      [],
+      NOW,
+    )
+    expect(result[0].accessCutoffAt).toBe('2026-08-01T00:00:00.000Z')
+  })
+})


### PR DESCRIPTION
## Description

Part of #493 (Phase 1 — non-payment enforcement). A super admin previously had no way to see past-due/at-risk schools without querying the DB directly:

- `app/[locale]/platform/billing/page.tsx` only lists `platform_payment_requests` (manual bank-transfer requests) — a Stripe subscriber that goes `past_due` never produces a row there.
- `app/[locale]/platform/tenants/page.tsx` selects `plan`/`status` but not `billing_status`.
- A grep of `app/[locale]/platform/**` for `billing_status`/`past_due` returned no matches outside those two files.

This adds `/platform/billing-health`, mirroring the metric-cards + by-school-table pattern already used elsewhere under `/platform/**`:

- **`lib/billing/billing-health.ts`** — pure `computeBillingHealth(tenants, subscriptions, now)`, unit-tested in isolation (no DB/date calls inside, `now` passed explicitly).
- **`app/actions/platform/billing-health.ts`** — `'use server'` action, re-verifies super admin (defense in depth on top of the already-gated `/platform` layout), fetches `tenants` where `billing_status = 'past_due'` joined with `platform_subscriptions`.
- **`app/[locale]/platform/billing-health/page.tsx`** — metric cards (past-due count, manual-transfer grace running, Stripe dunning in progress) + a by-school table with urgency coloring (red ≤3 days, amber ≤7 days).
- **`components/platform-sidebar.tsx`** / **`app/[locale]/platform/layout.tsx`** — new "Billing Health" nav item with an at-risk-count badge, following the exact pattern the existing "Billing" nav badge already uses.

**Key design decision — no fabricated countdowns.** Two independent past-due paths exist in the backend, and they carry different amounts of information:

- **Manual-transfer** (`app/api/cron/expire-platform-subscriptions/route.ts`) stamps a real `platform_subscriptions.grace_period_end` — the panel shows an exact "downgrades in N days" countdown.
- **Stripe** (`app/api/stripe/platform-webhook/route.ts`) has no local grace deadline — Stripe's own dunning/retry schedule decides when `customer.subscription.deleted` eventually fires, and that schedule isn't read anywhere in this codebase. The panel shows a "Stripe-managed" badge instead of guessing a date — showing a specific but wrong number is worse than being honest that we don't have one.

Out of scope: this is a read-only visibility addition. It doesn't touch `downgradeTenantToFree()`, the cron, or the webhook handlers.

## Type of change

- [x] New feature (visibility panel; no existing behavior changed)

Closes #495 (Phase 1 sub-task of epic #493).

## Testing

- [x] `npx vitest run tests/unit/billing-health.test.ts` — 6/6 new tests passing (manual-transfer countdown, expired grace, Stripe estimate/no-countdown, missing-subscription-row edge case, sort order, `access_cutoff_at` pass-through).
- [x] `npm run test:unit` — 259/259 passing, no regressions.
- [x] `npm run typecheck` — clean.
- [x] `npm run lint` — no new errors/warnings on any changed file (repo has pre-existing, unrelated lint debt elsewhere).
- [x] `npm run build` — succeeds; `/platform/billing-health` registered as a route.
- [x] Manual verification against local Supabase: seeded one `manual_transfer` tenant 3 days from its grace deadline and one `stripe` tenant with no grace data, loaded `/platform/billing-health` as a super admin (`owner@e2etest.com`), confirmed metric cards, urgency coloring, and the "Stripe-managed" badge all render correctly; reverted the seeded test data afterward.

### QA verification steps

1. Log in as a super admin (locally: `owner@e2etest.com` / `password123`) and open `/platform/billing-health`.
2. With no past-due tenants, confirm the empty state ("No schools currently past-due.") and all metric cards read 0.
3. In a local Supabase shell, set a tenant's `billing_status` to `past_due` and its `platform_subscriptions` row to `payment_method='manual_transfer'` with `grace_period_end` a few days out — confirm it appears in the table with a colored day-countdown and the sidebar "Billing Health" badge count increments.
4. Repeat with `payment_method='stripe'` — confirm it shows a "Stripe-managed" badge instead of a countdown.
5. Revert both test tenants' fields back to their original values.

## Screenshot

A full-page screenshot of the panel (both test scenarios rendered) is attached as a PR comment.
