### PR TITLE
fix(security): gate the write side on entitlements, not on self-issuable rows (#543)

### DIFF
--- a/app/api/certificates/issue/route.ts
+++ b/app/api/certificates/issue/route.ts
@@ -8,10 +8,25 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { getCurrentTenantId } from '@/lib/supabase/tenant'
+import { resolveCourseAccessState } from '@/lib/services/course-access'
 import { sendEmail } from '@/lib/email/send'
 import { certificateIssuedTemplate } from '@/lib/email/templates/certificate-issued'
 
 export const dynamic = 'force-dynamic'
+
+/** Shape of `check_and_issue_certificate`'s jsonb return (it is typed `Json`). */
+type CertificateCompletion = {
+  totalLessons?: number | null
+  completedLessons?: number | null
+  completionPercentage?: number | null
+}
+type CertificateEligibility = {
+  success?: boolean
+  eligible?: boolean
+  certificateId?: string
+  reason?: string
+  completion?: CertificateCompletion
+}
 
 export async function POST(request: NextRequest) {
   try {
@@ -64,6 +79,26 @@ export async function POST(request: NextRequest) {
       // Verify teacher owns this course (unless admin)
       if (tenantUser?.role !== 'admin' && course.author_id !== user.id) {
         return NextResponse.json({ error: 'Not authorized for this course' }, { status: 403 })
+      }
+    } else {
+      // Self-serve issuance (#543). Eligibility below falls through to a raw
+      // `lesson_completions` count, so without this the school's credential is
+      // mintable by anyone who can write completions — and until this change
+      // that was any authenticated user, for any lesson id. `entitlements` is
+      // the source of truth; an `enrollments` row is not an access grant.
+      const accessState = await resolveCourseAccessState(supabase, user.id, Number(courseId))
+      if (accessState !== 'granted') {
+        return NextResponse.json(
+          {
+            error:
+              accessState === 'suspended'
+                ? "Your school's access is currently suspended"
+                : 'You do not have access to this course',
+            accessDenied: true,
+            accessSuspended: accessState === 'suspended',
+          },
+          { status: 403 }
+        )
       }
     }
 
@@ -157,13 +192,13 @@ async function simplifiedIssuance(
   issuedBy?: string,
 ) {
   // Check eligibility via RPC (or fallback to lesson count)
-  let completionData: any = {}
+  let completionData: CertificateCompletion = {}
 
   try {
     const { data: eligibility } = await supabase
       .rpc('check_and_issue_certificate', { p_user_id: userId, p_course_id: courseId })
 
-    const result = eligibility as any
+    const result = eligibility as CertificateEligibility | null
     if (result && !result.success && !result.eligible && !result.certificateId) {
       return NextResponse.json({
         success: false,
@@ -357,10 +392,11 @@ export async function GET(request: NextRequest) {
 
       if (error) throw error
 
+      const eligibility = data as CertificateEligibility | null
       return NextResponse.json({
-        eligible: (data as any)?.eligible || false,
-        completion: (data as any)?.completion,
-        reason: (data as any)?.reason,
+        eligible: eligibility?.eligible || false,
+        completion: eligibility?.completion,
+        reason: eligibility?.reason,
       })
     } catch {
       // Fallback: simple completion check

--- a/app/api/lesson-checkpoints/[checkpointId]/attempt/route.ts
+++ b/app/api/lesson-checkpoints/[checkpointId]/attempt/route.ts
@@ -52,7 +52,9 @@ export async function POST(
 ) {
   const auth = await getApiAuthContext(req)
   if (!auth) return new Response('Unauthorized', { status: 401 })
-  const { supabase, user, tenantId } = auth
+  // No user-scoped client here: every table this route touches is read or
+  // written with the admin client behind the explicit gate below (#543).
+  const { user, tenantId } = auth
 
   const checkpointId = Number.parseInt((await params).checkpointId, 10)
   if (!Number.isInteger(checkpointId) || checkpointId <= 0) {
@@ -282,16 +284,19 @@ export async function POST(
     evaluator_type: evaluatorType,
   }
 
-  // Insert with the caller's RLS client so DB policies are the last word.
+  // Server-write-only (#543): `authenticated` holds no INSERT grant on this
+  // table, because every column above is a grading output. The caller's RLS
+  // client cannot be the last word on a row it is not allowed to author — the
+  // access gate is resolveCourseAccessState() at the top of this route (#535).
   let attemptNumber = (count ?? 0) + 1
-  let { data: attempt, error: insertError } = await supabase
+  let { data: attempt, error: insertError } = await adminClient
     .from('lesson_checkpoint_attempts')
     .insert({ ...baseRow, attempt_number: attemptNumber })
     .select('id, attempt_number')
     .single()
   if (insertError?.code === '23505') {
     attemptNumber += 1
-    ;({ data: attempt, error: insertError } = await supabase
+    ;({ data: attempt, error: insertError } = await adminClient
       .from('lesson_checkpoint_attempts')
       .insert({ ...baseRow, attempt_number: attemptNumber })
       .select('id, attempt_number')

--- a/supabase/migrations/20260726110000_write_side_entitlement_gates.sql
+++ b/supabase/migrations/20260726110000_write_side_entitlement_gates.sql
@@ -1,0 +1,240 @@
+-- Issue #543 (EPIC #540 §1.3) — a client may not assert its own grade,
+-- completion, mastery or tenant.
+--
+-- #532 (20260725160000) stamped the rule on `enrollments`: "Never gate content,
+-- APIs or RLS on the presence of an enrollment row." Four write-side policies
+-- were never brought along. Each constrains WHO the row belongs to and nothing
+-- about whether the writer earned it:
+--
+--   lesson_completions       WITH CHECK (auth.uid() = user_id)
+--   exam_submissions         WITH CHECK (auth.uid() = student_id AND tenant_id = get_tenant_id())
+--   lesson_checkpoint_attempts  pins identity + checkpoint consistency + access,
+--                            but leaves score/passed/completed/evaluator_type free
+--   practice_attempts        FOR ALL USING/WITH CHECK (user_id = auth.uid()) — no tenant predicate
+--
+-- Plus one read-side straggler: `lesson_checkpoints` SELECT still authorizes by
+-- joining `enrollments`, which no revocation path ever removes.
+--
+-- SHAPE. The three predicates below mirror the #509 content read policies
+-- (20260724150000): tenant match AND (staff OR course author OR
+-- has_course_access). Teachers and admins hold no entitlement for the courses
+-- they author, so the staff/author branches are what keep authoring and course
+-- preview working; students only ever match the has_course_access branch.
+--
+-- `has_course_access(uuid, integer)` takes integer. `lessons.course_id` and
+-- `practice_attempts.course_id` are bigint, hence the ::integer casts;
+-- `exams.course_id` is already integer.
+
+-- ---------------------------------------------------------------------------
+-- 1. lesson_completions — completion is the certificate's eligibility source.
+--
+-- `app/api/certificates/issue/route.ts` counts these rows to decide whether to
+-- mint the school's credential, so a self-issuable completion is a
+-- self-issuable certificate. The table has no `tenant_id` (see CLAUDE.md), so
+-- the course is reached through `lessons`.
+--
+-- Preview lessons (#426) are deliberately NOT a branch here: a prospective
+-- buyer may read a preview lesson, but recording progress against a course
+-- they have not bought is exactly what this policy exists to stop.
+-- ---------------------------------------------------------------------------
+
+DROP POLICY IF EXISTS "Students can mark lessons complete" ON public.lesson_completions;
+
+CREATE POLICY "Students can mark lessons complete"
+  ON public.lesson_completions FOR INSERT TO authenticated
+  WITH CHECK (
+    (SELECT auth.uid()) = user_id
+    AND EXISTS (
+      SELECT 1 FROM public.lessons l
+      WHERE l.id = lesson_completions.lesson_id
+        AND (
+          (SELECT public.is_tenant_staff())
+          OR EXISTS (
+            SELECT 1 FROM public.courses c
+            WHERE c.course_id = l.course_id
+              AND c.author_id = (SELECT auth.uid())
+          )
+          OR public.has_course_access((SELECT auth.uid()), l.course_id::integer)
+        )
+    )
+  );
+
+COMMENT ON TABLE public.lesson_completions IS
+  'Progress record, and the eligibility source /api/certificates/issue counts. '
+  'INSERT requires course access (#543) — a completion is not self-issuable.';
+
+-- ---------------------------------------------------------------------------
+-- 2. exam_submissions — submitting enqueues AI grading on the school's budget.
+--
+-- Without an access predicate, a student with no entitlement (or one past the
+-- tenant's `access_cutoff_at`, which lives inside has_course_access) can POST
+-- submissions that `app/actions/exam-grading.ts` then grades against the
+-- school's plan allowance.
+-- ---------------------------------------------------------------------------
+
+DROP POLICY IF EXISTS "Students can create own exam submissions" ON public.exam_submissions;
+
+CREATE POLICY "Students can create own exam submissions"
+  ON public.exam_submissions FOR INSERT TO authenticated
+  WITH CHECK (
+    (SELECT auth.uid()) = student_id
+    AND tenant_id = (SELECT public.get_tenant_id())
+    AND EXISTS (
+      SELECT 1 FROM public.exams e
+      WHERE e.exam_id = exam_submissions.exam_id
+        AND e.tenant_id = exam_submissions.tenant_id
+        AND (
+          (SELECT public.is_tenant_staff())
+          OR EXISTS (
+            SELECT 1 FROM public.courses c
+            WHERE c.course_id = e.course_id
+              AND c.author_id = (SELECT auth.uid())
+          )
+          OR public.has_course_access((SELECT auth.uid()), e.course_id)
+        )
+    )
+  );
+
+-- ---------------------------------------------------------------------------
+-- 3. lesson_checkpoint_attempts — server-write-only, per the #538 pattern.
+--
+-- #532 gated WHO may insert (own user, enabled checkpoint, consistent
+-- checkpoint/lesson/exercise/tenant, has_course_access) and that part holds.
+-- What no policy could express is that `score`, `passed`, `completed`,
+-- `evaluation`, `response`, `evaluator_type` and `attempt_number` must be the
+-- server grader's output rather than the caller's claim:
+--
+--   * `{passed: true, score: 100, completed: true}` satisfies any is_required
+--     checkpoint without answering — lib/checkpoints/load.ts reads
+--     `latestAttempt.passed` off the newest row and required checkpoints gate
+--     lesson progression.
+--   * rows tagged `evaluator_type = 'ai'` are what countAiAttempts() bills
+--     against the per-student AND per-tenant monthly AI allowance, so one
+--     student could exhaust AI evaluation for every classmate in the school.
+--
+-- The only legitimate writer is app/api/lesson-checkpoints/[checkpointId]/
+-- attempt/route.ts, which already holds an admin client and already carries
+-- its own resolveCourseAccessState() gate (#535). Its insert moves to that
+-- client in this change, so the student INSERT grant has no remaining user.
+-- Reads are untouched: students still read their own rows, staff the tenant's.
+-- ---------------------------------------------------------------------------
+
+DROP POLICY IF EXISTS lesson_checkpoint_attempts_students_insert_own_rows
+  ON public.lesson_checkpoint_attempts;
+
+REVOKE INSERT, UPDATE, DELETE ON public.lesson_checkpoint_attempts FROM authenticated;
+REVOKE INSERT, UPDATE, DELETE ON public.lesson_checkpoint_attempts FROM anon;
+
+COMMENT ON TABLE public.lesson_checkpoint_attempts IS
+  'Server-write-only (#543). Every column but the identity ones is a grading '
+  'output; the attempt API route writes them with the service-role client after '
+  'grading. `authenticated` holds SELECT only — a user-scoped INSERT failing '
+  'with "permission denied for table lesson_checkpoint_attempts" is by design.';
+
+-- ---------------------------------------------------------------------------
+-- 4. practice_attempts — two SECURITY DEFINER triggers fire on a row the
+--    caller fully controls.
+--
+--   handle_practice_attempt_elo → elo_apply_match(new.tenant_id, …) writes the
+--     TENANT-SHARED `item_ratings` anchors and `student_topic_ratings`.
+--   handle_practice_attempt_xp  → award_xp(…, new.tenant_id) upserts a
+--     `gamification_profiles` row for (user_id, new.tenant_id) unconditionally,
+--     which is the eligibility source rollover_leagues() scans — so a
+--     non-member appears in another school's league standings.
+--
+-- 20260716120000_create_elo_ratings.sql justified the trigger design with "a
+-- student session cannot write shared rating rows from application code". That
+-- only holds if the row's tenant is the caller's own, which nothing checked.
+--
+-- The blanket FOR ALL policy is split so graded history is append-only: no
+-- UPDATE or DELETE policy, and the grants go with it.
+-- ---------------------------------------------------------------------------
+
+DROP POLICY IF EXISTS students_own_practice_attempts ON public.practice_attempts;
+
+CREATE POLICY practice_attempts_students_read_own_rows
+  ON public.practice_attempts FOR SELECT TO authenticated
+  USING (user_id = (SELECT auth.uid()));
+
+CREATE POLICY practice_attempts_students_insert_own_rows
+  ON public.practice_attempts FOR INSERT TO authenticated
+  WITH CHECK (
+    user_id = (SELECT auth.uid())
+    -- Membership of the tenant being written to, from `tenant_users` rather
+    -- than the client-settable x-tenant-id header.
+    AND EXISTS (
+      SELECT 1 FROM public.tenant_users tu
+      WHERE tu.user_id = (SELECT auth.uid())
+        AND tu.tenant_id = practice_attempts.tenant_id
+        AND tu.status = 'active'
+    )
+    -- Topic-only drills carry no course. When one is named, it must be a
+    -- course the caller can reach — the same gate that let them read the
+    -- exercise the drill was generated from.
+    AND (
+      course_id IS NULL
+      OR (SELECT public.is_tenant_staff())
+      OR public.has_course_access((SELECT auth.uid()), course_id::integer)
+    )
+  );
+
+REVOKE UPDATE, DELETE ON public.practice_attempts FROM authenticated;
+REVOKE INSERT, UPDATE, DELETE ON public.practice_attempts FROM anon;
+
+-- Self-reported figures still decide XP (#349), the #393 mastery gate and the
+-- #396 Elo update, so bound them to what a score can actually be.
+ALTER TABLE public.practice_attempts
+  DROP CONSTRAINT IF EXISTS practice_attempts_score_range;
+ALTER TABLE public.practice_attempts
+  ADD CONSTRAINT practice_attempts_score_range
+  CHECK (score >= 0 AND score <= 100);
+
+ALTER TABLE public.practice_attempts
+  DROP CONSTRAINT IF EXISTS practice_attempts_counts_coherent;
+ALTER TABLE public.practice_attempts
+  ADD CONSTRAINT practice_attempts_counts_coherent
+  CHECK (
+    total_questions > 0
+    AND correct_count >= 0
+    AND correct_count <= total_questions
+  );
+
+-- `mode` was pinned at 20260715120000; `source` never was.
+ALTER TABLE public.practice_attempts
+  DROP CONSTRAINT IF EXISTS practice_attempts_source_known;
+ALTER TABLE public.practice_attempts
+  ADD CONSTRAINT practice_attempts_source_known
+  CHECK (source IN ('mcp-tutor'));
+
+COMMENT ON TABLE public.practice_attempts IS
+  'AI-tutor drill history. Append-only for `authenticated` (#543): INSERT '
+  'requires active membership of the named tenant and access to the named '
+  'course, and score/count columns are range-checked, because two SECURITY '
+  'DEFINER triggers write tenant-shared Elo anchors and gamification rows '
+  'from this row.';
+
+-- ---------------------------------------------------------------------------
+-- 5. lesson_checkpoints SELECT — the last `enrollments` join in the feature.
+--
+-- A refunded student keeps their `enrollments` row (lib/payments/
+-- webhook-dispatch.ts revokes entitlements, never enrollments), so they kept
+-- reading every enabled checkpoint on the course. Same shape as before —
+-- is_enabled, tenant match, lesson in the same tenant — with the enrollment
+-- join replaced by the access gate the rest of the feature uses.
+-- Staff are already covered by lesson_checkpoints_teachers_manage_tenant.
+-- ---------------------------------------------------------------------------
+
+DROP POLICY IF EXISTS lesson_checkpoints_students_can_read_enrolled_lessons
+  ON public.lesson_checkpoints;
+
+CREATE POLICY lesson_checkpoints_students_can_read_entitled_lessons
+  ON public.lesson_checkpoints FOR SELECT TO authenticated
+  USING (
+    is_enabled
+    AND EXISTS (
+      SELECT 1 FROM public.lessons l
+      WHERE l.id = lesson_checkpoints.lesson_id
+        AND l.tenant_id = lesson_checkpoints.tenant_id
+        AND public.has_course_access((SELECT auth.uid()), l.course_id::integer)
+    )
+  );

--- a/supabase/migrations/20260726110000_write_side_entitlement_gates.sql
+++ b/supabase/migrations/20260726110000_write_side_entitlement_gates.sql
@@ -168,15 +168,16 @@ CREATE POLICY practice_attempts_students_insert_own_rows
         AND tu.tenant_id = practice_attempts.tenant_id
         AND tu.status = 'active'
     )
-    -- Topic-only drills carry no course. When one is named, it must be a
-    -- course the caller can reach — the same gate that let them read the
-    -- exercise the drill was generated from.
-    AND (
-      course_id IS NULL
-      OR (SELECT public.is_tenant_staff())
-      OR public.has_course_access((SELECT auth.uid()), course_id::integer)
-    )
   );
+
+-- Deliberately NOT gated on `course_id`. It is an optional, model-supplied
+-- label on the MCP tool ("Related course, if any" —
+-- mcp-server/src/tools/practice.ts), not a value derived from anything the
+-- server verified, so an access predicate on it would turn a mislabelled
+-- drill into a hard write failure. It also guards little: the cross-tenant
+-- attack this policy exists to stop is closed by the membership check above,
+-- and `course_id` only scopes `item_ratings` anchors WITHIN the caller's own
+-- tenant.
 
 REVOKE UPDATE, DELETE ON public.practice_attempts FROM authenticated;
 REVOKE INSERT, UPDATE, DELETE ON public.practice_attempts FROM anon;
@@ -208,10 +209,9 @@ ALTER TABLE public.practice_attempts
 
 COMMENT ON TABLE public.practice_attempts IS
   'AI-tutor drill history. Append-only for `authenticated` (#543): INSERT '
-  'requires active membership of the named tenant and access to the named '
-  'course, and score/count columns are range-checked, because two SECURITY '
-  'DEFINER triggers write tenant-shared Elo anchors and gamification rows '
-  'from this row.';
+  'requires active membership of the named tenant, and score/count columns '
+  'are range-checked, because two SECURITY DEFINER triggers write '
+  'tenant-shared Elo anchors and gamification rows from this row.';
 
 -- ---------------------------------------------------------------------------
 -- 5. lesson_checkpoints SELECT — the last `enrollments` join in the feature.

--- a/tests/playwright/checkpoint-access.spec.ts
+++ b/tests/playwright/checkpoint-access.spec.ts
@@ -16,7 +16,7 @@
 import { test, expect } from '@playwright/test'
 import { createClient as createSupabaseClient } from '@supabase/supabase-js'
 import { loginAsStudent } from './utils/auth'
-import { BASE } from './utils/constants'
+import { ACCOUNTS, BASE } from './utils/constants'
 
 const DEFAULT_TENANT = '00000000-0000-0000-0000-000000000001'
 const STUDENT_ID = 'a1000000-0000-0000-0000-000000000001'
@@ -190,6 +190,126 @@ test.describe('checkpoint attempt access gate (#532)', () => {
       expect(body.accessSuspended).toBe(true)
     } finally {
       await admin.from('tenants').update({ access_cutoff_at: null }).eq('id', DEFAULT_TENANT)
+    }
+  })
+})
+
+/**
+ * #543 — the gate above decides WHETHER an attempt may be recorded; these
+ * decide WHO gets to fill it in. Every column on `lesson_checkpoint_attempts`
+ * except the identity ones is a grading output, and the route's own comment
+ * used to claim "DB policies are the last word" while no policy mentioned
+ * `score`, `passed`, `completed` or `evaluator_type`. The table is now
+ * server-write-only (20260726110000).
+ */
+test.describe('checkpoint attempts are server-written (#543)', () => {
+  test('a student cannot write an attempt directly', async () => {
+    const client = createSupabaseClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_OR_ANON_KEY!,
+      { auth: { autoRefreshToken: false, persistSession: false } }
+    )
+    const { error: signInError } = await client.auth.signInWithPassword({
+      email: ACCOUNTS.student.email,
+      password: ACCOUNTS.student.password,
+    })
+    expect(signInError).toBeNull()
+
+    // A self-declared pass on a required checkpoint: this is what unlocked
+    // lesson progression, and what billed the tenant's AI allowance when
+    // tagged evaluator_type 'ai'.
+    const { error } = await client.from('lesson_checkpoint_attempts').insert({
+      tenant_id: DEFAULT_TENANT,
+      user_id: STUDENT_ID,
+      course_id: COURSE_ID,
+      lesson_id: LESSON_ID,
+      checkpoint_id: checkpointId,
+      exercise_id: exerciseId,
+      attempt_number: 999,
+      placement_source: 'inline',
+      response: {},
+      evaluation: {},
+      score: 100,
+      passed: true,
+      completed: true,
+      evaluator_type: 'ai',
+    })
+    expect(error, 'the INSERT grant must be revoked for authenticated').not.toBeNull()
+    expect(error!.code).toBe('42501')
+
+    const { count } = await getAdmin()
+      .from('lesson_checkpoint_attempts')
+      .select('id', { count: 'exact', head: true })
+      .eq('checkpoint_id', checkpointId)
+      .eq('attempt_number', 999)
+    expect(count).toBe(0)
+  })
+
+  test('the stored score and passed flag are the grader\'s, not the caller\'s', async ({
+    page,
+  }) => {
+    await loginAsStudent(page, BASE)
+    const res = await page.request.post(
+      `${BASE}/api/lesson-checkpoints/${checkpointId}/attempt`,
+      // 'Hammer' — deliberately wrong (correctIndex is 1).
+      { data: { kind: 'answers', answers: [{ questionId: 'q1', value: 0 }] } }
+    )
+    expect(res.status()).toBe(200)
+    const body = await res.json()
+    expect(body.passed).toBe(false)
+
+    const { data: row } = await getAdmin()
+      .from('lesson_checkpoint_attempts')
+      .select('score, passed, evaluator_type')
+      .eq('checkpoint_id', checkpointId)
+      .eq('user_id', STUDENT_ID)
+      .order('attempt_number', { ascending: false })
+      .limit(1)
+      .single()
+    expect(row!.passed).toBe(false)
+    expect(Number(row!.score)).toBe(Number(body.score))
+    expect(row!.evaluator_type).toBe('deterministic')
+  })
+
+  test('a refunded student reads no checkpoints at all', async () => {
+    const admin = getAdmin()
+    const client = createSupabaseClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_OR_ANON_KEY!,
+      { auth: { autoRefreshToken: false, persistSession: false } }
+    )
+    const { error: signInError } = await client.auth.signInWithPassword({
+      email: ACCOUNTS.student.email,
+      password: ACCOUNTS.student.password,
+    })
+    expect(signInError).toBeNull()
+
+    // Sanity: with access, the checkpoint is visible.
+    const { data: visible } = await client
+      .from('lesson_checkpoints')
+      .select('id')
+      .eq('id', checkpointId)
+    expect(visible?.length).toBe(1)
+
+    // The SELECT policy used to join `enrollments`, which a refund never
+    // touches — so the refunded student kept reading every enabled checkpoint.
+    await admin
+      .from('entitlements')
+      .update({ status: 'revoked' })
+      .eq('user_id', STUDENT_ID)
+      .eq('course_id', COURSE_ID)
+    try {
+      const { data: hidden } = await client
+        .from('lesson_checkpoints')
+        .select('id')
+        .eq('id', checkpointId)
+      expect(hidden?.length).toBe(0)
+    } finally {
+      await admin
+        .from('entitlements')
+        .update({ status: 'active', revoked_at: null })
+        .eq('user_id', STUDENT_ID)
+        .eq('course_id', COURSE_ID)
     }
   })
 })

--- a/tests/playwright/write-side-rls.spec.ts
+++ b/tests/playwright/write-side-rls.spec.ts
@@ -1,0 +1,369 @@
+/**
+ * Write-side entitlement gates — issue #543 (EPIC #540 §1.3).
+ *
+ * Four write policies constrained WHO a row belonged to but never whether the
+ * writer had earned it. Migration 20260726110000 closes them. These tests drive
+ * PostgREST with a real student session — role `authenticated`, exactly what a
+ * browser holds — because that is the surface the policies guard; the UI never
+ * asks for these rows, so a UI-only test would pass either way.
+ *
+ *   lesson_completions  a completion for any lesson id was insertable by any
+ *                       authenticated user, and /api/certificates/issue counts
+ *                       those rows to mint the school's credential
+ *   exam_submissions    submitting with no entitlement enqueued AI grading on
+ *                       the school's plan budget
+ *   practice_attempts   nothing pinned `tenant_id`, so two SECURITY DEFINER
+ *                       triggers wrote another school's shared Elo anchors and
+ *                       created a gamification profile there
+ *
+ * The `lesson_checkpoint_attempts` half of #543 lives in checkpoint-access.spec.ts,
+ * next to the checkpoint fixtures it needs.
+ */
+import { test, expect } from '@playwright/test'
+import { createClient as createSupabaseClient } from '@supabase/supabase-js'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { loginAsStudent } from './utils/auth'
+import { ACCOUNTS, BASE } from './utils/constants'
+
+const DEFAULT_TENANT = '00000000-0000-0000-0000-000000000001'
+const CODE_ACADEMY_TENANT = '00000000-0000-0000-0000-000000000002'
+const STUDENT_ID = 'a1000000-0000-0000-0000-000000000001'
+const TEACHER_ID = 'a1000000-0000-0000-0000-000000000002'
+const ALICE_ID = 'a1000000-0000-0000-0000-000000000004'
+
+/** Entitled for student@e2etest.com. */
+const OWNED_COURSE = 1001
+const OWNED_LESSON = 1001
+/** Code Academy — student@e2etest.com holds no entitlement for it. */
+const FOREIGN_LESSON = 2001
+
+const QA_EXAM_TITLE = '[E2E] 543 Write-Side Exam'
+
+function getAdmin() {
+  return createSupabaseClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    { auth: { autoRefreshToken: false, persistSession: false } }
+  )
+}
+
+/** A user-scoped client — role `authenticated`, exactly what a browser holds. */
+async function signIn(email: string, password: string): Promise<SupabaseClient> {
+  const client = createSupabaseClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_OR_ANON_KEY!,
+    { auth: { autoRefreshToken: false, persistSession: false } }
+  )
+  const { error } = await client.auth.signInWithPassword({ email, password })
+  expect(error).toBeNull()
+  return client
+}
+
+const asStudent = () => signIn(ACCOUNTS.student.email, ACCOUNTS.student.password)
+const asAlice = () => signIn(ACCOUNTS.tenantStudent.email, ACCOUNTS.tenantStudent.password)
+
+/** Run `body` with the student's entitlement to `courseId` revoked, then restore it. */
+async function withRevokedEntitlement(
+  userId: string,
+  courseId: number,
+  body: () => Promise<void>
+) {
+  const admin = getAdmin()
+  await admin
+    .from('entitlements')
+    .update({ status: 'revoked' })
+    .eq('user_id', userId)
+    .eq('course_id', courseId)
+  try {
+    await body()
+  } finally {
+    await admin
+      .from('entitlements')
+      .update({ status: 'active', revoked_at: null })
+      .eq('user_id', userId)
+      .eq('course_id', courseId)
+  }
+}
+
+let qaExamId: number
+/** lesson ids the student had completed before this spec ran (restored in afterAll). */
+let completionsBefore: number[] = []
+
+test.beforeAll(async () => {
+  const admin = getAdmin()
+
+  const { data: existing } = await admin
+    .from('lesson_completions')
+    .select('lesson_id')
+    .eq('user_id', STUDENT_ID)
+  completionsBefore = (existing ?? []).map((row) => Number(row.lesson_id))
+
+  // Clean up anything a failed run left behind.
+  const { data: staleExams } = await admin
+    .from('exams')
+    .select('exam_id')
+    .eq('title', QA_EXAM_TITLE)
+  for (const row of staleExams ?? []) {
+    await admin.from('exam_submissions').delete().eq('exam_id', row.exam_id)
+  }
+  await admin.from('exams').delete().eq('title', QA_EXAM_TITLE)
+  await admin.from('practice_attempts').delete().eq('topic', '[E2E] 543 topic')
+
+  const { data: exam, error: examError } = await admin
+    .from('exams')
+    .insert({
+      title: QA_EXAM_TITLE,
+      description: 'Issue #543 regression fixture.',
+      course_id: OWNED_COURSE,
+      duration: 30,
+      created_by: TEACHER_ID,
+      tenant_id: DEFAULT_TENANT,
+      status: 'published',
+    })
+    .select('exam_id')
+    .single()
+  expect(examError).toBeNull()
+  qaExamId = Number(exam!.exam_id)
+})
+
+test.afterAll(async () => {
+  const admin = getAdmin()
+  // Restore first — a failed assertion must not leave an entitlement revoked
+  // for every later spec.
+  await admin
+    .from('entitlements')
+    .update({ status: 'active', revoked_at: null })
+    .eq('user_id', STUDENT_ID)
+    .eq('course_id', OWNED_COURSE)
+
+  if (qaExamId) {
+    await admin.from('exam_submissions').delete().eq('exam_id', qaExamId)
+    await admin.from('exams').delete().eq('exam_id', qaExamId)
+  }
+  await admin.from('practice_attempts').delete().eq('topic', '[E2E] 543 topic')
+
+  // Put the student's progress back exactly as it was — a stray completion
+  // would change what later specs (and the student journey) see on the course.
+  const { data: now } = await admin
+    .from('lesson_completions')
+    .select('id, lesson_id')
+    .eq('user_id', STUDENT_ID)
+  const added = (now ?? []).filter(
+    (row) => !completionsBefore.includes(Number(row.lesson_id))
+  )
+  for (const row of added) {
+    await admin.from('lesson_completions').delete().eq('id', row.id)
+  }
+})
+
+test.describe('lesson_completions INSERT is gated on course access (#543)', () => {
+  test('a lesson in a course the student cannot reach is refused', async () => {
+    const client = await asStudent()
+    const { error } = await client
+      .from('lesson_completions')
+      .insert({ user_id: STUDENT_ID, lesson_id: FOREIGN_LESSON })
+
+    expect(error, 'RLS must refuse a completion for an unreachable lesson').not.toBeNull()
+    expect(error!.code).toBe('42501')
+
+    // And nothing landed.
+    const { count } = await getAdmin()
+      .from('lesson_completions')
+      .select('id', { count: 'exact', head: true })
+      .eq('user_id', STUDENT_ID)
+      .eq('lesson_id', FOREIGN_LESSON)
+    expect(count).toBe(0)
+  })
+
+  test('a revoked entitlement stops completions on a course still enrolled in', async () => {
+    const admin = getAdmin()
+    // The enrollment row is left alone on purpose: refunds revoke entitlements,
+    // never enrollments, and #532 established that the row grants nothing.
+    const { data: enrollment } = await admin
+      .from('enrollments')
+      .select('enrollment_id')
+      .eq('user_id', STUDENT_ID)
+      .eq('course_id', OWNED_COURSE)
+      .maybeSingle()
+    expect(enrollment, 'seed should leave an active enrollment row in place').toBeTruthy()
+
+    await admin
+      .from('lesson_completions')
+      .delete()
+      .eq('user_id', STUDENT_ID)
+      .eq('lesson_id', OWNED_LESSON)
+
+    const client = await asStudent()
+    await withRevokedEntitlement(STUDENT_ID, OWNED_COURSE, async () => {
+      const { error } = await client
+        .from('lesson_completions')
+        .insert({ user_id: STUDENT_ID, lesson_id: OWNED_LESSON })
+      expect(error?.code).toBe('42501')
+    })
+
+    // Positive control: the same insert succeeds once access is back, so the
+    // policy is refusing on access and not on something incidental.
+    const { error: allowed } = await client
+      .from('lesson_completions')
+      .insert({ user_id: STUDENT_ID, lesson_id: OWNED_LESSON })
+    expect(allowed).toBeNull()
+  })
+})
+
+test.describe('exam_submissions INSERT is gated on course access (#543)', () => {
+  test('a student with no entitlement cannot open a submission', async () => {
+    const client = await asStudent()
+    await withRevokedEntitlement(STUDENT_ID, OWNED_COURSE, async () => {
+      const { error } = await client
+        .from('exam_submissions')
+        .insert({ exam_id: qaExamId, student_id: STUDENT_ID, tenant_id: DEFAULT_TENANT })
+      expect(error, 'RLS must refuse an ungated exam submission').not.toBeNull()
+      expect(error!.code).toBe('42501')
+    })
+
+    const { count } = await getAdmin()
+      .from('exam_submissions')
+      .select('submission_id', { count: 'exact', head: true })
+      .eq('exam_id', qaExamId)
+    expect(count).toBe(0)
+  })
+
+  test('an entitled student still submits', async () => {
+    const client = await asStudent()
+    const { data, error } = await client
+      .from('exam_submissions')
+      .insert({ exam_id: qaExamId, student_id: STUDENT_ID, tenant_id: DEFAULT_TENANT })
+      .select('submission_id')
+      .single()
+    expect(error).toBeNull()
+    expect(data?.submission_id).toBeTruthy()
+  })
+})
+
+test.describe('practice_attempts writes are tenant-bound and bounded (#543)', () => {
+  const baseRow = {
+    user_id: ALICE_ID,
+    topic: '[E2E] 543 topic',
+    questions: [],
+    answers: [],
+    total_questions: 5,
+    correct_count: 4,
+    score: 80,
+  }
+
+  test('a row naming a foreign tenant is refused', async () => {
+    const client = await asAlice()
+    // Alice belongs to Code Academy only. Naming the Default School tenant used
+    // to drive its shared Elo anchors and create a gamification profile there,
+    // which is what puts a non-member into that school's league standings.
+    const { error } = await client
+      .from('practice_attempts')
+      .insert({ ...baseRow, tenant_id: DEFAULT_TENANT })
+    expect(error, 'RLS must refuse a foreign-tenant practice row').not.toBeNull()
+    expect(error!.code).toBe('42501')
+
+    const { count } = await getAdmin()
+      .from('practice_attempts')
+      .select('id', { count: 'exact', head: true })
+      .eq('tenant_id', DEFAULT_TENANT)
+      .eq('topic', baseRow.topic)
+    expect(count).toBe(0)
+  })
+
+  test('an out-of-range score is refused', async () => {
+    const client = await asAlice()
+    const { error } = await client
+      .from('practice_attempts')
+      // 150 rather than something huge: `score` is numeric(5,2), so anything
+      // over 999.99 is caught by numeric overflow (22003) and would prove
+      // nothing about the constraint.
+      .insert({ ...baseRow, tenant_id: CODE_ACADEMY_TENANT, score: 150, correct_count: 5 })
+    // 23514 = check_violation
+    expect(error?.code).toBe('23514')
+  })
+
+  test('graded history is append-only', async () => {
+    const admin = getAdmin()
+    const { data: seeded, error: seedError } = await admin
+      .from('practice_attempts')
+      .insert({ ...baseRow, tenant_id: CODE_ACADEMY_TENANT })
+      .select('id')
+      .single()
+    expect(seedError).toBeNull()
+
+    const client = await asAlice()
+    const { error: updateError } = await client
+      .from('practice_attempts')
+      .update({ score: 100 })
+      .eq('id', seeded!.id)
+    expect(updateError, 'UPDATE grant must be revoked on graded history').not.toBeNull()
+
+    const { error: deleteError } = await client
+      .from('practice_attempts')
+      .delete()
+      .eq('id', seeded!.id)
+    expect(deleteError).not.toBeNull()
+
+    const { data: after } = await admin
+      .from('practice_attempts')
+      .select('score')
+      .eq('id', seeded!.id)
+      .single()
+    expect(Number(after!.score)).toBe(80)
+  })
+
+  test('a member still records practice in their own tenant', async () => {
+    const client = await asAlice()
+    const { data, error } = await client
+      .from('practice_attempts')
+      .insert({ ...baseRow, tenant_id: CODE_ACADEMY_TENANT })
+      .select('id')
+      .single()
+    expect(error).toBeNull()
+    expect(data?.id).toBeTruthy()
+  })
+})
+
+test.describe('/api/certificates/issue requires course access (#543)', () => {
+  test('completions alone do not mint a credential', async ({ page }) => {
+    const admin = getAdmin()
+
+    // The eligibility path this route falls back to is a raw lesson_completions
+    // count, so give it every completion it could ask for.
+    const { data: lessons } = await admin
+      .from('lessons')
+      .select('id')
+      .eq('course_id', OWNED_COURSE)
+    for (const lesson of lessons ?? []) {
+      await admin
+        .from('lesson_completions')
+        .upsert(
+          { user_id: STUDENT_ID, lesson_id: lesson.id },
+          { onConflict: 'user_id,lesson_id' }
+        )
+    }
+    await admin
+      .from('certificates')
+      .delete()
+      .eq('user_id', STUDENT_ID)
+      .eq('course_id', OWNED_COURSE)
+
+    await loginAsStudent(page, BASE)
+
+    await withRevokedEntitlement(STUDENT_ID, OWNED_COURSE, async () => {
+      const res = await page.request.post(`${BASE}/api/certificates/issue`, {
+        data: { courseId: OWNED_COURSE },
+      })
+      expect(res.status()).toBe(403)
+      const body = await res.json()
+      expect(body.accessDenied).toBe(true)
+    })
+
+    const { count } = await admin
+      .from('certificates')
+      .select('certificate_id', { count: 'exact', head: true })
+      .eq('user_id', STUDENT_ID)
+      .eq('course_id', OWNED_COURSE)
+    expect(count, 'no certificate may exist for a caller without access').toBe(0)
+  })
+})


### PR DESCRIPTION
## What

Closes #543 (EPIC #540 §1.3).

Adds a course-access predicate to four write-side policies that pinned *who a row belonged to* but never *whether the writer had earned it*, replaces the last `enrollments` join in the checkpoint feature, and gates `/api/certificates/issue` on entitlements.

Migration: `20260726110000_write_side_entitlement_gates.sql` (local only — not applied to cloud).

## Why

`20260725160000` (#532) stamped the rule on `enrollments`: *"Never gate content, APIs or RLS on the presence of an enrollment row."* The generalisation — **never let a client assert its own grade, completion, mastery or tenant** — was never applied elsewhere.

| Table | Was | Now |
|---|---|---|
| `lesson_completions` | `INSERT WITH CHECK (auth.uid() = user_id)` — any authenticated user could record a completion for **any** `lesson_id` | routed through `lessons` to `has_course_access` |
| `exam_submissions` | identity + tenant, no access gate — a student with no entitlement could enqueue AI grading on the school's plan budget | `has_course_access` on the exam's course |
| `lesson_checkpoint_attempts` | identity + checkpoint consistency + access, but `score`/`passed`/`completed`/`evaluator_type`/`attempt_number` unconstrained | **server-write-only** (the #538 pattern) |
| `practice_attempts` | `FOR ALL USING (user_id = auth.uid())` — no tenant predicate at all | split SELECT/INSERT, active `tenant_users` row required, score/count `CHECK`s, `source` pinned, append-only |

`practice_attempts.course_id` is deliberately **not** gated (see the second commit). It is an optional, model-supplied label on the MCP tool, not a server-derived value, so an access predicate on it would turn a mislabelled drill into a hard `42501` — and the cross-tenant attack is already closed by the membership check; `course_id` only scopes `item_ratings` within the caller's own tenant.

Two of these were more than theoretical:

- **The certificate was mintable.** `/api/certificates/issue` checks auth, tenant and duplicates but never checked access; eligibility falls through to a raw `lesson_completions` count. Self-issuable completions ⇒ self-issuable credential.
- **`practice_attempts` crossed tenants.** Two `SECURITY DEFINER` triggers fire on that fully caller-controlled row: `handle_practice_attempt_elo` writes the tenant-shared `item_ratings` anchors, and `handle_practice_attempt_xp` creates a `gamification_profiles` row for the named tenant — the exact eligibility source `rollover_leagues` scans, so a non-member surfaced in another school's league standings. `20260716120000`'s stated rationale ("a student session cannot write shared rating rows from application code") did not hold.

Bonus, same class: the `lesson_checkpoints` **SELECT** policy still authorized by joining `enrollments`. Refunds revoke entitlements and never enrollments, so a refunded student kept reading every enabled checkpoint on the course.

### Shape

The three added predicates mirror the #509 content read policies: tenant match AND (staff OR course author OR `has_course_access`). Teachers hold no entitlement for courses they author, so the staff/author branches are what keep authoring and preview working; students only ever match the access branch. Preview lessons (#426) are deliberately *not* a branch on `lesson_completions` — reading a preview is fine, recording progress against an unbought course is the thing being stopped.

`lesson_checkpoint_attempts` could not be fixed with a predicate: every column but the identity ones is a grading output. The route already held an admin client and its own `resolveCourseAccessState` gate (#535), so the insert moved there and the `authenticated` INSERT/UPDATE/DELETE grants were revoked.

## How to QA

On a fresh `npm run db:reset`, with `npm run dev` running:

```bash
npx playwright test tests/playwright/write-side-rls.spec.ts \
                    tests/playwright/checkpoint-access.spec.ts --workers=1
```

15 tests, one per acceptance criterion: a completion for an unreachable lesson, an exam submission without entitlement, a direct `{passed: true, score: 100}` checkpoint attempt, a `practice_attempts` row naming a foreign tenant, a wrong-answer attempt read back from the DB to prove the stored grade is the server's, `/api/certificates/issue` refused with completions present, and a refunded student reading zero checkpoints. Each negative has a positive control so a refusal can't pass for the wrong reason.

Manual, as `student@e2etest.com` on `lvh.me:3000`: complete a lesson, submit an exam, pass a checkpoint — unchanged. As `owner@e2etest.com`: teacher grading and authoring unchanged.

## Test results

| Gate | Result |
|---|---|
| `npm run typecheck` | pass |
| `npm run test:unit` | 370/370 (baseline) |
| `npm run build` | pass |
| `npx eslint` on changed files | clean (also cleared 5 pre-existing `any`s in the certificates route that pre-commit lints whole-file) |
| #543 specs | 15/15 |
| student journey + student-courses/exams/features, certificate-issuance, enrollment-flows, evaluations-security | 52 passed, 4 failed (pre-existing) |
| tenant-isolation | 10/10 |
| teacher-content | 13/13 |
| teacher-courses | 13/13 |
| admin-crud | 14 passed, 3 failed (pre-existing) |

Every failure above is **pre-existing**. The 3 `admin-crud` product-wizard failures (`product-creation-wizard` testid never renders) reproduce identically on `146a8cfa`. The 4 student-side failures are — `full-student-journey` and `certificate-issuance` plus two `student-features` sidebar tests. Verified by re-running them on `146a8cfa` with a fresh DB: identical failures. `full-student-journey` targets course 9999 / lessons 10000-10001, which `supabase/seed.sql` does not create.

One thing worth knowing for future E2E work: `student-exams.spec.ts:58` deletes Alice's `entitlements` row for course 2001 in its cleanup and never restores it. That leak was harmless while nothing gated on entitlements; now it makes later specs in the same run fail. Not fixed here (out of scope), but it is why a long mixed run shows failures a per-spec run does not.

## Screenshots / GIF

None — no user-visible surface changed. The one new user-facing string is the existing `accessDenied` / `accessSuspended` 403 shape from #535, reused verbatim by `/api/certificates/issue`.

## Checklist

- [x] `npm run typecheck` and `npm run test:unit` pass
- [x] `npm run build` passes
- [x] Every new tenant-scoped query filters by `tenant_id` (or the table genuinely has no such column — `lesson_completions` has none, so the course is reached through `lessons`)
- [x] Tested with every relevant role (student / teacher / admin)
- [x] Loading and error states handled
- [ ] New UI strings added to both `messages/en.json` and `messages/es.json` — n/a, no new strings
- [x] Migration applies cleanly on `npm run db:reset`; `lib/database.types.ts` needs no regeneration (policies and constraints only, no schema shape change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011SbrtmdXw6ZwH2UeTCuT2v
