### PR TITLE
fix(payments): clawback refunded transactions from payouts owed (#498)

### DIFF
--- a/app/[locale]/platform/payouts/page.tsx
+++ b/app/[locale]/platform/payouts/page.tsx
@@ -41,10 +41,12 @@ export default async function PlatformPayoutsPage() {
     currency: string
     grossCollected: number
     alreadyPaid: number
+    clawback: number
     netOwed: number
     byProvider: Record<string, number>
   }
   const rows: Row[] = []
+  const totalClawbackByCurrency: Record<string, number> = {}
 
   for (const tenant of owed) {
     let tenantHasOwed = false
@@ -52,6 +54,9 @@ export default async function PlatformPayoutsPage() {
       totalOwedByCurrency[balance.currency] = (totalOwedByCurrency[balance.currency] ?? 0) + balance.netOwed
       totalCollectedByCurrency[balance.currency] = (totalCollectedByCurrency[balance.currency] ?? 0) + balance.grossCollected
       totalPaidOutByCurrency[balance.currency] = (totalPaidOutByCurrency[balance.currency] ?? 0) + balance.alreadyPaid
+      if (balance.clawback > 0) {
+        totalClawbackByCurrency[balance.currency] = (totalClawbackByCurrency[balance.currency] ?? 0) + balance.clawback
+      }
       if (balance.netOwed > 0) tenantHasOwed = true
       rows.push({
         tenantId: tenant.tenantId,
@@ -60,12 +65,14 @@ export default async function PlatformPayoutsPage() {
         currency: balance.currency,
         grossCollected: balance.grossCollected,
         alreadyPaid: balance.alreadyPaid,
+        clawback: balance.clawback,
         netOwed: balance.netOwed,
         byProvider: balance.byProvider,
       })
     }
     if (tenantHasOwed) schoolsOwed++
   }
+  const hasClawbacks = Object.values(totalClawbackByCurrency).some((amount) => amount > 0)
 
   const metricCards = [
     {
@@ -127,6 +134,17 @@ export default async function PlatformPayoutsPage() {
         ))}
       </div>
 
+      {hasClawbacks && (
+        <div
+          className="mb-6 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800 dark:border-red-900/50 dark:bg-red-950/30 dark:text-red-300"
+          data-testid="payouts-clawback-banner"
+        >
+          <span className="font-medium">Refund clawback: {formatByCurrency(totalClawbackByCurrency)}.</span>{' '}
+          Some already-paid-out transactions were later refunded — this amount reduces what&apos;s
+          currently owed rather than being paid again.
+        </div>
+      )}
+
       <Card data-testid="payouts-by-tenant">
         <CardHeader>
           <CardTitle>By school</CardTitle>
@@ -145,6 +163,7 @@ export default async function PlatformPayoutsPage() {
                     <th className="pb-2 text-right font-medium">Collected</th>
                     <th className="pb-2 text-right font-medium">School %</th>
                     <th className="pb-2 text-right font-medium">Paid so far</th>
+                    <th className="pb-2 text-right font-medium">Clawback</th>
                     <th className="pb-2 text-right font-medium">Owed</th>
                     <th className="pb-2 text-right font-medium"></th>
                   </tr>
@@ -165,6 +184,15 @@ export default async function PlatformPayoutsPage() {
                       </td>
                       <td className="py-2.5 text-right tabular-nums text-muted-foreground">
                         {money(r.alreadyPaid, r.currency)}
+                      </td>
+                      <td className="py-2.5 text-right tabular-nums">
+                        {r.clawback > 0 ? (
+                          <span className="font-medium text-red-600 dark:text-red-400">
+                            −{money(r.clawback, r.currency)}
+                          </span>
+                        ) : (
+                          <span className="text-muted-foreground">—</span>
+                        )}
                       </td>
                       <td className="py-2.5 text-right tabular-nums font-medium text-amber-600 dark:text-amber-400">
                         {money(r.netOwed, r.currency)}

--- a/app/actions/platform/payouts.ts
+++ b/app/actions/platform/payouts.ts
@@ -29,8 +29,8 @@ export async function getPayoutsOwed(): Promise<TenantOwed[]> {
     admin.from('revenue_splits').select('tenant_id, school_percentage'),
     admin
       .from('transactions')
-      .select('tenant_id, payment_provider, amount, currency, school_percentage_snapshot')
-      .eq('status', 'successful')
+      .select('tenant_id, payment_provider, amount, currency, school_percentage_snapshot, status')
+      .in('status', ['successful', 'refunded'])
       .in('payment_provider', PLATFORM_SETTLED_PROVIDERS),
     admin.from('payouts').select('tenant_id, amount, currency').eq('payout_method', 'manual').eq('status', 'paid'),
   ])
@@ -53,6 +53,7 @@ export async function getPayoutsOwed(): Promise<TenantOwed[]> {
         amount: t.amount as number,
         currency: t.currency || 'usd',
         schoolPercentageSnapshot: t.school_percentage_snapshot as number | null,
+        status: t.status as 'successful' | 'refunded',
       })),
     (paid || []).map((p) => ({ tenantId: p.tenant_id, amount: p.amount, currency: p.currency || 'usd' }))
   )

