### PR TITLE
feat(payments): manual payout tracking for single-account providers (#493)

### DIFF
--- a/app/[locale]/platform/payouts/page.tsx
+++ b/app/[locale]/platform/payouts/page.tsx
@@ -1,0 +1,151 @@
+import { getPayoutsOwed } from '@/app/actions/platform/payouts'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { MarkPayoutPaidDialog } from '@/components/platform/mark-payout-paid-dialog'
+import {
+  IconCoin,
+  IconReportMoney,
+  IconWalletOff,
+} from '@tabler/icons-react'
+
+const usd = (n: number) =>
+  new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(n ?? 0)
+
+const PROVIDER_LABEL: Record<string, string> = {
+  paypal: 'PayPal',
+  binance: 'Binance Pay',
+  lemonsqueezy: 'Lemon Squeezy',
+}
+
+export default async function PlatformPayoutsPage() {
+  const owed = await getPayoutsOwed()
+
+  const totalOwed = owed.reduce((sum, t) => sum + t.netOwed, 0)
+  const totalCollected = owed.reduce((sum, t) => sum + t.grossCollected, 0)
+  const totalPaidOut = owed.reduce((sum, t) => sum + t.alreadyPaid, 0)
+  const schoolsOwed = owed.filter((t) => t.netOwed > 0).length
+
+  const metricCards = [
+    {
+      title: 'Currently Owed',
+      value: usd(totalOwed),
+      sub: `${schoolsOwed} school${schoolsOwed === 1 ? '' : 's'} awaiting payout`,
+      icon: IconWalletOff,
+      bg: 'bg-amber-50 dark:bg-amber-950/40',
+      iconColor: 'text-amber-600 dark:text-amber-400',
+    },
+    {
+      title: 'Collected (single-account providers)',
+      value: usd(totalCollected),
+      sub: 'PayPal, Binance Pay, Lemon Squeezy — 100% lands in your account',
+      icon: IconCoin,
+      bg: 'bg-blue-50 dark:bg-blue-950/40',
+      iconColor: 'text-blue-600 dark:text-blue-400',
+    },
+    {
+      title: 'Paid Out (all time)',
+      value: usd(totalPaidOut),
+      sub: 'Manually recorded payouts to schools',
+      icon: IconReportMoney,
+      bg: 'bg-emerald-50 dark:bg-emerald-950/40',
+      iconColor: 'text-emerald-600 dark:text-emerald-400',
+    },
+  ]
+
+  return (
+    <main className="flex-1 px-4 py-6 sm:px-6 lg:px-8" data-testid="platform-payouts">
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold tracking-tight">Payouts</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          PayPal, Binance Pay, and Lemon Squeezy don&apos;t split automatically — 100% of every sale
+          lands in your account. This is what you owe each school back, based on their revenue split.
+        </p>
+      </div>
+
+      <div className="mb-8 grid gap-3 sm:grid-cols-3" data-testid="payouts-metrics">
+        {metricCards.map((card) => (
+          <Card key={card.title} className="relative overflow-hidden">
+            <CardContent className="p-5">
+              <div className="flex items-start justify-between">
+                <div className="min-w-0 flex-1">
+                  <p className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+                    {card.title}
+                  </p>
+                  <p className="mt-2 text-2xl font-bold tracking-tight tabular-nums" data-testid="metric-value">
+                    {card.value}
+                  </p>
+                  <p className="mt-1 text-[11px] text-muted-foreground/70">{card.sub}</p>
+                </div>
+                <div className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-lg ${card.bg}`}>
+                  <card.icon className={`h-[18px] w-[18px] ${card.iconColor}`} strokeWidth={1.75} />
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      <Card data-testid="payouts-by-tenant">
+        <CardHeader>
+          <CardTitle>By school</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {owed.length === 0 ? (
+            <p className="text-muted-foreground text-sm">No schools yet.</p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b text-left text-[11px] uppercase tracking-wider text-muted-foreground">
+                    <th className="pb-2 font-medium">School</th>
+                    <th className="pb-2 font-medium">Providers</th>
+                    <th className="pb-2 text-right font-medium">Collected</th>
+                    <th className="pb-2 text-right font-medium">School %</th>
+                    <th className="pb-2 text-right font-medium">Paid so far</th>
+                    <th className="pb-2 text-right font-medium">Owed</th>
+                    <th className="pb-2 text-right font-medium"></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {owed.map((t) => (
+                    <tr key={t.tenantId} className="border-b last:border-0">
+                      <td className="py-2.5 font-medium">{t.tenantName}</td>
+                      <td className="py-2.5 text-muted-foreground">
+                        {Object.keys(t.byProvider).length === 0
+                          ? '—'
+                          : Object.keys(t.byProvider).map((p) => PROVIDER_LABEL[p] ?? p).join(', ')}
+                      </td>
+                      <td className="py-2.5 text-right tabular-nums">{usd(t.grossCollected)}</td>
+                      <td className="py-2.5 text-right tabular-nums text-muted-foreground">
+                        {t.schoolPercentage}%
+                      </td>
+                      <td className="py-2.5 text-right tabular-nums text-muted-foreground">
+                        {usd(t.alreadyPaid)}
+                      </td>
+                      <td className="py-2.5 text-right tabular-nums font-medium text-amber-600 dark:text-amber-400">
+                        {usd(t.netOwed)}
+                      </td>
+                      <td className="py-2.5 text-right">
+                        <MarkPayoutPaidDialog
+                          tenantId={t.tenantId}
+                          tenantName={t.tenantName}
+                          netOwed={t.netOwed}
+                        />
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <p className="mt-6 text-[11px] text-muted-foreground/70">
+        Stripe and Solana sales already split automatically and never appear here. Binance Pay
+        (personal account) and manual/offline sales settle straight to the school and also never
+        appear here — only PayPal, Binance Pay (merchant), and Lemon Squeezy do, since those settle
+        100% into your account today.
+      </p>
+    </main>
+  )
+}

--- a/app/actions/platform/payouts.ts
+++ b/app/actions/platform/payouts.ts
@@ -1,0 +1,75 @@
+'use server'
+
+import { createClient } from '@/lib/supabase/server'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { isSuperAdmin } from '@/lib/supabase/get-user-role'
+import { revalidatePath } from 'next/cache'
+import { getCurrentUserId } from '@/lib/supabase/tenant'
+import { PROVIDER_CAPABILITIES, type PaymentProvider } from '@/lib/payments/types'
+import { computeOwedBalances, type TenantOwed } from '@/lib/payments/payouts-owed'
+
+async function verifySuperAdmin() {
+  const supabase = await createClient()
+  const userId = await getCurrentUserId()
+  if (!userId) throw new Error('Not authenticated')
+  if (!(await isSuperAdmin())) throw new Error('Super admin only')
+  return userId
+}
+
+const PLATFORM_SETTLED_PROVIDERS = (Object.keys(PROVIDER_CAPABILITIES) as PaymentProvider[]).filter(
+  (provider) => PROVIDER_CAPABILITIES[provider].settlesToPlatformAccount
+)
+
+const DEFAULT_SCHOOL_PERCENTAGE = 80
+
+export async function getPayoutsOwed(): Promise<TenantOwed[]> {
+  await verifySuperAdmin()
+  const admin = createAdminClient()
+
+  const [{ data: tenants }, { data: splits }, { data: txns }, { data: paid }] = await Promise.all([
+    admin.from('tenants').select('id, name'),
+    admin.from('revenue_splits').select('tenant_id, school_percentage'),
+    admin
+      .from('transactions')
+      .select('tenant_id, payment_provider, amount')
+      .eq('status', 'successful')
+      .in('payment_provider', PLATFORM_SETTLED_PROVIDERS),
+    admin.from('payouts').select('tenant_id, amount').eq('payout_method', 'manual').eq('status', 'paid'),
+  ])
+
+  const schoolPercentageByTenant = new Map(
+    (splits || []).map((s) => [s.tenant_id, s.school_percentage as number])
+  )
+
+  return computeOwedBalances(
+    (tenants || []).map((t) => ({
+      tenantId: t.id,
+      tenantName: t.name,
+      schoolPercentage: schoolPercentageByTenant.get(t.id) ?? DEFAULT_SCHOOL_PERCENTAGE,
+    })),
+    (txns || [])
+      .filter((t) => t.tenant_id && t.payment_provider && t.amount != null)
+      .map((t) => ({ tenantId: t.tenant_id as string, paymentProvider: t.payment_provider as string, amount: t.amount as number })),
+    (paid || []).map((p) => ({ tenantId: p.tenant_id, amount: p.amount }))
+  )
+}
+
+export async function markPayoutPaid(tenantId: string, amount: number, note?: string) {
+  const userId = await verifySuperAdmin()
+  if (!(amount > 0)) throw new Error('Amount must be positive')
+
+  const admin = createAdminClient()
+  const { error } = await admin.from('payouts').insert({
+    tenant_id: tenantId,
+    amount,
+    currency: 'usd',
+    status: 'paid',
+    payout_method: 'manual',
+    paid_at: new Date().toISOString(),
+    recorded_by: userId,
+    note: note || null,
+  })
+  if (error) throw new Error(error.message)
+
+  revalidatePath('/platform/payouts')
+}

--- a/components/platform-sidebar.tsx
+++ b/components/platform-sidebar.tsx
@@ -14,6 +14,7 @@ import {
   IconSchool,
   IconSettings,
   IconUsers,
+  IconWallet,
 } from "@tabler/icons-react"
 import {
   Sidebar,
@@ -49,6 +50,7 @@ export function PlatformSidebar({ pendingBillingCount = 0, atRiskCount = 0, ...p
     { title: "Overview", href: "/platform", icon: IconChartBar },
     { title: "Tenants", href: "/platform/tenants", icon: IconSchool },
     { title: "Revenue", href: "/platform/revenue", icon: IconReportMoney },
+    { title: "Payouts", href: "/platform/payouts", icon: IconWallet },
     { title: "Billing", href: "/platform/billing", icon: IconCreditCard, badge: pendingBillingCount },
     { title: "Billing Health", href: "/platform/billing-health", icon: IconAlertTriangle, badge: atRiskCount },
     { title: "Plans", href: "/platform/plans", icon: IconBuildingStore },

--- a/components/platform/mark-payout-paid-dialog.tsx
+++ b/components/platform/mark-payout-paid-dialog.tsx
@@ -1,0 +1,104 @@
+"use client"
+
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+import { toast } from "sonner"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { markPayoutPaid } from "@/app/actions/platform/payouts"
+
+interface Props {
+  tenantId: string
+  tenantName: string
+  netOwed: number
+}
+
+export function MarkPayoutPaidDialog({ tenantId, tenantName, netOwed }: Props) {
+  const router = useRouter()
+  const [open, setOpen] = useState(false)
+  const [amount, setAmount] = useState(netOwed.toFixed(2))
+  const [note, setNote] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  async function handleConfirm() {
+    const parsed = Number(amount)
+    if (!(parsed > 0)) {
+      toast.error('Enter a positive amount')
+      return
+    }
+    setLoading(true)
+    try {
+      await markPayoutPaid(tenantId, parsed, note.trim() || undefined)
+      toast.success(`Recorded $${parsed.toFixed(2)} paid to ${tenantName}`)
+      setOpen(false)
+      setNote('')
+      router.refresh()
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Failed to record payout')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <>
+      <Button
+        size="sm"
+        variant="outline"
+        onClick={() => setOpen(true)}
+        disabled={netOwed <= 0}
+        data-testid="mark-paid-btn"
+      >
+        Mark as Paid
+      </Button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent data-testid="mark-paid-dialog">
+          <DialogHeader>
+            <DialogTitle>Record payout to {tenantName}</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-3 py-2">
+            <div className="space-y-1.5">
+              <Label htmlFor="payout-amount">Amount paid (USD)</Label>
+              <Input
+                id="payout-amount"
+                type="number"
+                step="0.01"
+                min="0"
+                value={amount}
+                onChange={(e) => setAmount(e.target.value)}
+                data-testid="mark-paid-amount-input"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="payout-note">Note (optional)</Label>
+              <Textarea
+                id="payout-note"
+                placeholder="e.g. wire reference, date sent…"
+                value={note}
+                onChange={(e) => setNote(e.target.value)}
+                rows={2}
+                data-testid="mark-paid-note-input"
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setOpen(false)}>Cancel</Button>
+            <Button onClick={handleConfirm} disabled={loading} data-testid="confirm-mark-paid-btn">
+              {loading ? 'Recording…' : 'Record Payout'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/lib/payments/binance-personal-provider.ts
+++ b/lib/payments/binance-personal-provider.ts
@@ -99,6 +99,7 @@ export class BinancePersonalProvider implements IPaymentProvider {
     selfManagedPeriod: true,
     createsCatalog: false,
     supportsPlanChange: false,
+    settlesToPlatformAccount: false,
   }
 
   private readonly apiKey?: string

--- a/lib/payments/binance-provider.ts
+++ b/lib/payments/binance-provider.ts
@@ -68,6 +68,7 @@ export class BinancePayProvider implements IPaymentProvider {
     selfManagedPeriod: true,
     createsCatalog: false,
     supportsPlanChange: false,
+    settlesToPlatformAccount: true,
   }
 
   private readonly apiKey: string

--- a/lib/payments/lemonsqueezy-provider.ts
+++ b/lib/payments/lemonsqueezy-provider.ts
@@ -49,6 +49,7 @@ export class LemonSqueezyProvider implements IPaymentProvider {
     selfManagedPeriod: false,
     createsCatalog: false,
     supportsPlanChange: true,
+    settlesToPlatformAccount: true,
   }
 
   private readonly apiKey: string

--- a/lib/payments/manual-provider.ts
+++ b/lib/payments/manual-provider.ts
@@ -30,6 +30,7 @@ export class ManualPaymentProvider implements IPaymentProvider {
     selfManagedPeriod: true,
     createsCatalog: false,
     supportsPlanChange: false,
+    settlesToPlatformAccount: false,
   }
 
   convertAmount(amount: number, fromUnit: 'base' | 'major'): number {

--- a/lib/payments/payouts-owed.ts
+++ b/lib/payments/payouts-owed.ts
@@ -1,0 +1,83 @@
+/**
+ * Manual payout tracking for "single-account" providers (paypal, binance
+ * hosted, lemonsqueezy) — providers where 100% of every sale lands in the
+ * PLATFORM's own account (see `ProviderCapabilities.settlesToPlatformAccount`
+ * in `lib/payments/types.ts`), with no automatic split like Stripe Connect or
+ * Solana. The platform owner owes each school its share and pays it out
+ * manually; this computes a running balance: all-time collected × the
+ * tenant's school_percentage, minus all-time manual payouts already marked
+ * paid. Callers pre-filter transactions to platform-settled providers only —
+ * this module has no DB/provider knowledge, just arithmetic.
+ */
+
+export interface TenantOwedInput {
+  tenantId: string
+  tenantName: string
+  /** revenue_splits.school_percentage for this tenant (0–100). */
+  schoolPercentage: number
+}
+
+export interface PlatformSettledTxn {
+  tenantId: string
+  paymentProvider: string
+  /** Successful transaction amount, major units. */
+  amount: number
+}
+
+export interface ManualPayoutRecord {
+  tenantId: string
+  amount: number
+}
+
+export interface TenantOwed {
+  tenantId: string
+  tenantName: string
+  schoolPercentage: number
+  /** Sum of platform-settled transaction amounts (100% of what was collected). */
+  grossCollected: number
+  /** grossCollected * schoolPercentage / 100 — the school's all-time share. */
+  grossOwed: number
+  /** Sum of manual payouts already recorded as paid for this tenant. */
+  alreadyPaid: number
+  /** max(grossOwed - alreadyPaid, 0) — what's currently owed. */
+  netOwed: number
+  /** Per-provider breakdown of grossCollected. */
+  byProvider: Record<string, number>
+}
+
+export function computeOwedBalances(
+  tenants: TenantOwedInput[],
+  txns: PlatformSettledTxn[],
+  paidPayouts: ManualPayoutRecord[],
+): TenantOwed[] {
+  const collectedByTenant = new Map<string, number>()
+  const byProviderByTenant = new Map<string, Record<string, number>>()
+  for (const txn of txns) {
+    collectedByTenant.set(txn.tenantId, (collectedByTenant.get(txn.tenantId) ?? 0) + txn.amount)
+    const byProvider = byProviderByTenant.get(txn.tenantId) ?? {}
+    byProvider[txn.paymentProvider] = (byProvider[txn.paymentProvider] ?? 0) + txn.amount
+    byProviderByTenant.set(txn.tenantId, byProvider)
+  }
+
+  const paidByTenant = new Map<string, number>()
+  for (const payout of paidPayouts) {
+    paidByTenant.set(payout.tenantId, (paidByTenant.get(payout.tenantId) ?? 0) + payout.amount)
+  }
+
+  return tenants.map((tenant) => {
+    const grossCollected = collectedByTenant.get(tenant.tenantId) ?? 0
+    const grossOwed = (grossCollected * tenant.schoolPercentage) / 100
+    const alreadyPaid = paidByTenant.get(tenant.tenantId) ?? 0
+    const netOwed = Math.max(grossOwed - alreadyPaid, 0)
+    return {
+      tenantId: tenant.tenantId,
+      tenantName: tenant.tenantName,
+      schoolPercentage: tenant.schoolPercentage,
+      grossCollected,
+      grossOwed,
+      alreadyPaid,
+      netOwed,
+      byProvider: byProviderByTenant.get(tenant.tenantId) ?? {},
+    }
+  })
+}

--- a/lib/payments/paypal-provider.ts
+++ b/lib/payments/paypal-provider.ts
@@ -84,6 +84,7 @@ export class PayPalPaymentProvider implements IPaymentProvider {
     selfManagedPeriod: false,
     createsCatalog: true,
     supportsPlanChange: false,
+    settlesToPlatformAccount: true,
   }
 
   private readonly clientId: string

--- a/lib/payments/solana-provider.ts
+++ b/lib/payments/solana-provider.ts
@@ -52,6 +52,7 @@ export class SolanaProvider implements IPaymentProvider {
     selfManagedPeriod: true,
     createsCatalog: false,
     supportsPlanChange: false,
+    settlesToPlatformAccount: false,
   }
 
   private readonly rpcUrl: string

--- a/lib/payments/solana-subscriptions-provider.ts
+++ b/lib/payments/solana-subscriptions-provider.ts
@@ -53,6 +53,7 @@ export class SolanaSubscriptionsProvider implements IPaymentProvider {
     selfManagedPeriod: false,
     createsCatalog: false,
     supportsPlanChange: false,
+    settlesToPlatformAccount: false,
   }
 
   /**

--- a/lib/payments/stripe-provider.ts
+++ b/lib/payments/stripe-provider.ts
@@ -36,6 +36,7 @@ export class StripePaymentProvider implements IPaymentProvider {
     selfManagedPeriod: false,
     createsCatalog: true,
     supportsPlanChange: true,
+    settlesToPlatformAccount: false,
   }
   private stripe: Stripe
 

--- a/lib/payments/types.ts
+++ b/lib/payments/types.ts
@@ -135,6 +135,13 @@ export interface ProviderCapabilities {
    * provider-native swap. The plan-change flow (#463) branches on THIS.
    */
   supportsPlanChange: boolean
+  /**
+   * Provider settles 100% of every sale into the PLATFORM's own account —
+   * no per-tenant connected account (unlike Stripe Connect) and no on-chain
+   * split (unlike Solana). The school's share must be paid out manually
+   * (see `lib/payments/payouts-owed.ts`) rather than arriving automatically.
+   */
+  settlesToPlatformAccount: boolean
 }
 
 /**
@@ -153,6 +160,7 @@ export const PROVIDER_CAPABILITIES: Record<PaymentProvider, ProviderCapabilities
     selfManagedPeriod: false,
     createsCatalog: true,
     supportsPlanChange: true,
+    settlesToPlatformAccount: false, // school's own Connect account
   },
   paypal: {
     supportsNativeSubscriptions: true,
@@ -163,6 +171,7 @@ export const PROVIDER_CAPABILITIES: Record<PaymentProvider, ProviderCapabilities
     selfManagedPeriod: false,
     createsCatalog: true,
     supportsPlanChange: false,
+    settlesToPlatformAccount: true, // one global PAYPAL_CLIENT_ID/SECRET — no per-tenant merchant onboarding
   },
   lemonsqueezy: {
     supportsNativeSubscriptions: true,
@@ -173,6 +182,7 @@ export const PROVIDER_CAPABILITIES: Record<PaymentProvider, ProviderCapabilities
     selfManagedPeriod: false,
     createsCatalog: false,
     supportsPlanChange: true,
+    settlesToPlatformAccount: true, // one global LS store — Merchant of Record, single platform-owned account
   },
   solana: {
     supportsNativeSubscriptions: false,
@@ -183,6 +193,7 @@ export const PROVIDER_CAPABILITIES: Record<PaymentProvider, ProviderCapabilities
     selfManagedPeriod: true,
     createsCatalog: false,
     supportsPlanChange: false,
+    settlesToPlatformAccount: false, // split on-chain in one tx (lib/payments/solana-split.ts)
   },
   // Native on-chain auto-pull subscriptions (solana-program/subscriptions). WE
   // drive renewal via an off-chain crank cron (no provider webhook, no on-chain
@@ -199,6 +210,7 @@ export const PROVIDER_CAPABILITIES: Record<PaymentProvider, ProviderCapabilities
     // On-chain auto-pull is a fixed-amount delegation; changing plan requires a
     // fresh subscriber-signed delegation, so there is no in-place swap.
     supportsPlanChange: false,
+    settlesToPlatformAccount: false, // split on-chain per pull (lib/payments/solana-subscription-pull.ts)
   },
   manual: {
     supportsNativeSubscriptions: false,
@@ -209,6 +221,7 @@ export const PROVIDER_CAPABILITIES: Record<PaymentProvider, ProviderCapabilities
     selfManagedPeriod: true,
     createsCatalog: false,
     supportsPlanChange: false,
+    settlesToPlatformAccount: false, // bank transfer straight to the school's own account
   },
   // Binance Pay: hosted crypto checkout (USDT-denominated). No native
   // recurring billing — plan purchases are one-time payments whose period WE
@@ -223,6 +236,7 @@ export const PROVIDER_CAPABILITIES: Record<PaymentProvider, ProviderCapabilities
     selfManagedPeriod: true,
     createsCatalog: false,
     supportsPlanChange: false,
+    settlesToPlatformAccount: true, // one global BINANCE_PAY_API_KEY/SECRET merchant account — no sub-merchant split
   },
   // Binance Pay on a PERSONAL (non-merchant, no-KYB) account. No hosted
   // checkout and no webhooks: the buyer transfers manually to the school's
@@ -239,6 +253,7 @@ export const PROVIDER_CAPABILITIES: Record<PaymentProvider, ProviderCapabilities
     selfManagedPeriod: true,
     createsCatalog: false,
     supportsPlanChange: false,
+    settlesToPlatformAccount: false, // per-tenant Pay ID — straight to the school's own account
   },
 }
 
@@ -360,7 +375,7 @@ export interface PaymentProviderConfig {
   apiKey: string
   webhookSecret?: string
   environment?: 'test' | 'production'
-  additionalConfig?: Record<string, any>
+  additionalConfig?: Record<string, unknown>
 }
 
 /**

--- a/supabase/migrations/20260724120000_manual_payouts.sql
+++ b/supabase/migrations/20260724120000_manual_payouts.sql
@@ -1,0 +1,24 @@
+-- Extend the (previously dead — nothing ever inserted into it) `payouts`
+-- table so it can also record MANUAL payouts: for single-account providers
+-- (paypal, binance hosted, lemonsqueezy) 100% of every sale lands in the
+-- platform's own account with no automatic split, so the school's share has
+-- to be wired manually and recorded here.
+
+ALTER TABLE payouts
+  ADD COLUMN payout_method VARCHAR(20) NOT NULL DEFAULT 'stripe_connect'
+    CHECK (payout_method IN ('stripe_connect', 'manual')),
+  ADD COLUMN note TEXT,
+  ADD COLUMN recorded_by UUID REFERENCES auth.users(id);
+
+-- Manual payouts are a running balance, not tied to a Stripe Connect payout
+-- period — period_start/period_end no longer required.
+ALTER TABLE payouts ALTER COLUMN period_start DROP NOT NULL;
+ALTER TABLE payouts ALTER COLUMN period_end DROP NOT NULL;
+
+ALTER TABLE payouts DROP CONSTRAINT payouts_period_order;
+ALTER TABLE payouts ADD CONSTRAINT payouts_period_order
+  CHECK (period_start IS NULL OR period_end IS NULL OR period_start < period_end);
+
+COMMENT ON COLUMN payouts.payout_method IS 'stripe_connect = automated Connect payout webhook; manual = admin-recorded wire/transfer for single-account providers (paypal/binance/lemonsqueezy)';
+COMMENT ON COLUMN payouts.note IS 'Optional note left by the admin recording a manual payout';
+COMMENT ON COLUMN payouts.recorded_by IS 'Super admin who recorded a manual payout';

--- a/tests/unit/payouts-owed.test.ts
+++ b/tests/unit/payouts-owed.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest'
+import { computeOwedBalances } from '@/lib/payments/payouts-owed'
+
+describe('computeOwedBalances', () => {
+  it('single tenant, single provider, nothing paid yet', () => {
+    const result = computeOwedBalances(
+      [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 80 }],
+      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100 }],
+      [],
+    )
+    expect(result).toEqual([
+      {
+        tenantId: 't1',
+        tenantName: 'School A',
+        schoolPercentage: 80,
+        grossCollected: 100,
+        grossOwed: 80,
+        alreadyPaid: 0,
+        netOwed: 80,
+        byProvider: { paypal: 100 },
+      },
+    ])
+  })
+
+  it('sums multiple transactions across multiple providers for the same tenant', () => {
+    const result = computeOwedBalances(
+      [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 80 }],
+      [
+        { tenantId: 't1', paymentProvider: 'paypal', amount: 100 },
+        { tenantId: 't1', paymentProvider: 'paypal', amount: 50 },
+        { tenantId: 't1', paymentProvider: 'binance', amount: 25 },
+      ],
+      [],
+    )
+    expect(result[0].grossCollected).toBe(175)
+    expect(result[0].grossOwed).toBeCloseTo(140) // 175 * 0.8
+    expect(result[0].byProvider).toEqual({ paypal: 150, binance: 25 })
+  })
+
+  it('subtracts already-paid manual payouts from the gross owed', () => {
+    const result = computeOwedBalances(
+      [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 80 }],
+      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100 }],
+      [{ tenantId: 't1', amount: 30 }],
+    )
+    expect(result[0].grossOwed).toBe(80)
+    expect(result[0].alreadyPaid).toBe(30)
+    expect(result[0].netOwed).toBe(50)
+  })
+
+  it('sums multiple manual payouts already paid', () => {
+    const result = computeOwedBalances(
+      [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 80 }],
+      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100 }],
+      [{ tenantId: 't1', amount: 30 }, { tenantId: 't1', amount: 50 }],
+    )
+    expect(result[0].alreadyPaid).toBe(80)
+    expect(result[0].netOwed).toBe(0)
+  })
+
+  it('floors netOwed at 0 when payouts exceed what was owed (overpay/rounding)', () => {
+    const result = computeOwedBalances(
+      [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 80 }],
+      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100 }],
+      [{ tenantId: 't1', amount: 500 }],
+    )
+    expect(result[0].netOwed).toBe(0)
+  })
+
+  it('tenant with zero platform-settled transactions owes nothing', () => {
+    const result = computeOwedBalances(
+      [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 80 }],
+      [],
+      [],
+    )
+    expect(result[0]).toMatchObject({
+      grossCollected: 0,
+      grossOwed: 0,
+      alreadyPaid: 0,
+      netOwed: 0,
+      byProvider: {},
+    })
+  })
+
+  it('boundary schoolPercentage=0 → platform keeps everything, nothing owed', () => {
+    const result = computeOwedBalances(
+      [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 0 }],
+      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100 }],
+      [],
+    )
+    expect(result[0].netOwed).toBe(0)
+  })
+
+  it('boundary schoolPercentage=100 → school is owed the full amount collected', () => {
+    const result = computeOwedBalances(
+      [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 100 }],
+      [{ tenantId: 't1', paymentProvider: 'lemonsqueezy', amount: 100 }],
+      [],
+    )
+    expect(result[0].netOwed).toBe(100)
+  })
+
+  it('keeps tenants isolated from each other', () => {
+    const result = computeOwedBalances(
+      [
+        { tenantId: 't1', tenantName: 'School A', schoolPercentage: 80 },
+        { tenantId: 't2', tenantName: 'School B', schoolPercentage: 90 },
+      ],
+      [
+        { tenantId: 't1', paymentProvider: 'paypal', amount: 100 },
+        { tenantId: 't2', paymentProvider: 'paypal', amount: 200 },
+      ],
+      [{ tenantId: 't1', amount: 10 }],
+    )
+    const a = result.find((r) => r.tenantId === 't1')!
+    const b = result.find((r) => r.tenantId === 't2')!
+    expect(a.netOwed).toBe(70) // 100*0.8 - 10
+    expect(b.netOwed).toBe(180) // 200*0.9, unaffected by t1's payout
+  })
+
+  it('returns one row per tenant, even with no matching transactions/payouts', () => {
+    const result = computeOwedBalances(
+      [
+        { tenantId: 't1', tenantName: 'School A', schoolPercentage: 80 },
+        { tenantId: 't2', tenantName: 'School B', schoolPercentage: 80 },
+      ],
+      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100 }],
+      [],
+    )
+    expect(result).toHaveLength(2)
+  })
+})


### PR DESCRIPTION
## Description

Part of epic #493 (Payout & non-payment enforcement integrity). This is the foundational piece the epic's Phase 2/3 sub-issues (#496–#500) build on top of — it had been implemented and live-verified locally but never actually committed anywhere, so nothing in the epic's Phase 2/3 list could be worked on until it existed on a branch.

PayPal, Binance Pay (merchant/hosted), and Lemon Squeezy all settle 100% of every sale into the *platform's own* account — unlike Stripe Connect (per-tenant connected account, automatic `application_fee_amount` split) or Solana (on-chain split in the same transaction). For those three providers, the school's revenue share has to be paid out manually, and the `payouts` table existed in the schema but nothing had ever inserted into it.

## Changes made

- **`lib/payments/types.ts`** — new `ProviderCapabilities.settlesToPlatformAccount` flag, set per-provider (`true` for `paypal`, `lemonsqueezy`, `binance`; `false` for `stripe`, `solana`, `solana_subs`, `manual`, `binance_personal`) — the single source of truth for which providers route through this manual-payout path.
- **`lib/payments/payouts-owed.ts`** — pure `computeOwedBalances()`: gross collected per platform-settled provider × the tenant's `revenue_splits.school_percentage`, minus manual payouts already recorded, per tenant. No DB access, fully unit-tested in isolation.
- **`app/actions/platform/payouts.ts`** — `getPayoutsOwed()` (super-admin-gated, wires the DB reads to the pure function) and `markPayoutPaid()` (inserts a `payouts` row with `payout_method: 'manual'`).
- **`app/[locale]/platform/payouts/page.tsx`** + **`components/platform/mark-payout-paid-dialog.tsx`** — metric cards (currently owed / collected / paid out all-time) + a by-school table with a "Mark as Paid" action, mirroring the visual pattern already used by the other `/platform/**` admin pages.
- **`components/platform-sidebar.tsx`** — new "Payouts" nav item.
- **`supabase/migrations/20260724120000_manual_payouts.sql`** — extends the previously-dead `payouts` table with `payout_method` (`stripe_connect` | `manual`), `note`, `recorded_by`, and makes `period_start`/`period_end` nullable (manual payouts are a running balance, not tied to a Connect payout period).

## Type of change

- [x] New feature

Part of #493 (not closing it — the epic's Phase 2 money-accuracy issues #496–#499 and Phase 3 deployment issue #500 are follow-up work building on this).

## Testing

- [x] `npx vitest run tests/unit/payouts-owed.test.ts` — 10/10 passing.
- [x] `npm run test:unit` — 269/269 passing, no regressions.
- [x] `npm run typecheck` — clean (also fixed one pre-existing `any` in `lib/payments/types.ts` that lint-staged surfaced because the file was touched, unrelated to this feature's logic).
- [x] `npm run lint` — no errors on any changed file.
- [x] `npm run build` — succeeds; `/platform/payouts` registered as a route.
- [x] Manual verification against local Supabase: applied the migration via `db:reset`, logged in as a super admin (`owner@e2etest.com`), loaded `/platform/payouts` — metric cards, empty-state table, and the disabled "Mark as Paid" state (at $0 owed) all render correctly. A full PayPal-sale-to-payout flow was live-verified in an earlier local session (see epic #493's description: $10 sale → $8.00 owed at 80% split → Mark as Paid → $0.00, `payouts` row inserted correctly) — not re-run here since the computation logic is what changed shape, and that's covered by the unit tests.

**Known gaps, tracked as follow-up issues, not fixed here:** revenue split isn't time-sliced (#496), amounts aren't grouped by currency (#497), no refund/chargeback clawback (#498), no overpayment guardrail or tenant-facing visibility (#499). This PR intentionally ships the feature as originally built so those can be reviewed and fixed as independent, reviewable diffs rather than one large change.

### QA verification steps

1. Log in as a super admin (locally: `owner@e2etest.com` / `password123`) and open `/platform/payouts`.
2. With no successful platform-settled transactions, confirm all three metric cards read $0.00 and "Mark as Paid" is disabled for every school.
3. Create a successful PayPal transaction for a tenant (or use existing seed data), reload the page, and confirm "Currently Owed" reflects `amount × school_percentage`.
4. Click "Mark as Paid", confirm the pre-filled amount matches the owed amount, submit, and confirm the row now shows the payout recorded and "Owed" drops to $0.00.

## Screenshot

A screenshot of the empty-state `/platform/payouts` page is attached as a PR comment.
