### PR TITLE
chore(payments): deploy manual-payouts + related migrations to cloud (#500)

### DIFF
--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -4397,10 +4397,13 @@ export type Database = {
           currency: string | null
           failed_at: string | null
           failure_reason: string | null
+          note: string | null
           paid_at: string | null
           payout_id: number
-          period_end: string
-          period_start: string
+          payout_method: string
+          period_end: string | null
+          period_start: string | null
+          recorded_by: string | null
           status: string
           stripe_metadata: Json | null
           stripe_payout_id: string | null
@@ -4412,10 +4415,13 @@ export type Database = {
           currency?: string | null
           failed_at?: string | null
           failure_reason?: string | null
+          note?: string | null
           paid_at?: string | null
           payout_id?: number
-          period_end: string
-          period_start: string
+          payout_method?: string
+          period_end?: string | null
+          period_start?: string | null
+          recorded_by?: string | null
           status?: string
           stripe_metadata?: Json | null
           stripe_payout_id?: string | null
@@ -4427,10 +4433,13 @@ export type Database = {
           currency?: string | null
           failed_at?: string | null
           failure_reason?: string | null
+          note?: string | null
           paid_at?: string | null
           payout_id?: number
-          period_end?: string
-          period_start?: string
+          payout_method?: string
+          period_end?: string | null
+          period_start?: string | null
+          recorded_by?: string | null
           status?: string
           stripe_metadata?: Json | null
           stripe_payout_id?: string | null
@@ -5911,6 +5920,7 @@ export type Database = {
           provider_charge_id: string | null
           provider_metadata: Json | null
           provider_subscription_id: string | null
+          school_percentage_snapshot: number | null
           settlement_base: number | null
           settlement_currency: string | null
           settlement_mint: string | null
@@ -5932,6 +5942,7 @@ export type Database = {
           provider_charge_id?: string | null
           provider_metadata?: Json | null
           provider_subscription_id?: string | null
+          school_percentage_snapshot?: number | null
           settlement_base?: number | null
           settlement_currency?: string | null
           settlement_mint?: string | null
@@ -5953,6 +5964,7 @@ export type Database = {
           provider_charge_id?: string | null
           provider_metadata?: Json | null
           provider_subscription_id?: string | null
+          school_percentage_snapshot?: number | null
           settlement_base?: number | null
           settlement_currency?: string | null
           settlement_mint?: string | null

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -7,30 +7,10 @@ export type Json =
   | Json[]
 
 export type Database = {
-  graphql_public: {
-    Tables: {
-      [_ in never]: never
-    }
-    Views: {
-      [_ in never]: never
-    }
-    Functions: {
-      graphql: {
-        Args: {
-          extensions?: Json
-          operationName?: string
-          query?: string
-          variables?: Json
-        }
-        Returns: Json
-      }
-    }
-    Enums: {
-      [_ in never]: never
-    }
-    CompositeTypes: {
-      [_ in never]: never
-    }
+  // Allows to automatically instantiate createClient with right options
+  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
+  __InternalSupabase: {
+    PostgrestVersion: "12.0.2 (a4e00ff)"
   }
   public: {
     Tables: {
@@ -3796,6 +3776,7 @@ export type Database = {
           summary: string | null
           tenant_id: string
           title: string | null
+          transcript: Json | null
           updated_at: string | null
           video_url: string | null
         }
@@ -3816,6 +3797,7 @@ export type Database = {
           summary?: string | null
           tenant_id?: string
           title?: string | null
+          transcript?: Json | null
           updated_at?: string | null
           video_url?: string | null
         }
@@ -3836,6 +3818,7 @@ export type Database = {
           summary?: string | null
           tenant_id?: string
           title?: string | null
+          transcript?: Json | null
           updated_at?: string | null
           video_url?: string | null
         }
@@ -5463,6 +5446,7 @@ export type Database = {
           start_date: string
           subscription_id: number
           subscription_status: Database["public"]["Enums"]["subscription_status"]
+          superseded_by: number | null
           tenant_id: string
           transaction_id: number
           trial_end: string | null
@@ -5485,6 +5469,7 @@ export type Database = {
           start_date?: string
           subscription_id?: number
           subscription_status?: Database["public"]["Enums"]["subscription_status"]
+          superseded_by?: number | null
           tenant_id?: string
           transaction_id: number
           trial_end?: string | null
@@ -5507,6 +5492,7 @@ export type Database = {
           start_date?: string
           subscription_id?: number
           subscription_status?: Database["public"]["Enums"]["subscription_status"]
+          superseded_by?: number | null
           tenant_id?: string
           transaction_id?: number
           trial_end?: string | null
@@ -5520,6 +5506,13 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "plans"
             referencedColumns: ["plan_id"]
+          },
+          {
+            foreignKeyName: "subscriptions_superseded_by_fkey"
+            columns: ["superseded_by"]
+            isOneToOne: false
+            referencedRelation: "subscriptions"
+            referencedColumns: ["subscription_id"]
           },
           {
             foreignKeyName: "subscriptions_tenant_id_fkey"
@@ -6077,6 +6070,27 @@ export type Database = {
         }
         Relationships: []
       }
+      user_ui_state: {
+        Row: {
+          key: string
+          updated_at: string
+          user_id: string
+          value: Json
+        }
+        Insert: {
+          key: string
+          updated_at?: string
+          user_id: string
+          value: Json
+        }
+        Update: {
+          key?: string
+          updated_at?: string
+          user_id?: string
+          value?: Json
+        }
+        Relationships: []
+      }
       webhook_events: {
         Row: {
           error: string | null
@@ -6271,6 +6285,38 @@ export type Database = {
         Args: { _plan_id: number; _user_id: string }
         Returns: undefined
       }
+      change_subscription_plan: {
+        Args: { _new_plan_id: number }
+        Returns: {
+          cancel_at: string
+          cancel_at_period_end: boolean | null
+          canceled_at: string | null
+          created: string
+          current_period_end: string
+          current_period_start: string
+          end_date: string
+          ended_at: string | null
+          payment_provider: string
+          plan_id: number
+          provider_metadata: Json | null
+          provider_subscription_id: string | null
+          start_date: string
+          subscription_id: number
+          subscription_status: Database["public"]["Enums"]["subscription_status"]
+          superseded_by: number | null
+          tenant_id: string
+          transaction_id: number
+          trial_end: string | null
+          trial_start: string | null
+          user_id: string
+        }
+        SetofOptions: {
+          from: "*"
+          to: "subscriptions"
+          isOneToOne: true
+          isSetofReturn: false
+        }
+      }
       check_and_issue_certificate: {
         Args: { p_course_id: number; p_user_id: string }
         Returns: Json
@@ -6385,7 +6431,6 @@ export type Database = {
         Args: { _plan_id: number; _user_id: string }
         Returns: undefined
       }
-      handle_manual_subscription_expiry: { Args: never; Returns: undefined }
       handle_new_subscription: {
         Args: {
           _plan_id: number
@@ -6688,9 +6733,6 @@ export type CompositeTypes<
     : never
 
 export const Constants = {
-  graphql_public: {
-    Enums: {},
-  },
   public: {
     Enums: {
       ai_sender_type: [
@@ -6752,4 +6794,3 @@ export const Constants = {
     },
   },
 } as const
-


### PR DESCRIPTION
## Description

Deploys `20260724120000_manual_payouts.sql` to the cloud Supabase project (per #500) and regenerates `lib/database.types.ts` for the columns it adds.

While smoke-testing, found that `/platform/payouts` (`getPayoutsOwed()` in `app/actions/platform/payouts.ts`) already selects `transactions.school_percentage_snapshot` — a column from `20260724140000_transaction_split_snapshot.sql` (#496, merged to master) that was also cloud-only-missing. That means the payouts page was erroring in production before this change. `tenants.access_cutoff_at` (`20260724130000_access_cutoff_enforcement.sql`, #494) was in the same state. All three are simple additive `ALTER TABLE`s with no interdependency, so — after confirming with the repo owner — this PR deploys all three together rather than leaving production broken between #500 and separate deploy issues for #494/#496 (neither of which exists yet).

## Changes made

- Applied to the cloud project: `manual_payouts`, `access_cutoff_enforcement`, `transaction_split_snapshot`.
- Repaired cloud migration history (`supabase_migrations.schema_migrations`) so each version/name matches the repo filename exactly.
- Regenerated `lib/database.types.ts` fully against cloud (two commits: the first applied just the affected columns for these three migrations, the second did a full regen to also fix pre-existing type drift found while reviewing the diff — see below). No code changes needed elsewhere; `npm run typecheck`, `lint`, and `build` all pass clean.
- The full regen also fixes drift unrelated to any migration in this PR, already deployed to both local and cloud but never previously regenerated into the committed file: adds `lessons.transcript`, `subscriptions.superseded_by` (+ FK), the `user_ui_state` table, and the `change_subscription_plan` RPC return shape; removes the dead `handle_manual_subscription_expiry` function type (dropped by migration `20260719130000`, confirmed no live callers — replaced by the app-layer cron at `app/api/cron/expire-platform-subscriptions/route.ts`); and picks up the current typegen output format (adds the `__InternalSupabase` version marker, drops the empty `graphql_public` schema block — nothing in the codebase references it).

## Type of change

- [x] Chore (infrastructure/deployment)
- [x] Fix (production `/platform/payouts` was erroring on the missing `school_percentage_snapshot` column)

## Relationship

Closes #500

## Testing

- [x] `npm run typecheck` — passes clean on the changed file.
- [x] Cloud schema verified post-migration: `payouts` has `payout_method`/`note`/`recorded_by`, `period_start`/`period_end` nullable — matches local.
- [x] `mcp__supabase-cloud__get_advisors(security)` — no new findings referencing `payouts`, `access_cutoff_at`, `has_course_access`, or `transactions`. RLS policies on `payouts` are row-level only (`tenant_id`/`is_super_admin`), unaffected by new columns.
- [x] Ran the exact query shape from `getPayoutsOwed()` against cloud — executes cleanly (0 rows currently, no live PayPal/Binance/LemonSqueezy transactions in production yet, but no longer errors on the missing column).
- [x] Ran the exact insert shape from `markPayoutPaid()` against cloud inside `BEGIN...ROLLBACK` — succeeds, no data persisted (`count(*) = 0` confirmed after).
- [ ] No E2E/browser test — this is a pure backend/database deployment change, nothing new to click through. Existing `/platform/payouts` UI code is unchanged.

### QA verification steps

1. As a super admin, load `/platform/payouts` in production (or against the cloud project) and confirm the page renders without a server error (previously would 500 on the missing `school_percentage_snapshot` column).
2. Confirm the "payouts owed" table shows expected balances per tenant/currency.
3. Record a manual payout via "Mark as Paid" for a tenant with a nonzero balance; confirm the row appears in `payouts` with `payout_method = 'manual'`, `recorded_by` set to your user id, and (if provided) `note` populated.
4. Confirm `supabase migration list` (or `mcp__supabase-cloud__list_migrations`) shows `20260724120000_manual_payouts`, `20260724130000_access_cutoff_enforcement`, and `20260724140000_transaction_split_snapshot` all present with versions matching the repo filenames.
