### PR TITLE
fix(payouts): stop the school payout history summing across currencies (#531)

### DIFF
--- a/app/[locale]/dashboard/admin/payouts/page.tsx
+++ b/app/[locale]/dashboard/admin/payouts/page.tsx
@@ -4,6 +4,7 @@ import { getTranslations } from 'next-intl/server'
 import { format } from 'date-fns'
 import { es, enUS } from 'date-fns/locale'
 import { getCurrentTenantId, getCurrentUserId } from '@/lib/supabase/tenant'
+import { formatByCurrency, formatMoney, sumByCurrency } from '@/lib/payments/format-money'
 import { AdminBreadcrumb } from '@/components/admin/admin-breadcrumb'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
@@ -72,18 +73,12 @@ export default async function AdminPayoutsPage({
 
   const rows = payouts || []
 
-  // Summary calculations
-  const totalPaid = rows
-    .filter((p) => p.status === 'paid')
-    .reduce((sum, p) => sum + (p.amount || 0), 0)
+  // Summary calculations. Paid payouts are totalled per currency and rendered as
+  // one figure each — a school selling in USD and EUR reads two figures, not
+  // their sum in dollars (#531, same invariant #497 fixed on the platform page).
+  const totalPaidByCurrency = sumByCurrency(rows.filter((p) => p.status === 'paid'))
 
   const pendingCount = rows.filter((p) => p.status === 'pending' || p.status === 'processing').length
-
-  const fmt = (amount: number, currency: string) =>
-    new Intl.NumberFormat(locale, {
-      style: 'currency',
-      currency: (currency || 'USD').toUpperCase(),
-    }).format(amount)
 
   const statusBadge = (status: string) => {
     switch (status) {
@@ -149,8 +144,11 @@ export default async function AdminPayoutsPage({
                   <p className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
                     {t('stats.totalPaid')}
                   </p>
-                  <p className="mt-2 text-2xl font-bold tracking-tight tabular-nums">
-                    {fmt(totalPaid, 'USD')}
+                  <p
+                    className="mt-2 text-2xl font-bold tracking-tight tabular-nums break-words"
+                    data-testid="total-paid-value"
+                  >
+                    {formatByCurrency(totalPaidByCurrency, locale)}
                   </p>
                   <p className="mt-1 text-[11px] text-muted-foreground/70">
                     {t('stats.totalPaidDesc')}
@@ -232,7 +230,7 @@ export default async function AdminPayoutsPage({
                             : '—'}
                         </TableCell>
                         <TableCell className="text-right font-semibold tabular-nums">
-                          {fmt(payout.amount || 0, payout.currency || 'USD')}
+                          {formatMoney(payout.amount, payout.currency, locale)}
                         </TableCell>
                         <TableCell>
                           {statusBadge(payout.status || '')}

--- a/app/[locale]/platform/payouts/page.tsx
+++ b/app/[locale]/platform/payouts/page.tsx
@@ -3,6 +3,7 @@ import { getTranslations } from 'next-intl/server'
 import { getPayoutsOwed } from '@/app/actions/platform/payouts'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { MarkPayoutPaidDialog } from '@/components/platform/mark-payout-paid-dialog'
+import { formatByCurrency, formatMoney } from '@/lib/payments/format-money'
 import {
   IconArrowBackUp,
   IconCoin,
@@ -11,19 +12,9 @@ import {
   IconWalletOff,
 } from '@tabler/icons-react'
 
-/**
- * Formatted in the reader's locale; the currency code always comes from the row
- * itself — balances are grouped per currency and never converted (#497).
- */
-const money = (n: number, currency: string, locale: string) =>
-  new Intl.NumberFormat(locale, { style: 'currency', currency: currency.toUpperCase() }).format(n ?? 0)
-
-/** Renders one line per currency — amounts in different currencies are never summed into one number (#497). */
-function formatByCurrency(byCurrency: Record<string, number>, locale: string) {
-  const entries = Object.entries(byCurrency).filter(([, amount]) => amount !== 0)
-  if (entries.length === 0) return money(0, 'usd', locale)
-  return entries.map(([currency, amount]) => money(amount, currency, locale)).join(' · ')
-}
+// `formatMoney` / `formatByCurrency` live in lib/payments/format-money.ts — the
+// no-cross-currency-sums rule this page established in #497 is shared with the
+// school-facing payout history rather than re-derived there (#531).
 
 const PROVIDER_LABEL: Record<string, string> = {
   paypal: 'PayPal',
@@ -291,24 +282,24 @@ export default async function PlatformPayoutsPage({
                           ? '—'
                           : Object.keys(r.byProvider).map((p) => PROVIDER_LABEL[p] ?? p).join(', ')}
                       </td>
-                      <td className="py-2.5 text-right tabular-nums">{money(r.grossCollected, r.currency, locale)}</td>
+                      <td className="py-2.5 text-right tabular-nums">{formatMoney(r.grossCollected, r.currency, locale)}</td>
                       <td className="py-2.5 text-right tabular-nums text-muted-foreground">
                         {r.schoolPercentage}%
                       </td>
                       <td className="py-2.5 text-right tabular-nums text-muted-foreground">
-                        {money(r.alreadyPaid, r.currency, locale)}
+                        {formatMoney(r.alreadyPaid, r.currency, locale)}
                       </td>
                       <ClawbackCell
                         amount={r.clawback}
-                        formatted={money(r.clawback, r.currency, locale)}
+                        formatted={formatMoney(r.clawback, r.currency, locale)}
                         hint={t('table.clawbackHint')}
                       />
                       <td className="py-2.5 text-right tabular-nums font-medium text-amber-600 dark:text-amber-400">
-                        {money(r.netOwed, r.currency, locale)}
+                        {formatMoney(r.netOwed, r.currency, locale)}
                       </td>
                       <OverpaidCell
                         amount={r.overpaid}
-                        formatted={money(r.overpaid, r.currency, locale)}
+                        formatted={formatMoney(r.overpaid, r.currency, locale)}
                         hint={t('table.overpaidHint')}
                       />
                       <td className="py-2.5 text-right">

--- a/lib/payments/format-money.ts
+++ b/lib/payments/format-money.ts
@@ -1,0 +1,66 @@
+/**
+ * Money formatting for the payout screens.
+ *
+ * The invariant these helpers exist to hold: **amounts in different currencies
+ * are never added together, and a currency code is never hardcoded at the
+ * render site.** #497 fixed that on the super-admin payouts page, but the fix
+ * lived in that page's local scope, so the school-facing payout history added
+ * later re-introduced the same bug (#531). Keeping the grouping and the
+ * formatting here — tested, in one place — is what stops the next payout screen
+ * from re-deriving it a third time.
+ *
+ * No conversion happens anywhere in this module. A USD figure and a EUR figure
+ * stay two figures.
+ */
+
+/** The minimum shape a row needs to be groupable: an amount and the currency it is denominated in. */
+export interface MoneyRow {
+  amount: number | null
+  currency: string | null
+}
+
+/** Totals keyed by upper-cased ISO currency code, e.g. `{ USD: 1240.5, EUR: 860 }`. */
+export type AmountsByCurrency = Record<string, number>
+
+const DEFAULT_CURRENCY = 'USD'
+
+/** Upper-cases the code and falls back to USD, so `'usd'`, `'USD'` and a null column share one bucket. */
+const normalizeCurrency = (currency: string | null | undefined) =>
+  (currency || DEFAULT_CURRENCY).toUpperCase()
+
+/**
+ * Formatted in the reader's locale; the currency code always comes from the
+ * data, never from the call site.
+ */
+export function formatMoney(amount: number | null | undefined, currency: string | null | undefined, locale: string) {
+  return new Intl.NumberFormat(locale, {
+    style: 'currency',
+    currency: normalizeCurrency(currency),
+  }).format(amount ?? 0)
+}
+
+/**
+ * Groups rows into one total per currency. Callers filter first (e.g. to `paid`
+ * payouts) and pass what survives — this only ever adds an amount to the bucket
+ * for its own currency, so there is no arrangement of inputs that produces a
+ * cross-currency sum.
+ */
+export function sumByCurrency(rows: readonly MoneyRow[]): AmountsByCurrency {
+  const totals: AmountsByCurrency = {}
+  for (const row of rows) {
+    const currency = normalizeCurrency(row.currency)
+    totals[currency] = (totals[currency] ?? 0) + (row.amount ?? 0)
+  }
+  return totals
+}
+
+/**
+ * Renders one figure per currency, joined — `"$1,240.50 · €860.00"`. Currencies
+ * that net to zero are dropped so the common single-currency school still reads
+ * as a single number; an empty set renders one zero rather than an empty card.
+ */
+export function formatByCurrency(byCurrency: AmountsByCurrency, locale: string) {
+  const entries = Object.entries(byCurrency).filter(([, amount]) => amount !== 0)
+  if (entries.length === 0) return formatMoney(0, DEFAULT_CURRENCY, locale)
+  return entries.map(([currency, amount]) => formatMoney(amount, currency, locale)).join(' · ')
+}

--- a/tests/unit/format-money.test.ts
+++ b/tests/unit/format-money.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest'
+import { formatByCurrency, formatMoney, sumByCurrency } from '@/lib/payments/format-money'
+
+/**
+ * The rule under test is the one #497 established and #531 found broken on the
+ * school-facing payout history: payout amounts are grouped per currency and
+ * never added across currencies, and the currency code always comes from the
+ * data. Formatting assertions use `toContain` on the digits plus a separate
+ * symbol check, so a change in ICU's spacing or grouping doesn't produce a false
+ * failure about arithmetic.
+ */
+
+const rows = (...pairs: Array<[number | null, string | null]>) =>
+  pairs.map(([amount, currency]) => ({ amount, currency }))
+
+describe('sumByCurrency', () => {
+  it('keeps each currency in its own bucket', () => {
+    expect(sumByCurrency(rows([1240.5, 'usd'], [860, 'eur']))).toEqual({ USD: 1240.5, EUR: 860 })
+  })
+
+  it('sums multiple rows within one currency', () => {
+    expect(sumByCurrency(rows([100, 'usd'], [25.5, 'usd'], [10, 'eur']))).toEqual({
+      USD: 125.5,
+      EUR: 10,
+    })
+  })
+
+  it('treats currency codes case-insensitively so one currency never splits into two lines', () => {
+    expect(sumByCurrency(rows([100, 'usd'], [50, 'USD'], [1, 'Usd']))).toEqual({ USD: 151 })
+  })
+
+  it('buckets a null currency as USD (the payouts.currency column default) rather than dropping the row', () => {
+    expect(sumByCurrency(rows([40, null], [60, 'usd']))).toEqual({ USD: 100 })
+  })
+
+  it('treats a null amount as zero', () => {
+    expect(sumByCurrency(rows([null, 'usd'], [10, 'usd']))).toEqual({ USD: 10 })
+  })
+
+  it('returns an empty object for no rows', () => {
+    expect(sumByCurrency([])).toEqual({})
+  })
+
+  it('never produces a total larger than any single currency bucket (the #531 regression)', () => {
+    const totals = sumByCurrency(rows([1240.5, 'usd'], [860, 'eur']))
+    // The bug summed these to 2100.5 and labelled it USD. No bucket may hold that.
+    expect(Object.values(totals)).not.toContain(2100.5)
+    expect(totals.USD).toBe(1240.5)
+  })
+})
+
+describe('formatMoney', () => {
+  it('formats with the currency it is given, not a hardcoded one', () => {
+    expect(formatMoney(860, 'eur', 'en')).toContain('860')
+    expect(formatMoney(860, 'eur', 'en')).toContain('€')
+    expect(formatMoney(1240.5, 'usd', 'en')).toContain('$')
+  })
+
+  it('accepts lower-case codes', () => {
+    expect(formatMoney(10, 'gbp', 'en')).toContain('£')
+  })
+
+  it('falls back to USD for a missing currency and to zero for a missing amount', () => {
+    expect(formatMoney(10, null, 'en')).toContain('$')
+    expect(formatMoney(null, 'usd', 'en')).toContain('0')
+  })
+
+  it('respects the reader locale', () => {
+    // es-ES puts the symbol after the number; the point is that locale is honoured,
+    // not which side it lands on.
+    expect(formatMoney(1240.5, 'eur', 'es')).toContain('€')
+  })
+})
+
+describe('formatByCurrency', () => {
+  it('renders one figure per currency instead of a single mixed number', () => {
+    const rendered = formatByCurrency({ USD: 1240.5, EUR: 860 }, 'en')
+    expect(rendered).toContain('$')
+    expect(rendered).toContain('€')
+    expect(rendered).toContain('1,240.50')
+    expect(rendered).toContain('860')
+    expect(rendered).not.toContain('2,100.50')
+  })
+
+  it('renders a single-currency school as one plain figure', () => {
+    const rendered = formatByCurrency({ USD: 1240.5 }, 'en')
+    expect(rendered).toContain('$1,240.50')
+    expect(rendered).not.toContain('·')
+  })
+
+  it('drops currencies that net to zero', () => {
+    const rendered = formatByCurrency({ USD: 100, EUR: 0 }, 'en')
+    expect(rendered).toContain('$100')
+    expect(rendered).not.toContain('€')
+  })
+
+  it('renders one zero rather than an empty card when there is nothing to show', () => {
+    expect(formatByCurrency({}, 'en')).toContain('0')
+    expect(formatByCurrency({ USD: 0, EUR: 0 }, 'en')).toContain('0')
+  })
+
+  it('composes with sumByCurrency end to end for the #531 case', () => {
+    const paid = rows([1240.5, 'usd'], [860, 'eur'])
+    const rendered = formatByCurrency(sumByCurrency(paid), 'en')
+    expect(rendered).toBe('$1,240.50 · €860.00')
+  })
+})


### PR DESCRIPTION
## What

The school-facing "Total paid out" card on `/dashboard/admin/payouts` no longer adds payout amounts across currencies, and no longer labels the result USD. It now renders one figure per currency — `$1,240.50 · €860.00` — the same way the super-admin page has since #497.

The grouping and formatting behind both pages moved into a new shared module, `lib/payments/format-money.ts`, with unit coverage.

Closes #531

## Why

`app/[locale]/dashboard/admin/payouts/page.tsx` reduced every `paid` payout into one scalar and rendered it with a hardcoded currency:

```ts
const totalPaid = rows.filter((p) => p.status === 'paid')
  .reduce((sum, p) => sum + (p.amount || 0), 0)
...
{fmt(totalPaid, 'USD')}
```

The per-row amounts below it were correct — each formatted in its own `payouts.currency` — so a school with USD and EUR payouts read honest rows underneath a summary that was their arithmetic sum, denominated in dollars. That figure corresponds to nothing, and it is the one a school owner would reconcile against. It made the #493 acceptance criterion "Payout totals never silently mix currencies" false for the tenant-facing half of the feature.

#497 fixed exactly this on the super-admin page, but its `money()` and `formatByCurrency()` helpers were private to that page module. The invariant lived in one file's local scope, so the payout history added later by #499 had nothing to inherit and re-derived the bug. Extracting the helpers is the part of this PR that stops it happening a third time:

- `sumByCurrency(rows)` — groups `{ amount, currency }` rows into per-currency totals. It only ever adds an amount to the bucket for its own currency, so no arrangement of inputs produces a cross-currency sum. Currency codes are normalized (`'usd'` and `'USD'` share a bucket) and a null currency falls back to USD, matching the column default.
- `formatMoney(amount, currency, locale)` — the currency code always comes from the data, never the call site.
- `formatByCurrency(totals, locale)` — one figure per currency, joined with `·`; zero-valued currencies dropped so a single-currency school still reads as one plain number; an empty set renders one zero rather than an empty card.

The platform page now imports these instead of defining its own. Its behaviour is unchanged by design — same separator, same zero-filtering, same empty fallback — and I verified its rendering against a before screenshot (see comment).

No query, schema, RLS, or i18n change. The page already selected `currency`; this is presentation only. `pendingCount` is a count and was never affected.

## How to QA

On a fresh `npm run db:reset`, as `owner@e2etest.com` / `password123` on `default.lvh.me:3000`. The seed has no payouts, so QA needs a couple of rows:

```sql
insert into payouts (tenant_id, amount, currency, status, period_start, period_end, paid_at, payout_method, note)
values
 ('00000000-0000-0000-0000-000000000001', 1240.50, 'usd', 'paid',    '2026-05-01', '2026-05-31', '2026-06-02', 'manual', 'qa-531'),
 ('00000000-0000-0000-0000-000000000001',  860.00, 'eur', 'paid',    '2026-06-01', '2026-06-30', '2026-07-02', 'manual', 'qa-531'),
 ('00000000-0000-0000-0000-000000000001',  310.75, 'usd', 'pending', '2026-07-01', '2026-07-31', null,         'manual', 'qa-531');
```

(`payouts` has a unique constraint on tenant + period, so keep the three periods distinct.)

1. Go to `/en/dashboard/admin/payouts`. **"Total paid out" reads `$1,240.50 · €860.00`** — two figures, not `$2,100.50`. On `master` this same data shows `$2,100.50`.
2. Check the "Payout history" table below: `$1,240.50`, `€860.00` and `$310.75` each keep their own currency symbol, unchanged from before.
3. Check "Pending / Processing" still reads `1` — it counts rows and is not currency-grouped.
4. Switch to `/es/dashboard/admin/payouts`. The card reads `1240,50 US$ · 860,00 €` — locale formatting applies, currency codes still come from the data.
5. Narrow the window to ~420px. The card wraps rather than clipping; add a third currency (e.g. a `gbp` row) if you want to push it further.
6. Regression check on the super-admin side: as the same account (it is also a super admin), open `/en/platform/payouts`. "Paid out (all time)" reads `$1,240.50 · €860.00` and the by-school table shows one row per (school, currency) — identical to `master`.
7. `delete from payouts where note = 'qa-531';` when done.

## Screenshots / GIF

Before/after screenshots (school page, both locales, plus the platform page for the refactor regression check) and a verification GIF follow as a comment — the repo is private, so they have to be attached through the browser rather than linked.

## Checklist

- [x] `npm run typecheck` and `npm run test:unit` pass — typecheck clean; unit suite **358 passed (30 files)**, including the new `tests/unit/format-money.test.ts` (16 tests)
- [x] `npm run build` passes
- [x] Every new tenant-scoped query filters by `tenant_id` (or the table genuinely has no such column) — no queries added or changed; the existing `payouts` query keeps its `.eq('tenant_id', tenantId)` and the page's `tenant_users` admin check is untouched
- [x] Tested with every relevant role (student / teacher / admin) — admin (`owner@e2etest.com`) on the school page and super admin on `/platform/payouts`; the page is admin-only by design (non-admins get the existing access-denied state, unchanged) and there is no student or teacher view of payouts
- [x] Loading and error states handled — no new data fetching; the existing empty state ("no payouts yet") and the access-denied branch are untouched
- [x] New UI strings added to both `messages/en.json` and `messages/es.json` — no new strings; `stats.totalPaid` / `stats.totalPaidDesc` keep their current wording in both locales, only the value expression changed
- [ ] Migration (if any) applies cleanly on `npm run db:reset`, has RLS policies, and `lib/database.types.ts` was regenerated — n/a, no migration

## Not in this PR

§2.4 of #493 also asked for schools to see "the platform owes us $X" alongside "we were paid $Y", and #531 notes that this page still has no owed figure. That needs a tenant-side equivalent of `getPayoutsOwed()` and is a feature rather than a correctness fix, so it is left for its own issue — this PR only stops the existing card from lying.
