### PR TITLE
fix(payments): stop double-subtracting refunds from payout balances (#511)

### DIFF
--- a/app/[locale]/platform/payouts/page.tsx
+++ b/app/[locale]/platform/payouts/page.tsx
@@ -140,8 +140,9 @@ export default async function PlatformPayoutsPage() {
           data-testid="payouts-clawback-banner"
         >
           <span className="font-medium">Refund clawback: {formatByCurrency(totalClawbackByCurrency)}.</span>{' '}
-          Some already-paid-out transactions were later refunded — this amount reduces what&apos;s
-          currently owed rather than being paid again.
+          That much of what you already paid out was for sales that have since been refunded. It is
+          already netted out of the balances below, so don&apos;t collect it again — nothing extra to
+          do here.
         </div>
       )}
 
@@ -163,7 +164,7 @@ export default async function PlatformPayoutsPage() {
                     <th className="pb-2 text-right font-medium">Collected</th>
                     <th className="pb-2 text-right font-medium">School %</th>
                     <th className="pb-2 text-right font-medium">Paid so far</th>
-                    <th className="pb-2 text-right font-medium">Clawback</th>
+                    <th className="pb-2 text-right font-medium">Of which refunded</th>
                     <th className="pb-2 text-right font-medium">Owed</th>
                     <th className="pb-2 text-right font-medium"></th>
                   </tr>
@@ -187,8 +188,14 @@ export default async function PlatformPayoutsPage() {
                       </td>
                       <td className="py-2.5 text-right tabular-nums">
                         {r.clawback > 0 ? (
-                          <span className="font-medium text-red-600 dark:text-red-400">
-                            −{money(r.clawback, r.currency)}
+                          // Not a deduction column: this is the slice of "Paid so far"
+                          // that covered sales later refunded. "Owed" already accounts
+                          // for it (#511), so it carries no minus sign.
+                          <span
+                            className="font-medium text-red-600 dark:text-red-400"
+                            title="Part of what was already paid out, for sales later refunded. Already reflected in Owed."
+                          >
+                            {money(r.clawback, r.currency)}
                           </span>
                         ) : (
                           <span className="text-muted-foreground">—</span>

--- a/app/actions/platform/payouts.ts
+++ b/app/actions/platform/payouts.ts
@@ -29,10 +29,14 @@ export async function getPayoutsOwed(): Promise<TenantOwed[]> {
     admin.from('revenue_splits').select('tenant_id, school_percentage'),
     admin
       .from('transactions')
-      .select('tenant_id, payment_provider, amount, currency, school_percentage_snapshot, status')
+      .select('tenant_id, payment_provider, amount, currency, school_percentage_snapshot, status, transaction_date')
       .in('status', ['successful', 'refunded'])
       .in('payment_provider', PLATFORM_SETTLED_PROVIDERS),
-    admin.from('payouts').select('tenant_id, amount, currency').eq('payout_method', 'manual').eq('status', 'paid'),
+    admin
+      .from('payouts')
+      .select('tenant_id, amount, currency, period_end, paid_at, created_at')
+      .eq('payout_method', 'manual')
+      .eq('status', 'paid'),
   ])
 
   const schoolPercentageByTenant = new Map(
@@ -54,8 +58,17 @@ export async function getPayoutsOwed(): Promise<TenantOwed[]> {
         currency: t.currency || 'usd',
         schoolPercentageSnapshot: t.school_percentage_snapshot as number | null,
         status: t.status as 'successful' | 'refunded',
+        transactionDate: t.transaction_date as string | null,
       })),
-    (paid || []).map((p) => ({ tenantId: p.tenant_id, amount: p.amount, currency: p.currency || 'usd' }))
+    // `period_end` is the exact "covered through" when a payout recorded a period;
+    // manually recorded ones leave it null today, so fall back to when the money
+    // actually moved (issue #511).
+    (paid || []).map((p) => ({
+      tenantId: p.tenant_id,
+      amount: p.amount,
+      currency: p.currency || 'usd',
+      coveredThrough: p.period_end ?? p.paid_at ?? p.created_at,
+    }))
   )
 }
 

--- a/lib/payments/payouts-owed.ts
+++ b/lib/payments/payouts-owed.ts
@@ -24,13 +24,40 @@
  * `transactions.currency` and `payouts.currency` are trusted as given; this
  * module does no currency conversion, only grouping.
  *
