### PR TITLE
fix(payments): claw back refunded subscription payments (#515)

### DIFF
--- a/lib/payments/lemonsqueezy-provider.ts
+++ b/lib/payments/lemonsqueezy-provider.ts
@@ -300,9 +300,12 @@ export class LemonSqueezyProvider implements IPaymentProvider {
           raw: payload,
         }
 
-      // One-time order refund. Maps to `refund.succeeded`; the shared dispatcher
-      // flips the transaction → refunded and revokes the product entitlements
-      // (subscription refunds are handled by subscription_cancelled/expired).
+      // Order refund. Maps to `refund.succeeded`; the shared dispatcher flips the
+      // transaction → refunded so payouts stop counting it, and additionally
+      // revokes entitlements when the order was a one-time product. LS also
+      // raises `order_refunded` for a subscription's first order, and the
+      // dispatcher records the money for those too (#515) — subscription ACCESS
+      // stays owned by subscription_cancelled/expired.
       case 'order_refunded':
         return {
           type: 'refund.succeeded',

--- a/lib/payments/webhook-dispatch.ts
+++ b/lib/payments/webhook-dispatch.ts
@@ -212,12 +212,29 @@ export async function dispatchBillingEvent(
     }
 
     case 'refund.succeeded': {
-      // One-time order refund (Lemon Squeezy `order_refunded`). Mirrors the
-      // Stripe Connect route's charge.refunded product path: flip → refunded and
-      // EXPLICITLY revoke the product entitlements — no trigger does this for
-      // products (trigger_manage_transactions only acts on successful/failed).
-      // Subscription refunds are owned by subscription.canceled/expired, so skip
-      // when plan_id is set. Status-guarded for idempotency.
+      // A refund on a completed purchase — one-time product OR subscription
+      // (Lemon Squeezy `order_refunded`, PayPal `PAYMENT.CAPTURE.REFUNDED`,
+      // Binance `PAY_REFUND`/`REFUND_SUCCESS`). Two separate decisions here,
+      // which used to be conflated into a single product-only guard (#515):
+      //
+      //   1. RECORD THE MONEY. `transactions.status` → 'refunded' for both kinds.
+      //      This is what `getPayoutsOwed()` reads: `computeOwedBalances` leaves
+      //      refunded sales out of `grossOwed`, so the school is no longer owed
+      //      a share of money the platform gave back. Skipping this for plan
+      //      rows meant a refunded subscription was never clawed back on the
+      //      platform-settled providers (#498 follow-up). The legacy Stripe
+      //      Connect route already flips both kinds (`charge.refunded`).
+      //
+      //   2. REVOKE ACCESS. Products only, unchanged. No trigger revokes product
+      //      entitlements (trigger_manage_transactions acts on
+      //      successful/failed), so it is done explicitly here. Subscription
+      //      access stays owned by subscription.canceled/expired, which write
+      //      `subscriptions.subscription_status` and let the DB trigger cascade.
+      //
+      // Flipping a plan row to 'refunded' is inert in the DB — the trigger
+      // matches neither branch — and drops the row out of the partial unique
+      // index transactions_unique_plan, which frees the buyer to re-subscribe
+      // to that plan later. Status-guarded for idempotency on redelivery.
       if (!event.reference) break
       const txnId = Number.parseInt(event.reference, 10)
       if (Number.isNaN(txnId)) break
@@ -228,8 +245,9 @@ export async function dispatchBillingEvent(
         .eq('transaction_id', txnId)
         .maybeSingle()
 
-      // Only act on a completed one-time product purchase.
-      if (!tx || tx.plan_id || !tx.product_id || tx.status !== 'successful') break
+      // Only act on a completed purchase of one of the two kinds.
+      if (!tx || tx.status !== 'successful') break
+      if (!tx.product_id && !tx.plan_id) break
 
       const { error: refErr } = await admin
         .from('transactions')
@@ -238,13 +256,15 @@ export async function dispatchBillingEvent(
         .eq('status', 'successful')
       if (refErr) throw new Error(`dispatch ${event.type} failed: ${refErr.message}`)
 
-      const { error: entErr } = await admin
-        .from('entitlements')
-        .update({ status: 'revoked', revoked_at: new Date().toISOString() })
-        .eq('user_id', tx.user_id)
-        .eq('source_type', 'product')
-        .eq('source_id', tx.product_id)
-      if (entErr) throw new Error(`dispatch ${event.type} entitlement revoke failed: ${entErr.message}`)
+      if (tx.product_id) {
+        const { error: entErr } = await admin
+          .from('entitlements')
+          .update({ status: 'revoked', revoked_at: new Date().toISOString() })
+          .eq('user_id', tx.user_id)
+          .eq('source_type', 'product')
+          .eq('source_id', tx.product_id)
+        if (entErr) throw new Error(`dispatch ${event.type} entitlement revoke failed: ${entErr.message}`)
+      }
       break
     }
 

--- a/tests/unit/webhook-dispatch.test.ts
+++ b/tests/unit/webhook-dispatch.test.ts
@@ -259,7 +259,7 @@ describe('dispatchBillingEvent', () => {
     expect(calls.updates.find((u) => u.table === 'transactions')).toBeUndefined()
   })
 
-  it('refund.succeeded → no writes', async () => {
+  it('refund.succeeded without a reference → no writes', async () => {
     const { admin, calls } = makeFakeAdmin()
     await dispatchBillingEvent(event('refund.succeeded', { providerPaymentId: 'pi_1' }), {
       provider: PROVIDER,
@@ -267,6 +267,59 @@ describe('dispatchBillingEvent', () => {
     })
     expect(calls.updates).toHaveLength(0)
     expect(calls.rpc).toHaveLength(0)
+  })
+
+  it('refund.succeeded on a product purchase → flips tx to refunded AND revokes the product entitlements', async () => {
+    const { admin, calls } = makeFakeAdmin('successful', { user_id: 'u1', product_id: 7, plan_id: null })
+    await dispatchBillingEvent(event('refund.succeeded', { reference: '42', providerPaymentId: 'pi_1' }), {
+      provider: PROVIDER,
+      admin,
+    })
+    expect(calls.updates.find((u) => u.table === 'transactions')?.values).toMatchObject({ status: 'refunded' })
+    expect(calls.updates.find((u) => u.table === 'entitlements')?.values).toMatchObject({ status: 'revoked' })
+  })
+
+  it('refund.succeeded on a SUBSCRIPTION purchase → flips tx to refunded so payouts claw it back (#515)', async () => {
+    // Regression for #515: a plan row (product_id null, plan_id set) used to exit
+    // the handler untouched, so `getPayoutsOwed()` kept counting a refunded
+    // subscription payment inside `grossOwed` and the school was paid its share
+    // of money the platform had already given back.
+    const { admin, calls } = makeFakeAdmin('successful', { user_id: 'u1', product_id: null, plan_id: 3 })
+    await dispatchBillingEvent(event('refund.succeeded', { reference: '42', providerPaymentId: 'pi_1' }), {
+      provider: PROVIDER,
+      admin,
+    })
+    expect(calls.updates.find((u) => u.table === 'transactions')?.values).toMatchObject({ status: 'refunded' })
+    // Subscription ACCESS stays owned by subscription.canceled/expired — this
+    // handler must not revoke entitlements for a plan row.
+    expect(calls.updates.find((u) => u.table === 'entitlements')).toBeUndefined()
+  })
+
+  it('refund.succeeded on an already-refunded tx → no writes (idempotent redelivery)', async () => {
+    const { admin, calls } = makeFakeAdmin('refunded', { user_id: 'u1', product_id: null, plan_id: 3 })
+    await dispatchBillingEvent(event('refund.succeeded', { reference: '42', providerPaymentId: 'pi_1' }), {
+      provider: PROVIDER,
+      admin,
+    })
+    expect(calls.updates).toHaveLength(0)
+  })
+
+  it('refund.succeeded on a tx with neither product_id nor plan_id → no writes', async () => {
+    const { admin, calls } = makeFakeAdmin('successful', { user_id: 'u1', product_id: null, plan_id: null })
+    await dispatchBillingEvent(event('refund.succeeded', { reference: '42', providerPaymentId: 'pi_1' }), {
+      provider: PROVIDER,
+      admin,
+    })
+    expect(calls.updates).toHaveLength(0)
+  })
+
+  it('refund.succeeded with no matching transaction row → no writes', async () => {
+    const { admin, calls } = makeFakeAdmin(null)
+    await dispatchBillingEvent(event('refund.succeeded', { reference: '42', providerPaymentId: 'pi_1' }), {
+      provider: PROVIDER,
+      admin,
+    })
+    expect(calls.updates).toHaveLength(0)
   })
 
   it('payment.failed with reference → flips the abandoned pending tx to failed (frees retry, #479)', async () => {


### PR DESCRIPTION
Closes #515.

## Description

The shared `refund.succeeded` handler in `lib/payments/webhook-dispatch.ts` required a one-time product purchase before it would do anything:

```ts
if (!tx || tx.plan_id || !tx.product_id || tx.status !== 'successful') break
```

Two of those conditions exclude subscriptions — `tx.plan_id` truthy exits, and a plan transaction has `product_id IS NULL` so `!tx.product_id` exits as well. A refund event whose `reference` resolved to a subscription transaction therefore returned without writing anything.

The guard's comment ("subscription refunds are owned by `subscription.canceled`/`expired`") was accurate about *entitlements*, but those handlers only write `subscriptions.subscription_status` and `ended_at`. Nothing on the unified webhook path ever wrote `transactions.status = 'refunded'` for a plan row.

All three platform-settled providers do deliver the event with a usable `reference`, so it arrived and was dropped downstream:

- `lib/payments/paypal-provider.ts` — `PAYMENT.CAPTURE.REFUNDED`
- `lib/payments/binance-provider.ts` — `PAY_REFUND` / `REFUND_SUCCESS`
- `lib/payments/lemonsqueezy-provider.ts` — `order_refunded` (Lemon Squeezy raises this for a subscription's first order too)

The legacy Stripe Connect route was already the counter-example: `app/api/stripe/webhook/route.ts` (`charge.refunded`) flips the transaction for product *and* plan rows alike. The unified dispatcher was the outlier.

### Impact

`getPayoutsOwed()` selects transactions with `status IN ('successful','refunded')` and `computeOwedBalances` leaves refunded sales out of `grossOwed`. A subscription refund that never reached `refunded` therefore stayed inside `grossOwed`: the platform kept showing the school's share of a payment it had already given back, and paid it out on the next cycle. `clawback` under-reported for the same reason, since it is derived from the same refunded rows.

Note that the issue was filed before #511 (PR #521) changed the payout arithmetic. The bug is unchanged, but the mechanism is now the `grossOwed` exclusion rather than a `clawback` subtraction — this PR is written against current `master`.

## Changes made

**`lib/payments/webhook-dispatch.ts`** — split the guard into the two decisions it was conflating:

1. **Record the money, for both kinds of purchase.** `transactions.status` → `refunded` for product *and* plan rows, keeping the `.eq('status','successful')` guard so a webhook redelivery is a no-op. This is the value the payout computation reads.
2. **Revoke access, for products only — unchanged.** No trigger revokes product entitlements (`trigger_manage_transactions` acts on `successful`/`failed` only), so it stays explicit here. Subscription access remains owned by `subscription.canceled`/`subscription.expired`, exactly as before.

Rows in a status other than `successful`, and rows with neither `product_id` nor `plan_id`, still break out without writing.

`refunded` is an existing value of the `transaction_status` enum and is already written by the legacy Stripe route, so **no migration is needed**.

**`lib/payments/lemonsqueezy-provider.ts`** — comment only. The `order_refunded` docblock claimed subscription refunds were handled entirely by `subscription_cancelled`/`expired`, which is now only true of access, not of the money.

**`tests/unit/webhook-dispatch.test.ts`** — five `refund.succeeded` cases replacing the single "no writes" case.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [x] `npm run test:unit` — **318 passed, 27 files**, 0 failures
- [x] `npx vitest run tests/unit/webhook-dispatch.test.ts tests/unit/payouts-owed.test.ts` — **48 passed** (22 dispatcher + 26 payout-arithmetic; the #511 arithmetic is untouched by this change)
- [x] `npm run typecheck` — clean, no errors
- [x] `npm run build` — production build succeeded
- [x] `npx eslint` on the three changed files — **0 errors**. 13 warnings, all pre-existing `no-unused-vars` on underscore-prefixed interface stubs in `lemonsqueezy-provider.ts` and the test's `_cols` parameter; none on changed lines.

### The regression test was confirmed to fail against the old code

The new `#515` case is not a test that would pass either way. With the previous guard restored in place, the suite reports exactly one failure — that case — and passes again once the fix is reapplied:

```
Tests  1 failed | 21 passed (22)
```

### Live database verification

The unit tests use a fake Supabase client, so the one claim they cannot prove is what the *database* does when a plan row flips to `refunded`. Verified directly against the local database inside a transaction that was rolled back:

| Check | Result |
|---|---|
| `UPDATE transactions SET status='refunded'` on a plan row | `UPDATE 1` — no trigger error |
| `subscriptions.subscription_status` afterwards | unchanged (`active`) |
| `entitlements` for that user afterwards | unchanged (all `active`) |
| Re-subscribing to the same plan afterwards | now permitted — a new `pending` row inserts |

The first three confirm the flip is inert: `after_transaction_update` → `trigger_manage_transactions` branches on `status = 'successful'` and `status = 'failed'`, and matches neither. The fourth is a welcome side effect — the row leaves the partial unique index `transactions_unique_plan` (`WHERE product_id IS NULL AND status IN ('pending','successful')`), so a refunded student can re-subscribe to that plan. Previously the refunded-but-still-`successful` row blocked that purchase permanently. The product path already behaved this way.

### QA verification steps

No UI changed in this PR, so there are no screenshots. To verify end to end:

1. Pick (or seed) a subscription transaction on a platform-settled provider — `payment_provider` in `paypal`, `binance` or `lemonsqueezy` — with `plan_id` set, `product_id` null, and `status = 'successful'`. It also needs `school_percentage_snapshot` set for the payout figures to be meaningful.
2. Sign in as a super admin and open `/platform/payouts`. Note the school's `grossOwed` and `netOwed` for that currency.
3. POST that provider's refund webhook payload to `/api/payments/webhook/<provider>`, with the transaction id round-tripped as `reference` (`custom_id` for PayPal, `merchantTradeNo`/passthrough for Binance, `custom_data` for Lemon Squeezy).
4. Confirm the transaction now reads `status = 'refunded'`.
5. Reload `/platform/payouts` — the school's share of that sale is gone from `grossOwed`, and `netOwed` drops by the same amount.
6. Confirm the student's `subscriptions` row and `entitlements` are **unchanged** — this PR deliberately does not touch access.
7. Redeliver the same webhook. Nothing changes (the `status = 'successful'` guard makes it a no-op).
8. Sanity-check the unchanged path: refund a one-time **product** purchase and confirm the transaction flips *and* its entitlements are revoked, as before.

## Known limitations (deliberate, not regressions)

Both are pre-existing and unchanged by this PR; recording them so a reviewer does not have to rediscover them:

- **Access is not revoked on refund.** Per the issue's scope, entitlement handling stays with `subscription.canceled`/`expired`. A refund arriving without an accompanying cancel event books the refund while the student keeps access until the period ends. This PR fixes the money side only.
- **Renewal refunds attach to the first charge.** A renewal does not insert a new transaction row (`transactions_unique_plan` blocks it; `extend_subscription_period` extends the existing row instead), so a refund of a *renewal* resolves to the original first-charge transaction and flips that one. The amount is correct for a fixed-price plan, but the row it lands on is the first charge. Fixing this properly needs per-period transaction rows and is out of scope here.

## Checklist

- [x] Tenant filter applied where relevant (this path resolves a single transaction by primary key from a signed provider event; the existing owner-binding guards on `payment.succeeded`/`subscription.activated` are untouched)
- [x] Tested with all relevant roles (payout figures are super-admin only)
- [x] Loading and error states handled (webhook errors continue to throw with a `dispatch <event>` prefix)
- [x] No new migration required
