### PR TITLE
fix(security): pin transaction status and columns for user-scoped writes (#528)

### DIFF
--- a/.claude/gh-workflow.config.json
+++ b/.claude/gh-workflow.config.json
@@ -1,5 +1,5 @@
 {
   "projectBoard": null,
-  "prTemplate": null,
+  "prTemplate": ".github/pull_request_template.md",
   "branchConvention": "<type>/<slug>-<N>"
 }

--- a/app/[locale]/(public)/checkout/actions.ts
+++ b/app/[locale]/(public)/checkout/actions.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { createClient as createServerClient } from '@/lib/supabase/server';
+import { createAdminClient } from '@/lib/supabase/admin';
 import { revalidatePath } from 'next/cache';
 import { getCurrentUserId, getCurrentTenantId } from '@/lib/supabase/tenant'
 import { headers } from 'next/headers';
@@ -26,6 +27,16 @@ export async function enrollUser(courseId?: string, planId?: string, paymentMeth
     }
     const tenantId = await getCurrentTenantId();
 
+    // Since #528 the transactions INSERT policy pins `status = 'pending'` for the
+    // user-scoped client, because a student could otherwise POST a 'successful'
+    // row straight to PostgREST and let the after_transaction_insert trigger hand
+    // them the course. This action legitimately needs to write 'successful', so
+    // the two inserts below use the admin client. Per CLAUDE.md, that shifts the
+    // tenant check to us: `userId` comes from the session, and the product/plan
+    // lookups that follow are tenant-scoped reads on the USER-scoped client, so a
+    // caller can only reach rows their own tenant owns.
+    const adminClient = createAdminClient();
+
     try {
         if (courseId) {
             // Get product for this course (pick first match, scoped to tenant)
@@ -49,7 +60,7 @@ export async function enrollUser(courseId?: string, planId?: string, paymentMeth
             // Create the transaction. The after_transaction_insert trigger
             // enrolls the user (entitlements + enrollment record) — no explicit
             // RPC call here, the trigger is the single enrollment path.
-            const { data: transaction, error: txError } = await supabase
+            const { data: transaction, error: txError } = await adminClient
                 .from('transactions')
                 .insert({
                     user_id: userId,
@@ -97,7 +108,7 @@ export async function enrollUser(courseId?: string, planId?: string, paymentMeth
             // Create the transaction. The after_transaction_insert trigger
             // creates the subscription + entitlements (or extends an existing
             // subscription on renewal).
-            const { data: transaction, error: txError } = await supabase
+            const { data: transaction, error: txError } = await adminClient
                 .from('transactions')
                 .insert({
                     user_id: userId,

--- a/supabase/migrations/20260725170000_transactions_column_hardening.sql
+++ b/supabase/migrations/20260725170000_transactions_column_hardening.sql
@@ -1,0 +1,141 @@
+-- Issue #528 — transactions RLS restricts rows but not columns.
+--
+-- `transactions` grants table-level INSERT/UPDATE to `authenticated`
+-- (20260126190500_lms_complete.sql), and the RLS policies in
+-- 20260313025318_rls_transactions.sql constrain only WHICH ROWS a user may
+-- write, never which columns:
+--
+--   CREATE POLICY "Users can create own transactions"
+--     ON public.transactions FOR INSERT TO authenticated
+--     WITH CHECK (auth.uid() = user_id AND tenant_id = get_tenant_id());
+--
+-- So an authenticated student can POST /rest/v1/transactions with any column
+-- values they like, provided user_id is theirs and tenant_id is their current
+-- tenant. Two consequences, both reached without touching a payment provider:
+--
+--   1. FREE ENROLMENT. `trigger_manage_transactions` (AFTER INSERT/UPDATE) calls
+--      enroll_user(NEW.user_id, NEW.product_id) whenever product_id is set and
+--      status = 'successful', and handle_new_subscription(...) on the plan_id
+--      branch. A self-inserted 'successful' row therefore writes `entitlements`
+--      — i.e. paid course access — with no money involved.
+--   2. FABRICATED PAYOUT LIABILITY. getPayoutsOwed() (app/actions/platform/
+--      payouts.ts:52) reads transactions WHERE status IN ('successful','refunded')
+--      AND payment_provider IN (paypal, lemonsqueezy, binance). A self-inserted
+--      row carrying one of those providers lands in grossOwed, so the platform's
+--      own payout dashboard reports it owes a school money for a sale that never
+--      happened.
+--
+-- #512 (20260725110000) closed `school_percentage_snapshot` specifically, by
+-- making the database compute and freeze that one column. The rest of the row is
+-- still caller-controlled. This migration closes the two impacts above.
+--
+-- THE SHAPE OF THE FIX.
+--
+-- Both impacts are gated on the SAME thing: a row reaching 'successful' (or, for
+-- the payout half, 'refunded'). Neither is reachable from a 'pending' row. So the
+-- invariant worth enforcing is narrow and checkable — an untrusted caller may
+-- open a transaction, but may not declare it paid. Only the webhook, verify and
+-- reconcile paths, which all run on the service-role client and bypass RLS
+-- entirely, may do that.
+--
+-- Two layers, because they defend against different mechanics:
+--
+--   (a) INSERT policy pins status = 'pending'. Closes the self-INSERT path.
+--
+--   (b) UPDATE is restricted to the three columns a legitimate user-scoped caller
+--       actually writes, and the policy pins the reachable statuses. Closes the
+--       self-ESCALATE path — owning a genuine pending row is otherwise a second
+--       route to the same place, since after_transaction_update fires the very
+--       same trigger.
+--
+-- WHY (b) NEEDS A COLUMN GRANT AND NOT JUST A POLICY.
+--
+-- An RLS WITH CHECK sees only the NEW row; it cannot compare NEW to OLD. So a
+-- policy alone cannot make a column immutable. Without the column grant a student
+-- can open a legitimate pending transaction for a cheap product, PATCH its
+-- product_id to an expensive one, pay the cheap price, and let the provider's
+-- webhook flip the row to 'successful' — at which point the trigger enrols them
+-- in the expensive course. Column privileges close that mechanically, at the
+-- grant layer, without needing OLD.
+--
+-- Note the ordering requirement: a bare REVOKE ... (column) is a NO-OP while the
+-- table-level grant is held, so table-level UPDATE must be revoked FIRST and the
+-- allowed columns re-granted after.
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- (a) INSERT — an untrusted caller may only open a PENDING transaction.
+-- ---------------------------------------------------------------------------
+--
+-- Permissive policies OR together, so this has to replace the existing policy
+-- rather than sit alongside it: an additional policy would widen the grant, not
+-- narrow it.
+--
+-- Callers unaffected (verified against every application write site):
+--   app/api/payments/checkout/route.ts:233          status: 'pending'
+--   app/api/stripe/create-payment-intent/route.ts:140  status: 'pending'
+--
+-- Callers that bypass RLS and are therefore untouched: every createAdminClient()
+-- / service-role path (the Stripe webhook, lib/payments/webhook-dispatch.ts, the
+-- Solana and Binance reconcilers, the two cron routes, payment-requests.ts,
+-- admin/binance-personal.ts), plus grant_free_subscription() — SECURITY DEFINER
+-- runs as the table owner and the table is not FORCE ROW LEVEL SECURITY, so the
+-- free-plan path still inserts its zero-amount 'successful' row.
+
+DROP POLICY IF EXISTS "Users can create own transactions" ON public.transactions;
+
+CREATE POLICY "Users can create own transactions"
+  ON public.transactions FOR INSERT TO authenticated
+  WITH CHECK (
+    (SELECT auth.uid()) = user_id
+    AND tenant_id = (SELECT get_tenant_id())
+    AND status = 'pending'
+  );
+
+-- ---------------------------------------------------------------------------
+-- (b) UPDATE — narrow to the three columns a user-scoped caller actually writes.
+-- ---------------------------------------------------------------------------
+--
+-- The complete set of user-scoped UPDATE sites and the columns they write:
+--   app/api/payments/checkout/route.ts:320            provider_subscription_id
+--   app/api/payments/checkout/route.ts:337            status -> 'failed'
+--   app/api/stripe/create-payment-intent/route.ts:187 provider_subscription_id
+--   app/api/stripe/create-payment-intent/route.ts:203 status -> 'failed'
+--   app/api/stripe/create-payment-intent/route.ts:241 stripe_payment_intent_id
+--
+-- Everything else — amount, currency, product_id, plan_id, payment_provider,
+-- user_id, tenant_id, the settlement_* columns, provider_charge_id,
+-- provider_metadata, payment_method, transaction_date, school_percentage_snapshot
+-- — becomes unwritable by `authenticated`. A future user-scoped update of any of
+-- them fails loudly with `permission denied for column`, which is the intended
+-- trade-off: this is a payments table, and a silent success is the worse outcome.
+
+REVOKE UPDATE ON TABLE public.transactions FROM authenticated;
+
+GRANT UPDATE (status, provider_subscription_id, stripe_payment_intent_id)
+  ON TABLE public.transactions TO authenticated;
+
+-- USING pins the rows a user may touch at all to their own still-pending ones;
+-- every legitimate user-scoped update above runs against a row created moments
+-- earlier in the same request, so it is always still 'pending'. WITH CHECK pins
+-- where that row may land: 'pending' (a metadata-only update leaves it alone) or
+-- 'failed' (the provider-session rollback). 'successful' and 'refunded' — the two
+-- statuses the trigger and the payout query care about — are unreachable.
+
+DROP POLICY IF EXISTS "Users can update own transactions" ON public.transactions;
+
+CREATE POLICY "Users can update own transactions"
+  ON public.transactions FOR UPDATE TO authenticated
+  USING (
+    (SELECT auth.uid()) = user_id
+    AND tenant_id = (SELECT get_tenant_id())
+    AND status = 'pending'
+  )
+  WITH CHECK (
+    (SELECT auth.uid()) = user_id
+    AND tenant_id = (SELECT get_tenant_id())
+    AND status IN ('pending', 'failed')
+  );
+
+COMMIT;

--- a/supabase/migrations/rollback/20260725170000_transactions_column_hardening.down.sql
+++ b/supabase/migrations/rollback/20260725170000_transactions_column_hardening.down.sql
@@ -1,0 +1,33 @@
+-- Rollback for 20260725170000_transactions_column_hardening.sql (issue #528).
+--
+-- NOT APPLIED BY DEFAULT. Running this restores the policies and grants exactly
+-- as 20260313025318_rls_transactions.sql left them — which means it REOPENS both
+-- impacts described in #528: an authenticated student regains the ability to
+-- self-insert a 'successful' transaction (free course access via the
+-- after_transaction_insert trigger) and to fabricate a platform-settled sale that
+-- inflates getPayoutsOwed(). Only run it if the column grant has broken a
+-- legitimate write path and the fix has to be re-cut.
+
+BEGIN;
+
+DROP POLICY IF EXISTS "Users can create own transactions" ON public.transactions;
+
+CREATE POLICY "Users can create own transactions"
+  ON public.transactions FOR INSERT TO authenticated
+  WITH CHECK (auth.uid() = user_id AND tenant_id = get_tenant_id());
+
+-- Drop the column-level grants before restoring the table-level one, so no
+-- narrower privilege is left dangling behind the broad grant.
+REVOKE UPDATE (status, provider_subscription_id, stripe_payment_intent_id)
+  ON TABLE public.transactions FROM authenticated;
+
+GRANT UPDATE ON TABLE public.transactions TO authenticated;
+
+DROP POLICY IF EXISTS "Users can update own transactions" ON public.transactions;
+
+CREATE POLICY "Users can update own transactions"
+  ON public.transactions FOR UPDATE TO authenticated
+  USING (auth.uid() = user_id AND tenant_id = get_tenant_id())
+  WITH CHECK (auth.uid() = user_id AND tenant_id = get_tenant_id());
+
+COMMIT;

--- a/supabase/snippets/verify_transactions_column_hardening.sql
+++ b/supabase/snippets/verify_transactions_column_hardening.sql
@@ -1,0 +1,83 @@
+-- Verify 20260725170000_transactions_column_hardening.sql (issue #528).
+--
+-- Asserts the FINAL grant + policy state on public.transactions rather than the
+-- text of the migration, so it also catches a later migration re-widening things.
+-- Every row should report PASS. Run with:
+--
+--   docker exec -i supabase_db_lms-front psql -U postgres -d postgres \
+--     -f - < supabase/snippets/verify_transactions_column_hardening.sql
+--
+-- (or paste into the Supabase SQL editor for the cloud project).
+
+\echo '== 1. authenticated must NOT hold table-level INSERT/UPDATE beyond the column grant =='
+SELECT
+  'table-level UPDATE revoked from authenticated' AS check,
+  CASE WHEN NOT has_table_privilege('authenticated', 'public.transactions', 'UPDATE')
+       THEN 'PASS' ELSE 'FAIL' END AS result;
+
+\echo '== 2. exactly the three intended columns are UPDATE-able by authenticated =='
+SELECT
+  'column UPDATE grants' AS check,
+  CASE WHEN (
+    SELECT array_agg(a.attname::text ORDER BY a.attname)
+    FROM pg_attribute a
+    WHERE a.attrelid = 'public.transactions'::regclass
+      AND a.attnum > 0 AND NOT a.attisdropped
+      AND has_column_privilege('authenticated', a.attrelid, a.attname, 'UPDATE')
+  ) = ARRAY['provider_subscription_id', 'status', 'stripe_payment_intent_id']
+  THEN 'PASS' ELSE 'FAIL' END AS result,
+  (
+    SELECT string_agg(a.attname, ', ' ORDER BY a.attname)
+    FROM pg_attribute a
+    WHERE a.attrelid = 'public.transactions'::regclass
+      AND a.attnum > 0 AND NOT a.attisdropped
+      AND has_column_privilege('authenticated', a.attrelid, a.attname, 'UPDATE')
+  ) AS actual;
+
+\echo '== 3. financial columns are NOT UPDATE-able by authenticated =='
+SELECT
+  a.attname AS column,
+  CASE WHEN has_column_privilege('authenticated', a.attrelid, a.attname, 'UPDATE')
+       THEN 'FAIL' ELSE 'PASS' END AS result
+FROM pg_attribute a
+WHERE a.attrelid = 'public.transactions'::regclass
+  AND a.attname IN ('amount', 'currency', 'product_id', 'plan_id', 'payment_provider',
+                    'user_id', 'tenant_id', 'settlement_base', 'settlement_currency',
+                    'school_percentage_snapshot')
+ORDER BY a.attname;
+
+\echo '== 4. the INSERT policy pins status = pending =='
+SELECT
+  polname AS policy,
+  CASE WHEN pg_get_expr(polwithcheck, polrelid) LIKE '%pending%'
+       THEN 'PASS' ELSE 'FAIL' END AS result,
+  pg_get_expr(polwithcheck, polrelid) AS with_check
+FROM pg_policy
+WHERE polrelid = 'public.transactions'::regclass
+  AND polcmd = 'a';
+
+\echo '== 5. the UPDATE policy cannot reach successful/refunded =='
+SELECT
+  polname AS policy,
+  CASE WHEN pg_get_expr(polqual, polrelid) LIKE '%pending%'
+        AND pg_get_expr(polwithcheck, polrelid) LIKE '%pending%'
+        AND pg_get_expr(polwithcheck, polrelid) LIKE '%failed%'
+        AND pg_get_expr(polwithcheck, polrelid) NOT LIKE '%successful%'
+        AND pg_get_expr(polwithcheck, polrelid) NOT LIKE '%refunded%'
+       THEN 'PASS' ELSE 'FAIL' END AS result,
+  pg_get_expr(polqual, polrelid) AS using_expr,
+  pg_get_expr(polwithcheck, polrelid) AS with_check
+FROM pg_policy
+WHERE polrelid = 'public.transactions'::regclass
+  AND polcmd = 'w';
+
+\echo '== 6. RLS is still enabled, and there is still no DELETE path for authenticated =='
+SELECT
+  'RLS enabled' AS check,
+  CASE WHEN relrowsecurity THEN 'PASS' ELSE 'FAIL' END AS result
+FROM pg_class WHERE oid = 'public.transactions'::regclass
+UNION ALL
+SELECT
+  'DELETE not granted to authenticated',
+  CASE WHEN NOT has_table_privilege('authenticated', 'public.transactions', 'DELETE')
+       THEN 'PASS' ELSE 'FAIL' END;


### PR DESCRIPTION
## What

`transactions` RLS now restricts which **columns** a user-scoped caller may write, not just which rows. The INSERT policy pins `status = 'pending'`, and table-level `UPDATE` is revoked from `authenticated` and re-granted on only the three columns a legitimate caller actually writes.

Closes #528

## Why

`transactions` grants table-level `INSERT`/`UPDATE` to `authenticated` (`20260126190500_lms_complete.sql`), and the policies in `20260313025318_rls_transactions.sql` constrain only which rows a user may write:

```sql
CREATE POLICY "Users can create own transactions"
  ON public.transactions FOR INSERT TO authenticated
  WITH CHECK (auth.uid() = user_id AND tenant_id = get_tenant_id());
```

So an authenticated student could `POST /rest/v1/transactions` with any column values they liked, as long as `user_id` was theirs and `tenant_id` was their current tenant. Both impacts were reproduced end-to-end against a local database, signed in as `alice@student.com` with nothing but the anon key:

**1. Free enrolment.** `trigger_manage_transactions` (AFTER INSERT/UPDATE) calls `enroll_user(NEW.user_id, NEW.product_id)` whenever `product_id` is set and `status = 'successful'`. A single self-inserted row bought a $49 course for one cent:

```
POST /rest/v1/transactions
{"product_id":2001,"amount":0.01,"status":"successful", ...}       -> HTTP 201

GET  /rest/v1/entitlements?user_id=eq.<alice>&course_id=eq.2001
[{"course_id":2001,"source_type":"product","source_id":2001,"status":"active"}]
```

**2. Fabricated payout liability.** `getPayoutsOwed()` (`app/actions/platform/payouts.ts:52`) reads transactions with `status IN ('successful','refunded')` and a platform-settled `payment_provider`. A self-inserted row landed in `grossOwed`, so the platform's own payout dashboard reported it owed a school money for a sale that never happened:

```
POST /rest/v1/transactions
{"amount":9999,"status":"successful","payment_provider":"paypal"}  -> HTTP 201
```

#512 (PR #525) closed `school_percentage_snapshot` specifically, by making the database compute and freeze that one column. The rest of the row was still caller-controlled.

### The shape of the fix

Both impacts are gated on the same thing — a row reaching `'successful'` (or `'refunded'` for the payout half) — and neither is reachable from a `pending` row. So the invariant enforced is narrow and checkable: an untrusted caller may *open* a transaction, but may not *declare it paid*. Only the webhook, verify and reconcile paths, which all run on the service-role client and bypass RLS entirely, may do that.

Two layers, defending against different mechanics:

- **INSERT policy pins `status = 'pending'`** — closes the self-insert path. Permissive policies OR together, so this replaces the existing policy rather than sitting alongside it.
- **UPDATE is narrowed to three columns** (`status`, `provider_subscription_id`, `stripe_payment_intent_id`) via column-level grants, and the policy pins `USING (status = 'pending')` / `WITH CHECK (status IN ('pending','failed'))` — closes the self-escalate path. `after_transaction_update` fires the *same* trigger, so owning a genuine pending row was a second route to the same place.

The column grant is **not redundant** with the policy. An RLS `WITH CHECK` sees only the NEW row and cannot compare it to OLD, so a policy alone cannot make a column immutable. Without the grant, a student could open a legitimate pending transaction for a cheap product, `PATCH` its `product_id` to an expensive one, pay the cheap price, and let the provider's webhook flip the row to `successful` — at which point the trigger enrols them in the expensive course. Column privileges close that at the grant layer, without needing OLD.

Ordering matters: a bare `REVOKE ... (column)` is a no-op while the table-level grant is held, so table-level `UPDATE` is revoked first and the allowed columns re-granted after.

### Why `enrollUser()` moved to the admin client

A full inventory of application write sites found **7 user-scoped writes**. Five already write `'pending'` or `'failed'` and are unaffected. The two inserts in `enrollUser()` (`app/[locale]/(public)/checkout/actions.ts`, the mock/sandbox checkout) write `'successful'` and would have broken, so they move to `createAdminClient()`. Both already validate tenant ownership before writing — the product/plan lookups are `.eq('tenant_id', tenantId)` reads on the user-scoped client, and `user_id` comes from the session — which satisfies the `createAdminClient()` rule in `CLAUDE.md`.

Worth stating explicitly, because it bounds how much this matters: `enrollUser()` is reachable only from the "Pay & Enroll (Test)" sandbox button, which `components/public/checkout-form.tsx:678` gates behind `process.env.NODE_ENV !== 'production'`. In production a Stripe product renders `StripePaymentForm` (the webhook grants enrollment) and a provider-less product renders a "card unavailable" notice, so neither reaches this action. The move to the admin client therefore keeps local development and the E2E sandbox flow working; it is not covering a production payment path.

Everything on a service-role client (the Stripe webhook, `lib/payments/webhook-dispatch.ts`, the Solana and Binance reconcilers, both cron routes, `payment-requests.ts`, `admin/binance-personal.ts`) bypasses RLS and is untouched. `grant_free_subscription()` is `SECURITY DEFINER` and the table is not `FORCE ROW LEVEL SECURITY`, so it runs as the table owner and still inserts its zero-amount `'successful'` row — **verified live**, not assumed.

## How to QA

On a fresh `npm run db:reset`, signed in as `alice@student.com` / `password123` on `code-academy.lvh.me:3000` (Code Academy Pro).

**Automated state check** — every row should report `PASS`:

```bash
docker exec -i supabase_db_lms-front psql -U postgres -d postgres \
  -f - < supabase/snippets/verify_transactions_column_hardening.sql
```

This asserts the *final* grant and policy state rather than the migration text, so it also catches a later migration re-widening things.

**Manual — the attacks must fail.** Get a student JWT and hit PostgREST directly (this is the part that matters; RLS is invisible to the type checker):

```bash
URL=http://127.0.0.1:54321
ANON=<NEXT_PUBLIC_SUPABASE_PUBLISHABLE_OR_ANON_KEY from .env.local>
JWT=$(curl -s -X POST "$URL/auth/v1/token?grant_type=password" \
  -H "apikey: $ANON" -H "Content-Type: application/json" \
  -d '{"email":"alice@student.com","password":"password123"}' | jq -r .access_token)
ALICE=a1000000-0000-0000-0000-000000000004
TENANT=00000000-0000-0000-0000-000000000002
```

1. **Self-insert a `successful` sale** → expect `403`, `new row violates row-level security policy`:
   ```bash
   curl -s -X POST "$URL/rest/v1/transactions" -H "apikey: $ANON" \
     -H "Authorization: Bearer $JWT" -H "Content-Type: application/json" \
     -d "{\"user_id\":\"$ALICE\",\"tenant_id\":\"$TENANT\",\"product_id\":2001,\"amount\":0.01,\"currency\":\"usd\",\"status\":\"successful\"}"
   ```
2. **Confirm no entitlement was created** → expect `[]`:
   ```bash
   curl -s "$URL/rest/v1/entitlements?user_id=eq.$ALICE&course_id=eq.2001&select=course_id,status" \
     -H "apikey: $ANON" -H "Authorization: Bearer $JWT"
   ```
3. **Self-insert a fake platform-settled sale** (`"amount":9999,"status":"successful","payment_provider":"paypal"`) → expect `403`.
4. **Open a legitimate pending row** (same body as step 1 but `"product_id":2002,"amount":19,"status":"pending","payment_provider":"stripe"`) → expect `201`. Keep the returned `transaction_id`.
5. **Rewrite financial columns on that pending row** (`PATCH ...?transaction_id=eq.<id>` with `{"amount":0.01,"payment_provider":"paypal"}`) → expect `403`, `permission denied for table transactions`.
6. **Escalate that pending row** (`{"status":"successful"}`) → expect `403`, RLS violation.
7. **Roll it back to failed** (`{"status":"failed"}`) → expect `200`. This is `app/api/payments/checkout/route.ts:337` and must keep working.
8. **Write the two provider-metadata columns** on a fresh pending row (`{"provider_subscription_id":"sub_test_123"}`, then `{"stripe_payment_intent_id":"pi_test_123"}`) → both expect `200`. These are `payments/checkout/route.ts:320` and `create-payment-intent/route.ts:241`.

**Manual — the app must still work.** Free-course and free-plan checkout (`enrollFree` / `subscribeFree`, both on `SECURITY DEFINER` RPCs) still enrol, and the inline mock checkout on a paid product still grants access.

## Screenshots / GIF

No UI change — this is grant/policy DDL plus a Supabase client swap in a server action. The verification evidence is the before/after PostgREST transcript above: the same 8 requests returned `201/200` for all four attacks before the migration and `403` for all four after, with both legitimate paths unchanged.

## Checklist

- [x] `npm run typecheck` and `npm run test:unit` pass — typecheck clean; 370 tests across 31 files pass
- [x] `npm run build` passes
- [x] Every new tenant-scoped query filters by `tenant_id` (or the table genuinely has no such column) — no new queries; the two `enrollUser()` inserts already carry `tenant_id` and keep it on the admin client
- [x] Tested with every relevant role (student / teacher / admin) — exercised as a student (the only role that can reach the vector) and as the service-role/`SECURITY DEFINER` paths; teacher and admin have SELECT-only policies on this table and are unaffected
- [x] Loading and error states handled — no UI surface; rejected writes surface through the existing `txError` branches
- [x] New UI strings added to both `messages/en.json` and `messages/es.json` — n/a, no new strings
- [x] Migration applies cleanly on `npm run db:reset`, has RLS policies, and `lib/database.types.ts` was regenerated — applies clean from scratch; the migration *is* RLS policies; no regeneration needed, as it changes no columns or types (grants and policies only)

## Follow-up (deliberately out of scope)

One adjacent problem surfaced while surveying. It is real, it is not what #528 describes, and folding it in would have made this unreviewable.

**Settlement columns are still caller-controlled at INSERT.** `settlement_base`, `settlement_currency`, `settlement_mint` and `settlement_sol_usd` remain writable, and `app/api/payments/solana/verify/route.ts` prices the on-chain payment against them. A self-inserted `pending` row carrying `settlement_base: 1` is a pay-one-lamport-for-a-$100-course path, and it **survives this PR** because the row is legitimately `pending` — the invariant enforced here is "an untrusted caller may not declare a row paid", which does not constrain what a pending row claims it is owed. Closing it properly needs the checkout RPC (direction 3 in the issue), since the SOL/USD rate is fetched off-platform and cannot be recomputed in a trigger. Filed separately.