- * Refunds/chargebacks (issue #498): a transaction can flip from `successful`
- * to `refunded` after its payout was already recorded. Callers pass refunded
- * transactions through alongside successful ones (tagged via `status`); this
- * module scales each refund by the same split percentage a sale would've
- * used and surfaces it as a distinct `clawback` figure, subtracted from
- * `netOwed` on the next cycle rather than silently vanishing from
- * `grossCollected`/`grossOwed` with no trace.
+ * Refunds/chargebacks (issues #498, #511): a transaction can flip from
+ * `successful` to `refunded` after its payout was already recorded. Callers
+ * pass refunded transactions through alongside successful ones (tagged via
+ * `status`), and refunded sales are simply left out of
+ * `grossCollected`/`grossOwed`.
+ *
+ * That exclusion is the ONLY place a refund moves `netOwed`, and it is
+ * sufficient on its own: `alreadyPaid` is the all-time sum of recorded
+ * payouts, so it still contains whatever was paid out for a sale that later
+ * flipped to `refunded`. Dropping the sale from `grossOwed` while leaving its
+ * payout inside `alreadyPaid` recovers the overpayment automatically —
+ * 1000 successful plus a refunded 100 at an 80% split with 80 already paid
+ * gives `800 - 80 = 720`, the correct figure. Subtracting the refund a second
+ * time as a `clawback` term (as this module did before #511) understated the
+ * balance and also penalised refunds that had never been paid out at all.
+ *
+ * `clawback` therefore survives as a REPORTING-ONLY figure and is not part of
+ * the `netOwed` arithmetic. It answers "how much of what we already paid this
+ * school was for sales that have since been refunded?", so an operator can
+ * see why a balance dropped. Because it is already netted out of `netOwed` via
+ * `alreadyPaid`, it must never be collected a second time.
+ *
+ * A refund only counts toward `clawback` when a payout plausibly covered it:
+ * its `transactionDate` must fall at or before the latest `coveredThrough` of
+ * that tenant's payouts IN THE SAME CURRENCY. This is a heuristic — the module
+ * has no record of which transactions a given payout settled — so it can
+ * overstate `clawback` when a payout deliberately skipped a sale. That
+ * inaccuracy cannot move `netOwed`; making it exact needs real payout-to-
+ * transaction linkage on `payouts`.
+ *
+ * `netOwed` keeps its `Math.max(…, 0)` floor, so a school overpaid beyond its
+ * outstanding balance reads 0 rather than a negative — only a payout row moves
+ * money, and this view never invents a reverse one. The unrecovered remainder
+ * in that situation is visible through `clawback`.
  */
 
 /** Used when a tenant has no `revenue_splits` row yet (shouldn't normally happen, but keeps callers from dividing by an absent value). */
@@ -52,8 +79,15 @@ export interface PlatformSettledTxn {
   currency: string
   /** revenue_splits.school_percentage in effect when this transaction was created (0–100), or null for pre-#496 rows. */
   schoolPercentageSnapshot: number | null
-  /** 'successful' contributes to grossCollected/grossOwed as normal; 'refunded' contributes its scaled amount to `clawback` instead (issue #498). */
+  /** 'successful' contributes to grossCollected/grossOwed as normal; 'refunded' is left out of both (issues #498, #511). */
   status: 'successful' | 'refunded'
+  /**
+   * `transactions.transaction_date` (ISO 8601) — that table has no `created_at`.
+   * Only read for refunded rows, to decide whether a payout plausibly covered
+   * this sale before it was refunded (issue #511). Null means "unknown", which
+   * is treated as not covered rather than assumed covered.
+   */
+  transactionDate: string | null
 }
 
 export interface ManualPayoutRecord {
@@ -61,6 +95,14 @@ export interface ManualPayoutRecord {
   amount: number
   /** payouts.currency — the currency this payout was actually recorded in. */
   currency: string
+  /**
+   * The point in time this payout is understood to settle up to (ISO 8601) —
+   * `payouts.period_end` when the payout recorded one, else `paid_at`, else
+   * `created_at`. Refunded sales dated at or before it are counted as having
+   * been paid out already (issue #511). Null means "unknown", and covers
+   * nothing.
+   */
+  coveredThrough: string | null
 }
 
 export interface CurrencyBalance {
@@ -71,9 +113,15 @@ export interface CurrencyBalance {
   grossOwed: number
   /** Sum of manual payouts already recorded as paid in this currency. */
   alreadyPaid: number
-  /** Sum over refunded transactions of amount × (that transaction's snapshotted split, or the tenant's current split) — money already paid out for sales that later got refunded (issue #498). */
+  /**
+   * REPORTING ONLY — not a term in `netOwed` (issue #511). Sum, over refunded
+   * transactions a payout plausibly covered, of amount × (that transaction's
+   * snapshotted split, or the tenant's current split): how much of what was
+   * already paid to this school was for sales that have since been refunded.
+   * `alreadyPaid` already accounts for it, so it must not be recovered again.
+   */
   clawback: number
-  /** max(grossOwed - alreadyPaid - clawback, 0) — what's currently owed in this currency. */
+  /** max(grossOwed - alreadyPaid, 0) — what's currently owed in this currency. */
   netOwed: number
   /** Per-provider breakdown of grossCollected in this currency. */
   byProvider: Record<string, number>
@@ -111,20 +159,11 @@ export function computeOwedBalances(
     return entry
   }
 
-  for (const txn of txns) {
-    const entry = bucket(txn.tenantId, txn.currency)
-    const effectivePercentage = txn.schoolPercentageSnapshot ?? schoolPercentageByTenant.get(txn.tenantId) ?? 0
-    const scaledAmount = (txn.amount * effectivePercentage) / 100
-    if (txn.status === 'refunded') {
-      entry.clawback += scaledAmount
-      continue
-    }
-    entry.grossCollected += txn.amount
-    entry.grossOwed += scaledAmount
-    entry.byProvider[txn.paymentProvider] = (entry.byProvider[txn.paymentProvider] ?? 0) + txn.amount
-  }
-
   const paidByTenantCurrency = new Map<string, Map<string, number>>()
+  // tenantId -> currency -> latest `coveredThrough` across that currency's payouts.
+  // Payouts are cumulative and all-time, so the latest one bounds everything any
+  // payout could have settled.
+  const coveredThroughByTenantCurrency = new Map<string, Map<string, number>>()
   for (const payout of paidPayouts) {
     let byCurrency = paidByTenantCurrency.get(payout.tenantId)
     if (!byCurrency) {
@@ -132,6 +171,52 @@ export function computeOwedBalances(
       paidByTenantCurrency.set(payout.tenantId, byCurrency)
     }
     byCurrency.set(payout.currency, (byCurrency.get(payout.currency) ?? 0) + payout.amount)
+
+    if (payout.coveredThrough) {
+      // Parsed rather than string-compared: `paid_at` and `period_end` reach us
+      // as whatever offset format their source used ('…Z' vs '…+00:00'), which
+      // lexicographic comparison gets wrong across formats.
+      const covered = Date.parse(payout.coveredThrough)
+      if (Number.isNaN(covered)) continue
+      let coveredByCurrency = coveredThroughByTenantCurrency.get(payout.tenantId)
+      if (!coveredByCurrency) {
+        coveredByCurrency = new Map()
+        coveredThroughByTenantCurrency.set(payout.tenantId, coveredByCurrency)
+      }
+      const previous = coveredByCurrency.get(payout.currency)
+      if (previous == null || covered > previous) {
+        coveredByCurrency.set(payout.currency, covered)
+      }
+    }
+  }
+
+  /**
+   * True when a payout in the same tenant AND currency settled up to a point at
+   * or after this sale, so its share plausibly went out before the refund. A
+   * missing date on either side answers false — an unjustifiable clawback is
+   * worse than a missing one (issue #511).
+   */
+  function wasPlausiblyPaidOut(txn: PlatformSettledTxn) {
+    if (!txn.transactionDate) return false
+    const soldAt = Date.parse(txn.transactionDate)
+    if (Number.isNaN(soldAt)) return false
+    const coveredThrough = coveredThroughByTenantCurrency.get(txn.tenantId)?.get(txn.currency)
+    return coveredThrough != null && soldAt <= coveredThrough
+  }
+
+  for (const txn of txns) {
+    const entry = bucket(txn.tenantId, txn.currency)
+    const effectivePercentage = txn.schoolPercentageSnapshot ?? schoolPercentageByTenant.get(txn.tenantId) ?? 0
+    const scaledAmount = (txn.amount * effectivePercentage) / 100
+    if (txn.status === 'refunded') {
+      // Reporting only. Leaving the sale out of grossOwed below is what actually
+      // corrects the balance; this just names the amount for the operator.
+      if (wasPlausiblyPaidOut(txn)) entry.clawback += scaledAmount
+      continue
+    }
+    entry.grossCollected += txn.amount
+    entry.grossOwed += scaledAmount
+    entry.byProvider[txn.paymentProvider] = (entry.byProvider[txn.paymentProvider] ?? 0) + txn.amount
   }
 
   return tenants.map((tenant) => {
@@ -148,7 +233,11 @@ export function computeOwedBalances(
       const grossOwed = entry?.grossOwed ?? 0
       const clawback = entry?.clawback ?? 0
       const alreadyPaid = paid.get(currency) ?? 0
-      const netOwed = Math.max(grossOwed - alreadyPaid - clawback, 0)
+      // `clawback` is deliberately absent here — refunded sales are already out
+      // of `grossOwed`, and their payouts are still inside `alreadyPaid`, so the
+      // overpayment nets out on its own. Subtracting it again double-counted the
+      // refund (issue #511).
+      const netOwed = Math.max(grossOwed - alreadyPaid, 0)
       return {
         currency,
         grossCollected,

--- a/tests/unit/payouts-owed.test.ts
+++ b/tests/unit/payouts-owed.test.ts
@@ -9,7 +9,7 @@ describe('computeOwedBalances', () => {
   it('single tenant, single provider, single currency, nothing paid yet', () => {
     const result = computeOwedBalances(
       [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 80 }],
-      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null , status: 'successful' }],
+      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null , status: 'successful', transactionDate: null }],
       [],
     )
     expect(result).toHaveLength(1)
@@ -30,9 +30,9 @@ describe('computeOwedBalances', () => {
     const result = computeOwedBalances(
       [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 80 }],
       [
-        { tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null , status: 'successful' },
-        { tenantId: 't1', paymentProvider: 'paypal', amount: 50, currency: 'usd', schoolPercentageSnapshot: null , status: 'successful' },
-        { tenantId: 't1', paymentProvider: 'binance', amount: 25, currency: 'usd', schoolPercentageSnapshot: null , status: 'successful' },
+        { tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null , status: 'successful', transactionDate: null },
+        { tenantId: 't1', paymentProvider: 'paypal', amount: 50, currency: 'usd', schoolPercentageSnapshot: null , status: 'successful', transactionDate: null },
+        { tenantId: 't1', paymentProvider: 'binance', amount: 25, currency: 'usd', schoolPercentageSnapshot: null , status: 'successful', transactionDate: null },
       ],
       [],
     )
@@ -46,8 +46,8 @@ describe('computeOwedBalances', () => {
     const result = computeOwedBalances(
       [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 80 }],
       [
-        { tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null , status: 'successful' },
-        { tenantId: 't1', paymentProvider: 'paypal', amount: 80, currency: 'eur', schoolPercentageSnapshot: null , status: 'successful' },
+        { tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null , status: 'successful', transactionDate: null },
+        { tenantId: 't1', paymentProvider: 'paypal', amount: 80, currency: 'eur', schoolPercentageSnapshot: null , status: 'successful', transactionDate: null },
       ],
       [],
     )
@@ -64,8 +64,8 @@ describe('computeOwedBalances', () => {
   it('subtracts already-paid manual payouts from the gross owed, in the matching currency only', () => {
     const result = computeOwedBalances(
       [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 80 }],
-      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null , status: 'successful' }],
-      [{ tenantId: 't1', amount: 30, currency: 'usd' }],
+      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null , status: 'successful', transactionDate: null }],
+      [{ tenantId: 't1', amount: 30, currency: 'usd', coveredThrough: null }],
     )
     const usd = balanceFor(result, 't1', 'usd')!
     expect(usd.grossOwed).toBe(80)
@@ -76,8 +76,8 @@ describe('computeOwedBalances', () => {
   it('#497: a EUR payout does not reduce what is owed in USD', () => {
     const result = computeOwedBalances(
       [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 80 }],
-      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null , status: 'successful' }],
-      [{ tenantId: 't1', amount: 30, currency: 'eur' }],
+      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null , status: 'successful', transactionDate: null }],
+      [{ tenantId: 't1', amount: 30, currency: 'eur', coveredThrough: null }],
     )
     const usd = balanceFor(result, 't1', 'usd')!
     expect(usd.netOwed).toBe(80) // unaffected by the EUR payout
@@ -88,8 +88,8 @@ describe('computeOwedBalances', () => {
   it('floors netOwed at 0 when payouts exceed what was owed (overpay/rounding)', () => {
     const result = computeOwedBalances(
       [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 80 }],
-      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null , status: 'successful' }],
-      [{ tenantId: 't1', amount: 500, currency: 'usd' }],
+      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null , status: 'successful', transactionDate: null }],
+      [{ tenantId: 't1', amount: 500, currency: 'usd', coveredThrough: null }],
     )
     expect(balanceFor(result, 't1', 'usd')!.netOwed).toBe(0)
   })
@@ -106,7 +106,7 @@ describe('computeOwedBalances', () => {
   it('boundary schoolPercentage=0 → platform keeps everything, nothing owed', () => {
     const result = computeOwedBalances(
       [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 0 }],
-      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null , status: 'successful' }],
+      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null , status: 'successful', transactionDate: null }],
       [],
     )
     expect(balanceFor(result, 't1', 'usd')!.netOwed).toBe(0)
@@ -115,7 +115,7 @@ describe('computeOwedBalances', () => {
   it('boundary schoolPercentage=100 → school is owed the full amount collected', () => {
     const result = computeOwedBalances(
       [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 100 }],
-      [{ tenantId: 't1', paymentProvider: 'lemonsqueezy', amount: 100, currency: 'usd', schoolPercentageSnapshot: null , status: 'successful' }],
+      [{ tenantId: 't1', paymentProvider: 'lemonsqueezy', amount: 100, currency: 'usd', schoolPercentageSnapshot: null , status: 'successful', transactionDate: null }],
       [],
     )
     expect(balanceFor(result, 't1', 'usd')!.netOwed).toBe(100)
@@ -128,10 +128,10 @@ describe('computeOwedBalances', () => {
         { tenantId: 't2', tenantName: 'School B', schoolPercentage: 90 },
       ],
       [
-        { tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null , status: 'successful' },
-        { tenantId: 't2', paymentProvider: 'paypal', amount: 200, currency: 'usd', schoolPercentageSnapshot: null , status: 'successful' },
+        { tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null , status: 'successful', transactionDate: null },
+        { tenantId: 't2', paymentProvider: 'paypal', amount: 200, currency: 'usd', schoolPercentageSnapshot: null , status: 'successful', transactionDate: null },
       ],
-      [{ tenantId: 't1', amount: 10, currency: 'usd' }],
+      [{ tenantId: 't1', amount: 10, currency: 'usd', coveredThrough: null }],
     )
     expect(balanceFor(result, 't1', 'usd')!.netOwed).toBe(70) // 100*0.8 - 10
     expect(balanceFor(result, 't2', 'usd')!.netOwed).toBe(180) // 200*0.9, unaffected by t1's payout
@@ -143,7 +143,7 @@ describe('computeOwedBalances', () => {
         { tenantId: 't1', tenantName: 'School A', schoolPercentage: 80 },
         { tenantId: 't2', tenantName: 'School B', schoolPercentage: 80 },
       ],
-      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null , status: 'successful' }],
+      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null , status: 'successful', transactionDate: null }],
       [],
     )
     expect(result).toHaveLength(2)
@@ -153,7 +153,7 @@ describe('computeOwedBalances', () => {
   it('#496: a plan change after a sale does not retroactively reprice it — uses the snapshotted split, not the current one', () => {
     const result = computeOwedBalances(
       [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 90 }],
-      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 10000, currency: 'usd', schoolPercentageSnapshot: 100 , status: 'successful' }],
+      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 10000, currency: 'usd', schoolPercentageSnapshot: 100 , status: 'successful', transactionDate: null }],
       [],
     )
     expect(balanceFor(result, 't1', 'usd')!.grossOwed).toBe(10000)
@@ -162,7 +162,7 @@ describe('computeOwedBalances', () => {
   it('#496: transactions predating the snapshot column fall back to the tenant\'s current split', () => {
     const result = computeOwedBalances(
       [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 80 }],
-      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null , status: 'successful' }],
+      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null , status: 'successful', transactionDate: null }],
       [],
     )
     expect(balanceFor(result, 't1', 'usd')!.grossOwed).toBe(80)
@@ -172,8 +172,8 @@ describe('computeOwedBalances', () => {
     const result = computeOwedBalances(
       [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 90 }],
       [
-        { tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: 80 , status: 'successful' },
-        { tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null , status: 'successful' },
+        { tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: 80 , status: 'successful', transactionDate: null },
+        { tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null , status: 'successful', transactionDate: null },
       ],
       [],
     )
@@ -182,62 +182,167 @@ describe('computeOwedBalances', () => {
     expect(usd.grossOwed).toBe(80 + 90) // 100*0.8 + 100*0.9
   })
 
-  it('#498: a transaction refunded after being paid out reduces what is owed on the next cycle via a visible clawback', () => {
+  // #511: the four #498 cases below used to assert the double-subtraction as
+  // intended behavior. Refunded sales now leave `grossOwed` and nothing else —
+  // `clawback` is reporting-only and never a term in `netOwed`.
+  //
+  // Fixed dates so the "was this refund plausibly paid out?" comparison is
+  // deterministic. A refund counts toward `clawback` only when a payout in the
+  // same currency settled up to a point at or after the sale.
+  const SOLD_AT = '2026-01-10T00:00:00.000Z'
+  const PAID_AFTER_SALE = '2026-02-01T00:00:00.000Z'
+  const PAID_BEFORE_SALE = '2026-01-01T00:00:00.000Z'
+
+  it('#511: a refund already paid out is netted via alreadyPaid, not subtracted a second time as clawback', () => {
     const result = computeOwedBalances(
       [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 80 }],
       [
-        { tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null, status: 'successful' },
-        { tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null, status: 'refunded' },
+        // Asymmetric on purpose: the answer sits far from 0, so the Math.max floor
+        // cannot mask a sign error the way it did in the old 100/100/80 fixture.
+        { tenantId: 't1', paymentProvider: 'paypal', amount: 1000, currency: 'usd', schoolPercentageSnapshot: null, status: 'successful', transactionDate: SOLD_AT },
+        { tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null, status: 'refunded', transactionDate: SOLD_AT },
       ],
-      [{ tenantId: 't1', amount: 80, currency: 'usd' }],
+      [{ tenantId: 't1', amount: 80, currency: 'usd', coveredThrough: PAID_AFTER_SALE }],
     )
     const usd = balanceFor(result, 't1', 'usd')!
     // Only the still-successful sale counts toward gross collected/owed.
-    expect(usd.grossCollected).toBe(100)
-    expect(usd.grossOwed).toBe(80)
+    expect(usd.grossCollected).toBe(1000)
+    expect(usd.grossOwed).toBe(800)
     expect(usd.alreadyPaid).toBe(80)
-    // The refunded sale's scaled share is a distinct, visible clawback — not silently netted away.
+    // Visible, because a payout plausibly covered the refunded sale...
     expect(usd.clawback).toBe(80) // 100 * 0.8
-    expect(usd.netOwed).toBe(0) // max(80 - 80 - 80, 0)
+    // ...but reporting only: 80% of net sales, minus what was already paid.
+    expect(usd.netOwed).toBe(720) // was 640 before #511
   })
 
-  it('#498: clawback is not silently absorbed — it is reported separately from grossOwed/alreadyPaid', () => {
+  it('#511: a refund that was never paid out does not reduce the balance at all', () => {
     const result = computeOwedBalances(
       [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 80 }],
-      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null, status: 'refunded' }],
+      [
+        { tenantId: 't1', paymentProvider: 'paypal', amount: 1000, currency: 'usd', schoolPercentageSnapshot: null, status: 'successful', transactionDate: SOLD_AT },
+        { tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null, status: 'refunded', transactionDate: SOLD_AT },
+      ],
+      [], // nothing was ever paid out, so there is nothing to claw back
+    )
+    const usd = balanceFor(result, 't1', 'usd')!
+    expect(usd.clawback).toBe(0)
+    expect(usd.netOwed).toBe(800) // was 720 before #511
+  })
+
+  it('#511: a refunded sale made after the last payout is not clawed back', () => {
+    const result = computeOwedBalances(
+      [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 80 }],
+      [
+        { tenantId: 't1', paymentProvider: 'paypal', amount: 500, currency: 'usd', schoolPercentageSnapshot: null, status: 'successful', transactionDate: SOLD_AT },
+        { tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null, status: 'refunded', transactionDate: SOLD_AT },
+      ],
+      // Settled up to BEFORE the refunded sale even happened — it cannot have paid for it.
+      [{ tenantId: 't1', amount: 120, currency: 'usd', coveredThrough: PAID_BEFORE_SALE }],
+    )
+    const usd = balanceFor(result, 't1', 'usd')!
+    expect(usd.clawback).toBe(0)
+    expect(usd.netOwed).toBe(280) // 500*0.8 - 120
+  })
+
+  it('#511: a payout in another currency cannot make a refund count as clawed back', () => {
+    const result = computeOwedBalances(
+      [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 80 }],
+      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null, status: 'refunded', transactionDate: SOLD_AT }],
+      [{ tenantId: 't1', amount: 80, currency: 'eur', coveredThrough: PAID_AFTER_SALE }],
+    )
+    expect(balanceFor(result, 't1', 'usd')!.clawback).toBe(0)
+  })
+
+  it('#511: an undated refund is not clawed back — an unjustifiable clawback is worse than a missing one', () => {
+    const result = computeOwedBalances(
+      [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 80 }],
+      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null, status: 'refunded', transactionDate: null }],
+      [{ tenantId: 't1', amount: 80, currency: 'usd', coveredThrough: PAID_AFTER_SALE }],
+    )
+    expect(balanceFor(result, 't1', 'usd')!.clawback).toBe(0)
+  })
+
+  it('#511: a payout with no recorded date covers nothing', () => {
+    const result = computeOwedBalances(
+      [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 80 }],
+      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null, status: 'refunded', transactionDate: SOLD_AT }],
+      [{ tenantId: 't1', amount: 80, currency: 'usd', coveredThrough: null }],
+    )
+    expect(balanceFor(result, 't1', 'usd')!.clawback).toBe(0)
+  })
+
+  it('#511: the LATEST payout date bounds the clawback window, not the first one', () => {
+    const result = computeOwedBalances(
+      [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 80 }],
+      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null, status: 'refunded', transactionDate: SOLD_AT }],
+      [
+        { tenantId: 't1', amount: 40, currency: 'usd', coveredThrough: PAID_BEFORE_SALE },
+        { tenantId: 't1', amount: 40, currency: 'usd', coveredThrough: PAID_AFTER_SALE },
+      ],
+    )
+    expect(balanceFor(result, 't1', 'usd')!.clawback).toBe(80)
+  })
+
+  it('#511: mixed offset formats compare by instant, not lexicographically', () => {
+    const result = computeOwedBalances(
+      [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 80 }],
+      // '+00:00' sorts before 'Z' as a string but is the LATER instant here.
+      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null, status: 'refunded', transactionDate: '2026-01-10T00:00:00+00:00' }],
+      [{ tenantId: 't1', amount: 80, currency: 'usd', coveredThrough: '2026-01-09T00:00:00.000Z' }],
+    )
+    expect(balanceFor(result, 't1', 'usd')!.clawback).toBe(0)
+  })
+
+  it('#498/#511: a refunded sale is excluded from grossCollected/grossOwed but still yields a balance row', () => {
+    const result = computeOwedBalances(
+      [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 80 }],
+      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null, status: 'refunded', transactionDate: SOLD_AT }],
       [],
     )
     const usd = balanceFor(result, 't1', 'usd')!
     expect(usd.grossCollected).toBe(0) // refunded sale never counted as collected
     expect(usd.grossOwed).toBe(0)