--- a/lib/payments/payouts-owed.ts
+++ b/lib/payments/payouts-owed.ts
@@ -23,6 +23,14 @@
  * EUR sales owes two separate numbers, never one meaningless summed total.
  * `transactions.currency` and `payouts.currency` are trusted as given; this
  * module does no currency conversion, only grouping.
+ *
+ * Refunds/chargebacks (issue #498): a transaction can flip from `successful`
+ * to `refunded` after its payout was already recorded. Callers pass refunded
+ * transactions through alongside successful ones (tagged via `status`); this
+ * module scales each refund by the same split percentage a sale would've
+ * used and surfaces it as a distinct `clawback` figure, subtracted from
+ * `netOwed` on the next cycle rather than silently vanishing from
+ * `grossCollected`/`grossOwed` with no trace.
  */
 
 /** Used when a tenant has no `revenue_splits` row yet (shouldn't normally happen, but keeps callers from dividing by an absent value). */
@@ -38,12 +46,14 @@ export interface TenantOwedInput {
 export interface PlatformSettledTxn {
   tenantId: string
   paymentProvider: string
-  /** Successful transaction amount, major units, in `currency`. */
+  /** Transaction amount, major units, in `currency` — always positive regardless of `status`. */
   amount: number
   /** transactions.currency (e.g. 'usd', 'eur'). */
   currency: string
   /** revenue_splits.school_percentage in effect when this transaction was created (0–100), or null for pre-#496 rows. */
   schoolPercentageSnapshot: number | null
+  /** 'successful' contributes to grossCollected/grossOwed as normal; 'refunded' contributes its scaled amount to `clawback` instead (issue #498). */
+  status: 'successful' | 'refunded'
 }
 
 export interface ManualPayoutRecord {
@@ -61,7 +71,9 @@ export interface CurrencyBalance {
   grossOwed: number
   /** Sum of manual payouts already recorded as paid in this currency. */
   alreadyPaid: number
-  /** max(grossOwed - alreadyPaid, 0) — what's currently owed in this currency. */
+  /** Sum over refunded transactions of amount × (that transaction's snapshotted split, or the tenant's current split) — money already paid out for sales that later got refunded (issue #498). */
+  clawback: number
+  /** max(grossOwed - alreadyPaid - clawback, 0) — what's currently owed in this currency. */
   netOwed: number
   /** Per-provider breakdown of grossCollected in this currency. */
   byProvider: Record<string, number>
@@ -83,7 +95,7 @@ export function computeOwedBalances(
   const schoolPercentageByTenant = new Map(tenants.map((t) => [t.tenantId, t.schoolPercentage]))
 
   // tenantId -> currency -> partial balance
-  const byTenantCurrency = new Map<string, Map<string, { grossCollected: number; grossOwed: number; byProvider: Record<string, number> }>>()
+  const byTenantCurrency = new Map<string, Map<string, { grossCollected: number; grossOwed: number; clawback: number; byProvider: Record<string, number> }>>()
 
   function bucket(tenantId: string, currency: string) {
     let byCurrency = byTenantCurrency.get(tenantId)
@@ -93,7 +105,7 @@ export function computeOwedBalances(
     }
     let entry = byCurrency.get(currency)
     if (!entry) {
-      entry = { grossCollected: 0, grossOwed: 0, byProvider: {} }
+      entry = { grossCollected: 0, grossOwed: 0, clawback: 0, byProvider: {} }
       byCurrency.set(currency, entry)
     }
     return entry
@@ -101,9 +113,14 @@ export function computeOwedBalances(
 
   for (const txn of txns) {
     const entry = bucket(txn.tenantId, txn.currency)
-    entry.grossCollected += txn.amount
     const effectivePercentage = txn.schoolPercentageSnapshot ?? schoolPercentageByTenant.get(txn.tenantId) ?? 0
-    entry.grossOwed += (txn.amount * effectivePercentage) / 100
+    const scaledAmount = (txn.amount * effectivePercentage) / 100
+    if (txn.status === 'refunded') {
+      entry.clawback += scaledAmount
+      continue
+    }
+    entry.grossCollected += txn.amount
+    entry.grossOwed += scaledAmount
     entry.byProvider[txn.paymentProvider] = (entry.byProvider[txn.paymentProvider] ?? 0) + txn.amount
   }
 
@@ -129,13 +146,15 @@ export function computeOwedBalances(
       const entry = collected.get(currency)
       const grossCollected = entry?.grossCollected ?? 0
       const grossOwed = entry?.grossOwed ?? 0
+      const clawback = entry?.clawback ?? 0
       const alreadyPaid = paid.get(currency) ?? 0
-      const netOwed = Math.max(grossOwed - alreadyPaid, 0)
+      const netOwed = Math.max(grossOwed - alreadyPaid - clawback, 0)
       return {
         currency,
         grossCollected,
         grossOwed,
         alreadyPaid,
+        clawback,
         netOwed,
         byProvider: entry?.byProvider ?? {},
       }

--- a/tests/unit/payouts-owed.test.ts
+++ b/tests/unit/payouts-owed.test.ts
@@ -9,7 +9,7 @@ describe('computeOwedBalances', () => {
   it('single tenant, single provider, single currency, nothing paid yet', () => {
     const result = computeOwedBalances(
       [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 80 }],
-      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null }],
+      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null , status: 'successful' }],
       [],
     )
     expect(result).toHaveLength(1)
@@ -19,6 +19,7 @@ describe('computeOwedBalances', () => {
         grossCollected: 100,
         grossOwed: 80,
         alreadyPaid: 0,
+        clawback: 0,
         netOwed: 80,
         byProvider: { paypal: 100 },
       },
@@ -29,9 +30,9 @@ describe('computeOwedBalances', () => {
     const result = computeOwedBalances(
       [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 80 }],
       [
-        { tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null },
-        { tenantId: 't1', paymentProvider: 'paypal', amount: 50, currency: 'usd', schoolPercentageSnapshot: null },
-        { tenantId: 't1', paymentProvider: 'binance', amount: 25, currency: 'usd', schoolPercentageSnapshot: null },
+        { tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null , status: 'successful' },
+        { tenantId: 't1', paymentProvider: 'paypal', amount: 50, currency: 'usd', schoolPercentageSnapshot: null , status: 'successful' },
+        { tenantId: 't1', paymentProvider: 'binance', amount: 25, currency: 'usd', schoolPercentageSnapshot: null , status: 'successful' },
       ],
       [],
     )
@@ -45,8 +46,8 @@ describe('computeOwedBalances', () => {
     const result = computeOwedBalances(
       [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 80 }],
       [
-        { tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null },
-        { tenantId: 't1', paymentProvider: 'paypal', amount: 80, currency: 'eur', schoolPercentageSnapshot: null },
+        { tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null , status: 'successful' },
+        { tenantId: 't1', paymentProvider: 'paypal', amount: 80, currency: 'eur', schoolPercentageSnapshot: null , status: 'successful' },
       ],
       [],
     )
@@ -63,7 +64,7 @@ describe('computeOwedBalances', () => {
   it('subtracts already-paid manual payouts from the gross owed, in the matching currency only', () => {
     const result = computeOwedBalances(
       [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 80 }],
-      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null }],
+      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null , status: 'successful' }],
       [{ tenantId: 't1', amount: 30, currency: 'usd' }],
     )
     const usd = balanceFor(result, 't1', 'usd')!
@@ -75,7 +76,7 @@ describe('computeOwedBalances', () => {
   it('#497: a EUR payout does not reduce what is owed in USD', () => {
     const result = computeOwedBalances(
       [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 80 }],
-      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null }],
+      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null , status: 'successful' }],
       [{ tenantId: 't1', amount: 30, currency: 'eur' }],
     )
     const usd = balanceFor(result, 't1', 'usd')!
@@ -87,7 +88,7 @@ describe('computeOwedBalances', () => {
   it('floors netOwed at 0 when payouts exceed what was owed (overpay/rounding)', () => {
     const result = computeOwedBalances(
       [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 80 }],
-      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null }],
+      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null , status: 'successful' }],
       [{ tenantId: 't1', amount: 500, currency: 'usd' }],
     )
     expect(balanceFor(result, 't1', 'usd')!.netOwed).toBe(0)
@@ -105,7 +106,7 @@ describe('computeOwedBalances', () => {
   it('boundary schoolPercentage=0 → platform keeps everything, nothing owed', () => {
     const result = computeOwedBalances(
       [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 0 }],
-      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null }],
+      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null , status: 'successful' }],
       [],
     )
     expect(balanceFor(result, 't1', 'usd')!.netOwed).toBe(0)
@@ -114,7 +115,7 @@ describe('computeOwedBalances', () => {
   it('boundary schoolPercentage=100 → school is owed the full amount collected', () => {
     const result = computeOwedBalances(
       [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 100 }],
-      [{ tenantId: 't1', paymentProvider: 'lemonsqueezy', amount: 100, currency: 'usd', schoolPercentageSnapshot: null }],
+      [{ tenantId: 't1', paymentProvider: 'lemonsqueezy', amount: 100, currency: 'usd', schoolPercentageSnapshot: null , status: 'successful' }],
       [],
     )
     expect(balanceFor(result, 't1', 'usd')!.netOwed).toBe(100)
@@ -127,8 +128,8 @@ describe('computeOwedBalances', () => {
         { tenantId: 't2', tenantName: 'School B', schoolPercentage: 90 },
       ],
       [
-        { tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null },
-        { tenantId: 't2', paymentProvider: 'paypal', amount: 200, currency: 'usd', schoolPercentageSnapshot: null },
+        { tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null , status: 'successful' },
+        { tenantId: 't2', paymentProvider: 'paypal', amount: 200, currency: 'usd', schoolPercentageSnapshot: null , status: 'successful' },
       ],
       [{ tenantId: 't1', amount: 10, currency: 'usd' }],
     )
@@ -142,7 +143,7 @@ describe('computeOwedBalances', () => {
         { tenantId: 't1', tenantName: 'School A', schoolPercentage: 80 },
         { tenantId: 't2', tenantName: 'School B', schoolPercentage: 80 },
       ],
-      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null }],
+      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null , status: 'successful' }],
       [],
     )
     expect(result).toHaveLength(2)
@@ -152,7 +153,7 @@ describe('computeOwedBalances', () => {
   it('#496: a plan change after a sale does not retroactively reprice it — uses the snapshotted split, not the current one', () => {
     const result = computeOwedBalances(
       [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 90 }],
-      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 10000, currency: 'usd', schoolPercentageSnapshot: 100 }],
+      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 10000, currency: 'usd', schoolPercentageSnapshot: 100 , status: 'successful' }],
       [],
     )
     expect(balanceFor(result, 't1', 'usd')!.grossOwed).toBe(10000)
@@ -161,7 +162,7 @@ describe('computeOwedBalances', () => {
   it('#496: transactions predating the snapshot column fall back to the tenant\'s current split', () => {
     const result = computeOwedBalances(
       [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 80 }],
-      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null }],
+      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null , status: 'successful' }],
       [],
     )
     expect(balanceFor(result, 't1', 'usd')!.grossOwed).toBe(80)
@@ -171,13 +172,72 @@ describe('computeOwedBalances', () => {
     const result = computeOwedBalances(
       [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 90 }],
       [
-        { tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: 80 },
-        { tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null },
+        { tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: 80 , status: 'successful' },
+        { tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null , status: 'successful' },
       ],
       [],
     )
     const usd = balanceFor(result, 't1', 'usd')!
     expect(usd.grossCollected).toBe(200)
     expect(usd.grossOwed).toBe(80 + 90) // 100*0.8 + 100*0.9
+  })
+
+  it('#498: a transaction refunded after being paid out reduces what is owed on the next cycle via a visible clawback', () => {
+    const result = computeOwedBalances(
+      [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 80 }],
+      [
+        { tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null, status: 'successful' },
+        { tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null, status: 'refunded' },
+      ],
+      [{ tenantId: 't1', amount: 80, currency: 'usd' }],
+    )
+    const usd = balanceFor(result, 't1', 'usd')!
+    // Only the still-successful sale counts toward gross collected/owed.
+    expect(usd.grossCollected).toBe(100)
+    expect(usd.grossOwed).toBe(80)
+    expect(usd.alreadyPaid).toBe(80)
+    // The refunded sale's scaled share is a distinct, visible clawback — not silently netted away.
+    expect(usd.clawback).toBe(80) // 100 * 0.8
+    expect(usd.netOwed).toBe(0) // max(80 - 80 - 80, 0)
+  })
+
+  it('#498: clawback is not silently absorbed — it is reported separately from grossOwed/alreadyPaid', () => {
+    const result = computeOwedBalances(
+      [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 80 }],
+      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null, status: 'refunded' }],
+      [],
+    )
+    const usd = balanceFor(result, 't1', 'usd')!
+    expect(usd.grossCollected).toBe(0) // refunded sale never counted as collected
+    expect(usd.grossOwed).toBe(0)
+    expect(usd.clawback).toBe(80) // still visible, even with nothing else outstanding
+    expect(usd.netOwed).toBe(0)
+  })
+
+  it('#498: a refund in one currency does not clawback a balance owed in another currency', () => {
+    const result = computeOwedBalances(
+      [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 80 }],
+      [
+        { tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null, status: 'successful' },
+        { tenantId: 't1', paymentProvider: 'paypal', amount: 50, currency: 'eur', schoolPercentageSnapshot: null, status: 'refunded' },
+      ],
+      [],
+    )
+    const usd = balanceFor(result, 't1', 'usd')!
+    const eur = balanceFor(result, 't1', 'eur')!
+    expect(usd.clawback).toBe(0)
+    expect(usd.netOwed).toBe(80) // unaffected by the EUR refund
+    expect(eur.clawback).toBe(40) // 50 * 0.8
+    expect(eur.netOwed).toBe(0)
+  })
+
+  it('#498: refund uses the transaction\'s own snapshotted split, same as a normal sale would', () => {
+    const result = computeOwedBalances(
+      [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 50 }],
+      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: 90, status: 'refunded' }],
+      [],
+    )
+    // Uses the 90% split in effect when the original sale happened, not the tenant's current 50%.
+    expect(balanceFor(result, 't1', 'usd')!.clawback).toBe(90)
   })
 })


