### PR TITLE
fix(billing): gate past-due fields on past-due reasons, flatten at-risk fetch (#514)

### DIFF
--- a/app/[locale]/platform/billing-health/page.tsx
+++ b/app/[locale]/platform/billing-health/page.tsx
@@ -1,4 +1,5 @@
 import { getAtRiskTenants } from '@/app/actions/platform/billing-health'
+import type { AtRiskReason } from '@/lib/billing/billing-health'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { format } from 'date-fns'
@@ -6,19 +7,33 @@ import {
   IconAlertTriangle,
   IconClockPause,
   IconCreditCardOff,
+  IconLockExclamation,
 } from '@tabler/icons-react'
+
+const REASON_LABELS: Record<AtRiskReason, string> = {
+  tenant_past_due: 'Past due',
+  subscription_past_due: 'Subscription past due',
+  access_cutoff_scheduled: 'Cutoff scheduled',
+}
 
 export default async function PlatformBillingHealthPage() {
   const atRisk = await getAtRiskTenants()
 
-  const manualTransfer = atRisk.filter((t) => t.paymentMethod === 'manual_transfer')
-  const stripeDunning = atRisk.filter((t) => t.paymentMethod !== 'manual_transfer')
+  // The metric cards deliberately keep counting past-due tenants only, so the
+  // numbers do not silently change meaning now that #514 also lists tenants
+  // that are merely over their plan limits. Cutoffs get their own card.
+  const pastDue = atRisk.filter(
+    (t) => t.reasons.includes('tenant_past_due') || t.reasons.includes('subscription_past_due'),
+  )
+  const manualTransfer = pastDue.filter((t) => t.paymentMethod === 'manual_transfer')
+  const stripeDunning = pastDue.filter((t) => t.paymentMethod !== 'manual_transfer')
+  const cutoffScheduled = atRisk.filter((t) => t.reasons.includes('access_cutoff_scheduled'))
   const urgent = manualTransfer.filter((t) => t.daysUntilDowngrade !== null && t.daysUntilDowngrade <= 3)
 
   const metricCards = [
     {
       title: 'Past-Due Schools',
-      value: String(atRisk.length),
+      value: String(pastDue.length),
       sub: 'Total schools currently behind on payment',
       icon: IconAlertTriangle,
       bg: 'bg-red-50 dark:bg-red-950/40',
@@ -40,6 +55,14 @@ export default async function PlatformBillingHealthPage() {
       bg: 'bg-blue-50 dark:bg-blue-950/40',
       iconColor: 'text-blue-600 dark:text-blue-400',
     },
+    {
+      title: 'Access Cutoff Scheduled',
+      value: String(cutoffScheduled.length),
+      sub: 'Over plan limits — access pauses on the cutoff date',
+      icon: IconLockExclamation,
+      bg: 'bg-purple-50 dark:bg-purple-950/40',
+      iconColor: 'text-purple-600 dark:text-purple-400',
+    },
   ]
 
   return (
@@ -47,11 +70,12 @@ export default async function PlatformBillingHealthPage() {
       <div className="mb-8">
         <h1 className="text-2xl font-bold tracking-tight">Billing Health</h1>
         <p className="text-sm text-muted-foreground mt-1">
-          Schools currently past-due, with their grace-period countdown to automatic downgrade.
+          Schools that are past-due or over their plan limits, with their countdown to automatic
+          downgrade or access cutoff.
         </p>
       </div>
 
-      <div className="mb-8 grid gap-3 sm:grid-cols-3" data-testid="billing-health-metrics">
+      <div className="mb-8 grid gap-3 sm:grid-cols-2 lg:grid-cols-4" data-testid="billing-health-metrics">
         {metricCards.map((card) => (
           <Card key={card.title} className="relative overflow-hidden">
             <CardContent className="p-5">
@@ -80,7 +104,9 @@ export default async function PlatformBillingHealthPage() {
         </CardHeader>
         <CardContent>
           {atRisk.length === 0 ? (
-            <p className="text-muted-foreground text-sm">No schools currently past-due.</p>
+            <p className="text-muted-foreground text-sm">
+              No schools are past-due or over their plan limits.
+            </p>
           ) : (
             <div className="overflow-x-auto">
               <table className="w-full text-sm">
@@ -88,6 +114,7 @@ export default async function PlatformBillingHealthPage() {
                   <tr className="border-b text-left text-[11px] uppercase tracking-wider text-muted-foreground">
                     <th className="pb-2 font-medium">School</th>
                     <th className="pb-2 font-medium">Plan</th>
+                    <th className="pb-2 font-medium">Reason</th>
                     <th className="pb-2 font-medium">Payment method</th>
                     <th className="pb-2 font-medium">Past due since</th>
                     <th className="pb-2 font-medium">Downgrades in</th>
@@ -99,6 +126,15 @@ export default async function PlatformBillingHealthPage() {
                     <tr key={t.tenantId} className="border-b last:border-0" data-testid="at-risk-row" data-tenant-id={t.tenantId}>
                       <td className="py-2.5 font-medium">{t.tenantName}</td>
                       <td className="py-2.5 capitalize text-muted-foreground">{t.plan || '—'}</td>
+                      <td className="py-2.5" data-testid="at-risk-reasons" data-reasons={t.reasons.join(' ')}>
+                        <div className="flex flex-wrap gap-1">
+                          {t.reasons.map((reason) => (
+                            <Badge key={reason} variant="secondary" className="text-[10px] font-normal">
+                              {REASON_LABELS[reason]}
+                            </Badge>
+                          ))}
+                        </div>
+                      </td>
                       <td className="py-2.5 text-muted-foreground">
                         {t.paymentMethod === 'manual_transfer' ? 'Manual transfer' : t.paymentMethod === 'stripe' ? 'Stripe' : '—'}
                       </td>

--- a/app/[locale]/platform/billing-health/page.tsx
+++ b/app/[locale]/platform/billing-health/page.tsx
@@ -16,24 +16,40 @@ const REASON_LABELS: Record<AtRiskReason, string> = {
   access_cutoff_scheduled: 'Cutoff scheduled',
 }
 
+function reasonLabel(reason: AtRiskReason, cutoffActive: boolean): string {
+  // A cutoff date in the past means access is already paused, not pending.
+  if (reason === 'access_cutoff_scheduled' && cutoffActive) return 'Access paused'
+  return REASON_LABELS[reason]
+}
+
 export default async function PlatformBillingHealthPage() {
   const atRisk = await getAtRiskTenants()
 
   // The metric cards deliberately keep counting past-due tenants only, so the
   // numbers do not silently change meaning now that #514 also lists tenants
   // that are merely over their plan limits. Cutoffs get their own card.
-  const pastDue = atRisk.filter(
-    (t) => t.reasons.includes('tenant_past_due') || t.reasons.includes('subscription_past_due'),
-  )
-  const manualTransfer = pastDue.filter((t) => t.paymentMethod === 'manual_transfer')
-  const stripeDunning = pastDue.filter((t) => t.paymentMethod !== 'manual_transfer')
-  const cutoffScheduled = atRisk.filter((t) => t.reasons.includes('access_cutoff_scheduled'))
-  const urgent = manualTransfer.filter((t) => t.daysUntilDowngrade !== null && t.daysUntilDowngrade <= 3)
+  // Counted in one pass — five chained .filter() calls over the same list was
+  // five allocations for four numbers.
+  const counts = { pastDue: 0, manualTransfer: 0, stripeDunning: 0, cutoffScheduled: 0, urgent: 0 }
+  for (const t of atRisk) {
+    const isPastDue =
+      t.reasons.includes('tenant_past_due') || t.reasons.includes('subscription_past_due')
+    if (isPastDue) {
+      counts.pastDue++
+      if (t.paymentMethod === 'manual_transfer') {
+        counts.manualTransfer++
+        if (t.daysUntilDowngrade !== null && t.daysUntilDowngrade <= 3) counts.urgent++
+      } else {
+        counts.stripeDunning++
+      }
+    }
+    if (t.reasons.includes('access_cutoff_scheduled')) counts.cutoffScheduled++
+  }
 
   const metricCards = [
     {
       title: 'Past-Due Schools',
-      value: String(pastDue.length),
+      value: String(counts.pastDue),
       sub: 'Total schools currently behind on payment',
       icon: IconAlertTriangle,
       bg: 'bg-red-50 dark:bg-red-950/40',
@@ -41,15 +57,18 @@ export default async function PlatformBillingHealthPage() {
     },
     {
       title: 'Manual-Transfer Grace Running',
-      value: String(manualTransfer.length),
-      sub: urgent.length > 0 ? `${urgent.length} downgrading within 3 days` : 'None expiring imminently',
+      value: String(counts.manualTransfer),
+      sub:
+        counts.urgent > 0
+          ? `${counts.urgent} downgrading within 3 days`
+          : 'None expiring imminently',
       icon: IconClockPause,
       bg: 'bg-amber-50 dark:bg-amber-950/40',
       iconColor: 'text-amber-600 dark:text-amber-400',
     },
     {
       title: 'Stripe Dunning In Progress',
-      value: String(stripeDunning.length),
+      value: String(counts.stripeDunning),
       sub: 'Downgrade timing controlled by Stripe, not this app',
       icon: IconCreditCardOff,
       bg: 'bg-blue-50 dark:bg-blue-950/40',
@@ -57,7 +76,7 @@ export default async function PlatformBillingHealthPage() {
     },
     {
       title: 'Access Cutoff Scheduled',
-      value: String(cutoffScheduled.length),
+      value: String(counts.cutoffScheduled),
       sub: 'Over plan limits — access pauses on the cutoff date',
       icon: IconLockExclamation,
       bg: 'bg-purple-50 dark:bg-purple-950/40',
@@ -130,7 +149,7 @@ export default async function PlatformBillingHealthPage() {
                         <div className="flex flex-wrap gap-1">
                           {t.reasons.map((reason) => (
                             <Badge key={reason} variant="secondary" className="text-[10px] font-normal">
-                              {REASON_LABELS[reason]}
+                              {reasonLabel(reason, t.accessCutoffActive)}
                             </Badge>
                           ))}
                         </div>

--- a/app/actions/platform/billing-health.ts
+++ b/app/actions/platform/billing-health.ts
@@ -3,7 +3,11 @@
 import { createAdminClient } from '@/lib/supabase/admin'
 import { isSuperAdmin } from '@/lib/supabase/get-user-role'
 import { getCurrentUserId } from '@/lib/supabase/tenant'
-import { computeBillingHealth, type AtRiskTenant } from '@/lib/billing/billing-health'
+import {
+  computeBillingHealth,
+  type AtRiskReason,
+  type AtRiskTenant,
+} from '@/lib/billing/billing-health'
 
 async function verifySuperAdmin() {
   const userId = await getCurrentUserId()
@@ -12,36 +16,101 @@ async function verifySuperAdmin() {
   return userId
 }
 
+/**
+ * #514: "at risk" is a union across two tables, which PostgREST cannot express
+ * as a single `.or()`. Three reads, merged by tenant id:
+ *
+ *  1. `tenants.billing_status = 'past_due'`
+ *  2. tenants owning a `platform_subscriptions` row with `status = 'past_due'`
+ *     (drifts from #1 when only one side is synced)
+ *  3. `tenants.access_cutoff_at IS NOT NULL` (#494 scheduled a cutoff — the
+ *     tenant may be paying perfectly well and simply be over its plan limits)
+ *
+ * Each contributes a reason, so the UI can keep the three cases apart.
+ */
 export async function getAtRiskTenants(): Promise<AtRiskTenant[]> {
   await verifySuperAdmin()
   const admin = createAdminClient()
 
-  const { data: tenants } = await admin
-    .from('tenants')
-    .select('id, name, plan, access_cutoff_at')
-    .eq('billing_status', 'past_due')
+  const [
+    { data: pastDueTenants },
+    { data: pastDueSubscriptions },
+    { data: cutoffTenants },
+  ] = await Promise.all([
+    admin
+      .from('tenants')
+      .select('id, name, plan, access_cutoff_at')
+      .eq('billing_status', 'past_due'),
+    admin
+      .from('platform_subscriptions')
+      .select('tenant_id')
+      .eq('status', 'past_due'),
+    admin
+      .from('tenants')
+      .select('id, name, plan, access_cutoff_at')
+      .not('access_cutoff_at', 'is', null),
+  ])
 
-  const tenantIds = (tenants || []).map((t) => t.id)
+  const reasonsByTenant = new Map<string, Set<AtRiskReason>>()
+  const addReason = (tenantId: string, reason: AtRiskReason) => {
+    const existing = reasonsByTenant.get(tenantId)
+    if (existing) existing.add(reason)
+    else reasonsByTenant.set(tenantId, new Set([reason]))
+  }
+
+  type TenantRow = { id: string; name: string; plan: string | null; access_cutoff_at: string | null }
+  const tenantById = new Map<string, TenantRow>()
+
+  for (const tenant of (pastDueTenants || []) as TenantRow[]) {
+    tenantById.set(tenant.id, tenant)
+    addReason(tenant.id, 'tenant_past_due')
+  }
+  for (const tenant of (cutoffTenants || []) as TenantRow[]) {
+    tenantById.set(tenant.id, tenant)
+    addReason(tenant.id, 'access_cutoff_scheduled')
+  }
+
+  // Subscription-only past-due tenants have no row yet from either read above.
+  const subscriptionPastDueIds = [...new Set((pastDueSubscriptions || []).map((s) => s.tenant_id))]
+  for (const tenantId of subscriptionPastDueIds) {
+    addReason(tenantId, 'subscription_past_due')
+  }
+  const missingTenantIds = subscriptionPastDueIds.filter((id) => !tenantById.has(id))
+
+  if (missingTenantIds.length) {
+    const { data: extraTenants } = await admin
+      .from('tenants')
+      .select('id, name, plan, access_cutoff_at')
+      .in('id', missingTenantIds)
+    for (const tenant of (extraTenants || []) as TenantRow[]) {
+      tenantById.set(tenant.id, tenant)
+    }
+  }
+
+  const tenantIds = [...tenantById.keys()]
 
   const { data: subscriptions } = tenantIds.length
     ? await admin
         .from('platform_subscriptions')
-        .select('tenant_id, payment_method, current_period_end, grace_period_end')
+        .select('tenant_id, status, payment_method, current_period_end, grace_period_end, updated_at')
         .in('tenant_id', tenantIds)
     : { data: [] }
 
   return computeBillingHealth(
-    (tenants || []).map((t) => ({
+    [...tenantById.values()].map((t) => ({
       tenantId: t.id,
       tenantName: t.name,
       plan: t.plan,
       accessCutoffAt: t.access_cutoff_at,
+      reasons: [...(reasonsByTenant.get(t.id) ?? [])],
     })),
     (subscriptions || []).map((s) => ({
       tenantId: s.tenant_id,
+      status: s.status,
       paymentMethod: s.payment_method,
       currentPeriodEnd: s.current_period_end,
       gracePeriodEnd: s.grace_period_end,
+      updatedAt: s.updated_at,
     })),
     new Date(),
   )

--- a/app/actions/platform/billing-health.ts
+++ b/app/actions/platform/billing-health.ts
@@ -5,8 +5,10 @@ import { isSuperAdmin } from '@/lib/supabase/get-user-role'
 import { getCurrentUserId } from '@/lib/supabase/tenant'
 import {
   computeBillingHealth,
-  type AtRiskReason,
+  mergeAtRiskTenants,
   type AtRiskTenant,
+  type AtRiskTenantRow,
+  type PastDueSubscriptionInput,
 } from '@/lib/billing/billing-health'
 
 async function verifySuperAdmin() {
@@ -14,6 +16,46 @@ async function verifySuperAdmin() {
   if (!userId) throw new Error('Not authenticated')
   if (!(await isSuperAdmin())) throw new Error('Super admin only')
   return userId
+}
+
+const TENANT_SELECT = 'id, name, plan, access_cutoff_at'
+const SUBSCRIPTION_SELECT =
+  'tenant_id, status, payment_method, current_period_end, grace_period_end, updated_at'
+
+/**
+ * Mapped through helpers rather than an `as` cast so a drifting select list
+ * fails `tsc` here instead of rendering blanks in production.
+ */
+function toTenantRow(row: {
+  id: string
+  name: string
+  plan: string | null
+  access_cutoff_at: string | null
+}): AtRiskTenantRow {
+  return {
+    tenantId: row.id,
+    tenantName: row.name,
+    plan: row.plan,
+    accessCutoffAt: row.access_cutoff_at,
+  }
+}
+
+function toSubscriptionInput(row: {
+  tenant_id: string
+  status: string | null
+  payment_method: string | null
+  current_period_end: string | null
+  grace_period_end: string | null
+  updated_at: string | null
+}): PastDueSubscriptionInput {
+  return {
+    tenantId: row.tenant_id,
+    status: row.status,
+    paymentMethod: row.payment_method,
+    currentPeriodEnd: row.current_period_end,
+    gracePeriodEnd: row.grace_period_end,
+    updatedAt: row.updated_at,
+  }
 }
 
 /**
@@ -27,6 +69,17 @@ async function verifySuperAdmin() {
  *     tenant may be paying perfectly well and simply be over its plan limits)
  *
  * Each contributes a reason, so the UI can keep the three cases apart.
+ *
+ * Two round-trips, not four. The past-due subscription read takes the full
+ * column set, so the rows belonging to subscription-only tenants are already
+ * in hand; that makes the follow-up `tenants` fetch for those ids independent
+ * of the subscription fetch for the tenants we already know about, and the two
+ * go out together. Feeding both subscription lists to `computeBillingHealth`
+ * is safe because it ranks duplicate rows rather than taking the last one.
+ *
+ * The auth check deliberately stays *before* the reads and is never folded
+ * into the `Promise.all` — a non-super-admin caller must not cause tenant
+ * billing data to be read at all.
  */
 export async function getAtRiskTenants(): Promise<AtRiskTenant[]> {
   await verifySuperAdmin()
@@ -37,81 +90,45 @@ export async function getAtRiskTenants(): Promise<AtRiskTenant[]> {
     { data: pastDueSubscriptions },
     { data: cutoffTenants },
   ] = await Promise.all([
-    admin
-      .from('tenants')
-      .select('id, name, plan, access_cutoff_at')
-      .eq('billing_status', 'past_due'),
-    admin
-      .from('platform_subscriptions')
-      .select('tenant_id')
-      .eq('status', 'past_due'),
-    admin
-      .from('tenants')
-      .select('id, name, plan, access_cutoff_at')
-      .not('access_cutoff_at', 'is', null),
+    admin.from('tenants').select(TENANT_SELECT).eq('billing_status', 'past_due'),
+    admin.from('platform_subscriptions').select(SUBSCRIPTION_SELECT).eq('status', 'past_due'),
+    admin.from('tenants').select(TENANT_SELECT).not('access_cutoff_at', 'is', null),
   ])
 
-  const reasonsByTenant = new Map<string, Set<AtRiskReason>>()
-  const addReason = (tenantId: string, reason: AtRiskReason) => {
-    const existing = reasonsByTenant.get(tenantId)
-    if (existing) existing.add(reason)
-    else reasonsByTenant.set(tenantId, new Set([reason]))
-  }
+  const pastDueTenantRows = (pastDueTenants ?? []).map(toTenantRow)
+  const cutoffTenantRows = (cutoffTenants ?? []).map(toTenantRow)
+  const pastDueSubscriptionRows = (pastDueSubscriptions ?? []).map(toSubscriptionInput)
 
-  type TenantRow = { id: string; name: string; plan: string | null; access_cutoff_at: string | null }
-  const tenantById = new Map<string, TenantRow>()
+  const knownTenantIds = new Set([
+    ...pastDueTenantRows.map((t) => t.tenantId),
+    ...cutoffTenantRows.map((t) => t.tenantId),
+  ])
+  const subscriptionPastDueTenantIds = [
+    ...new Set(pastDueSubscriptionRows.map((s) => s.tenantId)),
+  ]
+  // Subscription-only past-due tenants appear in neither read above.
+  const missingTenantIds = subscriptionPastDueTenantIds.filter((id) => !knownTenantIds.has(id))
 
-  for (const tenant of (pastDueTenants || []) as TenantRow[]) {
-    tenantById.set(tenant.id, tenant)
-    addReason(tenant.id, 'tenant_past_due')
-  }
-  for (const tenant of (cutoffTenants || []) as TenantRow[]) {
-    tenantById.set(tenant.id, tenant)
-    addReason(tenant.id, 'access_cutoff_scheduled')
-  }
-
-  // Subscription-only past-due tenants have no row yet from either read above.
-  const subscriptionPastDueIds = [...new Set((pastDueSubscriptions || []).map((s) => s.tenant_id))]
-  for (const tenantId of subscriptionPastDueIds) {
-    addReason(tenantId, 'subscription_past_due')
-  }
-  const missingTenantIds = subscriptionPastDueIds.filter((id) => !tenantById.has(id))
-
-  if (missingTenantIds.length) {
-    const { data: extraTenants } = await admin
-      .from('tenants')
-      .select('id, name, plan, access_cutoff_at')
-      .in('id', missingTenantIds)
-    for (const tenant of (extraTenants || []) as TenantRow[]) {
-      tenantById.set(tenant.id, tenant)
-    }
-  }
-
-  const tenantIds = [...tenantById.keys()]
-
-  const { data: subscriptions } = tenantIds.length
-    ? await admin
-        .from('platform_subscriptions')
-        .select('tenant_id, status, payment_method, current_period_end, grace_period_end, updated_at')
-        .in('tenant_id', tenantIds)
-    : { data: [] }
+  const [{ data: extraTenants }, { data: knownSubscriptions }] = await Promise.all([
+    missingTenantIds.length
+      ? admin.from('tenants').select(TENANT_SELECT).in('id', missingTenantIds)
+      : Promise.resolve({ data: [] as never[] }),
+    knownTenantIds.size
+      ? admin
+          .from('platform_subscriptions')
+          .select(SUBSCRIPTION_SELECT)
+          .in('tenant_id', [...knownTenantIds])
+      : Promise.resolve({ data: [] as never[] }),
+  ])
 
   return computeBillingHealth(
-    [...tenantById.values()].map((t) => ({
-      tenantId: t.id,
-      tenantName: t.name,
-      plan: t.plan,
-      accessCutoffAt: t.access_cutoff_at,
-      reasons: [...(reasonsByTenant.get(t.id) ?? [])],
-    })),
-    (subscriptions || []).map((s) => ({
-      tenantId: s.tenant_id,
-      status: s.status,
-      paymentMethod: s.payment_method,
-      currentPeriodEnd: s.current_period_end,
-      gracePeriodEnd: s.grace_period_end,
-      updatedAt: s.updated_at,
-    })),
+    mergeAtRiskTenants({
+      pastDueTenants: pastDueTenantRows,
+      cutoffTenants: cutoffTenantRows,
+      subscriptionPastDueTenantIds,
+      extraTenants: (extraTenants ?? []).map(toTenantRow),
+    }),
+    [...pastDueSubscriptionRows, ...(knownSubscriptions ?? []).map(toSubscriptionInput)],
     new Date(),
   )
 }

--- a/lib/billing/billing-health.ts
+++ b/lib/billing/billing-health.ts
@@ -1,7 +1,17 @@
 /**
  * Computes the "billing health" view for super admins: which tenants are
- * currently `past_due` and how much runway they have before an automatic
- * downgrade to free.
+ * at risk and how much runway they have before an automatic downgrade to
+ * free.
+ *
+ * #514: "at risk" is a union of three populations, not just one. A tenant
+ * qualifies when `tenants.billing_status = 'past_due'`, **or** it has a
+ * `platform_subscriptions` row with `status = 'past_due'` (the two can drift
+ * apart, and the sub-only case used to be invisible here), **or** it has an
+ * `access_cutoff_at` scheduled by #494 — an over-limit tenant that is paying
+ * on time never showed up at all, so the cutoff column could only ever hold
+ * a value for a tenant that was *also* past due. Each row carries the
+ * `reasons` it qualified under; a tenant can qualify under several, and
+ * collapsing that would hide exactly the drift this view exists to surface.
  *
  * Two past-due paths write `tenants.billing_status = 'past_due'`, and they
  * carry different amounts of information:
@@ -20,18 +30,33 @@
 
 const DAY_MS = 24 * 60 * 60 * 1000
 
+/** Why a tenant appears in the at-risk list. A tenant may qualify under several. */
+export type AtRiskReason =
+  | 'tenant_past_due'
+  | 'subscription_past_due'
+  | 'access_cutoff_scheduled'
+
+const REASON_ORDER: AtRiskReason[] = [
+  'tenant_past_due',
+  'subscription_past_due',
+  'access_cutoff_scheduled',
+]
+
 export interface AtRiskTenantInput {
   tenantId: string
   tenantName: string
   plan: string | null
   accessCutoffAt: string | null
+  reasons: AtRiskReason[]
 }
 
 export interface PastDueSubscriptionInput {
   tenantId: string
+  status: string | null
   paymentMethod: string | null
   currentPeriodEnd: string | null
   gracePeriodEnd: string | null
+  updatedAt: string | null
 }
 
 export interface AtRiskTenant {
@@ -46,6 +71,44 @@ export interface AtRiskTenant {
   /** True when there is no fixed downgrade date to report (Stripe-managed dunning). */
   isEstimate: boolean
   accessCutoffAt: string | null
+  /** Which of the three at-risk conditions this tenant met, in a stable order. */
+  reasons: AtRiskReason[]
+}
+
+/**
+ * Ranks two subscription rows for the same tenant; higher wins.
+ *
+ * `platform_subscriptions` carries `UNIQUE (tenant_id)` today and every write
+ * path upserts on it, so a tenant cannot actually hold two rows — but the old
+ * plain `.set()` over an unordered list meant that if the constraint were ever
+ * relaxed (per-plan history, say), a stale `canceled` row could donate its
+ * `payment_method` and `grace_period_end`, and therefore its countdown, to the
+ * dashboard. Ranking explicitly costs nothing and removes the trap.
+ */
+function subscriptionRank(sub: PastDueSubscriptionInput): number {
+  if (sub.status === 'past_due') return 2
+  if (sub.status === 'active') return 1
+  return 0
+}
+
+function isMoreRelevantSubscription(
+  candidate: PastDueSubscriptionInput,
+  incumbent: PastDueSubscriptionInput,
+): boolean {
+  const candidateRank = subscriptionRank(candidate)
+  const incumbentRank = subscriptionRank(incumbent)
+  if (candidateRank !== incumbentRank) return candidateRank > incumbentRank
+
+  const candidateUpdated = candidate.updatedAt ? new Date(candidate.updatedAt).getTime() : null
+  const incumbentUpdated = incumbent.updatedAt ? new Date(incumbent.updatedAt).getTime() : null
+  if (candidateUpdated === null && incumbentUpdated === null) return false
+  if (incumbentUpdated === null) return true
+  if (candidateUpdated === null) return false
+  return candidateUpdated > incumbentUpdated
+}
+
+function normalizeReasons(reasons: AtRiskReason[]): AtRiskReason[] {
+  return REASON_ORDER.filter((reason) => reasons.includes(reason))
 }
 
 export function computeBillingHealth(
@@ -55,7 +118,10 @@ export function computeBillingHealth(
 ): AtRiskTenant[] {
   const subByTenant = new Map<string, PastDueSubscriptionInput>()
   for (const sub of subscriptions) {
-    subByTenant.set(sub.tenantId, sub)
+    const incumbent = subByTenant.get(sub.tenantId)
+    if (!incumbent || isMoreRelevantSubscription(sub, incumbent)) {
+      subByTenant.set(sub.tenantId, sub)
+    }
   }
 
   const results = tenants.map((tenant) => {
@@ -79,6 +145,7 @@ export function computeBillingHealth(
       daysUntilDowngrade,
       isEstimate: !isManualTransfer,
       accessCutoffAt: tenant.accessCutoffAt,
+      reasons: normalizeReasons(tenant.reasons),
     }
   })
 

--- a/lib/billing/billing-health.ts
+++ b/lib/billing/billing-health.ts
@@ -13,6 +13,16 @@
  * `reasons` it qualified under; a tenant can qualify under several, and
  * collapsing that would hide exactly the drift this view exists to surface.
  *
+ * Because that union admits tenants whose billing is perfectly healthy, every
+ * past-due-derived field (`pastDueSince`, `graceEndsAt`, `daysUntilDowngrade`,
+ * `isEstimate`) is gated on the tenant actually being past due. Without that
+ * gate a school that already lapsed to free keeps a stale
+ * `platform_subscriptions.grace_period_end` — `downgradeTenantToFree()` sets
+ * `status = 'canceled'` but never clears the grace stamp, and then schedules
+ * the very cutoff that puts the tenant on this list — so it would report a
+ * large negative countdown and sort *above* the schools that still have a
+ * downgrade to avert.
+ *
  * Two past-due paths write `tenants.billing_status = 'past_due'`, and they
  * carry different amounts of information:
  *  - manual_transfer (app/api/cron/expire-platform-subscriptions/route.ts)
@@ -42,12 +52,63 @@ const REASON_ORDER: AtRiskReason[] = [
   'access_cutoff_scheduled',
 ]
 
-export interface AtRiskTenantInput {
+/** A `tenants` row as read by any of the three at-risk queries. */
+export interface AtRiskTenantRow {
   tenantId: string
   tenantName: string
   plan: string | null
   accessCutoffAt: string | null
+}
+
+export interface AtRiskTenantInput extends AtRiskTenantRow {
   reasons: AtRiskReason[]
+}
+
+/**
+ * Merges the three at-risk populations into one deduplicated list, attaching
+ * every reason each tenant qualified under.
+ *
+ * Kept pure and exported so the union — the part of #514 with the actual new
+ * logic — is unit-testable without a database. `extraTenants` covers the
+ * subscription-only case: a tenant whose `platform_subscriptions.status` is
+ * `past_due` while `tenants.billing_status` says otherwise appears in neither
+ * of the other two reads, so the caller fetches those rows separately.
+ */
+export function mergeAtRiskTenants(input: {
+  pastDueTenants: AtRiskTenantRow[]
+  cutoffTenants: AtRiskTenantRow[]
+  subscriptionPastDueTenantIds: string[]
+  extraTenants: AtRiskTenantRow[]
+}): AtRiskTenantInput[] {
+  const reasonsByTenant = new Map<string, Set<AtRiskReason>>()
+  const addReason = (tenantId: string, reason: AtRiskReason) => {
+    const existing = reasonsByTenant.get(tenantId)
+    if (existing) existing.add(reason)
+    else reasonsByTenant.set(tenantId, new Set([reason]))
+  }
+
+  const tenantById = new Map<string, AtRiskTenantRow>()
+  for (const tenant of input.pastDueTenants) {
+    tenantById.set(tenant.tenantId, tenant)
+    addReason(tenant.tenantId, 'tenant_past_due')
+  }
+  for (const tenant of input.cutoffTenants) {
+    tenantById.set(tenant.tenantId, tenant)
+    addReason(tenant.tenantId, 'access_cutoff_scheduled')
+  }
+  for (const tenantId of input.subscriptionPastDueTenantIds) {
+    addReason(tenantId, 'subscription_past_due')
+  }
+  for (const tenant of input.extraTenants) {
+    if (!tenantById.has(tenant.tenantId)) tenantById.set(tenant.tenantId, tenant)
+  }
+
+  // A subscription id with no matching `tenants` row (deleted mid-read) is
+  // dropped rather than rendered as a nameless row.
+  return [...tenantById.values()].map((tenant) => ({
+    ...tenant,
+    reasons: normalizeReasons([...(reasonsByTenant.get(tenant.tenantId) ?? [])]),
+  }))
 }
 
 export interface PastDueSubscriptionInput {
@@ -66,11 +127,21 @@ export interface AtRiskTenant {
   paymentMethod: string | null
   pastDueSince: string | null
   graceEndsAt: string | null
-  /** Ceil'd days remaining before auto-downgrade; null when not computable (Stripe, or no grace data). */
+  /**
+   * Ceil'd days remaining before auto-downgrade; null when not computable
+   * (Stripe, no grace data) or when the tenant is not past due at all.
+   */
   daysUntilDowngrade: number | null
-  /** True when there is no fixed downgrade date to report (Stripe-managed dunning). */
+  /**
+   * True when the tenant is past due but there is no fixed downgrade date to
+   * report (Stripe-managed dunning). False for a tenant that is only on this
+   * list because of a scheduled cutoff — it has no downgrade pending to
+   * estimate.
+   */
   isEstimate: boolean
   accessCutoffAt: string | null
+  /** True once `accessCutoffAt` is in the past: access is already paused, not merely scheduled. */
+  accessCutoffActive: boolean
   /** Which of the three at-risk conditions this tenant met, in a stable order. */
   reasons: AtRiskReason[]
 }
@@ -125,34 +196,52 @@ export function computeBillingHealth(
   }
 
   const results = tenants.map((tenant) => {
+    const reasons = normalizeReasons(tenant.reasons)
+    // Only a past-due tenant has a downgrade to count down to. A cutoff-only
+    // tenant may still carry a subscription row with a long-expired
+    // `grace_period_end`, and reporting that as runway would be a lie.
+    const isPastDue =
+      reasons.includes('tenant_past_due') || reasons.includes('subscription_past_due')
+
     const sub = subByTenant.get(tenant.tenantId) ?? null
     const paymentMethod = sub?.paymentMethod ?? null
     const isManualTransfer = paymentMethod === 'manual_transfer'
 
-    const graceEndsAt = isManualTransfer ? sub?.gracePeriodEnd ?? null : null
-    const daysUntilDowngrade =
-      isManualTransfer && graceEndsAt
-        ? Math.ceil((new Date(graceEndsAt).getTime() - now.getTime()) / DAY_MS)
-        : null
+    const graceEndsAt = isPastDue && isManualTransfer ? sub?.gracePeriodEnd ?? null : null
+    const daysUntilDowngrade = graceEndsAt
+      ? Math.ceil((new Date(graceEndsAt).getTime() - now.getTime()) / DAY_MS)
+      : null
 
     return {
       tenantId: tenant.tenantId,
       tenantName: tenant.tenantName,
       plan: tenant.plan,
       paymentMethod,
-      pastDueSince: sub?.currentPeriodEnd ?? null,
+      pastDueSince: isPastDue ? sub?.currentPeriodEnd ?? null : null,
       graceEndsAt,
       daysUntilDowngrade,
-      isEstimate: !isManualTransfer,
+      isEstimate: isPastDue && !isManualTransfer,
       accessCutoffAt: tenant.accessCutoffAt,
-      reasons: normalizeReasons(tenant.reasons),
+      accessCutoffActive: tenant.accessCutoffAt
+        ? new Date(tenant.accessCutoffAt).getTime() <= now.getTime()
+        : false,
+      reasons,
     }
   })
 
+  // Soonest downgrade first. Rows with no countdown (Stripe dunning, or
+  // cutoff-only) fall to the back, ordered by soonest cutoff so that tail is
+  // not arbitrary, then by name for a stable render across reloads.
   return results.sort((a, b) => {
-    if (a.daysUntilDowngrade === null && b.daysUntilDowngrade === null) return 0
-    if (a.daysUntilDowngrade === null) return 1
-    if (b.daysUntilDowngrade === null) return -1
-    return a.daysUntilDowngrade - b.daysUntilDowngrade
+    if (a.daysUntilDowngrade !== null && b.daysUntilDowngrade !== null) {
+      return a.daysUntilDowngrade - b.daysUntilDowngrade
+    }
+    if (a.daysUntilDowngrade !== null) return -1
+    if (b.daysUntilDowngrade !== null) return 1
+
+    const aCutoff = a.accessCutoffAt ? new Date(a.accessCutoffAt).getTime() : Infinity
+    const bCutoff = b.accessCutoffAt ? new Date(b.accessCutoffAt).getTime() : Infinity
+    if (aCutoff !== bCutoff) return aCutoff - bCutoff
+    return a.tenantName.localeCompare(b.tenantName)
   })
 }

--- a/tests/unit/billing-health.test.ts
+++ b/tests/unit/billing-health.test.ts
@@ -3,16 +3,32 @@ import { computeBillingHealth } from '@/lib/billing/billing-health'
 
 const NOW = new Date('2026-07-24T00:00:00.000Z')
 
+const sub = (overrides: {
+  tenantId: string
+  status?: string | null
+  paymentMethod?: string | null
+  currentPeriodEnd?: string | null
+  gracePeriodEnd?: string | null
+  updatedAt?: string | null
+}) => ({
+  status: 'past_due',
+  paymentMethod: null,
+  currentPeriodEnd: null,
+  gracePeriodEnd: null,
+  updatedAt: null,
+  ...overrides,
+})
+
 describe('computeBillingHealth', () => {
   it('manual_transfer with grace time remaining computes a positive countdown', () => {
     const result = computeBillingHealth(
-      [{ tenantId: 't1', tenantName: 'School A', plan: 'starter', accessCutoffAt: null }],
-      [{
+      [{ tenantId: 't1', tenantName: 'School A', plan: 'starter', accessCutoffAt: null, reasons: ['tenant_past_due'] }],
+      [sub({
         tenantId: 't1',
         paymentMethod: 'manual_transfer',
         currentPeriodEnd: '2026-07-17T00:00:00.000Z',
         gracePeriodEnd: '2026-07-27T00:00:00.000Z',
-      }],
+      })],
       NOW,
     )
     expect(result[0].daysUntilDowngrade).toBe(3)
@@ -23,13 +39,13 @@ describe('computeBillingHealth', () => {
 
   it('manual_transfer with grace already expired still reports a (negative/zero) countdown, not a crash', () => {
     const result = computeBillingHealth(
-      [{ tenantId: 't1', tenantName: 'School A', plan: 'starter', accessCutoffAt: null }],
-      [{
+      [{ tenantId: 't1', tenantName: 'School A', plan: 'starter', accessCutoffAt: null, reasons: ['tenant_past_due'] }],
+      [sub({
         tenantId: 't1',
         paymentMethod: 'manual_transfer',
         currentPeriodEnd: '2026-07-01T00:00:00.000Z',
         gracePeriodEnd: '2026-07-08T00:00:00.000Z',
-      }],
+      })],
       NOW,
     )
     expect(result[0].daysUntilDowngrade).toBeLessThanOrEqual(0)
@@ -38,13 +54,13 @@ describe('computeBillingHealth', () => {
 
   it('stripe past_due reports an estimate with no fabricated countdown', () => {
     const result = computeBillingHealth(
-      [{ tenantId: 't2', tenantName: 'School B', plan: 'pro', accessCutoffAt: null }],
-      [{
+      [{ tenantId: 't2', tenantName: 'School B', plan: 'pro', accessCutoffAt: null, reasons: ['tenant_past_due'] }],
+      [sub({
         tenantId: 't2',
         paymentMethod: 'stripe',
         currentPeriodEnd: '2026-07-20T00:00:00.000Z',
         gracePeriodEnd: null,
-      }],
+      })],
       NOW,
     )
     expect(result[0].isEstimate).toBe(true)
@@ -55,7 +71,7 @@ describe('computeBillingHealth', () => {
 
   it('past_due tenant with no subscription row surfaces with nulls, not a throw', () => {
     const result = computeBillingHealth(
-      [{ tenantId: 't3', tenantName: 'School C', plan: 'free', accessCutoffAt: null }],
+      [{ tenantId: 't3', tenantName: 'School C', plan: 'free', accessCutoffAt: null, reasons: ['tenant_past_due'] }],
       [],
       NOW,
     )
@@ -68,14 +84,14 @@ describe('computeBillingHealth', () => {
   it('sorts soonest downgrade first, with estimates/nulls last', () => {
     const result = computeBillingHealth(
       [
-        { tenantId: 'stripe-tenant', tenantName: 'Stripe School', plan: 'pro', accessCutoffAt: null },
-        { tenantId: 'far', tenantName: 'Far School', plan: 'starter', accessCutoffAt: null },
-        { tenantId: 'soon', tenantName: 'Soon School', plan: 'starter', accessCutoffAt: null },
+        { tenantId: 'stripe-tenant', tenantName: 'Stripe School', plan: 'pro', accessCutoffAt: null, reasons: ['tenant_past_due'] },
+        { tenantId: 'far', tenantName: 'Far School', plan: 'starter', accessCutoffAt: null, reasons: ['tenant_past_due'] },
+        { tenantId: 'soon', tenantName: 'Soon School', plan: 'starter', accessCutoffAt: null, reasons: ['tenant_past_due'] },
       ],
       [
-        { tenantId: 'stripe-tenant', paymentMethod: 'stripe', currentPeriodEnd: null, gracePeriodEnd: null },
-        { tenantId: 'far', paymentMethod: 'manual_transfer', currentPeriodEnd: null, gracePeriodEnd: '2026-08-10T00:00:00.000Z' },
-        { tenantId: 'soon', paymentMethod: 'manual_transfer', currentPeriodEnd: null, gracePeriodEnd: '2026-07-25T00:00:00.000Z' },
+        sub({ tenantId: 'stripe-tenant', paymentMethod: 'stripe' }),
+        sub({ tenantId: 'far', paymentMethod: 'manual_transfer', gracePeriodEnd: '2026-08-10T00:00:00.000Z' }),
+        sub({ tenantId: 'soon', paymentMethod: 'manual_transfer', gracePeriodEnd: '2026-07-25T00:00:00.000Z' }),
       ],
       NOW,
     )
@@ -84,10 +100,117 @@ describe('computeBillingHealth', () => {
 
   it('passes through access_cutoff_at unchanged', () => {
     const result = computeBillingHealth(
-      [{ tenantId: 't1', tenantName: 'School A', plan: 'free', accessCutoffAt: '2026-08-01T00:00:00.000Z' }],
+      [{ tenantId: 't1', tenantName: 'School A', plan: 'free', accessCutoffAt: '2026-08-01T00:00:00.000Z', reasons: ['tenant_past_due'] }],
       [],
       NOW,
     )
     expect(result[0].accessCutoffAt).toBe('2026-08-01T00:00:00.000Z')
+  })
+
+  // #514 §1 — a tenant whose subscription went past due without
+  // `tenants.billing_status` being synced used to be invisible here.
+  it('surfaces a subscription-only past-due tenant and labels the reason', () => {
+    const result = computeBillingHealth(
+      [{ tenantId: 't4', tenantName: 'Drifted School', plan: 'pro', accessCutoffAt: null, reasons: ['subscription_past_due'] }],
+      [sub({
+        tenantId: 't4',
+        paymentMethod: 'manual_transfer',
+        currentPeriodEnd: '2026-07-10T00:00:00.000Z',
+        gracePeriodEnd: '2026-07-30T00:00:00.000Z',
+      })],
+      NOW,
+    )
+    expect(result).toHaveLength(1)
+    expect(result[0].reasons).toEqual(['subscription_past_due'])
+    expect(result[0].daysUntilDowngrade).toBe(6)
+  })
+
+  // #514 §2 — an over-limit tenant with healthy billing has a cutoff scheduled
+  // but no subscription problem; it must still be listed.
+  it('surfaces a cutoff-only tenant with healthy billing', () => {
+    const result = computeBillingHealth(
+      [{ tenantId: 't5', tenantName: 'Over Limit School', plan: 'starter', accessCutoffAt: '2026-08-07T00:00:00.000Z', reasons: ['access_cutoff_scheduled'] }],
+      [sub({ tenantId: 't5', status: 'active', paymentMethod: 'manual_transfer', gracePeriodEnd: null })],
+      NOW,
+    )
+    expect(result).toHaveLength(1)
+    expect(result[0].reasons).toEqual(['access_cutoff_scheduled'])
+    expect(result[0].accessCutoffAt).toBe('2026-08-07T00:00:00.000Z')
+    // No grace deadline on an active subscription, so no fabricated countdown.
+    expect(result[0].daysUntilDowngrade).toBeNull()
+  })
+
+  it('keeps every reason a tenant qualified under, in a stable order', () => {
+    const result = computeBillingHealth(
+      [{
+        tenantId: 't6',
+        tenantName: 'Doubly At-Risk School',
+        plan: 'starter',
+        accessCutoffAt: '2026-08-01T00:00:00.000Z',
+        // Deliberately out of canonical order.
+        reasons: ['access_cutoff_scheduled', 'subscription_past_due', 'tenant_past_due'],
+      }],
+      [],
+      NOW,
+    )
+    expect(result[0].reasons).toEqual([
+      'tenant_past_due',
+      'subscription_past_due',
+      'access_cutoff_scheduled',
+    ])
+  })
+
+  // #514 §3 — unreachable while `platform_subscriptions` carries
+  // UNIQUE (tenant_id), but the ranking must not depend on result order.
+  it('picks the current subscription row over a stale one regardless of input order', () => {
+    const stale = sub({
+      tenantId: 't7',
+      status: 'canceled',
+      paymentMethod: 'stripe',
+      currentPeriodEnd: '2026-01-01T00:00:00.000Z',
+      gracePeriodEnd: null,
+      updatedAt: '2026-01-02T00:00:00.000Z',
+    })
+    const current = sub({
+      tenantId: 't7',
+      status: 'past_due',
+      paymentMethod: 'manual_transfer',
+      currentPeriodEnd: '2026-07-15T00:00:00.000Z',
+      gracePeriodEnd: '2026-07-29T00:00:00.000Z',
+      updatedAt: '2026-07-15T00:00:00.000Z',
+    })
+    const tenants = [{ tenantId: 't7', tenantName: 'Multi-row School', plan: 'starter', accessCutoffAt: null, reasons: ['tenant_past_due' as const] }]
+
+    for (const subs of [[stale, current], [current, stale]]) {
+      const result = computeBillingHealth(tenants, subs, NOW)
+      expect(result[0].paymentMethod).toBe('manual_transfer')
+      expect(result[0].graceEndsAt).toBe('2026-07-29T00:00:00.000Z')
+      expect(result[0].daysUntilDowngrade).toBe(5)
+      expect(result[0].isEstimate).toBe(false)
+    }
+  })
+
+  it('breaks a same-status tie on updated_at, newest wins', () => {
+    const older = sub({
+      tenantId: 't8',
+      status: 'past_due',
+      paymentMethod: 'stripe',
+      gracePeriodEnd: null,
+      updatedAt: '2026-06-01T00:00:00.000Z',
+    })
+    const newer = sub({
+      tenantId: 't8',
+      status: 'past_due',
+      paymentMethod: 'manual_transfer',
+      gracePeriodEnd: '2026-07-28T00:00:00.000Z',
+      updatedAt: '2026-07-20T00:00:00.000Z',
+    })
+    const tenants = [{ tenantId: 't8', tenantName: 'Tie School', plan: 'pro', accessCutoffAt: null, reasons: ['tenant_past_due' as const] }]
+
+    for (const subs of [[older, newer], [newer, older]]) {
+      const result = computeBillingHealth(tenants, subs, NOW)
+      expect(result[0].paymentMethod).toBe('manual_transfer')
+      expect(result[0].daysUntilDowngrade).toBe(4)
+    }
   })
 })

--- a/tests/unit/billing-health.test.ts
+++ b/tests/unit/billing-health.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest'
-import { computeBillingHealth } from '@/lib/billing/billing-health'
+import {
+  computeBillingHealth,
+  mergeAtRiskTenants,
+  type AtRiskTenantRow,
+} from '@/lib/billing/billing-health'
 
 const NOW = new Date('2026-07-24T00:00:00.000Z')
 
@@ -212,5 +216,170 @@ describe('computeBillingHealth', () => {
       expect(result[0].paymentMethod).toBe('manual_transfer')
       expect(result[0].daysUntilDowngrade).toBe(4)
     }
+  })
+
+  // The union in #514 admits tenants whose billing is fine. `downgradeTenantToFree()`
+  // sets status='canceled' but never clears grace_period_end, then schedules the very
+  // cutoff that lists the tenant here — so this row shape is the common one, not exotic.
+  it('does not report a downgrade countdown for a cutoff-only tenant carrying a stale grace stamp', () => {
+    const result = computeBillingHealth(
+      [{
+        tenantId: 't9',
+        tenantName: 'Lapsed School',
+        plan: 'free',
+        accessCutoffAt: '2026-08-07T00:00:00.000Z',
+        reasons: ['access_cutoff_scheduled'],
+      }],
+      [sub({
+        tenantId: 't9',
+        status: 'canceled',
+        paymentMethod: 'manual_transfer',
+        currentPeriodEnd: '2026-06-01T00:00:00.000Z',
+        gracePeriodEnd: '2026-06-08T00:00:00.000Z',
+        updatedAt: '2026-06-08T00:00:00.000Z',
+      })],
+      NOW,
+    )
+    expect(result[0].daysUntilDowngrade).toBeNull()
+    expect(result[0].graceEndsAt).toBeNull()
+    // "Past due since" must stay empty for a tenant that is not past due.
+    expect(result[0].pastDueSince).toBeNull()
+    // No downgrade pending, so nothing to estimate — not Stripe dunning.
+    expect(result[0].isEstimate).toBe(false)
+  })
+
+  it('keeps a live past-due school above an already-downgraded cutoff-only one', () => {
+    const result = computeBillingHealth(
+      [
+        {
+          tenantId: 'lapsed',
+          tenantName: 'Lapsed School',
+          plan: 'free',
+          accessCutoffAt: '2026-08-07T00:00:00.000Z',
+          reasons: ['access_cutoff_scheduled'],
+        },
+        {
+          tenantId: 'live',
+          tenantName: 'Live School',
+          plan: 'starter',
+          accessCutoffAt: null,
+          reasons: ['tenant_past_due'],
+        },
+      ],
+      [
+        sub({
+          tenantId: 'lapsed',
+          status: 'canceled',
+          paymentMethod: 'manual_transfer',
+          gracePeriodEnd: '2026-06-08T00:00:00.000Z',
+        }),
+        sub({
+          tenantId: 'live',
+          paymentMethod: 'manual_transfer',
+          gracePeriodEnd: '2026-07-30T00:00:00.000Z',
+        }),
+      ],
+      NOW,
+    )
+    expect(result.map((r) => r.tenantId)).toEqual(['live', 'lapsed'])
+  })
+
+  it('orders the no-countdown tail by soonest cutoff, then by name', () => {
+    const cutoffOnly = (tenantId: string, tenantName: string, accessCutoffAt: string | null) => ({
+      tenantId,
+      tenantName,
+      plan: 'free',
+      accessCutoffAt,
+      reasons: ['access_cutoff_scheduled' as const],
+    })
+    const result = computeBillingHealth(
+      [
+        cutoffOnly('none', 'Zeta School', null),
+        cutoffOnly('late', 'Later School', '2026-09-01T00:00:00.000Z'),
+        cutoffOnly('soon', 'Sooner School', '2026-07-26T00:00:00.000Z'),
+      ],
+      [],
+      NOW,
+    )
+    expect(result.map((r) => r.tenantId)).toEqual(['soon', 'late', 'none'])
+  })
+
+  it('marks a cutoff already in the past as active, a future one as not', () => {
+    const result = computeBillingHealth(
+      [
+        { tenantId: 'past', tenantName: 'Paused School', plan: 'free', accessCutoffAt: '2026-07-01T00:00:00.000Z', reasons: ['access_cutoff_scheduled'] },
+        { tenantId: 'future', tenantName: 'Warned School', plan: 'free', accessCutoffAt: '2026-08-01T00:00:00.000Z', reasons: ['access_cutoff_scheduled'] },
+      ],
+      [],
+      NOW,
+    )
+    const byId = new Map(result.map((r) => [r.tenantId, r]))
+    expect(byId.get('past')!.accessCutoffActive).toBe(true)
+    expect(byId.get('future')!.accessCutoffActive).toBe(false)
+  })
+})
+
+describe('mergeAtRiskTenants', () => {
+  const row = (tenantId: string, accessCutoffAt: string | null = null): AtRiskTenantRow => ({
+    tenantId,
+    tenantName: `School ${tenantId}`,
+    plan: 'starter',
+    accessCutoffAt,
+  })
+
+  it('unions the three populations without duplicating a tenant', () => {
+    const merged = mergeAtRiskTenants({
+      pastDueTenants: [row('a'), row('shared')],
+      cutoffTenants: [row('shared', '2026-08-01T00:00:00.000Z'), row('c', '2026-08-02T00:00:00.000Z')],
+      subscriptionPastDueTenantIds: ['shared', 'd'],
+      extraTenants: [row('d')],
+    })
+    expect(merged.map((t) => t.tenantId).sort()).toEqual(['a', 'c', 'd', 'shared'])
+  })
+
+  it('accumulates every reason a tenant qualified under, in canonical order', () => {
+    const [tenant] = mergeAtRiskTenants({
+      pastDueTenants: [row('x')],
+      cutoffTenants: [row('x', '2026-08-01T00:00:00.000Z')],
+      subscriptionPastDueTenantIds: ['x'],
+      extraTenants: [],
+    })
+    expect(tenant.reasons).toEqual([
+      'tenant_past_due',
+      'subscription_past_due',
+      'access_cutoff_scheduled',
+    ])
+  })
+
+  it('surfaces a subscription-only tenant from the extra fetch', () => {
+    const merged = mergeAtRiskTenants({
+      pastDueTenants: [],
+      cutoffTenants: [],
+      subscriptionPastDueTenantIds: ['drifted'],
+      extraTenants: [row('drifted')],
+    })
+    expect(merged).toHaveLength(1)
+    expect(merged[0].reasons).toEqual(['subscription_past_due'])
+  })
+
+  it('drops a subscription whose tenant row could not be read', () => {
+    const merged = mergeAtRiskTenants({
+      pastDueTenants: [row('a')],
+      cutoffTenants: [],
+      subscriptionPastDueTenantIds: ['a', 'vanished'],
+      extraTenants: [],
+    })
+    expect(merged.map((t) => t.tenantId)).toEqual(['a'])
+  })
+
+  it('does not let the cutoff read overwrite a past-due tenant row', () => {
+    const merged = mergeAtRiskTenants({
+      pastDueTenants: [row('a')],
+      cutoffTenants: [{ ...row('a', '2026-08-01T00:00:00.000Z'), tenantName: 'School a' }],
+      subscriptionPastDueTenantIds: [],
+      extraTenants: [],
+    })
+    expect(merged[0].accessCutoffAt).toBe('2026-08-01T00:00:00.000Z')
+    expect(merged[0].reasons).toEqual(['tenant_past_due', 'access_cutoff_scheduled'])
   })
 })


### PR DESCRIPTION
Closes #514. Builds directly on @DPS0340's #523 — their commit is the first commit on this branch, unmodified, with authorship preserved. This PR is #523 plus the follow-ups from its review.

## What #523 got right (kept as-is)

The union fetch is the correct answer to §1 and §2: three reads merged by tenant id (`tenants.billing_status='past_due'`, tenants owning a `past_due` subscription, `tenants.access_cutoff_at IS NOT NULL`), each contributing an `AtRiskReason`, because PostgREST cannot express a disjunction spanning two tables. Keeping `reasons` as a set rather than collapsing to one enum is what makes the drift visible. The deterministic subscription ranking for §3 is also kept, along with its honest framing: `platform_subscriptions` carries `UNIQUE (tenant_id)` (`20260217040000_platform_billing.sql:46`) and every writer upserts on it, so §3 is unreachable today — the ranking is a trap-removal, not a live fix.

## What this PR adds

### 1. Past-due-derived fields are gated on the tenant being past due

Widening the population admits tenants whose billing is healthy, but `computeBillingHealth` still derived `pastDueSince`, `graceEndsAt`, `daysUntilDowngrade` and `isEstimate` from `payment_method` alone. That is wrong for the single most common cutoff-only population — a school that already lapsed to free and is now over the free plan's limits:

- `downgradeTenantToFree()` sets `status: 'canceled'` but **never clears `grace_period_end`** (`lib/billing/downgrade-tenant.ts:34-41`); only `confirmManualPayment` and the non-`liveCycle` branch of `changePlan` do.
- The same function then calls `reconcileAccessCutoff()` (`:64`) — which is exactly what stamps the `access_cutoff_at` the new query selects on.

So that tenant arrived with `payment_method: 'manual_transfer'` and a months-old grace stamp, and rendered **"Past due since Jun 1, 2026"** with a red **"Overdue"** in _Downgrades in_. Worse, the sort is ascending on `daysUntilDowngrade`, so its `-46` put it **above every school that still had a downgrade to avert**. A healthy Stripe tenant with a cutoff had the milder version: a *future* renewal date under "Past due since", plus the "Stripe-managed" dunning badge.

Those four fields now require `tenant_past_due` or `subscription_past_due` among the row's reasons. `isEstimate` also reads correctly again: false for a cutoff-only row, which has no downgrade to estimate rather than an unknowable one.

### 2. The no-countdown tail is ordered

Rows without a countdown used to compare equal to each other. They now sort by soonest `accessCutoffAt`, then by name, so the tail is meaningful and the render is stable across reloads.

### 3. Fetch flattened from four sequential round-trips to two

`await verifySuperAdmin()` → `Promise.all([3 reads])` → `tenants.in(missingIds)` → `subscriptions.in(ids)` was two more serial layers than the union needs. The past-due subscription read now takes the full column set instead of just `tenant_id`, so the subscription rows for subscription-only tenants are already in hand — which makes the follow-up `tenants` fetch independent of the subscription fetch, and the two go out together. Feeding both subscription lists to `computeBillingHealth` is safe precisely because of #523's ranking change: duplicate identical rows resolve to the incumbent instead of last-wins.

The super-admin check deliberately stays **ahead** of the reads and is not folded into the `Promise.all` — there is a comment saying so, because it is the kind of thing a later "parallelize everything" pass would break. A non-super-admin caller must not cause tenant billing data to be read at all.

### 4. Testability and typing

- `mergeAtRiskTenants()` is now a pure exported function, so the union — the part of #514 with the actual new logic, and the only part #523 left untested — is unit-testable without a database.
- Row mapping goes through typed helpers instead of `as TenantRow[]`, so a drifting `select` list fails `tsc` instead of rendering blanks.

### 5. UI

- A cutoff already in the past is labelled **"Access paused"** instead of "Cutoff scheduled" — access has already stopped, and `accessCutoffActive` is computed in the pure layer against the injected `now` so it stays deterministic.
- The four metric-card counts are computed in one pass over the list instead of five chained `.filter()` calls.

## Deliberately not in scope

- **i18n.** All strings are hardcoded English, which matches the convention: none of the 9 pages under `app/[locale]/platform/` use `next-intl`, since this console is super-admin-only. Localizing it is a separate change covering all 9 pages.
- **Reconciling `tenants.billing_status` against `platform_subscriptions.status` at write time.** #523 called this out and was right to leave it: this dashboard now stops *hiding* the drift; removing the drift is its own issue.
- No migration, no schema change, no new dependency.

## Testing

- [x] `npx vitest run` — **332 passed (27 files)**, up from 323. `tests/unit/billing-health.test.ts` goes 11 → 20: the stale-grace cutoff-only row reports no countdown and no "past due since", a live past-due school outranks an already-downgraded one, the no-countdown tail ordering, `accessCutoffActive` on both sides of `now`, and five cases for `mergeAtRiskTenants` (union without duplicates, reason accumulation, subscription-only surfacing, a subscription whose tenant row is missing, and the cutoff read not clobbering a past-due row).
- [x] `npx tsc --noEmit` — clean.
- [x] `npx eslint` on all four changed files — clean.
- [ ] **Not verified in a browser.** Docker is not running on this machine and there are no local Supabase containers, so the page was never rendered against real rows. Everything above is unit-level.

### QA script for the reviewer

With a local stack up (`supabase start && npm run db:reset`), as a super admin at `/platform/billing-health`:

1. **Cutoff-only, already downgraded** — pick a tenant, set `platform_subscriptions` to `status='canceled'`, `payment_method='manual_transfer'`, `grace_period_end` a month in the past, and `tenants.access_cutoff_at` a week in the future, with `billing_status` *not* `past_due`.
   Expect: listed with a single **Cutoff scheduled** badge, `—` in both _Past due since_ and _Downgrades in_, and positioned **below** any school with a live countdown. On master it is absent entirely; on #523 alone it shows a red "Overdue" at the top of the table.
2. **Cutoff already in force** — same tenant, `access_cutoff_at` in the past. Badge should read **Access paused**.
3. **Subscription-only past due** — set `platform_subscriptions.status='past_due'` while leaving `tenants.billing_status='active'`. Expect the school listed with a **Subscription past due** badge (invisible on master).
4. **Regression** — a genuinely past-due manual-transfer school with a future `grace_period_end` still shows its countdown, still colour-codes at ≤3 and ≤7 days, and still sorts first.
5. Metric cards: the first three count past-due schools only; the fourth counts scheduled cutoffs. Adding an over-limit school must not move the first three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WJDnXnWmdBDTX33bvTx62K