-    expect(usd.clawback).toBe(80) // still visible, even with nothing else outstanding
     expect(usd.netOwed).toBe(0)
+    expect(usd.byProvider).toEqual({}) // byProvider mirrors grossCollected
   })
 
-  it('#498: a refund in one currency does not clawback a balance owed in another currency', () => {
+  it('#498: a refund in one currency does not affect a balance owed in another currency', () => {
     const result = computeOwedBalances(
       [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 80 }],
       [
-        { tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null, status: 'successful' },
-        { tenantId: 't1', paymentProvider: 'paypal', amount: 50, currency: 'eur', schoolPercentageSnapshot: null, status: 'refunded' },
+        { tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: null, status: 'successful', transactionDate: SOLD_AT },
+        { tenantId: 't1', paymentProvider: 'paypal', amount: 50, currency: 'eur', schoolPercentageSnapshot: null, status: 'refunded', transactionDate: SOLD_AT },
       ],
-      [],
+      [{ tenantId: 't1', amount: 40, currency: 'eur', coveredThrough: PAID_AFTER_SALE }],
     )
     const usd = balanceFor(result, 't1', 'usd')!
     const eur = balanceFor(result, 't1', 'eur')!
     expect(usd.clawback).toBe(0)
     expect(usd.netOwed).toBe(80) // unaffected by the EUR refund
     expect(eur.clawback).toBe(40) // 50 * 0.8
-    expect(eur.netOwed).toBe(0)
+    expect(eur.netOwed).toBe(0) // nothing successful in EUR; the 40 paid is not re-owed
   })
 
   it('#498: refund uses the transaction\'s own snapshotted split, same as a normal sale would', () => {
     const result = computeOwedBalances(
       [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 50 }],
-      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: 90, status: 'refunded' }],
-      [],
+      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 100, currency: 'usd', schoolPercentageSnapshot: 90, status: 'refunded', transactionDate: SOLD_AT }],
+      [{ tenantId: 't1', amount: 90, currency: 'usd', coveredThrough: PAID_AFTER_SALE }],
     )
     // Uses the 90% split in effect when the original sale happened, not the tenant's current 50%.
     expect(balanceFor(result, 't1', 'usd')!.clawback).toBe(90)