### PR DESCRIPTION
## Description

Part of epic #493 (Phase 2 — payout money-accuracy). Branches directly off `master`, since #503/#504/#505 are all merged.

`markPayoutPaid` was a one-way ratchet: once a payout was recorded, nothing re-checked whether the underlying `transactions` it was based on later flipped to `refunded`. Since `getPayoutsOwed()` only ever queried `status = 'successful'`, a refunded transaction simply vanished from the calculation with no trace — `netOwed` would silently drop to `$0.00` for that tenant going forward, absorbing the loss with no record that a refund had happened.

## Changes made

- **`lib/payments/payouts-owed.ts`** — `PlatformSettledTxn` gained a `status: 'successful' | 'refunded'` field. `computeOwedBalances` now includes refunded transactions in the aggregation instead of relying on the caller to filter them out: a `refunded` transaction no longer contributes to `grossCollected`/`grossOwed`/`byProvider`, but its scaled amount (same split-percentage logic as any sale — snapshot-or-current) is added to a new `clawback` figure. `netOwed` is now `max(grossOwed - alreadyPaid - clawback, 0)`.
- **`CurrencyBalance`** gained a `clawback: number` field — always present and visible, even when `0`.
- **`app/actions/platform/payouts.ts`** — `getPayoutsOwed()` now selects `status` and queries `.in('status', ['successful', 'refunded'])` instead of `.eq('status', 'successful')`, and passes `status` through to `computeOwedBalances`.
- **`app/[locale]/platform/payouts/page.tsx`** — adds a "Clawback" column to the by-school table (shown as `−$X.XX` in red when non-zero, `—` otherwise) and a red banner above the table summarizing total clawback per currency whenever any tenant has one, so a refund-after-payout is visible rather than silently netted away.

