### PR TITLE
fix(db): make the split snapshot database-owned, not caller-supplied (#512)

### DIFF
--- a/app/api/payments/checkout/route.ts
+++ b/app/api/payments/checkout/route.ts
@@ -207,9 +207,18 @@ export async function POST(req: NextRequest) {
 
     // Snapshot the tenant's CURRENT revenue split onto this transaction (#496)
     // so a later plan change doesn't retroactively reprice it in the payouts
-    // computation — revenue_splits is super-admin-only under RLS, so this
-    // needs the admin client even though the rest of this route uses the
-    // user-scoped one.
+    // computation. The admin client is belt-and-braces, not a requirement: this
+    // comment used to say revenue_splits is "super-admin-only under RLS", which
+    // is wrong — the SELECT policy is `tenant_id = get_tenant_id() OR
+    // is_super_admin()`, so the user-scoped client could read it too (#512).
+    //
+    // Since #512 the DATABASE owns this column: the BEFORE INSERT trigger in
+    // 20260725110000_transaction_split_snapshot_backstop.sql recomputes it from
+    // the same table and ignores whatever we send, because the column is
+    // writable by any authenticated client (transactions RLS restricts rows, not
+    // columns) and a student-supplied value must not survive. This write is kept
+    // deliberately: it computes the identical number, and it keeps the rollback
+    // migration a safe lever — drop the trigger and this path still snapshots.
     const adminClientForSplit = createAdminClient()
     const { data: revenueSplit } = await adminClientForSplit
       .from('revenue_splits')

--- a/lib/payments/payouts-owed.ts
+++ b/lib/payments/payouts-owed.ts
@@ -14,10 +14,21 @@
  * snapshotted at insert time in `app/api/payments/checkout/route.ts` — see
  * issue #496), not the tenant's current split applied retroactively to the
  * whole sum. A plan change (which rewrites `revenue_splits`) therefore only
- * affects transactions created after the change. Transactions predating the
- * snapshot column (`schoolPercentageSnapshot: null`) fall back to the
- * tenant's current `schoolPercentage` — the same behavior this module had
- * before #496, so old data isn't retroactively wrong either way.
+ * affects transactions created after the change.
+ *
+ * That snapshot is also enforced in the database (issue #512): a
+ * BEFORE INSERT OR UPDATE trigger on `transactions` fills it from
+ * `revenue_splits` whenever a caller omits it, so a transaction-insert path
+ * that forgets — or a webhook that sets `payment_provider` on an existing row
+ * post-insert — cannot silently fall back to the current-split behaviour.
+ * The trigger never overwrites a non-NULL snapshot, so the app-layer write
+ * stays authoritative and history is never re-stamped.
+ *
+ * Transactions predating the snapshot column (`schoolPercentageSnapshot:
+ * null`) still fall back to the tenant's current `schoolPercentage` — the
+ * same behavior this module had before #496, so old data isn't retroactively
+ * wrong either way. They were deliberately not backfilled: stamping today's
+ * split onto history would manufacture the very repricing #496 removed.
  *
  * Balances are grouped PER CURRENCY (issue #497) — a tenant with both USD and
  * EUR sales owes two separate numbers, never one meaningless summed total.

--- a/lib/payments/payouts-owed.ts
+++ b/lib/payments/payouts-owed.ts
@@ -16,19 +16,31 @@
  * whole sum. A plan change (which rewrites `revenue_splits`) therefore only
  * affects transactions created after the change.
  *
- * That snapshot is also enforced in the database (issue #512): a
- * BEFORE INSERT OR UPDATE trigger on `transactions` fills it from
- * `revenue_splits` whenever a caller omits it, so a transaction-insert path
- * that forgets — or a webhook that sets `payment_provider` on an existing row
- * post-insert — cannot silently fall back to the current-split behaviour.
- * The trigger never overwrites a non-NULL snapshot, so the app-layer write
- * stays authoritative and history is never re-stamped.
+ * Since issue #512 that snapshot is OWNED BY THE DATABASE, not by the caller.
+ * `20260725110000_transaction_split_snapshot_backstop.sql` computes it from
+ * `revenue_splits` on INSERT and freezes it on UPDATE, so:
+ *
+ *   - a transaction-insert path that forgets it (four of the five do) can't
+ *     silently fall back to the current-split behaviour;
+ *   - a webhook that sets `payment_provider` on an existing row post-insert
+ *     (`lib/payments/webhook-dispatch.ts`) can't either;
+ *   - and no client can supply the number. `transactions` grants ALL to
+ *     `authenticated` and its RLS policies restrict which ROWS a user may
+ *     write, never which columns — so without the trigger a student could set
+ *     `school_percentage_snapshot: 100` on their own transaction and inflate
+ *     `grossOwed` below.
+ *
+ * The value never changes once written, so history is never re-stamped —
+ * re-stamping would be the #496 bug, not a fix for it.
  *
  * Transactions predating the snapshot column (`schoolPercentageSnapshot:
  * null`) still fall back to the tenant's current `schoolPercentage` — the
  * same behavior this module had before #496, so old data isn't retroactively
  * wrong either way. They were deliberately not backfilled: stamping today's
- * split onto history would manufacture the very repricing #496 removed.
+ * split onto history would manufacture the very repricing #496 removed. Such
+ * a row is snapshotted in exactly one situation — a provider activating it
+ * (its `payment_provider` changing), the one moment at which today's split is
+ * the honest answer for it.
  *
  * Balances are grouped PER CURRENCY (issue #497) — a tenant with both USD and
  * EUR sales owes two separate numbers, never one meaningless summed total.

--- a/supabase/migrations/20260725110000_transaction_split_snapshot_backstop.sql
+++ b/supabase/migrations/20260725110000_transaction_split_snapshot_backstop.sql
@@ -1,0 +1,90 @@
+-- Issue #512 — database backstop for the revenue-split snapshot.
+--
+-- #496 fixed retroactive repricing by snapshotting revenue_splits.school_percentage
+-- onto each transaction, but that snapshot is written at exactly ONE call site
+-- (app/api/payments/checkout/route.ts). Every other transaction-insert path
+-- omits it, and nothing fails when they do: computeOwedBalances() silently falls
+-- back to the tenant's CURRENT split, which is the #496 bug returning by a side
+-- door. The number is just quietly wrong.
+--
+-- WHY INSERT *OR UPDATE*, not INSERT alone.
+--
+-- The obvious backstop is BEFORE INSERT, on the reasoning that the unsnapshotted
+-- insert sites are harmless because they leave payment_provider NULL (they write
+-- payment_method instead) or use Stripe Connect, and getPayoutsOwed() filters on
+-- platform-settled payment_provider values. That reasoning holds for the insert
+-- and fails for the row's lifetime: payment_provider is also written by UPDATE,
+-- after the row exists —
+--
+--   lib/payments/webhook-dispatch.ts:205  .update({ status, payment_provider })
+--   app/api/stripe/webhook/route.ts:406   same shape, Stripe subscriptions
+--
+-- dispatchBillingEvent is the shared activation path for PayPal, the unified
+-- provider webhook (Lemon Squeezy et al), and Stripe. PayPal and Lemon Squeezy
+-- are precisely the settlesToPlatformAccount providers the payout computation
+-- reads. So a row can be inserted with payment_provider NULL, sail past a
+-- BEFORE INSERT trigger with nothing to do, and only then be turned into a
+-- platform-settled transaction by a webhook — arriving in the payout math with
+-- a NULL snapshot. Covering UPDATE closes that path.
+--
+-- WHAT IT DELIBERATELY DOES NOT DO.
+--
+-- 1. It never overwrites an existing snapshot. On UPDATE it acts only while the
+--    value is still NULL, so a historical transaction is never re-stamped with a
+--    newer split — re-stamping would BE the #496 bug, not a fix for it. The
+--    app-layer write therefore stays authoritative; this only fills gaps.
+--
+-- 2. It does not backfill existing NULLs. Rows predating 20260724140000 are
+--    documented (in that migration and in lib/payments/payouts-owed.ts) to fall
+--    back to the tenant's current split. Backfilling would stamp TODAY's split
+--    onto history and manufacture exactly the retroactive repricing #496
+--    removed — and it would look authoritative while doing it, which is worse
+--    than a documented fallback.
+--
+-- A CHECK constraint was the alternative offered in the issue. It cannot read
+-- revenue_splits, and a check like `payment_provider IS NULL OR snapshot IS NOT
+-- NULL` would hard-fail the webhook UPDATE above for any legacy NULL-snapshot
+-- row a provider later activates — converting a quiet mispricing into a failed
+-- activation and a lost sale. Filling the value beats rejecting the row.
+
+-- Mirrors DEFAULT_SCHOOL_PERCENTAGE in lib/payments/payouts-owed.ts, the 20%
+-- platform default in app/api/stripe/create-payment-intent/route.ts, and the
+-- row seeded by 20260216212440_create_revenue_infrastructure.sql. Used only
+-- when a tenant has no revenue_splits row at all.
+CREATE OR REPLACE FUNCTION public.set_transaction_split_snapshot()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_school_percentage numeric;
+BEGIN
+  -- Explicit app-layer value wins, always.
+  IF NEW.school_percentage_snapshot IS NOT NULL THEN
+    RETURN NEW;
+  END IF;
+
+  IF NEW.tenant_id IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT school_percentage INTO v_school_percentage
+  FROM revenue_splits
+  WHERE tenant_id = NEW.tenant_id;
+
+  NEW.school_percentage_snapshot := COALESCE(v_school_percentage, 80);
+
+  RETURN NEW;
+END;
+$function$;
+
+COMMENT ON FUNCTION public.set_transaction_split_snapshot() IS
+  'Backstop for #496 (issue #512): fills transactions.school_percentage_snapshot from revenue_splits when a caller omits it. Never overwrites a non-NULL snapshot, so historical rows are not repriced. Fires on UPDATE too, because payment_provider is set post-insert by the webhook activation path (lib/payments/webhook-dispatch.ts).';
+
+DROP TRIGGER IF EXISTS before_transaction_split_snapshot ON transactions;
+CREATE TRIGGER before_transaction_split_snapshot
+  BEFORE INSERT OR UPDATE ON transactions
+  FOR EACH ROW
+  WHEN (NEW.school_percentage_snapshot IS NULL)
+  EXECUTE FUNCTION public.set_transaction_split_snapshot();

--- a/supabase/migrations/20260725110000_transaction_split_snapshot_backstop.sql
+++ b/supabase/migrations/20260725110000_transaction_split_snapshot_backstop.sql
@@ -7,50 +7,103 @@
 -- back to the tenant's CURRENT split, which is the #496 bug returning by a side
 -- door. The number is just quietly wrong.
 --
--- WHY INSERT *OR UPDATE*, not INSERT alone.
+-- This makes `transactions.school_percentage_snapshot` a DATABASE-OWNED column:
+-- the value is computed here, from revenue_splits, and is immutable once set.
+-- No caller writes it and no caller can tamper with it.
 --
--- The obvious backstop is BEFORE INSERT, on the reasoning that the unsnapshotted
--- insert sites are harmless because they leave payment_provider NULL (they write
--- payment_method instead) or use Stripe Connect, and getPayoutsOwed() filters on
--- platform-settled payment_provider values. That reasoning holds for the insert
--- and fails for the row's lifetime: payment_provider is also written by UPDATE,
--- after the row exists —
+-- WHY THE COLUMN HAS TO BE DATABASE-OWNED, NOT MERELY DEFAULTED.
+--
+-- The obvious backstop is "fill it in when the caller omits it, and let an
+-- explicit value win." That cannot be the rule here, because the explicit value
+-- can come from a caller we do not trust. `transactions` grants ALL to
+-- `authenticated` (20260126190500_lms_complete.sql), and the RLS policies in
+-- 20260313025318_rls_transactions.sql restrict only WHICH ROWS a user may write,
+-- never which columns:
+--
+--   CREATE POLICY "Users can create own transactions"
+--     ON public.transactions FOR INSERT TO authenticated
+--     WITH CHECK (auth.uid() = user_id AND tenant_id = get_tenant_id());
+--
+-- So a student can POST /rest/v1/transactions with school_percentage_snapshot:
+-- 100 — or UPDATE their own row to set it later — and that number flows straight
+-- into computeOwedBalances()'s grossOwed, inflating what the platform believes it
+-- owes their school. A backstop that defers to the explicit value would preserve
+-- exactly the write we most need to override. Hence: computed on INSERT, frozen
+-- on UPDATE.
+--
+-- (The column-privilege alternative — REVOKE INSERT, UPDATE (school_percentage_
+-- snapshot) — is a no-op while the table-level grant is held. Closing it that way
+-- means revoking table-level INSERT/UPDATE from `authenticated` and re-granting an
+-- explicit column list, which silently breaks every column omitted from that list.
+-- Owning the value in a trigger is the narrower change.)
+--
+-- WHY UPDATE, not INSERT alone.
+--
+-- payment_provider — the field getPayoutsOwed() filters on — is also written by
+-- UPDATE, after the row exists:
 --
 --   lib/payments/webhook-dispatch.ts:205  .update({ status, payment_provider })
 --   app/api/stripe/webhook/route.ts:406   same shape, Stripe subscriptions
 --
 -- dispatchBillingEvent is the shared activation path for PayPal, the unified
--- provider webhook (Lemon Squeezy et al), and Stripe. PayPal and Lemon Squeezy
--- are precisely the settlesToPlatformAccount providers the payout computation
--- reads. So a row can be inserted with payment_provider NULL, sail past a
--- BEFORE INSERT trigger with nothing to do, and only then be turned into a
--- platform-settled transaction by a webhook — arriving in the payout math with
--- a NULL snapshot. Covering UPDATE closes that path.
+-- provider webhook (Lemon Squeezy et al), and Stripe. PayPal and Lemon Squeezy are
+-- precisely the settlesToPlatformAccount providers the payout computation reads.
+-- So a row inserted before this migration, carrying a NULL snapshot, can be turned
+-- into a platform-settled transaction by a webhook and arrive in the payout math
+-- with nothing snapshotted. Covering UPDATE closes that path.
 --
 -- WHAT IT DELIBERATELY DOES NOT DO.
 --
--- 1. It never overwrites an existing snapshot. On UPDATE it acts only while the
---    value is still NULL, so a historical transaction is never re-stamped with a
---    newer split — re-stamping would BE the #496 bug, not a fix for it. The
---    app-layer write therefore stays authoritative; this only fills gaps.
+-- 1. It never re-stamps a snapshot that already exists. Re-stamping a historical
+--    transaction with a newer split would BE the #496 bug, not a fix for it. On
+--    UPDATE the previous value is restored verbatim, so the row is frozen from the
+--    moment it is first written — against tampering and against drift alike.
 --
--- 2. It does not backfill existing NULLs. Rows predating 20260724140000 are
---    documented (in that migration and in lib/payments/payouts-owed.ts) to fall
---    back to the tenant's current split. Backfilling would stamp TODAY's split
---    onto history and manufacture exactly the retroactive repricing #496
---    removed — and it would look authoritative while doing it, which is worse
---    than a documented fallback.
+-- 2. It does not backfill existing NULLs, and it does not fill them on unrelated
+--    updates. Rows predating 20260724140000 are documented (in that migration and
+--    in lib/payments/payouts-owed.ts) to fall back to the tenant's current split.
+--    Stamping today's split onto a year-old sale is the same retroactive repricing
+--    #496 removed — it does not stop being that because it happens one row at a
+--    time, when something incidental (a refund, an archive) touches the row. A
+--    legacy NULL is therefore filled in exactly ONE case: the row is being
+--    activated by a provider right now (payment_provider is changing), which is
+--    the only moment at which today's split is the honest answer.
 --
 -- A CHECK constraint was the alternative offered in the issue. It cannot read
 -- revenue_splits, and a check like `payment_provider IS NULL OR snapshot IS NOT
--- NULL` would hard-fail the webhook UPDATE above for any legacy NULL-snapshot
--- row a provider later activates — converting a quiet mispricing into a failed
+-- NULL` would hard-fail the webhook UPDATE above for any legacy NULL-snapshot row
+-- a provider later activates — converting a quiet mispricing into a failed
 -- activation and a lost sale. Filling the value beats rejecting the row.
+--
+-- The pre-existing after_transaction_insert / after_transaction_update triggers
+-- are both AFTER, so these BEFORE triggers compose with them without ordering
+-- concerns.
 
--- Mirrors DEFAULT_SCHOOL_PERCENTAGE in lib/payments/payouts-owed.ts, the 20%
--- platform default in app/api/stripe/create-payment-intent/route.ts, and the
--- row seeded by 20260216212440_create_revenue_infrastructure.sql. Used only
--- when a tenant has no revenue_splits row at all.
+-- The fallback mirrors DEFAULT_SCHOOL_PERCENTAGE in lib/payments/payouts-owed.ts,
+-- the revenue_splits.school_percentage column default, the 20% platform default in
+-- app/api/stripe/create-payment-intent/route.ts, and the row seeded by
+-- 20260216212440_create_revenue_infrastructure.sql. It is used only when a tenant
+-- has no revenue_splits row at all. (tests/unit/transaction-split-snapshot-
+-- backstop.test.ts fails if this number and the TypeScript constant drift apart.)
+--
+-- SECURITY DEFINER, deliberately — but not for the reason the surrounding code
+-- comments claim. `app/api/payments/checkout/route.ts` says revenue_splits is
+-- "super-admin-only under RLS"; it isn't. Despite its name, the SELECT policy from
+-- 20260216212440 is:
+--
+--   "Admins can view own revenue split": tenant_id = get_tenant_id() OR is_super_admin()
+--
+-- — i.e. every member of the tenant, students included, can read their school's
+-- split (verified against a local database). So an INVOKER function would in fact
+-- work today, because the transactions INSERT policy already pins
+-- NEW.tenant_id = get_tenant_id().
+--
+-- That is exactly why it must not be INVOKER. The correctness of this trigger would
+-- then rest on a SELECT policy whose own name says it should be narrower — and the
+-- day someone tightens it to match the name, this function stops seeing the row and
+-- silently stamps the 80 fallback onto every checkout for every tenant. Wrong
+-- payout numbers, no error, no failing test. DEFINER removes that coupling.
+-- search_path is pinned for the usual reason.
 CREATE OR REPLACE FUNCTION public.set_transaction_split_snapshot()
 RETURNS trigger
 LANGUAGE plpgsql
@@ -60,12 +113,28 @@ AS $function$
 DECLARE
   v_school_percentage numeric;
 BEGIN
-  -- Explicit app-layer value wins, always.
-  IF NEW.school_percentage_snapshot IS NOT NULL THEN
-    RETURN NEW;
+  IF TG_OP = 'UPDATE' THEN
+    -- Already snapshotted: frozen. Restoring OLD rather than comparing-and-
+    -- raising means a tampering UPDATE is neutralised instead of failing the
+    -- whole webhook that happened to carry it.
+    IF OLD.school_percentage_snapshot IS NOT NULL THEN
+      NEW.school_percentage_snapshot := OLD.school_percentage_snapshot;
+      RETURN NEW;
+    END IF;
+
+    -- Legacy NULL row. Fill it only if a provider is activating it right now;
+    -- otherwise keep the documented NULL fallback and discard whatever the
+    -- caller tried to put there.
+    IF NEW.payment_provider IS NOT DISTINCT FROM OLD.payment_provider THEN
+      NEW.school_percentage_snapshot := NULL;
+      RETURN NEW;
+    END IF;
   END IF;
 
+  -- INSERT, or the legacy-row activation case above. Either way the value is
+  -- computed here; anything the caller supplied is ignored.
   IF NEW.tenant_id IS NULL THEN
+    NEW.school_percentage_snapshot := NULL;
     RETURN NEW;
   END IF;
 
@@ -80,11 +149,31 @@ END;
 $function$;
 
 COMMENT ON FUNCTION public.set_transaction_split_snapshot() IS
-  'Backstop for #496 (issue #512): fills transactions.school_percentage_snapshot from revenue_splits when a caller omits it. Never overwrites a non-NULL snapshot, so historical rows are not repriced. Fires on UPDATE too, because payment_provider is set post-insert by the webhook activation path (lib/payments/webhook-dispatch.ts).';
+  'Backstop for #496 (issue #512): owns transactions.school_percentage_snapshot. Computes it from revenue_splits on INSERT and freezes it on UPDATE, so neither an insert path that forgets nor a client that tampers (transactions RLS restricts rows, not columns) can affect the payout computation. Legacy NULL rows are filled only when a provider activates them (payment_provider changing), never on an incidental update.';
 
+-- Named without the _insert suffix in an earlier revision of this migration.
 DROP TRIGGER IF EXISTS before_transaction_split_snapshot ON transactions;
-CREATE TRIGGER before_transaction_split_snapshot
-  BEFORE INSERT OR UPDATE ON transactions
+
+-- No WHEN clause: the point is to override whatever the caller sent, so this has
+-- to run on every insert. It is one index lookup on revenue_splits (UNIQUE
+-- (tenant_id), 20260216212440) against a table only written on payment events.
+DROP TRIGGER IF EXISTS before_transaction_split_snapshot_insert ON transactions;
+CREATE TRIGGER before_transaction_split_snapshot_insert
+  BEFORE INSERT ON transactions
   FOR EACH ROW
-  WHEN (NEW.school_percentage_snapshot IS NULL)
+  EXECUTE FUNCTION public.set_transaction_split_snapshot();
+
+-- OLD cannot be referenced in a WHEN clause on a combined INSERT OR UPDATE
+-- trigger, which is why this is a second trigger rather than one. The clause
+-- keeps ordinary status-only updates from calling the function at all: it fires
+-- only when someone is touching the snapshot, or when a provider is activating
+-- the row.
+DROP TRIGGER IF EXISTS before_transaction_split_snapshot_update ON transactions;
+CREATE TRIGGER before_transaction_split_snapshot_update
+  BEFORE UPDATE ON transactions
+  FOR EACH ROW
+  WHEN (
+    NEW.school_percentage_snapshot IS DISTINCT FROM OLD.school_percentage_snapshot
+    OR NEW.payment_provider IS DISTINCT FROM OLD.payment_provider
+  )
   EXECUTE FUNCTION public.set_transaction_split_snapshot();

--- a/supabase/migrations/rollback/20260725110000_transaction_split_snapshot_backstop.down.sql
+++ b/supabase/migrations/rollback/20260725110000_transaction_split_snapshot_backstop.down.sql
@@ -1,15 +1,28 @@
 -- Rollback for 20260725110000_transaction_split_snapshot_backstop.sql (#512).
 --
--- Removes the database backstop that fills transactions.school_percentage_snapshot.
--- After this runs, only app/api/payments/checkout/route.ts sets the snapshot, and
--- any other path that creates a platform-settled transaction (or a webhook that
--- sets payment_provider on an existing row) silently falls back to the tenant's
--- CURRENT split in computeOwedBalances — i.e. the #496 retroactive-repricing bug
--- returns, quietly and with no failure. Only run this to unblock an incident.
+-- Removes the database ownership of transactions.school_percentage_snapshot.
+-- After this runs:
 --
--- Snapshots already written by the trigger are left in place: they record the
+--   1. Only app/api/payments/checkout/route.ts sets the snapshot. Any other path
+--      that creates a platform-settled transaction — or a webhook that sets
+--      payment_provider on an existing row — silently falls back to the tenant's
+--      CURRENT split in computeOwedBalances, i.e. the #496 retroactive-repricing
+--      bug returns, quietly and with no failure.
+--   2. The column becomes client-writable again. `transactions` grants ALL to
+--      `authenticated` and its RLS policies restrict rows, not columns, so a
+--      student can set school_percentage_snapshot on their own transaction and
+--      inflate what the platform believes it owes their school.
+--
+-- (2) is the reason to treat this as an incident-only lever rather than a clean
+-- revert. If you run it, watch /platform/payouts for balances that move without a
+-- corresponding sale.
+--
+-- Snapshots already written by the triggers are left in place: they record the
 -- split that was genuinely in effect, and clearing them would reintroduce the
 -- fallback for those rows too.
 
+DROP TRIGGER IF EXISTS before_transaction_split_snapshot_insert ON transactions;
+DROP TRIGGER IF EXISTS before_transaction_split_snapshot_update ON transactions;
+-- Name used by the first revision of the up-migration; harmless if absent.
 DROP TRIGGER IF EXISTS before_transaction_split_snapshot ON transactions;
 DROP FUNCTION IF EXISTS public.set_transaction_split_snapshot();

--- a/supabase/migrations/rollback/20260725110000_transaction_split_snapshot_backstop.down.sql
+++ b/supabase/migrations/rollback/20260725110000_transaction_split_snapshot_backstop.down.sql
@@ -1,0 +1,15 @@
+-- Rollback for 20260725110000_transaction_split_snapshot_backstop.sql (#512).
+--
+-- Removes the database backstop that fills transactions.school_percentage_snapshot.
+-- After this runs, only app/api/payments/checkout/route.ts sets the snapshot, and
+-- any other path that creates a platform-settled transaction (or a webhook that
+-- sets payment_provider on an existing row) silently falls back to the tenant's
+-- CURRENT split in computeOwedBalances — i.e. the #496 retroactive-repricing bug
+-- returns, quietly and with no failure. Only run this to unblock an incident.
+--
+-- Snapshots already written by the trigger are left in place: they record the
+-- split that was genuinely in effect, and clearing them would reintroduce the
+-- fallback for those rows too.
+
+DROP TRIGGER IF EXISTS before_transaction_split_snapshot ON transactions;
+DROP FUNCTION IF EXISTS public.set_transaction_split_snapshot();

--- a/supabase/snippets/verify_transaction_split_snapshot_backstop.sql
+++ b/supabase/snippets/verify_transaction_split_snapshot_backstop.sql
@@ -1,15 +1,27 @@
 -- Verification for 20260725110000_transaction_split_snapshot_backstop.sql (#512).
 --
+-- ⚠ LOCAL DATABASE ONLY. Run it against `supabase db reset`, never against cloud
+-- or production. Cases 4 and 7 need a row that genuinely starts with a NULL
+-- snapshot, which means `ALTER TABLE transactions DISABLE TRIGGER` — that takes a
+-- lock which blocks concurrent INSERT/UPDATE on the live payments table for as
+-- long as the script holds it, requires table ownership (it will not run as
+-- `service_role`), and leaves the trigger disabled for other sessions if the
+-- script dies with the transaction still open. The closing ROLLBACK protects the
+-- DATA, not availability.
+--
 -- The repo's vitest suite runs `environment: 'node'` with no database, so the
--- trigger cannot be covered there. Run this against a database that has the
--- migration applied; every SELECT below prints PASS or FAIL. It rolls itself
--- back, so it is safe to run against a populated environment.
+-- trigger's behaviour cannot be covered there; tests/unit/transaction-split-
+-- snapshot-backstop.test.ts only guards the fallback constant against drift.
+-- This file is the actual behavioural coverage. Every SELECT prints PASS or FAIL.
+--
+--   npm run db:reset
+--   docker exec -i supabase_db_lms-front psql -U postgres -d postgres \
+--     < supabase/snippets/verify_transaction_split_snapshot_backstop.sql
 --
 -- transactions.user_id is NOT NULL and references auth.users, so this borrows an
--- existing user rather than creating one. It also fires the pre-existing AFTER
--- INSERT/UPDATE trigger `after_transaction_insert` / `after_transaction_update`
--- (trigger_manage_transactions) — harmless here since the rows carry neither
--- product_id nor plan_id, and the whole thing is rolled back regardless.
+-- existing user rather than creating one. Inserts also fire the pre-existing AFTER
+-- triggers (trigger_manage_transactions) — harmless here, since that function
+-- branches only on product_id / plan_id and these rows carry neither.
 
 BEGIN;
 
@@ -42,13 +54,15 @@ RETURNING
     ELSE 'FAIL 1: got ' || COALESCE(school_percentage_snapshot::text, 'NULL') || ', expected 70'
   END AS result;
 
--- 2. An explicit app-layer snapshot is never overwritten.
+-- 2. THE TAMPER CASE. A caller-supplied snapshot is IGNORED, not honoured —
+--    `transactions` RLS restricts which rows a user may write, not which columns,
+--    so this value can come from a student inflating their school's balance.
 INSERT INTO transactions (user_id, tenant_id, amount, currency, status, payment_method, school_percentage_snapshot)
-SELECT id, '00000000-0000-0000-0000-0000000005a1', 100, 'usd', 'successful', 'mock', 55 FROM _snapshot_test_user
+SELECT id, '00000000-0000-0000-0000-0000000005a1', 100, 'usd', 'successful', 'mock', 100 FROM _snapshot_test_user
 RETURNING
-  CASE WHEN school_percentage_snapshot = 55
-    THEN 'PASS 2: explicit snapshot preserved (55)'
-    ELSE 'FAIL 2: got ' || COALESCE(school_percentage_snapshot::text, 'NULL') || ', expected 55'
+  CASE WHEN school_percentage_snapshot = 70
+    THEN 'PASS 2: client-supplied snapshot (100) overridden with the real split (70)'
+    ELSE 'FAIL 2: got ' || COALESCE(school_percentage_snapshot::text, 'NULL') || ', expected 70'
   END AS result;
 
 -- 3. A tenant with no revenue_splits row falls back to 80
@@ -61,34 +75,35 @@ RETURNING
     ELSE 'FAIL 3: got ' || COALESCE(school_percentage_snapshot::text, 'NULL') || ', expected 80'
   END AS result;
 
--- 4. THE CASE A BEFORE INSERT TRIGGER WOULD MISS: a row that starts with a NULL
---    snapshot and is later turned into a platform-settled transaction by the
---    webhook activation path (webhook-dispatch.ts sets status + payment_provider
---    on an existing row).
---    The trigger is temporarily disabled for the insert so the row genuinely
---    starts NULL, reproducing a pre-migration row.
-ALTER TABLE transactions DISABLE TRIGGER before_transaction_split_snapshot;
+-- Two rows that genuinely start NULL, reproducing pre-migration history.
+-- See the LOCAL-ONLY warning at the top before running this anywhere shared.
+ALTER TABLE transactions DISABLE TRIGGER before_transaction_split_snapshot_insert;
 INSERT INTO transactions (transaction_id, user_id, tenant_id, amount, currency, status, payment_method)
 SELECT -512001, id, '00000000-0000-0000-0000-0000000005a1', 100, 'usd', 'pending', 'mock' FROM _snapshot_test_user;
-ALTER TABLE transactions ENABLE TRIGGER before_transaction_split_snapshot;
+INSERT INTO transactions (transaction_id, user_id, tenant_id, amount, currency, status, payment_method)
+SELECT -512002, id, '00000000-0000-0000-0000-0000000005a1', 100, 'usd', 'successful', 'mock' FROM _snapshot_test_user;
+ALTER TABLE transactions ENABLE TRIGGER before_transaction_split_snapshot_insert;
 
-SELECT CASE WHEN school_percentage_snapshot IS NULL
-  THEN 'SETUP 4: row starts with NULL snapshot, as intended'
-  ELSE 'SETUP 4 BROKEN: expected NULL, got ' || school_percentage_snapshot::text
+SELECT CASE WHEN COUNT(*) FILTER (WHERE school_percentage_snapshot IS NULL) = 2
+  THEN 'SETUP: both legacy rows start with a NULL snapshot, as intended'
+  ELSE 'SETUP BROKEN: expected 2 NULL snapshots, got ' || COUNT(*) FILTER (WHERE school_percentage_snapshot IS NULL)::text
 END AS result
-FROM transactions WHERE transaction_id = -512001;
+FROM transactions WHERE transaction_id IN (-512001, -512002);
 
+-- 4. THE CASE A BEFORE INSERT TRIGGER WOULD MISS: a legacy NULL row turned into a
+--    platform-settled transaction by the webhook activation path
+--    (webhook-dispatch.ts sets status + payment_provider on an existing row).
 UPDATE transactions
 SET status = 'successful', payment_provider = 'paypal'
 WHERE transaction_id = -512001
 RETURNING
   CASE WHEN school_percentage_snapshot = 70
-    THEN 'PASS 4: webhook UPDATE filled the snapshot (70) — the BEFORE INSERT gap'
+    THEN 'PASS 4: provider activation filled the snapshot (70) — the BEFORE INSERT gap'
     ELSE 'FAIL 4: got ' || COALESCE(school_percentage_snapshot::text, 'NULL') || ', expected 70'
   END AS result;
 
--- 5. A later UPDATE must NOT re-stamp an existing snapshot, even if the tenant's
---    split has since changed. Re-stamping would be the #496 bug.
+-- 5. A later UPDATE must NOT re-stamp an existing snapshot, even once the tenant's
+--    split has changed. Re-stamping would be the #496 bug.
 UPDATE revenue_splits SET school_percentage = 90, platform_percentage = 10
 WHERE tenant_id = '00000000-0000-0000-0000-0000000005a1';
 
@@ -98,6 +113,30 @@ RETURNING
   CASE WHEN school_percentage_snapshot = 70
     THEN 'PASS 5: existing snapshot untouched by a later update (still 70, split now 90)'
     ELSE 'FAIL 5: snapshot was re-stamped to ' || COALESCE(school_percentage_snapshot::text, 'NULL')
+  END AS result;
+
+-- 6. Tampering with an ALREADY-SNAPSHOTTED row is reverted, not accepted.
+UPDATE transactions SET school_percentage_snapshot = 100
+WHERE transaction_id = -512001
+RETURNING
+  CASE WHEN school_percentage_snapshot = 70
+    THEN 'PASS 6: update tampering with an existing snapshot reverted to 70'
+    ELSE 'FAIL 6: snapshot became ' || COALESCE(school_percentage_snapshot::text, 'NULL')
+  END AS result;
+
+-- 7. A legacy NULL row is NOT lazily backfilled by an incidental update — neither
+--    by an ordinary status change nor by a caller trying to set the value. Doing
+--    so would stamp TODAY's split (now 90) onto a historical sale, one row at a
+--    time, which is the repricing #496 removed.
+UPDATE transactions SET status = 'archived'
+WHERE transaction_id = -512002;
+
+UPDATE transactions SET school_percentage_snapshot = 100
+WHERE transaction_id = -512002
+RETURNING
+  CASE WHEN school_percentage_snapshot IS NULL
+    THEN 'PASS 7: legacy NULL row still NULL after an incidental update and a tamper attempt'
+    ELSE 'FAIL 7: snapshot became ' || school_percentage_snapshot::text || ' (expected NULL)'
   END AS result;
 
 ROLLBACK;

--- a/supabase/snippets/verify_transaction_split_snapshot_backstop.sql
+++ b/supabase/snippets/verify_transaction_split_snapshot_backstop.sql
@@ -1,0 +1,103 @@
+-- Verification for 20260725110000_transaction_split_snapshot_backstop.sql (#512).
+--
+-- The repo's vitest suite runs `environment: 'node'` with no database, so the
+-- trigger cannot be covered there. Run this against a database that has the
+-- migration applied; every SELECT below prints PASS or FAIL. It rolls itself
+-- back, so it is safe to run against a populated environment.
+--
+-- transactions.user_id is NOT NULL and references auth.users, so this borrows an
+-- existing user rather than creating one. It also fires the pre-existing AFTER
+-- INSERT/UPDATE trigger `after_transaction_insert` / `after_transaction_update`
+-- (trigger_manage_transactions) — harmless here since the rows carry neither
+-- product_id nor plan_id, and the whole thing is rolled back regardless.
+
+BEGIN;
+
+-- Borrow any existing auth user for the FK.
+CREATE TEMP TABLE _snapshot_test_user ON COMMIT DROP AS
+SELECT id FROM auth.users LIMIT 1;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM _snapshot_test_user) THEN
+    RAISE EXCEPTION 'No auth.users row available — run this against a database with at least one user';
+  END IF;
+END $$;
+
+-- Isolated fixtures so nothing here depends on, or disturbs, real data.
+INSERT INTO tenants (id, name, slug)
+VALUES
+  ('00000000-0000-0000-0000-0000000005a1', 'Snapshot Test With Split', 'snapshot-test-with-split'),
+  ('00000000-0000-0000-0000-0000000005a2', 'Snapshot Test No Split', 'snapshot-test-no-split');
+
+INSERT INTO revenue_splits (tenant_id, platform_percentage, school_percentage)
+VALUES ('00000000-0000-0000-0000-0000000005a1', 30, 70);
+
+-- 1. Insert with no snapshot is filled from revenue_splits.
+INSERT INTO transactions (user_id, tenant_id, amount, currency, status, payment_method)
+SELECT id, '00000000-0000-0000-0000-0000000005a1', 100, 'usd', 'successful', 'mock' FROM _snapshot_test_user
+RETURNING
+  CASE WHEN school_percentage_snapshot = 70
+    THEN 'PASS 1: insert without snapshot filled from revenue_splits (70)'
+    ELSE 'FAIL 1: got ' || COALESCE(school_percentage_snapshot::text, 'NULL') || ', expected 70'
+  END AS result;
+
+-- 2. An explicit app-layer snapshot is never overwritten.
+INSERT INTO transactions (user_id, tenant_id, amount, currency, status, payment_method, school_percentage_snapshot)
+SELECT id, '00000000-0000-0000-0000-0000000005a1', 100, 'usd', 'successful', 'mock', 55 FROM _snapshot_test_user
+RETURNING
+  CASE WHEN school_percentage_snapshot = 55
+    THEN 'PASS 2: explicit snapshot preserved (55)'
+    ELSE 'FAIL 2: got ' || COALESCE(school_percentage_snapshot::text, 'NULL') || ', expected 55'
+  END AS result;
+
+-- 3. A tenant with no revenue_splits row falls back to 80
+--    (DEFAULT_SCHOOL_PERCENTAGE in lib/payments/payouts-owed.ts).
+INSERT INTO transactions (user_id, tenant_id, amount, currency, status, payment_method)
+SELECT id, '00000000-0000-0000-0000-0000000005a2', 100, 'usd', 'successful', 'mock' FROM _snapshot_test_user
+RETURNING
+  CASE WHEN school_percentage_snapshot = 80
+    THEN 'PASS 3: missing revenue_splits row falls back to 80'
+    ELSE 'FAIL 3: got ' || COALESCE(school_percentage_snapshot::text, 'NULL') || ', expected 80'
+  END AS result;
+
+-- 4. THE CASE A BEFORE INSERT TRIGGER WOULD MISS: a row that starts with a NULL
+--    snapshot and is later turned into a platform-settled transaction by the
+--    webhook activation path (webhook-dispatch.ts sets status + payment_provider
+--    on an existing row).
+--    The trigger is temporarily disabled for the insert so the row genuinely
+--    starts NULL, reproducing a pre-migration row.
+ALTER TABLE transactions DISABLE TRIGGER before_transaction_split_snapshot;
+INSERT INTO transactions (transaction_id, user_id, tenant_id, amount, currency, status, payment_method)
+SELECT -512001, id, '00000000-0000-0000-0000-0000000005a1', 100, 'usd', 'pending', 'mock' FROM _snapshot_test_user;
+ALTER TABLE transactions ENABLE TRIGGER before_transaction_split_snapshot;
+
+SELECT CASE WHEN school_percentage_snapshot IS NULL
+  THEN 'SETUP 4: row starts with NULL snapshot, as intended'
+  ELSE 'SETUP 4 BROKEN: expected NULL, got ' || school_percentage_snapshot::text
+END AS result
+FROM transactions WHERE transaction_id = -512001;
+
+UPDATE transactions
+SET status = 'successful', payment_provider = 'paypal'
+WHERE transaction_id = -512001
+RETURNING
+  CASE WHEN school_percentage_snapshot = 70
+    THEN 'PASS 4: webhook UPDATE filled the snapshot (70) — the BEFORE INSERT gap'
+    ELSE 'FAIL 4: got ' || COALESCE(school_percentage_snapshot::text, 'NULL') || ', expected 70'
+  END AS result;
+
+-- 5. A later UPDATE must NOT re-stamp an existing snapshot, even if the tenant's
+--    split has since changed. Re-stamping would be the #496 bug.
+UPDATE revenue_splits SET school_percentage = 90, platform_percentage = 10
+WHERE tenant_id = '00000000-0000-0000-0000-0000000005a1';
+
+UPDATE transactions SET status = 'refunded'
+WHERE transaction_id = -512001
+RETURNING
+  CASE WHEN school_percentage_snapshot = 70
+    THEN 'PASS 5: existing snapshot untouched by a later update (still 70, split now 90)'
+    ELSE 'FAIL 5: snapshot was re-stamped to ' || COALESCE(school_percentage_snapshot::text, 'NULL')
+  END AS result;
+
+ROLLBACK;

--- a/tests/unit/transaction-split-snapshot-backstop.test.ts
+++ b/tests/unit/transaction-split-snapshot-backstop.test.ts
@@ -1,14 +1,19 @@
 /**
- * Guards the one thing about #512's database backstop that CAN be checked
- * without a database: the fallback percentage is duplicated between the
- * migration's plpgsql and the TypeScript constant, and nothing else would
+ * STATIC DRIFT GUARDS — not behavioural coverage.
+ *
+ * #512's backstop is a plpgsql trigger, and this suite runs
+ * `environment: 'node'` with no database, so nothing here proves the trigger
+ * works; these assertions read the migration as text. They exist for the one
+ * failure mode that text can catch: the fallback percentage is duplicated
+ * between the plpgsql and the TypeScript constant, and nothing else would
  * notice if the two drifted apart.
  *
- * The trigger's actual behaviour is SQL, and this suite runs
- * `environment: 'node'` with no database — see
- * `supabase/snippets/verify_transaction_split_snapshot_backstop.sql` for the
- * executable coverage of insert-fills, explicit-value-wins, the webhook UPDATE
- * path, and the never-re-stamp rule.
+ * The behavioural coverage — insert computes, caller-supplied values are
+ * overridden, existing snapshots are frozen, legacy NULLs fill only on provider
+ * activation — lives in
+ * `supabase/snippets/verify_transaction_split_snapshot_backstop.sql` and has to
+ * be run against a local database. A green run of this file means nothing about
+ * whether the migration was ever applied.
  */
 import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'node:fs'
@@ -20,7 +25,7 @@ const MIGRATION = resolve(
   '../../supabase/migrations/20260725110000_transaction_split_snapshot_backstop.sql',
 )
 
-describe('#512 transaction split snapshot backstop', () => {
+describe('#512 transaction split snapshot backstop (static drift guards)', () => {
   const sql = readFileSync(MIGRATION, 'utf8')
 
   it('encodes the same fallback percentage the app layer uses', () => {
@@ -29,20 +34,21 @@ describe('#512 transaction split snapshot backstop', () => {
     expect(Number(match![1])).toBe(DEFAULT_SCHOOL_PERCENTAGE)
   })
 
-  it('fires on UPDATE as well as INSERT', () => {
-    // payment_provider is set post-insert by the webhook activation path
-    // (lib/payments/webhook-dispatch.ts), so an INSERT-only trigger would let a
-    // row become platform-settled while its snapshot is still NULL.
-    expect(sql).toMatch(/BEFORE INSERT OR UPDATE ON transactions/)
+  it('covers UPDATE as well as INSERT', () => {
+    // payment_provider — the field getPayoutsOwed() filters on — is set
+    // post-insert by the webhook activation path (lib/payments/webhook-dispatch.ts),
+    // so an INSERT-only backstop would let a row become platform-settled while
+    // its snapshot is still NULL.
+    expect(sql).toMatch(/BEFORE INSERT ON transactions/)
+    expect(sql).toMatch(/BEFORE UPDATE ON transactions/)
   })
 
-  it('only fires while the snapshot is still NULL, so history is never re-stamped', () => {
-    expect(sql).toMatch(/WHEN \(NEW\.school_percentage_snapshot IS NULL\)/)
-  })
-
-  it('does not backfill existing rows', () => {
-    // Backfilling would stamp today's split onto historical transactions —
-    // exactly the retroactive repricing #496 removed.
-    expect(sql).not.toMatch(/UPDATE\s+transactions\s+SET/i)
+  it('leaves the INSERT trigger unconditional, so a caller-supplied value cannot survive', () => {
+    // `transactions` grants ALL to `authenticated` and its RLS policies restrict
+    // rows, not columns — a WHEN (NEW.school_percentage_snapshot IS NULL) guard
+    // here would hand the number to the one writer we do not trust.
+    const insertTrigger = sql.slice(sql.indexOf('BEFORE INSERT ON transactions'))
+    const insertStatement = insertTrigger.slice(0, insertTrigger.indexOf(';'))
+    expect(insertStatement).not.toMatch(/WHEN\s*\(/i)
   })
 })

--- a/tests/unit/transaction-split-snapshot-backstop.test.ts
+++ b/tests/unit/transaction-split-snapshot-backstop.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Guards the one thing about #512's database backstop that CAN be checked
+ * without a database: the fallback percentage is duplicated between the
+ * migration's plpgsql and the TypeScript constant, and nothing else would
+ * notice if the two drifted apart.
+ *
+ * The trigger's actual behaviour is SQL, and this suite runs
+ * `environment: 'node'` with no database — see
+ * `supabase/snippets/verify_transaction_split_snapshot_backstop.sql` for the
+ * executable coverage of insert-fills, explicit-value-wins, the webhook UPDATE
+ * path, and the never-re-stamp rule.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { DEFAULT_SCHOOL_PERCENTAGE } from '@/lib/payments/payouts-owed'
+
+const MIGRATION = resolve(
+  __dirname,
+  '../../supabase/migrations/20260725110000_transaction_split_snapshot_backstop.sql',
+)
+
+describe('#512 transaction split snapshot backstop', () => {
+  const sql = readFileSync(MIGRATION, 'utf8')
+
+  it('encodes the same fallback percentage the app layer uses', () => {
+    const match = sql.match(/COALESCE\(v_school_percentage,\s*(\d+)\)/)
+    expect(match, 'COALESCE fallback not found in the migration').not.toBeNull()
+    expect(Number(match![1])).toBe(DEFAULT_SCHOOL_PERCENTAGE)
+  })
+
+  it('fires on UPDATE as well as INSERT', () => {
+    // payment_provider is set post-insert by the webhook activation path
+    // (lib/payments/webhook-dispatch.ts), so an INSERT-only trigger would let a
+    // row become platform-settled while its snapshot is still NULL.
+    expect(sql).toMatch(/BEFORE INSERT OR UPDATE ON transactions/)
+  })
+
+  it('only fires while the snapshot is still NULL, so history is never re-stamped', () => {
+    expect(sql).toMatch(/WHEN \(NEW\.school_percentage_snapshot IS NULL\)/)
+  })
+
+  it('does not backfill existing rows', () => {
+    // Backfilling would stamp today's split onto historical transactions —
+    // exactly the retroactive repricing #496 removed.
+    expect(sql).not.toMatch(/UPDATE\s+transactions\s+SET/i)
+  })
+})


### PR DESCRIPTION
Closes #512. Builds on @DPS0340's #525 — their commit is preserved as the first commit here, and the second is the hardening that came out of reviewing it against a live database. **If this lands, #525 should be closed as superseded** (the credit for the core insight is theirs).

## What #525 got right, and why it needed a second pass

The central finding in #525 is correct and worth restating: `payment_provider` — the field `getPayoutsOwed()` filters on — is written by **UPDATE**, after the row exists (`lib/payments/webhook-dispatch.ts:205`, `app/api/stripe/webhook/route.ts:406`). A `BEFORE INSERT` trigger, which is what the issue asked for, never sees that path. Covering UPDATE is right.

Reviewing it against a local database turned up two problems with the *rule* the trigger applied.

### 1. The column is client-writable, and "an explicit value always wins" preserves the one write we need to override

`transactions` grants `ALL` to `authenticated` (`20260126190500_lms_complete.sql:3692`), and the RLS policies restrict which **rows** a user may write, never which **columns** (`20260313025318_rls_transactions.sql`):

```sql
CREATE POLICY "Users can create own transactions"
  ON public.transactions FOR INSERT TO authenticated
  WITH CHECK (auth.uid() = user_id AND tenant_id = get_tenant_id());
```

So `school_percentage_snapshot` can be supplied by a student, and it flows straight into `computeOwedBalances()`'s `grossOwed`. Measured against #525 as submitted, on a local DB where the tenant's real split is 70:

```
INSERT tamper -> snapshot = 100  (real split is 70)
UPDATE tamper -> snapshot = 100  (was 70)
```

Both survive, because the trigger's first rule is to return early when the value is non-NULL. Same two statements after this PR:

```
INSERT tamper -> snapshot = 70.00  (real split is 70)
UPDATE tamper -> snapshot = 70.00  (was 70)
```

The column is now **database-owned**: computed from `revenue_splits` on INSERT (no `WHEN` guard — the point is to override what the caller sent), and frozen on UPDATE (the previous value is restored verbatim rather than raising, so a tampering UPDATE is neutralised instead of failing the webhook that carried it).

### 2. The UPDATE branch was a lazy, non-deterministic backfill

Once the trigger is installed, every new row is snapshotted at INSERT — so the UPDATE branch can only ever fire on **legacy NULL rows**. What #525 did to them was stamp *today's* split, permanently, at whatever arbitrary moment something incidental first touched the row. A May sale refunded next week would be frozen at next week's split.

That is the retroactive repricing #496 removed; it does not stop being that because it happens one row at a time. #525's own description argues against backfilling for exactly this reason, so this is a case of the implementation not matching its stated intent rather than a disagreement about the goal.

A legacy NULL is now filled in exactly one case: `payment_provider` is changing, i.e. a provider is activating the row right now — the one moment at which today's split is the honest answer for it. This needs two triggers rather than one, because `OLD` cannot be referenced in a `WHEN` clause on a combined `INSERT OR UPDATE` trigger.

## Correction: `revenue_splits` is not super-admin-only

The migration, the checkout route's comment, and #525's description all repeat that `revenue_splits` is super-admin-only under RLS. It isn't. Verified on a local DB:

```
policyname                          | qual
------------------------------------+---------------------------------------------------------
 Admins can view own revenue split  | tenant_id = get_tenant_id() OR is_super_admin()
```

Despite the policy's name, **every member of the tenant — students included — can read their school's split**. Two consequences:

- `SECURITY DEFINER` is kept, but for the opposite reason to the one given. An INVOKER function would work *today*; it would also make this trigger's correctness depend on a permissive policy whose own name contradicts it. The day someone tightens that policy to match its name, an INVOKER trigger stops seeing the row and silently stamps the 80 fallback onto every checkout, for every tenant — wrong payout numbers, no error, no failing test.
- The comment in `app/api/payments/checkout/route.ts` claiming the admin client is *required* there is corrected. It's belt-and-braces, not a requirement.

Unfiled follow-up, not touched here: that policy's name and its predicate disagree. The predicate looks deliberate (`dashboard/teacher/revenue` reads the table on the user-scoped client), so the name is what's wrong.

## Also in this PR

- **The verify snippet is relabelled LOCAL ONLY.** #525 described it as "safe against a populated database" because it rolls back. The rollback protects the *data*, not availability: it needs `ALTER TABLE transactions DISABLE TRIGGER`, which locks the live payments table against INSERT/UPDATE for as long as the script holds it, requires table ownership (it won't run as `service_role`), and leaves the trigger disabled for other sessions if the script dies with the transaction open. It also grew from 5 cases to 7 — both tamper paths and the no-lazy-backfill rule.
- **The unit tests are relabelled as static drift guards.** They are regexes over the migration's *text*; they pass identically whether the trigger works, is broken, or was never applied. The `DEFAULT_SCHOOL_PERCENTAGE` drift guard earns its place (that constant is genuinely duplicated into the plpgsql); the tautological `not.toMatch(/UPDATE\s+transactions\s+SET/i)` is dropped, and a guard that the INSERT trigger stays unconditional is added. A green run of that file is not evidence the migration works — the snippet is.
- The rollback script drops both triggers (and the old single-trigger name), and now says plainly that rolling back re-opens the client-writable column, not just the #496 fallback.

## Blast radius

`transactions` INSERT now always does one index lookup on `revenue_splits` (`UNIQUE (tenant_id)`), on a table written only on payment events. UPDATE calls the function only when the snapshot or `payment_provider` is actually changing — ordinary status-only updates don't fire it at all. The pre-existing `after_transaction_insert` / `after_transaction_update` triggers are AFTER, so ordering is unaffected. No app behaviour changes: the checkout route's own write is kept (it computes the identical number and keeps the rollback a safe lever), and every other insert path simply stops being wrong.

## Testing

Run against a local DB, not just statically:

```bash
npm run db:reset
docker exec -i supabase_db_lms-front psql -U postgres -d postgres \
  < supabase/snippets/verify_transaction_split_snapshot_backstop.sql
```

Expected, and what I got:

```
PASS 1: insert without snapshot filled from revenue_splits (70)
PASS 2: client-supplied snapshot (100) overridden with the real split (70)
PASS 3: missing revenue_splits row falls back to 80
PASS 4: provider activation filled the snapshot (70) — the BEFORE INSERT gap
PASS 5: existing snapshot untouched by a later update (still 70, split now 90)
PASS 6: update tampering with an existing snapshot reverted to 70
PASS 7: legacy NULL row still NULL after an incidental update and a tamper attempt
```

Also verified on the local DB:

- The rollback script drops both triggers and the function cleanly; the migration then re-applies and all 7 cases pass again.
- `SECURITY DEFINER` works from the real checkout shape — `SET LOCAL ROLE authenticated` with a tenant JWT claim, inserting with no snapshot supplied, yields the tenant's real split (65 in the fixture), not the 80 fallback.

Suite level: `npm run test:unit` 321 passed (28 files) · `npm run typecheck` clean · `npx eslint` clean on changed files.

**Not yet deployed to cloud** — `supabase db push` is still to run.

## Reviewer notes

- The verification snippet stays in `supabase/snippets/` despite that folder otherwise holding Studio dumps. `supabase/migrations/` would auto-apply it and `supabase/tests/` is reserved for pgTAP (`supabase test db`), so this is the least-bad existing home. Happy to move it if there's a preferred spot.
- Adjacent and **not** fixed here, because it's much wider than this issue: the same RLS gap lets a user insert `status: 'successful', payment_provider: 'paypal'` on their own row, which both self-enrols them via `trigger_manage_transactions` and lands a fabricated sale in the payout math. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NffLeUiW78cokcUXrt68n