+  })
+
+  it('#511: a fully refunded, fully paid-out school reads 0 owed, with the unrecovered share visible as clawback', () => {
+    const result = computeOwedBalances(
+      [{ tenantId: 't1', tenantName: 'School A', schoolPercentage: 80 }],
+      [{ tenantId: 't1', paymentProvider: 'paypal', amount: 250, currency: 'usd', schoolPercentageSnapshot: null, status: 'refunded', transactionDate: SOLD_AT }],
+      [{ tenantId: 't1', amount: 200, currency: 'usd', coveredThrough: PAID_AFTER_SALE }],
+    )
+    const usd = balanceFor(result, 't1', 'usd')!
+    // The floor holds: this view never invents a negative balance...
+    expect(usd.netOwed).toBe(0)
+    // ...so clawback is the only place the 200 still to recover shows up.
+    expect(usd.clawback).toBe(200) // 250 * 0.8
   })
 })


### PR DESCRIPTION
Closes #511.

Follow-up to #493 / #498. A refunded sale was being subtracted from a school's payout balance twice, and refunds that had never been paid out were clawed back anyway. Both understated what the platform owes.

## What was wrong

`computeOwedBalances` carried two mutually exclusive representations of a refund at the same time. The transaction loop excluded refunded sales from `grossCollected`/`grossOwed`, and then the balance builder subtracted their scaled share *again* as `clawback`:

```ts
const netOwed = Math.max(grossOwed - alreadyPaid - clawback, 0)
```

The second subtraction was never needed in the first place. `alreadyPaid` is the **all-time** sum of recorded payouts, so it still contains whatever was paid out for a sale that later flipped to `refunded`. Excluding that sale from `grossOwed` while leaving its payout inside `alreadyPaid` recovers the overpayment on its own — there is nothing left to claw back.

Separately, the module had no notion of *when* anything happened, so it could not distinguish a refund whose payout had already gone out from one that was never paid. It clawed back both.

## What changed

**1. One representation.** `netOwed` is now `max(grossOwed - alreadyPaid, 0)`. Refunded sales leaving `grossOwed` is the only place a refund moves the balance.

**2. `clawback` becomes reporting-only, and is gated on plausibility.** It answers "how much of what we already paid this school was for sales that have since been refunded?" — the number an operator needs to understand why a balance dropped, not a second deduction. A refund contributes only when a payout in the **same currency** settled up to a point at or after the sale. Refunds that were never paid out contribute nothing.

**3. Dates wired through, no migration needed.** `PlatformSettledTxn` gains `transactionDate`, `ManualPayoutRecord` gains `coveredThrough`.

- The column is `transactions.transaction_date` — that table has **no `created_at`**, so the issue's suggested comparison needed adjusting.
- `coveredThrough` reads `payouts.period_end ?? paid_at ?? created_at`. `period_end` is already in the schema and is exactly the `covered_through` the issue wished for; it is simply null for every manually recorded payout today, which falls back to `paid_at`. So the "exact" version the issue floated needs no new column — only for `markPayoutPaid` to start stamping a period, which I left alone as out of scope.
- Dates are compared as parsed instants, not strings: `paid_at` and `period_end` can reach us as `…Z` or `…+00:00` depending on their source, and `'+00:00' < 'Z'` lexicographically would silently invert the comparison.
- A missing or unparseable date on either side answers "not covered". An unjustifiable clawback is worse than a missing one.