## Type of change

- [x] Bug fix (money-accuracy — a refund on an already-paid-out sale previously vanished with no trace instead of reducing what's owed next cycle)

Closes #498 (Phase 2 sub-task of epic #493).

## Testing

- [x] `npx vitest run tests/unit/payouts-owed.test.ts` — 18/18 passing, including 4 new tests specific to #498 (refund-after-payout produces a visible clawback and reduces netOwed; clawback is reported even with nothing else outstanding; a refund in one currency doesn't clawback a balance in another currency; clawback uses the transaction's own snapshotted split, not the tenant's current one).
- [x] `npm run test:unit` — 277/277 passing, no regressions.
- [x] `npm run typecheck` — clean.
- [x] `npm run lint` on changed files — no new errors (one pre-existing unused-var warning in `payouts.ts` predates this change, unrelated to it).
- [x] `npm run build` — succeeds.
- [x] **Live-verified locally**: seeded a $100 USD PayPal sale with `status = 'refunded'` (80% split snapshot) for a tenant that already had an $80 manual payout recorded against it, then loaded `/platform/payouts` as a super admin. Screenshot attached below shows: Collected `$0.00` (the refunded sale no longer counts as collected), Paid so far `$80.00`, Clawback `−$80.00` in red, Owed `$0.00`, and the red clawback banner summarizing it above the table. Test data cleaned up afterward.

### QA verification steps

1. In a local Supabase shell, create a successful PayPal transaction for a tenant, record a manual payout against it via the "Mark as Paid" dialog on `/platform/payouts`.
2. Flip that transaction's `status` to `refunded` directly in the DB (simulating a later refund).
3. Reload `/platform/payouts` — confirm a red "Refund clawback" banner appears, the tenant's row shows a `−$X.XX` clawback figure, and "Owed" reflects the reduction (floored at `$0.00`, never negative).
4. Confirm the refunded transaction's amount is excluded from the "Collected" column (it never happened, from a bookkeeping standpoint) while still being visible via the clawback figure.

## Screenshot

Attached as a PR comment: the payouts page showing the clawback banner and table row for the refund-after-payout scenario.
