### PR TITLE
fix(payments): group payouts-owed by currency instead of summing across them (#497)

### DIFF
--- a/app/[locale]/platform/payouts/page.tsx
+++ b/app/[locale]/platform/payouts/page.tsx
@@ -7,8 +7,15 @@ import {
   IconWalletOff,
 } from '@tabler/icons-react'
 
-const usd = (n: number) =>
-  new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(n ?? 0)
+const money = (n: number, currency: string) =>
+  new Intl.NumberFormat('en-US', { style: 'currency', currency: currency.toUpperCase() }).format(n ?? 0)
+
+/** Renders one line per currency — amounts in different currencies are never summed into one number (#497). */
+function formatByCurrency(byCurrency: Record<string, number>) {
+  const entries = Object.entries(byCurrency).filter(([, amount]) => amount !== 0)
+  if (entries.length === 0) return money(0, 'usd')
+  return entries.map(([currency, amount]) => money(amount, currency)).join(' · ')
+}
 
 const PROVIDER_LABEL: Record<string, string> = {
   paypal: 'PayPal',
@@ -19,15 +26,51 @@ const PROVIDER_LABEL: Record<string, string> = {
 export default async function PlatformPayoutsPage() {
   const owed = await getPayoutsOwed()
 
-  const totalOwed = owed.reduce((sum, t) => sum + t.netOwed, 0)
-  const totalCollected = owed.reduce((sum, t) => sum + t.grossCollected, 0)
-  const totalPaidOut = owed.reduce((sum, t) => sum + t.alreadyPaid, 0)
-  const schoolsOwed = owed.filter((t) => t.netOwed > 0).length
+  // Per-currency totals across all tenants — kept separate, never summed together.
+  const totalOwedByCurrency: Record<string, number> = {}
+  const totalCollectedByCurrency: Record<string, number> = {}
+  const totalPaidOutByCurrency: Record<string, number> = {}
+  let schoolsOwed = 0
+
+  // One row per (tenant, currency) balance — a tenant with both USD and EUR
+  // sales gets two rows, not one summed row.
+  type Row = {
+    tenantId: string
+    tenantName: string
+    schoolPercentage: number
+    currency: string
+    grossCollected: number
+    alreadyPaid: number
+    netOwed: number
+    byProvider: Record<string, number>
+  }
+  const rows: Row[] = []
+
+  for (const tenant of owed) {
+    let tenantHasOwed = false
+    for (const balance of tenant.balances) {
+      totalOwedByCurrency[balance.currency] = (totalOwedByCurrency[balance.currency] ?? 0) + balance.netOwed
+      totalCollectedByCurrency[balance.currency] = (totalCollectedByCurrency[balance.currency] ?? 0) + balance.grossCollected
+      totalPaidOutByCurrency[balance.currency] = (totalPaidOutByCurrency[balance.currency] ?? 0) + balance.alreadyPaid
+      if (balance.netOwed > 0) tenantHasOwed = true
+      rows.push({
+        tenantId: tenant.tenantId,
+        tenantName: tenant.tenantName,
+        schoolPercentage: tenant.schoolPercentage,
+        currency: balance.currency,
+        grossCollected: balance.grossCollected,
+        alreadyPaid: balance.alreadyPaid,
+        netOwed: balance.netOwed,
+        byProvider: balance.byProvider,
+      })
+    }
+    if (tenantHasOwed) schoolsOwed++
+  }
 
   const metricCards = [
     {
       title: 'Currently Owed',
-      value: usd(totalOwed),
+      value: formatByCurrency(totalOwedByCurrency),
       sub: `${schoolsOwed} school${schoolsOwed === 1 ? '' : 's'} awaiting payout`,
       icon: IconWalletOff,
       bg: 'bg-amber-50 dark:bg-amber-950/40',
@@ -35,7 +78,7 @@ export default async function PlatformPayoutsPage() {
     },
     {
       title: 'Collected (single-account providers)',
-      value: usd(totalCollected),
+      value: formatByCurrency(totalCollectedByCurrency),
       sub: 'PayPal, Binance Pay, Lemon Squeezy — 100% lands in your account',
       icon: IconCoin,
       bg: 'bg-blue-50 dark:bg-blue-950/40',
@@ -43,7 +86,7 @@ export default async function PlatformPayoutsPage() {
     },
     {
       title: 'Paid Out (all time)',
-      value: usd(totalPaidOut),
+      value: formatByCurrency(totalPaidOutByCurrency),
       sub: 'Manually recorded payouts to schools',
       icon: IconReportMoney,
       bg: 'bg-emerald-50 dark:bg-emerald-950/40',
@@ -89,14 +132,15 @@ export default async function PlatformPayoutsPage() {
           <CardTitle>By school</CardTitle>
         </CardHeader>
         <CardContent>
-          {owed.length === 0 ? (
-            <p className="text-muted-foreground text-sm">No schools yet.</p>
+          {rows.length === 0 ? (
+            <p className="text-muted-foreground text-sm">No platform-settled sales yet.</p>
           ) : (
             <div className="overflow-x-auto">
               <table className="w-full text-sm">
                 <thead>
                   <tr className="border-b text-left text-[11px] uppercase tracking-wider text-muted-foreground">
                     <th className="pb-2 font-medium">School</th>
+                    <th className="pb-2 font-medium">Currency</th>
                     <th className="pb-2 font-medium">Providers</th>
                     <th className="pb-2 text-right font-medium">Collected</th>
                     <th className="pb-2 text-right font-medium">School %</th>
@@ -106,29 +150,31 @@ export default async function PlatformPayoutsPage() {
                   </tr>
                 </thead>
                 <tbody>
-                  {owed.map((t) => (
-                    <tr key={t.tenantId} className="border-b last:border-0">
-                      <td className="py-2.5 font-medium">{t.tenantName}</td>
+                  {rows.map((r) => (
+                    <tr key={`${r.tenantId}-${r.currency}`} className="border-b last:border-0">
+                      <td className="py-2.5 font-medium">{r.tenantName}</td>
+                      <td className="py-2.5 uppercase text-muted-foreground">{r.currency}</td>
                       <td className="py-2.5 text-muted-foreground">
-                        {Object.keys(t.byProvider).length === 0
+                        {Object.keys(r.byProvider).length === 0
                           ? '—'
-                          : Object.keys(t.byProvider).map((p) => PROVIDER_LABEL[p] ?? p).join(', ')}
+                          : Object.keys(r.byProvider).map((p) => PROVIDER_LABEL[p] ?? p).join(', ')}
                       </td>
-                      <td className="py-2.5 text-right tabular-nums">{usd(t.grossCollected)}</td>
+                      <td className="py-2.5 text-right tabular-nums">{money(r.grossCollected, r.currency)}</td>
                       <td className="py-2.5 text-right tabular-nums text-muted-foreground">
-                        {t.schoolPercentage}%
+                        {r.schoolPercentage}%
                       </td>
                       <td className="py-2.5 text-right tabular-nums text-muted-foreground">
-                        {usd(t.alreadyPaid)}
+                        {money(r.alreadyPaid, r.currency)}
                       </td>
                       <td className="py-2.5 text-right tabular-nums font-medium text-amber-600 dark:text-amber-400">
-                        {usd(t.netOwed)}
+                        {money(r.netOwed, r.currency)}
                       </td>
                       <td className="py-2.5 text-right">
                         <MarkPayoutPaidDialog
-                          tenantId={t.tenantId}
-                          tenantName={t.tenantName}
-                          netOwed={t.netOwed}
+                          tenantId={r.tenantId}
+                          tenantName={r.tenantName}
+                          netOwed={r.netOwed}
+                          currency={r.currency}
                         />
                       </td>
                     </tr>
@@ -144,7 +190,8 @@ export default async function PlatformPayoutsPage() {
         Stripe and Solana sales already split automatically and never appear here. Binance Pay
         (personal account) and manual/offline sales settle straight to the school and also never
         appear here — only PayPal, Binance Pay (merchant), and Lemon Squeezy do, since those settle
-        100% into your account today.
+        100% into your account today. Amounts in different currencies are shown and paid out
+        separately — they&apos;re never added together into one number.
       </p>
     </main>
   )

--- a/app/actions/platform/payouts.ts
+++ b/app/actions/platform/payouts.ts
@@ -29,10 +29,10 @@ export async function getPayoutsOwed(): Promise<TenantOwed[]> {
     admin.from('revenue_splits').select('tenant_id, school_percentage'),
     admin
       .from('transactions')
-      .select('tenant_id, payment_provider, amount, school_percentage_snapshot')
+      .select('tenant_id, payment_provider, amount, currency, school_percentage_snapshot')
       .eq('status', 'successful')
       .in('payment_provider', PLATFORM_SETTLED_PROVIDERS),
-    admin.from('payouts').select('tenant_id, amount').eq('payout_method', 'manual').eq('status', 'paid'),
+    admin.from('payouts').select('tenant_id, amount, currency').eq('payout_method', 'manual').eq('status', 'paid'),
   ])
 
   const schoolPercentageByTenant = new Map(
@@ -51,13 +51,14 @@ export async function getPayoutsOwed(): Promise<TenantOwed[]> {
         tenantId: t.tenant_id as string,
         paymentProvider: t.payment_provider as string,
         amount: t.amount as number,
+        currency: t.currency || 'usd',
         schoolPercentageSnapshot: t.school_percentage_snapshot as number | null,
       })),
-    (paid || []).map((p) => ({ tenantId: p.tenant_id, amount: p.amount }))
+    (paid || []).map((p) => ({ tenantId: p.tenant_id, amount: p.amount, currency: p.currency || 'usd' }))
   )
 }
 
-export async function markPayoutPaid(tenantId: string, amount: number, note?: string) {
+export async function markPayoutPaid(tenantId: string, amount: number, currency: string, note?: string) {
   const userId = await verifySuperAdmin()
   if (!(amount > 0)) throw new Error('Amount must be positive')
 
@@ -65,7 +66,7 @@ export async function markPayoutPaid(tenantId: string, amount: number, note?: st
   const { error } = await admin.from('payouts').insert({
     tenant_id: tenantId,
     amount,
-    currency: 'usd',
+    currency,
     status: 'paid',
     payout_method: 'manual',
     paid_at: new Date().toISOString(),

--- a/components/platform/mark-payout-paid-dialog.tsx
+++ b/components/platform/mark-payout-paid-dialog.tsx
@@ -20,9 +20,10 @@ interface Props {
   tenantId: string
   tenantName: string
   netOwed: number
+  currency: string
 }
 
-export function MarkPayoutPaidDialog({ tenantId, tenantName, netOwed }: Props) {
+export function MarkPayoutPaidDialog({ tenantId, tenantName, netOwed, currency }: Props) {
   const router = useRouter()
   const [open, setOpen] = useState(false)
   const [amount, setAmount] = useState(netOwed.toFixed(2))
@@ -37,8 +38,8 @@ export function MarkPayoutPaidDialog({ tenantId, tenantName, netOwed }: Props) {
     }
     setLoading(true)
     try {
-      await markPayoutPaid(tenantId, parsed, note.trim() || undefined)
-      toast.success(`Recorded $${parsed.toFixed(2)} paid to ${tenantName}`)
+      await markPayoutPaid(tenantId, parsed, currency, note.trim() || undefined)
+      toast.success(`Recorded ${parsed.toFixed(2)} ${currency.toUpperCase()} paid to ${tenantName}`)
       setOpen(false)
       setNote('')
       router.refresh()
@@ -68,7 +69,7 @@ export function MarkPayoutPaidDialog({ tenantId, tenantName, netOwed }: Props) {
           </DialogHeader>
           <div className="space-y-3 py-2">
             <div className="space-y-1.5">
-              <Label htmlFor="payout-amount">Amount paid (USD)</Label>
+              <Label htmlFor="payout-amount">Amount paid ({currency.toUpperCase()})</Label>
               <Input
                 id="payout-amount"
                 type="number"

--- a/lib/payments/payouts-owed.ts
+++ b/lib/payments/payouts-owed.ts
@@ -18,6 +18,11 @@
  * snapshot column (`schoolPercentageSnapshot: null`) fall back to the
  * tenant's current `schoolPercentage` — the same behavior this module had
  * before #496, so old data isn't retroactively wrong either way.
+ *
+ * Balances are grouped PER CURRENCY (issue #497) — a tenant with both USD and
+ * EUR sales owes two separate numbers, never one meaningless summed total.
+ * `transactions.currency` and `payouts.currency` are trusted as given; this
+ * module does no currency conversion, only grouping.
  */
 
 /** Used when a tenant has no `revenue_splits` row yet (shouldn't normally happen, but keeps callers from dividing by an absent value). */
@@ -33,8 +38,10 @@ export interface TenantOwedInput {
 export interface PlatformSettledTxn {
   tenantId: string
   paymentProvider: string
-  /** Successful transaction amount, major units. */
+  /** Successful transaction amount, major units, in `currency`. */
   amount: number
+  /** transactions.currency (e.g. 'usd', 'eur'). */
+  currency: string
   /** revenue_splits.school_percentage in effect when this transaction was created (0–100), or null for pre-#496 rows. */
   schoolPercentageSnapshot: number | null
 }
@@ -42,22 +49,30 @@ export interface PlatformSettledTxn {
 export interface ManualPayoutRecord {
   tenantId: string
   amount: number
+  /** payouts.currency — the currency this payout was actually recorded in. */
+  currency: string
+}
+
+export interface CurrencyBalance {
+  currency: string
+  /** Sum of platform-settled transaction amounts in this currency (100% of what was collected). */
+  grossCollected: number
+  /** Sum over this currency's transactions of amount × (that transaction's snapshotted split, or the tenant's current split if unsnapshotted). */
+  grossOwed: number
+  /** Sum of manual payouts already recorded as paid in this currency. */
+  alreadyPaid: number
+  /** max(grossOwed - alreadyPaid, 0) — what's currently owed in this currency. */
+  netOwed: number
+  /** Per-provider breakdown of grossCollected in this currency. */
+  byProvider: Record<string, number>
 }
 
 export interface TenantOwed {
   tenantId: string
   tenantName: string
   schoolPercentage: number
-  /** Sum of platform-settled transaction amounts (100% of what was collected). */
-  grossCollected: number
-  /** Sum over transactions of amount × (that transaction's snapshotted split, or the tenant's current split if unsnapshotted) — the school's all-time share. */
-  grossOwed: number
-  /** Sum of manual payouts already recorded as paid for this tenant. */
-  alreadyPaid: number
-  /** max(grossOwed - alreadyPaid, 0) — what's currently owed. */
-  netOwed: number
-  /** Per-provider breakdown of grossCollected. */
-  byProvider: Record<string, number>
+  /** One entry per currency this tenant has platform-settled activity or payouts in. Never summed across currencies. */
+  balances: CurrencyBalance[]
 }
 
 export function computeOwedBalances(
@@ -67,39 +82,70 @@ export function computeOwedBalances(
 ): TenantOwed[] {
   const schoolPercentageByTenant = new Map(tenants.map((t) => [t.tenantId, t.schoolPercentage]))
 
-  const collectedByTenant = new Map<string, number>()
-  const owedByTenant = new Map<string, number>()
-  const byProviderByTenant = new Map<string, Record<string, number>>()
-  for (const txn of txns) {
-    collectedByTenant.set(txn.tenantId, (collectedByTenant.get(txn.tenantId) ?? 0) + txn.amount)
+  // tenantId -> currency -> partial balance
+  const byTenantCurrency = new Map<string, Map<string, { grossCollected: number; grossOwed: number; byProvider: Record<string, number> }>>()
 
-    const effectivePercentage = txn.schoolPercentageSnapshot ?? schoolPercentageByTenant.get(txn.tenantId) ?? 0
-    owedByTenant.set(txn.tenantId, (owedByTenant.get(txn.tenantId) ?? 0) + (txn.amount * effectivePercentage) / 100)
-
-    const byProvider = byProviderByTenant.get(txn.tenantId) ?? {}
-    byProvider[txn.paymentProvider] = (byProvider[txn.paymentProvider] ?? 0) + txn.amount
-    byProviderByTenant.set(txn.tenantId, byProvider)
+  function bucket(tenantId: string, currency: string) {
+    let byCurrency = byTenantCurrency.get(tenantId)
+    if (!byCurrency) {
+      byCurrency = new Map()
+      byTenantCurrency.set(tenantId, byCurrency)
+    }
+    let entry = byCurrency.get(currency)
+    if (!entry) {
+      entry = { grossCollected: 0, grossOwed: 0, byProvider: {} }
+      byCurrency.set(currency, entry)
+    }
+    return entry
   }
 
-  const paidByTenant = new Map<string, number>()
+  for (const txn of txns) {
+    const entry = bucket(txn.tenantId, txn.currency)
+    entry.grossCollected += txn.amount
+    const effectivePercentage = txn.schoolPercentageSnapshot ?? schoolPercentageByTenant.get(txn.tenantId) ?? 0
+    entry.grossOwed += (txn.amount * effectivePercentage) / 100
+    entry.byProvider[txn.paymentProvider] = (entry.byProvider[txn.paymentProvider] ?? 0) + txn.amount
+  }
+
+  const paidByTenantCurrency = new Map<string, Map<string, number>>()
   for (const payout of paidPayouts) {
-    paidByTenant.set(payout.tenantId, (paidByTenant.get(payout.tenantId) ?? 0) + payout.amount)
+    let byCurrency = paidByTenantCurrency.get(payout.tenantId)
+    if (!byCurrency) {
+      byCurrency = new Map()
+      paidByTenantCurrency.set(payout.tenantId, byCurrency)
+    }
+    byCurrency.set(payout.currency, (byCurrency.get(payout.currency) ?? 0) + payout.amount)
   }
 
   return tenants.map((tenant) => {
-    const grossCollected = collectedByTenant.get(tenant.tenantId) ?? 0
-    const grossOwed = owedByTenant.get(tenant.tenantId) ?? 0
-    const alreadyPaid = paidByTenant.get(tenant.tenantId) ?? 0
-    const netOwed = Math.max(grossOwed - alreadyPaid, 0)
+    const collected = byTenantCurrency.get(tenant.tenantId) ?? new Map()
+    const paid = paidByTenantCurrency.get(tenant.tenantId) ?? new Map()
+
+    // A currency can appear only in payouts (fully paid off, no outstanding
+    // transactions left in this grouping) — union both key sets so it's not dropped.
+    const currencies = new Set<string>([...collected.keys(), ...paid.keys()])
+
+    const balances: CurrencyBalance[] = Array.from(currencies).map((currency) => {
+      const entry = collected.get(currency)
+      const grossCollected = entry?.grossCollected ?? 0
+      const grossOwed = entry?.grossOwed ?? 0
+      const alreadyPaid = paid.get(currency) ?? 0
+      const netOwed = Math.max(grossOwed - alreadyPaid, 0)
+      return {
+        currency,
+        grossCollected,
+        grossOwed,
+        alreadyPaid,
+        netOwed,
+        byProvider: entry?.byProvider ?? {},
+      }
+    })
+
     return {
       tenantId: tenant.tenantId,
       tenantName: tenant.tenantName,
       schoolPercentage: tenant.schoolPercentage,
-      grossCollected,
-      grossOwed,
-      alreadyPaid,
-      netOwed,
-      byProvider: byProviderByTenant.get(tenant.tenantId) ?? {},
+      balances,
     }
   })
 }

--- a/tests/unit/payouts-owed.test.ts
+++ b/tests/unit/payouts-owed.test.ts
@@ -1,18 +1,21 @@
 import { describe, it, expect } from 'vitest'
 import { computeOwedBalances } from '@/lib/payments/payouts-owed'
 
+function balanceFor(result: ReturnType<typeof computeOwedBalances>, tenantId: string, currency: string) {
+  return result.find((r) => r.tenantId === tenantId)?.balances.find((b) => b.currency === currency)
+}
+
 describe('computeOwedBalances', () => {
-  it('single tenant, single provider, nothing paid yet', () => {
+  it('single tenant, single provider, single currency, nothing paid yet', () => {
     const result = computeOwedBalances(
       [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 80 }],
-      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, schoolPercentageSnapshot: null }],
+      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null }],
       [],
     )
-    expect(result).toEqual([
+    expect(result).toHaveLength(1)
+    expect(result[0].balances).toEqual([
       {
-        tenantId: 't1',
-        tenantName: 'School A',
-        schoolPercentage: 80,
+        currency: 'usd',
         grossCollected: 100,
         grossOwed: 80,
         alreadyPaid: 0,
@@ -22,82 +25,99 @@ describe('computeOwedBalances', () => {
     ])
   })
 
-  it('sums multiple transactions across multiple providers for the same tenant', () => {
+  it('sums multiple transactions across multiple providers in the same currency', () => {
     const result = computeOwedBalances(
       [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 80 }],
       [
-        { tenantId: 't1', paymentProvider: 'paypal', amount: 100, schoolPercentageSnapshot: null },
-        { tenantId: 't1', paymentProvider: 'paypal', amount: 50, schoolPercentageSnapshot: null },
-        { tenantId: 't1', paymentProvider: 'binance', amount: 25, schoolPercentageSnapshot: null },
+        { tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null },
+        { tenantId: 't1', paymentProvider: 'paypal', amount: 50, currency: 'usd', schoolPercentageSnapshot: null },
+        { tenantId: 't1', paymentProvider: 'binance', amount: 25, currency: 'usd', schoolPercentageSnapshot: null },
       ],
       [],
     )
-    expect(result[0].grossCollected).toBe(175)
-    expect(result[0].grossOwed).toBeCloseTo(140) // 175 * 0.8
-    expect(result[0].byProvider).toEqual({ paypal: 150, binance: 25 })
+    const usd = balanceFor(result, 't1', 'usd')!
+    expect(usd.grossCollected).toBe(175)
+    expect(usd.grossOwed).toBeCloseTo(140) // 175 * 0.8
+    expect(usd.byProvider).toEqual({ paypal: 150, binance: 25 })
   })
 
-  it('subtracts already-paid manual payouts from the gross owed', () => {
+  it('#497: keeps USD and EUR sales as two separate balances, never summed together', () => {
     const result = computeOwedBalances(
       [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 80 }],
-      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, schoolPercentageSnapshot: null }],
-      [{ tenantId: 't1', amount: 30 }],
+      [
+        { tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null },
+        { tenantId: 't1', paymentProvider: 'paypal', amount: 80, currency: 'eur', schoolPercentageSnapshot: null },
+      ],
+      [],
     )
-    expect(result[0].grossOwed).toBe(80)
-    expect(result[0].alreadyPaid).toBe(30)
-    expect(result[0].netOwed).toBe(50)
+    const tenant = result.find((r) => r.tenantId === 't1')!
+    expect(tenant.balances).toHaveLength(2)
+    const usd = balanceFor(result, 't1', 'usd')!
+    const eur = balanceFor(result, 't1', 'eur')!
+    expect(usd.grossCollected).toBe(100)
+    expect(usd.netOwed).toBe(80)
+    expect(eur.grossCollected).toBe(80)
+    expect(eur.netOwed).toBe(64) // 80 * 0.8
   })
 
-  it('sums multiple manual payouts already paid', () => {
+  it('subtracts already-paid manual payouts from the gross owed, in the matching currency only', () => {
     const result = computeOwedBalances(
       [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 80 }],
-      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, schoolPercentageSnapshot: null }],
-      [{ tenantId: 't1', amount: 30 }, { tenantId: 't1', amount: 50 }],
+      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null }],
+      [{ tenantId: 't1', amount: 30, currency: 'usd' }],
     )
-    expect(result[0].alreadyPaid).toBe(80)
-    expect(result[0].netOwed).toBe(0)
+    const usd = balanceFor(result, 't1', 'usd')!
+    expect(usd.grossOwed).toBe(80)
+    expect(usd.alreadyPaid).toBe(30)
+    expect(usd.netOwed).toBe(50)
+  })
+
+  it('#497: a EUR payout does not reduce what is owed in USD', () => {
+    const result = computeOwedBalances(
+      [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 80 }],
+      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null }],
+      [{ tenantId: 't1', amount: 30, currency: 'eur' }],
+    )
+    const usd = balanceFor(result, 't1', 'usd')!
+    expect(usd.netOwed).toBe(80) // unaffected by the EUR payout
+    const eur = balanceFor(result, 't1', 'eur')!
+    expect(eur).toMatchObject({ grossCollected: 0, grossOwed: 0, alreadyPaid: 30, netOwed: 0 })
   })
 
   it('floors netOwed at 0 when payouts exceed what was owed (overpay/rounding)', () => {
     const result = computeOwedBalances(
       [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 80 }],
-      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, schoolPercentageSnapshot: null }],
-      [{ tenantId: 't1', amount: 500 }],
+      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null }],
+      [{ tenantId: 't1', amount: 500, currency: 'usd' }],
     )
-    expect(result[0].netOwed).toBe(0)
+    expect(balanceFor(result, 't1', 'usd')!.netOwed).toBe(0)
   })
 
-  it('tenant with zero platform-settled transactions owes nothing', () => {
+  it('tenant with zero platform-settled transactions has no balances', () => {
     const result = computeOwedBalances(
       [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 80 }],
       [],
       [],
     )
-    expect(result[0]).toMatchObject({
-      grossCollected: 0,
-      grossOwed: 0,
-      alreadyPaid: 0,
-      netOwed: 0,
-      byProvider: {},
-    })
+    expect(result[0].balances).toEqual([])
   })
 
   it('boundary schoolPercentage=0 → platform keeps everything, nothing owed', () => {
     const result = computeOwedBalances(
       [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 0 }],
-      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, schoolPercentageSnapshot: null }],
+      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null }],
       [],
     )
-    expect(result[0].netOwed).toBe(0)
+    expect(balanceFor(result, 't1', 'usd')!.netOwed).toBe(0)
   })
 
   it('boundary schoolPercentage=100 → school is owed the full amount collected', () => {
     const result = computeOwedBalances(
       [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 100 }],
-      [{ tenantId: 't1', paymentProvider: 'lemonsqueezy', amount: 100, schoolPercentageSnapshot: null }],
+      [{ tenantId: 't1', paymentProvider: 'lemonsqueezy', amount: 100, currency: 'usd', schoolPercentageSnapshot: null }],
       [],
     )
-    expect(result[0].netOwed).toBe(100)
+    expect(balanceFor(result, 't1', 'usd')!.netOwed).toBe(100)
   })
 
   it('keeps tenants isolated from each other', () => {
@@ -107,15 +127,13 @@ describe('computeOwedBalances', () => {
         { tenantId: 't2', tenantName: 'School B', schoolPercentage: 90 },
       ],
       [
-        { tenantId: 't1', paymentProvider: 'paypal', amount: 100, schoolPercentageSnapshot: null },
-        { tenantId: 't2', paymentProvider: 'paypal', amount: 200, schoolPercentageSnapshot: null },
+        { tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null },
+        { tenantId: 't2', paymentProvider: 'paypal', amount: 200, currency: 'usd', schoolPercentageSnapshot: null },
       ],
-      [{ tenantId: 't1', amount: 10 }],
+      [{ tenantId: 't1', amount: 10, currency: 'usd' }],
     )
-    const a = result.find((r) => r.tenantId === 't1')!
-    const b = result.find((r) => r.tenantId === 't2')!
-    expect(a.netOwed).toBe(70) // 100*0.8 - 10
-    expect(b.netOwed).toBe(180) // 200*0.9, unaffected by t1's payout
+    expect(balanceFor(result, 't1', 'usd')!.netOwed).toBe(70) // 100*0.8 - 10
+    expect(balanceFor(result, 't2', 'usd')!.netOwed).toBe(180) // 200*0.9, unaffected by t1's payout
   })
 
   it('returns one row per tenant, even with no matching transactions/payouts', () => {
@@ -124,47 +142,42 @@ describe('computeOwedBalances', () => {
         { tenantId: 't1', tenantName: 'School A', schoolPercentage: 80 },
         { tenantId: 't2', tenantName: 'School B', schoolPercentage: 80 },
       ],
-      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, schoolPercentageSnapshot: null }],
+      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null }],
       [],
     )
     expect(result).toHaveLength(2)
+    expect(result.find((r) => r.tenantId === 't2')!.balances).toEqual([])
   })
 
   it('#496: a plan change after a sale does not retroactively reprice it — uses the snapshotted split, not the current one', () => {
-    // School was on business (0% fee → 100% school_percentage) when this $10k sale
-    // happened, then got auto-downgraded to free (10% fee → 90% school_percentage
-    // *today*). The historical sale must still be owed at the 100% that was live
-    // when it happened, not repriced down to 90% just because the tenant's
-    // current split changed since.
     const result = computeOwedBalances(
       [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 90 }],
-      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 10000, schoolPercentageSnapshot: 100 }],
+      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 10000, currency: 'usd', schoolPercentageSnapshot: 100 }],
       [],
     )
-    expect(result[0].grossOwed).toBe(10000)
+    expect(balanceFor(result, 't1', 'usd')!.grossOwed).toBe(10000)
   })
 
   it('#496: transactions predating the snapshot column fall back to the tenant\'s current split', () => {
     const result = computeOwedBalances(
       [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 80 }],
-      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, schoolPercentageSnapshot: null }],
+      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null }],
       [],
     )
-    expect(result[0].grossOwed).toBe(80)
+    expect(balanceFor(result, 't1', 'usd')!.grossOwed).toBe(80)
   })
 
   it('#496: mixes snapshotted and legacy (null-snapshot) transactions correctly in the same tenant', () => {
     const result = computeOwedBalances(
       [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 90 }],
       [
-        // Sold at the old 80% split — snapshotted, unaffected by the later change.
-        { tenantId: 't1', paymentProvider: 'paypal', amount: 100, schoolPercentageSnapshot: 80 },
-        // A pre-#496 legacy row with no snapshot — falls back to the current 90%.
-        { tenantId: 't1', paymentProvider: 'paypal', amount: 100, schoolPercentageSnapshot: null },
+        { tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: 80 },
+        { tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null },
       ],
       [],
     )
-    expect(result[0].grossCollected).toBe(200)
-    expect(result[0].grossOwed).toBe(80 + 90) // 100*0.8 + 100*0.9
+    const usd = balanceFor(result, 't1', 'usd')!
+    expect(usd.grossCollected).toBe(200)
+    expect(usd.grossOwed).toBe(80 + 90) // 100*0.8 + 100*0.9
   })
 })


### PR DESCRIPTION
## Description

Part of epic #493 (Phase 2 — payout money-accuracy). Stacked on #504 (#496's time-sliced split fix) — the base is `fix/time-sliced-revenue-split-496`, not `master`. Once #503 → #504 → this PR merge in order, each PR's base updates automatically.

`transactions.currency` is a real, populated `currency_type` enum column (`usd`, `eur`, `mxn`, `cop`, `clp`, `pen`, `ars`, `brl` — LATAM markets matter here per this repo's user base), but `getPayoutsOwed()` selected only `tenant_id, payment_provider, amount` — currency was dropped — and `computeOwedBalances()` summed raw `amount` with no currency grouping. A tenant with both USD and EUR PayPal sales got one meaningless combined total (e.g. a displayed "$180.00" that was actually $100 + €80). `markPayoutPaid()` then hardcoded `currency: 'usd'` on every inserted `payouts` row regardless of what was actually collected, so the payout record itself was wrong the moment any non-USD sale was involved.

## Changes made

- **`lib/payments/payouts-owed.ts`** — `TenantOwed.balances` is now an array of per-currency `CurrencyBalance` entries (`currency`, `grossCollected`, `grossOwed`, `alreadyPaid`, `netOwed`, `byProvider`), computed by grouping transactions and payouts by currency before any arithmetic — never summed across currencies. A currency that only has payouts left (fully paid off) still gets an entry via a union of both key sets, so it isn't silently dropped.
- **`app/actions/platform/payouts.ts`** — `getPayoutsOwed()` selects `currency` from both `transactions` and `payouts` and threads it through. `markPayoutPaid(tenantId, amount, currency, note?)` takes an explicit `currency` argument instead of hardcoding `'usd'`.
- **`app/[locale]/platform/payouts/page.tsx`** — renders one table row per (tenant, currency) balance instead of one row per tenant; metric cards show one figure per currency joined with `·` (e.g. `$80.00 · €40.00`) instead of a single summed number.
- **`components/platform/mark-payout-paid-dialog.tsx`** — takes a `currency` prop, labels the amount field with it (`Amount paid (EUR)`), and passes it through to `markPayoutPaid`.

## Type of change

- [x] Bug fix (money-accuracy — payouts across multiple currencies were silently mixed into one wrong number, and payout records were mislabeled)

Closes #497 (Phase 2 sub-task of epic #493).

## Testing

- [x] `npx vitest run tests/unit/payouts-owed.test.ts` — 14/14 passing, including 2 new tests specific to #497 (USD/EUR kept as separate balances; a EUR payout doesn't reduce what's owed in USD) plus the full #496 suite still green (fixtures updated to include `currency` on each transaction fixture, no behavioral changes to the #496 tests otherwise).
- [x] `npm run test:unit` — 273/273 passing, no regressions.
- [x] `npm run typecheck` — clean.
- [x] `npm run lint` — no new errors on any changed file.
- [x] `npm run build` — succeeds.
- [x] **Live-verified locally**: seeded a $100 USD PayPal sale and a €50 EUR Lemon Squeezy sale for the same tenant (screenshot attached below shows the resulting page — two separate rows, metric cards showing `$80.00 · €40.00`, correct 80% split applied to both). Recorded a EUR payout through the dialog and confirmed via direct DB query that the inserted `payouts` row has `currency = 'eur'` (not `'usd'`) and that the USD row's owed amount was completely unaffected. Test data cleaned up afterward.

### QA verification steps

1. In a local Supabase shell, create two successful platform-settled transactions (e.g. one `paypal`/`usd`, one `lemonsqueezy`/`eur`) for the same tenant.
2. Load `/platform/payouts` as a super admin — confirm two separate rows for that school (one per currency), and that the "Currently Owed" metric card shows both amounts separately (e.g. `$X.XX · €Y.YY`), never added together.
3. Click "Mark as Paid" on the EUR row — confirm the dialog's amount label reads "Amount paid (EUR)" and the pre-filled amount matches the EUR owed figure, not the USD one.
4. Submit it, and confirm only the EUR row's "Owed" drops — the USD row is untouched.

## Screenshot

Attached as a PR comment: the payouts page with the seeded USD + EUR scenario, and the "Mark as Paid" dialog showing the EUR-specific label.