**4. UI copy on `/platform/payouts`.** The banner and the column used to read as a deduction the viewer should apply themselves, and the cell carried a minus sign. It is no longer a deduction, so the column is now "Of which refunded", the value has no sign, and the banner says the amount is already netted out and must not be collected again.

## Scope notes

- **The `Math.max(…, 0)` floor stays.** A school overpaid beyond its outstanding balance still reads `0`, not a negative — only a payout row moves money, and this view should not invent a reverse one. In that situation the unrecovered remainder is visible only through `clawback`, which is now the figure's most useful job. Documented in the module docstring.
- **The plausibility test is a heuristic**, and the docstring says so. A payout dated after a refunded sale is assumed to have covered it, even though the module has no record of which transactions a payout settled. That can overstate `clawback` when a payout deliberately skipped a sale. It cannot move `netOwed`, so the blast radius is a reported number, not money. Making it exact needs real payout-to-transaction linkage on `payouts` — happy to file that if you want it.

## Testing

- `npm run test:unit` — **313 passed, 27 files**. `tests/unit/payouts-owed.test.ts` is 26 tests, up from 20.
- `npm run typecheck` — clean.
- `npm run build` — clean.
- `npx eslint` on the 4 changed files — clean. The one warning (`'supabase' is assigned a value but never used`, `app/actions/platform/payouts.ts:12`) predates this branch and is untouched.

The four `#498` tests encoded the double-subtraction as intended behavior, so they are **rewritten rather than deleted** — the diff is the correction. Their old fixture (100 successful / 100 refunded / 80 paid) landed on the right answer only because the clamp lifted `-80` to `0`, so every new case uses asymmetric amounts where the result sits far from the floor:

| Case | Before | After |
|---|---|---|
| Refund already paid out (1000 + 100 refunded @ 80%, 80 paid) | `netOwed 640` | **`netOwed 720`**, `clawback 80` |
| Refund never paid out (same, no payout) | `netOwed 720`, `clawback 80` | **`netOwed 800`**, `clawback 0` |

New coverage: refund sold *after* the last payout, payout in a different currency, undated refund, undated payout, latest-payout-wins across several payouts, mixed ISO offset formats, and a fully-refunded/fully-paid school where the floor holds and `clawback` is the only trace.

## Browser QA

Live against local Supabase on `default.lvh.me:3005` as super admin (`owner@e2etest.com`), seeded to the issue's worked example exactly — Default School at 80%, PayPal 1000 successful + 100 refunded, one manual payout of 80 recorded after the sale. Fixture rows deleted afterwards.

**Before — `master`, the bug reproducing at $640.00:**

![Payouts page on master showing Currently Owed 640.00](https://raw.githubusercontent.com/guillermoscript/lms-front/master/docs/images/511-payouts-before.png?v=2)

**After — the correct $720.00, with the reworded clawback banner and column:**

![Payouts page with the fix showing Currently Owed 720.00](https://raw.githubusercontent.com/guillermoscript/lms-front/master/docs/images/511-payouts-after.png?v=2)

**After, with the payout removed — case B: $800.00, no clawback banner, `—` in the refunded column:**

![Payouts page with no payout recorded showing Currently Owed 800.00](https://raw.githubusercontent.com/guillermoscript/lms-front/master/docs/images/511-payouts-after-no-payout.png?v=2)

No GIF: there is no interactive flow here — the change is one number on a static server-rendered table, and the three states above are the evidence.
