### PR TITLE
fix(reads): page the nine remaining unbounded sweeps and the digest RPC (#548)

### DIFF
--- a/app/[locale]/dashboard/admin/payouts/page.tsx
+++ b/app/[locale]/dashboard/admin/payouts/page.tsx
@@ -4,6 +4,7 @@ import { getTranslations } from 'next-intl/server'
 import { format } from 'date-fns'
 import { es, enUS } from 'date-fns/locale'
 import { getCurrentTenantId, getCurrentUserId } from '@/lib/supabase/tenant'
+import { fetchAllRows } from '@/lib/supabase/fetch-all-rows'
 import { formatByCurrency, formatMoney, sumByCurrency } from '@/lib/payments/format-money'
 import { AdminBreadcrumb } from '@/components/admin/admin-breadcrumb'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -62,16 +63,23 @@ export default async function AdminPayoutsPage({
     )
   }
 
-  // Fetch payouts for this tenant
-  const { data: payouts } = await supabase
-    .from('payouts')
-    .select(
-      'payout_id, amount, currency, status, period_start, period_end, stripe_payout_id, paid_at, failure_reason, created_at, note, payout_method'
-    )
-    .eq('tenant_id', tenantId)
-    .order('created_at', { ascending: false })
-
-  const rows = payouts || []
+  // Fetch payouts for this tenant. Paged and count-verified (#548): the
+  // summary below sums this list, so a read truncated at the API row cap would
+  // understate the school's own "Total paid" without any error to notice.
+  // `created_at` is not unique, so `payout_id` breaks ties — an unstable sort
+  // makes `.range()` windows overlap or skip.
+  const rows = await fetchAllRows('payouts', (from, to) =>
+    supabase
+      .from('payouts')
+      .select(
+        'payout_id, amount, currency, status, period_start, period_end, stripe_payout_id, paid_at, failure_reason, created_at, note, payout_method',
+        { count: 'exact' }
+      )
+      .eq('tenant_id', tenantId)
+      .order('created_at', { ascending: false })
+      .order('payout_id', { ascending: false })
+      .range(from, to)
+  )
 
   // Summary calculations. Paid payouts are totalled per currency and rendered as
   // one figure each — a school selling in USD and EUR reads two figures, not

--- a/app/[locale]/dashboard/teacher/revenue/page.tsx
+++ b/app/[locale]/dashboard/teacher/revenue/page.tsx
@@ -1,5 +1,6 @@
 import { createAdminClient } from '@/lib/supabase/admin'
 import { getCurrentTenantId } from '@/lib/supabase/tenant'
+import { fetchAllRows } from '@/lib/supabase/fetch-all-rows'
 import { getUserRole } from '@/lib/supabase/get-user-role'
 import { redirect } from 'next/navigation'
 import { getTranslations } from 'next-intl/server'
@@ -23,12 +24,23 @@ export default async function RevenuePage() {
   const tenantId = await getCurrentTenantId()
   const t = await getTranslations('dashboard.teacher.revenue')
 
-  // Parallelize all 4 independent queries
-  const [{ data: tenant }, { data: split }, { data: transactions }, { data: payouts }] = await Promise.all([
+  // Parallelize all 4 independent queries.
+  //
+  // The transaction read is paged and count-verified (#548) — every figure on
+  // this page is a sum over it, so truncation at the API row cap would quietly
+  // understate the school's revenue rather than fail. `created_at` is not
+  // unique; `transaction_id` breaks ties so the paging windows are stable.
+  // The payout read is already bounded by `.limit(10)`.
+  const [{ data: tenant }, { data: split }, transactions, { data: payouts }] = await Promise.all([
     supabase.from('tenants').select('name, stripe_account_id').eq('id', tenantId).single(),
     supabase.from('revenue_splits').select('platform_percentage, school_percentage').eq('tenant_id', tenantId).single(),
-    supabase.from('transactions').select('amount, status, payment_provider, created_at')
-      .eq('tenant_id', tenantId).eq('status', 'successful').order('created_at', { ascending: false }),
+    fetchAllRows('transactions', (from, to) =>
+      supabase.from('transactions').select('amount, status, payment_provider, created_at', { count: 'exact' })
+        .eq('tenant_id', tenantId).eq('status', 'successful')
+        .order('created_at', { ascending: false })
+        .order('transaction_id', { ascending: false })
+        .range(from, to)
+    ),
     supabase.from('payouts').select('*').eq('tenant_id', tenantId).order('created_at', { ascending: false }).limit(10),
   ])
 
@@ -114,6 +126,10 @@ export default async function RevenuePage() {
               <p className="mt-0.5 text-xs text-amber-700 dark:text-amber-400">
                 {t('stripeNotConnected.description')}
               </p>
+              {/* Stays a plain anchor: /api/stripe/connect is a route handler that
+                  mints a Stripe onboarding link and redirects. next/link would
+                  prefetch it and fire that side effect on hover. */}
+              {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
               <a
                 href="/api/stripe/connect"
                 className="mt-3 inline-flex items-center justify-center rounded-lg text-xs font-medium bg-amber-600 text-white hover:bg-amber-700 h-8 px-4 transition-colors"

--- a/app/actions/admin/revenue.ts
+++ b/app/actions/admin/revenue.ts
@@ -3,6 +3,8 @@
 import { createClient } from '@/lib/supabase/server'
 import { createAdminClient } from '@/lib/supabase/admin'
 import {getCurrentTenantId, getCurrentUserId } from '@/lib/supabase/tenant'
+import { fetchAllRows } from '@/lib/supabase/fetch-all-rows'
+import { fetchAllRowsIn } from '@/lib/supabase/fetch-all-rows-in'
 
 async function verifyAdminAccess() {
   const supabase = await createClient()
@@ -29,14 +31,26 @@ export async function getRevenueOverview() {
   const { tenantId } = await verifyAdminAccess()
   const adminClient = await createAdminClient()
 
-  // Get all successful transactions for this tenant
-  const { data: transactions } = await adminClient
-    .from('transactions')
-    .select('amount, currency, transaction_date, product_id, plan_id, stripe_payment_intent_id')
-    .eq('tenant_id', tenantId)
-    .eq('status', 'successful')
+  // Get all successful transactions for this tenant. Paged and count-verified
+  // (#548): everything this action returns — total revenue, platform fees,
+  // per-product breakdown, the monthly trend — is a sum over this list, so a
+  // read truncated at the API row cap would report a confidently wrong number
+  // instead of an error. Ordered by the primary key so the paging windows
+  // neither overlap nor skip.
+  const transactions = await fetchAllRows('transactions', (from, to) =>
+    adminClient
+      .from('transactions')
+      .select(
+        'amount, currency, transaction_date, product_id, plan_id, stripe_payment_intent_id',
+        { count: 'exact' }
+      )
+      .eq('tenant_id', tenantId)
+      .eq('status', 'successful')
+      .order('transaction_id')
+      .range(from, to)
+  )
 
-  if (!transactions || transactions.length === 0) {
+  if (transactions.length === 0) {
     return {
       totalRevenue: 0,
       platformFees: 0,
@@ -79,16 +93,20 @@ export async function getRevenueOverview() {
     revenueByProduct[key] = (revenueByProduct[key] || 0) + Number(tx.amount)
   }
 
-  // Get product names
+  // Get product names. The id list is as long as the transaction set is
+  // varied, so it is chunked as well as paged (#548) — an over-long `.in()`
+  // fails on the request side, before any of the response paging matters.
   const productIds = [...new Set(transactions.map(t => t.product_id).filter(Boolean))]
-  const { data: products } = productIds.length > 0
-    ? await adminClient
-        .from('products')
-        .select('product_id, name')
-        .in('product_id', productIds)
-    : { data: [] }
+  const products = await fetchAllRowsIn('products', productIds, (chunk, from, to) =>
+    adminClient
+      .from('products')
+      .select('product_id, name', { count: 'exact' })
+      .in('product_id', chunk)
+      .order('product_id')
+      .range(from, to)
+  )
 
-  const productMap = new Map((products || []).map(p => [p.product_id, p.name]))
+  const productMap = new Map(products.map(p => [p.product_id, p.name]))
 
   const revenueByCourse = Object.entries(revenueByProduct).map(([id, amount]) => ({
     id: Number(id),

--- a/app/actions/platform/billing-health.ts
+++ b/app/actions/platform/billing-health.ts
@@ -3,6 +3,8 @@
 import { createAdminClient } from '@/lib/supabase/admin'
 import { isSuperAdmin } from '@/lib/supabase/get-user-role'
 import { getCurrentUserId } from '@/lib/supabase/tenant'
+import { fetchAllRows } from '@/lib/supabase/fetch-all-rows'
+import { fetchAllRowsIn } from '@/lib/supabase/fetch-all-rows-in'
 import {
   computeBillingHealth,
   mergeAtRiskTenants,
@@ -85,19 +87,42 @@ export async function getAtRiskTenants(): Promise<AtRiskTenant[]> {
   await verifySuperAdmin()
   const admin = createAdminClient()
 
-  const [
-    { data: pastDueTenants },
-    { data: pastDueSubscriptions },
-    { data: cutoffTenants },
-  ] = await Promise.all([
-    admin.from('tenants').select(TENANT_SELECT).eq('billing_status', 'past_due'),
-    admin.from('platform_subscriptions').select(SUBSCRIPTION_SELECT).eq('status', 'past_due'),
-    admin.from('tenants').select(TENANT_SELECT).not('access_cutoff_at', 'is', null),
+  // All five reads are paged and count-verified (#548). This dashboard exists
+  // to make sure no at-risk school goes unnoticed, so a read silently capped
+  // at the API row limit defeats its entire purpose: the missing school looks
+  // exactly like a healthy one. Each is ordered by its primary key — `tenants`
+  // and `platform_subscriptions` have no natural sort here, and an unordered
+  // `.range()` window is not a stable page.
+  const [pastDueTenants, pastDueSubscriptions, cutoffTenants] = await Promise.all([
+    fetchAllRows('tenants:past_due', (from, to) =>
+      admin
+        .from('tenants')
+        .select(TENANT_SELECT, { count: 'exact' })
+        .eq('billing_status', 'past_due')
+        .order('id')
+        .range(from, to)
+    ),
+    fetchAllRows('platform_subscriptions:past_due', (from, to) =>
+      admin
+        .from('platform_subscriptions')
+        .select(SUBSCRIPTION_SELECT, { count: 'exact' })
+        .eq('status', 'past_due')
+        .order('subscription_id')
+        .range(from, to)
+    ),
+    fetchAllRows('tenants:access_cutoff', (from, to) =>
+      admin
+        .from('tenants')
+        .select(TENANT_SELECT, { count: 'exact' })
+        .not('access_cutoff_at', 'is', null)
+        .order('id')
+        .range(from, to)
+    ),
   ])
 
-  const pastDueTenantRows = (pastDueTenants ?? []).map(toTenantRow)
-  const cutoffTenantRows = (cutoffTenants ?? []).map(toTenantRow)
-  const pastDueSubscriptionRows = (pastDueSubscriptions ?? []).map(toSubscriptionInput)
+  const pastDueTenantRows = pastDueTenants.map(toTenantRow)
+  const cutoffTenantRows = cutoffTenants.map(toTenantRow)
+  const pastDueSubscriptionRows = pastDueSubscriptions.map(toSubscriptionInput)
 
   const knownTenantIds = new Set([
     ...pastDueTenantRows.map((t) => t.tenantId),
@@ -109,16 +134,21 @@ export async function getAtRiskTenants(): Promise<AtRiskTenant[]> {
   // Subscription-only past-due tenants appear in neither read above.
   const missingTenantIds = subscriptionPastDueTenantIds.filter((id) => !knownTenantIds.has(id))
 
-  const [{ data: extraTenants }, { data: knownSubscriptions }] = await Promise.all([
-    missingTenantIds.length
-      ? admin.from('tenants').select(TENANT_SELECT).in('id', missingTenantIds)
-      : Promise.resolve({ data: [] as never[] }),
-    knownTenantIds.size
-      ? admin
-          .from('platform_subscriptions')
-          .select(SUBSCRIPTION_SELECT)
-          .in('tenant_id', [...knownTenantIds])
-      : Promise.resolve({ data: [] as never[] }),
+  // Both follow-ups look up by id list, which grows with the reads above — so
+  // they are chunked as well as paged: past a few hundred ids the `.in()` URL
+  // is the thing that breaks, before any row cap is reached.
+  const [extraTenants, knownSubscriptions] = await Promise.all([
+    fetchAllRowsIn('tenants:subscription_only', missingTenantIds, (chunk, from, to) =>
+      admin.from('tenants').select(TENANT_SELECT, { count: 'exact' }).in('id', chunk).order('id').range(from, to)
+    ),
+    fetchAllRowsIn('platform_subscriptions:known', [...knownTenantIds], (chunk, from, to) =>
+      admin
+        .from('platform_subscriptions')
+        .select(SUBSCRIPTION_SELECT, { count: 'exact' })
+        .in('tenant_id', chunk)
+        .order('subscription_id')
+        .range(from, to)
+    ),
   ])
 
   return computeBillingHealth(
@@ -126,9 +156,9 @@ export async function getAtRiskTenants(): Promise<AtRiskTenant[]> {
       pastDueTenants: pastDueTenantRows,
       cutoffTenants: cutoffTenantRows,
       subscriptionPastDueTenantIds,
-      extraTenants: (extraTenants ?? []).map(toTenantRow),
+      extraTenants: extraTenants.map(toTenantRow),
     }),
-    [...pastDueSubscriptionRows, ...(knownSubscriptions ?? []).map(toSubscriptionInput)],
+    [...pastDueSubscriptionRows, ...knownSubscriptions.map(toSubscriptionInput)],
     new Date(),
   )
 }

--- a/app/api/cron/solana-pull/route.ts
+++ b/app/api/cron/solana-pull/route.ts
@@ -20,6 +20,7 @@ import { timingSafeEqual } from 'crypto'
 import { getSubscriptionState } from '@/lib/payments/solana-subscriptions'
 import { pullSplitForSubscription } from '@/lib/payments/solana-subscription-pull'
 import { decidePullAction } from '@/lib/payments/solana-pull-decision'
+import { fetchAllRows } from '@/lib/supabase/fetch-all-rows'
 
 export const runtime = 'nodejs'
 
@@ -43,6 +44,24 @@ interface SolanaSubMeta {
   mint: string
 }
 
+/** One row of the crank's work queue, as selected below. */
+interface SolanaSubRow {
+  subscription_id: string
+  tenant_id: string
+  plan_id: number | null
+  provider_metadata: unknown
+  subscription_status: string | null
+  cancel_at_period_end: boolean | null
+  cancel_at: string | null
+  /**
+   * The embedded `plans(price)`. Left `unknown`: the untyped service-role
+   * client types every embed as an array, while a to-one embed arrives as an
+   * object at runtime — the read site below narrows it with the same cast it
+   * always used.
+   */
+  plans: unknown
+}
+
 export async function GET(req: NextRequest) {
   const cronSecret = process.env.CRON_SECRET
   const provided = req.headers.get('authorization')?.replace('Bearer ', '')
@@ -63,17 +82,32 @@ export async function GET(req: NextRequest) {
   // Active native-subscription rows, with their on-chain coordinates + amount.
   // We also pull the cancel fields so the pull/cancel decision (which must never
   // charge a canceled sub — issue #460) has the full DB state.
-  const { data: subs, error } = await admin
-    .from('subscriptions')
-    .select('subscription_id, tenant_id, plan_id, provider_metadata, subscription_status, cancel_at_period_end, cancel_at, plans(price)')
-    .eq('payment_provider', 'solana_subs')
-    .eq('subscription_status', 'active')
-
-  if (error) {
-    console.error('[solana-pull] query error', error)
+  //
+  // Paged and count-verified (#548). This read IS the crank's work queue, and
+  // the crank is the only thing that ever charges a native Solana
+  // subscription: a row silently dropped at the API cap is a period that never
+  // gets billed, for a subscriber whose access we keep extending. Ordered by
+  // primary key so the pages are stable. `fetchAllRows` throws on an
+  // incomplete read, so a short queue can no longer look like a finished one.
+  let subs: SolanaSubRow[]
+  try {
+    subs = await fetchAllRows<SolanaSubRow>('subscriptions', (from, to) =>
+      admin
+        .from('subscriptions')
+        .select(
+          'subscription_id, tenant_id, plan_id, provider_metadata, subscription_status, cancel_at_period_end, cancel_at, plans(price)',
+          { count: 'exact' },
+        )
+        .eq('payment_provider', 'solana_subs')
+        .eq('subscription_status', 'active')
+        .order('subscription_id')
+        .range(from, to),
+    )
+  } catch (err) {
+    console.error('[solana-pull] query error', err)
     return NextResponse.json({ error: 'Query failed' }, { status: 500 })
   }
-  if (!subs?.length) return NextResponse.json({ pulled: 0 })
+  if (!subs.length) return NextResponse.json({ pulled: 0 })
 
   const nowSec = Math.floor(Date.now() / 1000)
   let pulled = 0

--- a/app/api/cron/solana-reconcile/route.ts
+++ b/app/api/cron/solana-reconcile/route.ts
@@ -28,6 +28,7 @@ import {
   reconcileSolanaOneTimeTransaction,
   type OneTimeSolanaTx,
 } from '@/lib/payments/solana-reconcile'
+import { fetchAllRows } from '@/lib/supabase/fetch-all-rows'
 
 export const runtime = 'nodejs'
 
@@ -79,19 +80,32 @@ export async function GET(req: NextRequest) {
   // wallet + split). solana_subs is intentionally excluded — its initial
   // confirmation needs the server-captured subscriber pubkey and is a separate
   // path from one-time payments.
-  const { data: pending, error } = await admin
-    .from('transactions')
-    .select(
-      'transaction_id, amount, tenant_id, provider_subscription_id, settlement_currency, settlement_base, settlement_mint, status, payment_provider, transaction_date',
+  //
+  // Paged and count-verified (#548). This read IS the reconciler's work queue:
+  // a row silently dropped at the API cap is a student who paid on-chain and
+  // never gets the entitlement, and whose stranded row keeps blocking their
+  // retry. Ordered by primary key so the pages are stable. `fetchAllRows`
+  // throws on an incomplete read, so a short queue can no longer masquerade as
+  // an empty one — hence the try/catch rather than an `error` check.
+  let pending: PendingRow[]
+  try {
+    pending = await fetchAllRows<PendingRow>('transactions', (from, to) =>
+      admin
+        .from('transactions')
+        .select(
+          'transaction_id, amount, tenant_id, provider_subscription_id, settlement_currency, settlement_base, settlement_mint, status, payment_provider, transaction_date',
+          { count: 'exact' },
+        )
+        .eq('payment_provider', 'solana')
+        .eq('status', 'pending')
+        .order('transaction_id')
+        .range(from, to),
     )
-    .eq('payment_provider', 'solana')
-    .eq('status', 'pending')
-
-  if (error) {
-    console.error('[solana-reconcile] query error', error)
+  } catch (err) {
+    console.error('[solana-reconcile] query error', err)
     return NextResponse.json({ error: 'Query failed' }, { status: 500 })
   }
-  if (!pending?.length) {
+  if (!pending.length) {
     return NextResponse.json({ reconciled: 0, expired: 0, errors: 0 })
   }
 
@@ -100,7 +114,7 @@ export async function GET(req: NextRequest) {
   let expired = 0
   const errors: string[] = []
 
-  for (const tx of pending as PendingRow[]) {
+  for (const tx of pending) {
     try {
       const result = await reconcileSolanaOneTimeTransaction(admin, tx)
 

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -6420,7 +6420,11 @@ export type Database = {
         Returns: number
       }
       get_daily_digest_candidates: {
-        Args: never
+        Args: {
+          _after_tenant_id?: string | null
+          _after_user_id?: string | null
+          _limit?: number | null
+        }
         Returns: {
           current_streak: number
           due_cards: number

--- a/lib/notifications/daily-digest.ts
+++ b/lib/notifications/daily-digest.ts
@@ -15,6 +15,8 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 import { sendEmail } from '@/lib/email/send'
 import { dailyDigestEmailTemplate, streakNudgeEmailTemplate } from '@/lib/email/templates/daily-digest'
+import { fetchAllRows } from '@/lib/supabase/fetch-all-rows'
+import { fetchAllRowsIn } from '@/lib/supabase/fetch-all-rows-in'
 
 export type DigestLocale = 'en' | 'es'
 export type DigestKind = 'daily_digest' | 'streak_nudge'
@@ -38,7 +40,7 @@ export const DIGEST_STREAK_MIN = 3
 /** Minimum streak that earns the evening nudge (the Duolingo mechanic). */
 export const NUDGE_STREAK_MIN = 7
 
-interface CandidateRow {
+export interface CandidateRow {
   tenant_id: string
   user_id: string
   email: string | null
@@ -215,6 +217,64 @@ export function pickTemplate(
 }
 
 /**
+ * Candidates requested per RPC call. Below the 1000 row cap so a page is never
+ * clamped in the common case — but nothing here depends on that, see below.
+ */
+export const DIGEST_CANDIDATE_PAGE_SIZE = 500
+
+/** Runaway guard, mirroring `fetchAllRows`'s. Covers 1,000,000 candidates. */
+const MAX_CANDIDATE_PAGES = 2000
+
+/**
+ * Read every digest candidate, across every tenant (#548).
+ *
+ * `get_daily_digest_candidates` is a SETOF function, so PostgREST caps its
+ * result exactly as it caps a table read and hands back the truncated set as a
+ * plain 200. Before the function was ordered and given a cursor, one
+ * unparameterised call past 1000 candidates meant the cron processed an
+ * arbitrary subset — a different one each run — and no student, admin or log
+ * line could tell.
+ *
+ * The stop condition is an EMPTY page, never a short one. A page shorter than
+ * `pageSize` is ambiguous: it is the end of the set, or it is the server's row
+ * cap clamping us below what we asked for. Reading "short" as "done" is the
+ * original bug in a new place. Termination is instead guaranteed by the
+ * cursor, which advances strictly on every non-empty page.
+ *
+ * @throws if a page errors or the set outlasts `MAX_CANDIDATE_PAGES`.
+ */
+export async function fetchDigestCandidates(
+  admin: SupabaseClient,
+  pageSize: number = DIGEST_CANDIDATE_PAGE_SIZE
+): Promise<CandidateRow[]> {
+  const rows: CandidateRow[] = []
+  let afterTenantId: string | null = null
+  let afterUserId: string | null = null
+
+  for (let page = 0; page < MAX_CANDIDATE_PAGES; page++) {
+    const { data, error } = await admin.rpc('get_daily_digest_candidates', {
+      _after_tenant_id: afterTenantId,
+      _after_user_id: afterUserId,
+      _limit: pageSize,
+    })
+    if (error) throw new Error(error.message)
+
+    const batch = (data ?? []) as CandidateRow[]
+    if (batch.length === 0) return rows
+    rows.push(...batch)
+
+    const last = batch[batch.length - 1]
+    afterTenantId = last.tenant_id
+    afterUserId = last.user_id
+  }
+
+  throw new Error(
+    `get_daily_digest_candidates: still returning rows after ${MAX_CANDIDATE_PAGES} pages ` +
+      `(${rows.length} candidates); refusing to loop further.`
+  )
+}
+
+/**
  * Run one hourly tick. Idempotent per (user, kind, tenant-local day): re-runs
  * and cron retries within the same day never double-send.
  */
@@ -229,12 +289,13 @@ export async function runDailyDigest(admin: SupabaseClient, now: Date = new Date
     errors: [],
   }
 
-  const { data: candidates, error: candErr } = await admin.rpc('get_daily_digest_candidates')
-  if (candErr) {
-    result.errors.push(`candidates query failed: ${candErr.message}`)
+  let rows: CandidateRow[]
+  try {
+    rows = await fetchDigestCandidates(admin)
+  } catch (err) {
+    result.errors.push(`candidates query failed: ${err instanceof Error ? err.message : String(err)}`)
     return result
   }
-  const rows = (candidates ?? []) as CandidateRow[]
   if (rows.length === 0) return result
 
   const byTenant = new Map<string, CandidateRow[]>()
@@ -246,12 +307,40 @@ export async function runDailyDigest(admin: SupabaseClient, now: Date = new Date
   const tenantIds = [...byTenant.keys()]
   result.tenantsConsidered = tenantIds.length
 
-  const [{ data: tenants }, { data: settingRows }] = await Promise.all([
-    admin.from('tenants').select('id, name, slug').in('id', tenantIds),
-    admin.from('tenant_settings').select('tenant_id, setting_value').eq('setting_key', 'daily_digest').in('tenant_id', tenantIds),
-  ])
-  const tenantById = new Map((tenants ?? []).map((t) => [t.id as string, t as { id: string; name: string; slug: string | null }]))
-  const settingsByTenant = new Map((settingRows ?? []).map((s) => [s.tenant_id as string, s.setting_value]))
+  // Chunked and paged (#548). `tenantIds` is as long as the candidate set is
+  // wide, so both the `.in()` URL and the response can overflow. A tenant
+  // missing from either read is skipped below (`if (!tenant) continue`) — that
+  // is correct for a tenant that genuinely does not exist and silently wrong
+  // for one the read merely dropped, so this must be complete or fail loudly.
+  let tenants: Array<{ id: string; name: string; slug: string | null }>
+  let settingRows: Array<{ tenant_id: string; setting_value: unknown }>
+  try {
+    ;[tenants, settingRows] = await Promise.all([
+      fetchAllRowsIn<{ id: string; name: string; slug: string | null }, string>(
+        'tenants',
+        tenantIds,
+        (chunk, from, to) =>
+          admin.from('tenants').select('id, name, slug', { count: 'exact' }).in('id', chunk).order('id').range(from, to)
+      ),
+      fetchAllRowsIn<{ tenant_id: string; setting_value: unknown }, string>(
+        'tenant_settings',
+        tenantIds,
+        (chunk, from, to) =>
+          admin
+            .from('tenant_settings')
+            .select('tenant_id, setting_value', { count: 'exact' })
+            .eq('setting_key', 'daily_digest')
+            .in('tenant_id', chunk)
+            .order('id')
+            .range(from, to)
+      ),
+    ])
+  } catch (err) {
+    result.errors.push(`tenant lookup failed: ${err instanceof Error ? err.message : String(err)}`)
+    return result
+  }
+  const tenantById = new Map(tenants.map((t) => [t.id, t]))
+  const settingsByTenant = new Map(settingRows.map((s) => [s.tenant_id, s.setting_value]))
 
   for (const tenantId of tenantIds) {
     const tenant = tenantById.get(tenantId)
@@ -278,12 +367,36 @@ export async function runDailyDigest(admin: SupabaseClient, now: Date = new Date
       .in('name', [`daily_digest_${settings.locale}`, `streak_nudge_${settings.locale}`])
       .or(`tenant_id.is.null,tenant_id.eq.${tenantId}`)
 
+    // Chunked and paged (#548), and — unlike before — a failure here aborts the
+    // tenant instead of falling through with an empty map.
+    //
+    // This is the read whose truncation is not a wrong number but wrong
+    // behaviour: `resolveChannels(undefined)` treats a missing row as the
+    // schema default `{ inApp: true, email: true }`, so every student the read
+    // dropped gets emailed — including the ones who went and turned email off.
+    // "Read fewer preferences" must never be able to mean "send more email".
     const userIds = allCandidates.map((c) => c.user_id)
-    const { data: prefRows } = await admin
-      .from('notification_preferences')
-      .select('user_id, in_app_enabled, email_enabled, email_frequency')
-      .in('user_id', userIds)
-    const prefsByUser = new Map(((prefRows ?? []) as PreferencesRow[]).map((p) => [p.user_id, p]))
+    let prefRows: PreferencesRow[]
+    try {
+      prefRows = await fetchAllRowsIn<PreferencesRow, string>(
+        'notification_preferences',
+        userIds,
+        (chunk, from, to) =>
+          admin
+            .from('notification_preferences')
+            .select('user_id, in_app_enabled, email_enabled, email_frequency', { count: 'exact' })
+            .in('user_id', chunk)
+            .order('id')
+            .range(from, to)
+      )
+    } catch (err) {
+      result.errors.push(
+        `tenant ${tenantId}: preferences read failed, skipping tenant rather than risk emailing opted-out students: ` +
+          `${err instanceof Error ? err.message : String(err)}`
+      )
+      continue
+    }
+    const prefsByUser = new Map(prefRows.map((p) => [p.user_id, p]))
 
     for (const kind of kinds) {
       const recipients = allCandidates.filter((c) =>
@@ -296,17 +409,32 @@ export async function runDailyDigest(admin: SupabaseClient, now: Date = new Date
       if (recipients.length === 0) continue
 
       // Idempotency: users already notified (this kind, this tenant-local day).
-      const { data: sentRows, error: sentErr } = await admin
-        .from('notifications')
-        .select('target_user_ids')
-        .eq('tenant_id', tenantId)
-        .eq('metadata->>kind', kind)
-        .eq('metadata->>date', dateStr)
-      if (sentErr) {
-        result.errors.push(`tenant ${tenantId} ${kind}: idempotency check failed: ${sentErr.message}`)
+      //
+      // Paged and count-verified (#548). One notification row is written per
+      // recipient, so this read is the same size as yesterday's send — in a
+      // tenant past the row cap it truncated, and every recipient missing from
+      // `alreadySent` was sent to again. That turns the module's documented
+      // "re-runs and cron retries never double-send" guarantee into its
+      // opposite precisely when a retry happens. Ordered by primary key.
+      let sentRows: Array<{ target_user_ids: string[] | null }>
+      try {
+        sentRows = await fetchAllRows<{ target_user_ids: string[] | null }>('notifications', (from, to) =>
+          admin
+            .from('notifications')
+            .select('target_user_ids', { count: 'exact' })
+            .eq('tenant_id', tenantId)
+            .eq('metadata->>kind', kind)
+            .eq('metadata->>date', dateStr)
+            .order('id')
+            .range(from, to)
+        )
+      } catch (err) {
+        result.errors.push(
+          `tenant ${tenantId} ${kind}: idempotency check failed: ${err instanceof Error ? err.message : String(err)}`
+        )
         continue
       }
-      const alreadySent = new Set((sentRows ?? []).flatMap((r) => (r.target_user_ids ?? []) as string[]))
+      const alreadySent = new Set(sentRows.flatMap((r) => r.target_user_ids ?? []))
 
       for (const candidate of recipients) {
         if (alreadySent.has(candidate.user_id)) {

--- a/lib/supabase/fetch-all-rows-in.ts
+++ b/lib/supabase/fetch-all-rows-in.ts
@@ -1,0 +1,91 @@
+/**
+ * Complete reads for `.in(column, ids)` lookups (issue #548).
+ *
+ * `fetchAllRows` (#533) fixes truncation on the RESPONSE side. An `.in()`
+ * lookup has a second, independent ceiling on the REQUEST side: PostgREST
+ * takes the id list as a URL query parameter, so a few hundred uuids already
+ * push the request past the gateway's URL limit and the read fails outright
+ * (or, worse, is quietly rewritten). Paging the response does not help — the
+ * request never gets to be made.
+ *
+ * Both ceilings bite the same callers, because the id lists here are derived
+ * from the very sweeps #533 unbounded: the daily digest looks up notification
+ * preferences for every candidate student platform-wide, so `userIds` is
+ * exactly as large as the candidate set. A student missing from a truncated
+ * preferences read falls through `resolveChannels(undefined)` to
+ * `{ inApp: true, email: true }` — they get emailed *because* the read was
+ * short, having explicitly opted out.
+ *
+ * So: chunk the ids, and read each chunk through `fetchAllRows` so the
+ * response side stays verified too.
+ */
+
+import { fetchAllRows } from './fetch-all-rows'
+
+/**
+ * Ids per request. At 36 bytes per uuid plus PostgREST's `in.(...)` quoting
+ * and percent-encoding, 200 ids is roughly a 10KB query string — comfortably
+ * inside the 16KB most gateways (Kong included) allow, with room for the rest
+ * of the URL. Smaller than it needs to be on purpose: the cost of one extra
+ * round trip is nothing next to a read that 414s in production.
+ */
+export const IN_FILTER_CHUNK_SIZE = 200
+
+/** The shape of a `count: 'exact'` PostgREST response, narrowed to what this helper reads. */
+interface CountedPage<T> {
+  data: T[] | null
+  error: { message: string } | null
+  count: number | null
+}
+
+/** Split into fixed-size chunks, preserving order. */
+export function chunkIds<Id>(ids: readonly Id[], size: number = IN_FILTER_CHUNK_SIZE): Id[][] {
+  if (size < 1) throw new Error(`chunkIds: size must be >= 1, got ${size}`)
+  const out: Id[][] = []
+  for (let i = 0; i < ids.length; i += size) out.push(ids.slice(i, i + size))
+  return out
+}
+
+/**
+ * Read every row matching `.in(column, ids)`, for any number of ids.
+ *
+ * Duplicate ids are collapsed first — they cost URL budget and buy nothing.
+ * Each chunk is read through `fetchAllRows`, so the caller's `page` builder
+ * carries the same two obligations as there: `{ count: 'exact' }` on the
+ * select, and a stable `.order()` on a primary key.
+ *
+ * ```ts
+ * const prefs = await fetchAllRowsIn('notification_preferences', userIds, (chunk, from, to) =>
+ *   admin
+ *     .from('notification_preferences')
+ *     .select('user_id, email_enabled', { count: 'exact' })
+ *     .in('user_id', chunk)
+ *     .order('id')
+ *     .range(from, to)
+ * )
+ * ```
+ *
+ * Chunks are read sequentially rather than with `Promise.all`: these are
+ * service-role sweeps running in cron routes, where a burst of concurrent
+ * requests against the same table is a worse failure mode than taking a few
+ * extra seconds.
+ *
+ * @param relation Name used in error messages.
+ * @param ids Full id list. An empty list short-circuits — no request is made.
+ * @throws whatever `fetchAllRows` throws, including its completeness assertion.
+ */
+export async function fetchAllRowsIn<T, Id>(
+  relation: string,
+  ids: readonly Id[],
+  page: (chunk: Id[], from: number, to: number) => PromiseLike<CountedPage<T>>,
+  chunkSize: number = IN_FILTER_CHUNK_SIZE,
+): Promise<T[]> {
+  const unique = [...new Set(ids)]
+  if (unique.length === 0) return []
+
+  const rows: T[] = []
+  for (const chunk of chunkIds(unique, chunkSize)) {
+    rows.push(...(await fetchAllRows<T>(relation, (from, to) => page(chunk, from, to))))
+  }
+  return rows
+}

--- a/scripts/qa-548-cap-forcing.mts
+++ b/scripts/qa-548-cap-forcing.mts
@@ -1,0 +1,137 @@
+/**
+ * Cap-forcing verification for the #548 pagination sweep.
+ *
+ * The recipe #533 established, and the only kind of proof that means anything
+ * here: a test that passes on a development dataset proves nothing, because on
+ * a development dataset every unpaged read is already complete. So lower the
+ * API row cap below the fixture, then assert the totals are still right.
+ *
+ *   1. Lower `max_rows` (supabase/config.toml:18) to 5. The equivalent live
+ *      knob is the `pgrst.db_max_rows` role setting, which PostgREST adopts on
+ *      NOTIFY without restarting the shared local stack:
+ *
+ *        ALTER ROLE authenticator SET pgrst.db_max_rows = '5';
+ *        NOTIFY pgrst, 'reload config';
+ *
+ *   2. Seed well past it (37 transactions, 23 payouts, 37 digest candidates).
+ *   3. Run the REAL helpers against the REAL PostgREST and assert the totals.
+ *
+ * Step 0 below re-proves the cap is actually biting on every run — otherwise a
+ * green result would only mean the override silently failed to apply.
+ *
+ * Usage (seed + teardown SQL live alongside this file in the PR description):
+ *   npx tsx scripts/qa-548-cap-forcing.mts
+ */
+
+import { createClient } from '@supabase/supabase-js'
+import { execSync } from 'node:child_process'
+import { fetchAllRows } from '../lib/supabase/fetch-all-rows'
+import { fetchAllRowsIn } from '../lib/supabase/fetch-all-rows-in'
+import { fetchDigestCandidates } from '../lib/notifications/daily-digest'
+
+const TENANT = '00000000-0000-0000-0000-0000005480ff'
+const EXPECTED = { transactions: 37, transactionTotal: 370, payouts: 23, payoutTotal: 69, candidates: 37 }
+
+function env(): { url: string; key: string } {
+  const out = execSync('npx supabase status -o env', { encoding: 'utf8' })
+  const pick = (name: string) => out.match(new RegExp(`^${name}="?([^"\\n]+)"?$`, 'm'))?.[1]
+  const url = pick('API_URL')
+  const key = pick('SERVICE_ROLE_KEY')
+  if (!url || !key) throw new Error('could not read API_URL / SERVICE_ROLE_KEY from `supabase status`')
+  return { url, key }
+}
+
+let failures = 0
+function check(label: string, actual: unknown, expected: unknown) {
+  const ok = JSON.stringify(actual) === JSON.stringify(expected)
+  if (!ok) failures++
+  console.log(`${ok ? '  PASS' : '  FAIL'}  ${label} — got ${JSON.stringify(actual)}, expected ${JSON.stringify(expected)}`)
+}
+
+const { url, key } = env()
+const admin = createClient(url, key, { auth: { persistSession: false } })
+
+console.log('\n0. The cap is real (unpaged reads must come back short)')
+const bare = await admin.from('transactions').select('amount', { count: 'exact' }).eq('tenant_id', TENANT)
+check('unpaged transactions rows returned', bare.data?.length, 5)
+check('...while count reports the true total', bare.count, EXPECTED.transactions)
+const bareRpc = await admin.rpc('get_daily_digest_candidates', {
+  _after_tenant_id: null,
+  _after_user_id: null,
+  _limit: 500,
+})
+check('unpaged candidates RPC rows returned', (bareRpc.data ?? []).length, 5)
+if (bare.data?.length !== 5) {
+  console.log('\n  The cap is NOT in force — everything below would pass vacuously. Aborting.')
+  process.exit(1)
+}
+
+console.log('\n1. app/actions/admin/revenue.ts + teacher/revenue — transaction sweep')
+const txns = await fetchAllRows<{ amount: string }>('transactions', (from, to) =>
+  admin
+    .from('transactions')
+    .select('amount, currency, transaction_date, product_id, plan_id', { count: 'exact' })
+    .eq('tenant_id', TENANT)
+    .eq('status', 'successful')
+    .order('transaction_id')
+    .range(from, to)
+)
+check('rows read', txns.length, EXPECTED.transactions)
+check('summed revenue', txns.reduce((s, t) => s + Number(t.amount), 0), EXPECTED.transactionTotal)
+check('no duplicate rows from unstable paging', new Set(txns.map((t) => JSON.stringify(t))).size > 0, true)
+
+console.log('\n2. dashboard/admin/payouts — school-facing ledger')
+const payouts = await fetchAllRows<{ amount: string; status: string }>('payouts', (from, to) =>
+  admin
+    .from('payouts')
+    .select('payout_id, amount, currency, status, created_at', { count: 'exact' })
+    .eq('tenant_id', TENANT)
+    .order('created_at', { ascending: false })
+    .order('payout_id', { ascending: false })
+    .range(from, to)
+)
+check('rows read', payouts.length, EXPECTED.payouts)
+check(
+  'summed "Total paid"',
+  payouts.filter((p) => p.status === 'paid').reduce((s, p) => s + Number(p.amount), 0),
+  EXPECTED.payoutTotal
+)
+
+console.log('\n3. lib/notifications/daily-digest — keyset-paginated candidates RPC')
+const candidates = await fetchDigestCandidates(admin)
+const mine = candidates.filter((c) => c.tenant_id === TENANT)
+check('candidates read for the seeded tenant', mine.length, EXPECTED.candidates)
+check('every candidate distinct (keyset advanced strictly)', new Set(mine.map((c) => c.user_id)).size, EXPECTED.candidates)
+
+console.log('\n4. lib/notifications/daily-digest — chunked .in() preference lookup')
+const userIds = mine.map((c) => c.user_id)
+const prefs = await fetchAllRowsIn<{ user_id: string; email_enabled: boolean }, string>('notification_preferences', userIds, (chunk, from, to) =>
+  admin
+    .from('notification_preferences')
+    .select('user_id, in_app_enabled, email_enabled, email_frequency', { count: 'exact' })
+    .in('user_id', chunk)
+    .order('id')
+    .range(from, to)
+)
+// Whatever rows exist must ALL come back; a short read here silently re-enables
+// email for everyone it dropped.
+const { count: prefCount } = await admin
+  .from('notification_preferences')
+  .select('user_id', { count: 'exact', head: true })
+  .in('user_id', userIds.slice(0, 200))
+check('preference rows read matches the true count', prefs.length, prefCount ?? 0)
+
+// The acceptance criterion, stated directly: the seeded opt-out sits at index
+// 30, far outside a 5-row response. The paged read must see them; the unpaged
+// read must not — and whoever the unpaged read misses gets emailed, because
+// `resolveChannels(undefined)` reads a missing row as "email on".
+const OPTED_OUT = '00000000-0000-0000-0000-548000000030'
+const unpaged = await admin
+  .from('notification_preferences')
+  .select('user_id, email_enabled')
+  .in('user_id', userIds.slice(0, 200))
+check('paged read sees the opted-out student', prefs.find((p) => p.user_id === OPTED_OUT)?.email_enabled, false)
+check('unpaged read would have MISSED them', (unpaged.data ?? []).some((p) => p.user_id === OPTED_OUT), false)
+
+console.log(`\n${failures === 0 ? 'ALL CHECKS PASSED' : `${failures} CHECK(S) FAILED`}\n`)
+process.exit(failures === 0 ? 0 : 1)

--- a/supabase/migrations/20260726140000_daily_digest_candidates_pagination.sql
+++ b/supabase/migrations/20260726140000_daily_digest_candidates_pagination.sql
@@ -1,0 +1,115 @@
+-- Keyset pagination for get_daily_digest_candidates() (issue #548, epic #540 §3.5).
+--
+-- The digest cron reads this SETOF function across ALL tenants with a single
+-- `admin.rpc(...)` call. PostgREST applies the API "Max rows" cap to function
+-- results exactly as it does to tables (`supabase/config.toml:18` = 1000
+-- locally; the hosted project runs the same default), and returns the capped
+-- result as an ordinary 200. The function had no ORDER BY, so past 1000
+-- candidates the cron silently processed an ARBITRARY — and, run to run,
+-- DIFFERENT — subset. Students dropped from the read simply never got their
+-- digest, and nothing anywhere reported a problem.
+--
+-- `fetchAllRows` cannot rescue this from the caller side: `.range()` on an
+-- unordered set is not a stable window, and the helper's completeness
+-- assertion needs an exact count that a SETOF function does not provide.
+-- Pagination has to live in the function.
+--
+-- Keyset, not LIMIT/OFFSET. The candidate set is computed live from
+-- review_cards / study_goals / gamification_profiles, so it shifts under a
+-- sweep that takes several seconds; OFFSET over a shifting set skips and
+-- repeats rows. A keyset cursor on (tenant_id, user_id) — UNIQUE via
+-- tenant_users_unique, so a total order with no ties — is stable regardless:
+-- each page resumes strictly after the last row the caller actually saw.
+--
+-- The signature change is compatible: every parameter has a default, so the
+-- existing zero-argument call still resolves and returns the first page.
+
+-- Dropped rather than replaced: adding defaulted parameters to a live function
+-- creates an OVERLOAD, and a zero-arg call against both candidates is
+-- ambiguous (PostgREST would 300).
+DROP FUNCTION IF EXISTS public.get_daily_digest_candidates();
+
+CREATE OR REPLACE FUNCTION public.get_daily_digest_candidates(
+    _after_tenant_id uuid DEFAULT NULL,
+    _after_user_id uuid DEFAULT NULL,
+    _limit integer DEFAULT 500
+)
+RETURNS TABLE (
+    tenant_id uuid,
+    user_id uuid,
+    email text,
+    full_name text,
+    due_cards bigint,
+    goals_pending bigint,
+    current_streak integer,
+    last_activity_date date
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT
+        tu.tenant_id,
+        tu.user_id,
+        au.email::text,
+        p.full_name,
+        COALESCE(rc.due_count, 0) AS due_cards,
+        COALESCE(sg.pending_count, 0) AS goals_pending,
+        COALESCE(gp.current_streak, 0) AS current_streak,
+        gp.last_activity_date
+    FROM tenant_users tu
+    JOIN auth.users au ON au.id = tu.user_id
+    LEFT JOIN profiles p ON p.id = tu.user_id
+    LEFT JOIN gamification_profiles gp
+        ON gp.user_id = tu.user_id AND gp.tenant_id = tu.tenant_id
+    LEFT JOIN LATERAL (
+        SELECT count(*) AS due_count
+        FROM review_cards rc
+        WHERE rc.user_id = tu.user_id
+          AND rc.tenant_id = tu.tenant_id
+          AND rc.suspended = false
+          AND rc.due_at <= now()
+    ) rc ON true
+    LEFT JOIN LATERAL (
+        SELECT count(*) AS pending_count
+        FROM study_goals sg
+        WHERE sg.user_id = tu.user_id
+          AND sg.tenant_id = tu.tenant_id
+          AND sg.week_start = (date_trunc('week', (now() AT TIME ZONE 'utc')))::date
+          AND sg.done = false
+    ) sg ON true
+    WHERE tu.role = 'student'
+      AND tu.status = 'active'
+      AND (
+        COALESCE(rc.due_count, 0) > 0
+        OR COALESCE(sg.pending_count, 0) > 0
+        OR (COALESCE(gp.current_streak, 0) >= 3
+            AND gp.last_activity_date = CURRENT_DATE - 1)
+      )
+      -- Cursor. NULL _after_tenant_id means "from the beginning"; the COALESCE
+      -- keeps a caller that passes only the tenant half from silently getting
+      -- an empty page (row comparison against NULL is NULL, not false).
+      AND (
+        _after_tenant_id IS NULL
+        OR (tu.tenant_id, tu.user_id)
+             > (_after_tenant_id, COALESCE(_after_user_id, '00000000-0000-0000-0000-000000000000'::uuid))
+      )
+    -- Load-bearing, not cosmetic: this is what makes the cursor above mean
+    -- anything. Without it the "next" page is unrelated to the previous one.
+    ORDER BY tu.tenant_id, tu.user_id
+    -- Clamped: a caller asking for more than the API cap would get a silently
+    -- truncated page back, which is the bug this migration exists to remove.
+    -- 1000 is the ceiling the caller can rely on receiving in full.
+    LIMIT LEAST(GREATEST(COALESCE(_limit, 500), 1), 1000);
+$$;
+
+-- Service-role only, unchanged: the function reads auth.users and crosses tenants.
+REVOKE ALL ON FUNCTION public.get_daily_digest_candidates(uuid, uuid, integer) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.get_daily_digest_candidates(uuid, uuid, integer) FROM anon;
+REVOKE ALL ON FUNCTION public.get_daily_digest_candidates(uuid, uuid, integer) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.get_daily_digest_candidates(uuid, uuid, integer) TO service_role;
+
+COMMENT ON FUNCTION public.get_daily_digest_candidates(uuid, uuid, integer) IS
+    'Daily-digest candidates, keyset-paginated on (tenant_id, user_id). Callers must page '
+    'until an empty result: a short page may be the PostgREST row cap, not the end of the set (#548).';

--- a/tests/unit/daily-digest-pagination.test.ts
+++ b/tests/unit/daily-digest-pagination.test.ts
@@ -1,0 +1,321 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+const sentEmails: Array<{ to: string; subject: string }> = []
+vi.mock('@/lib/email/send', () => ({
+  sendEmail: vi.fn(async (msg: { to: string; subject: string }) => {
+    sentEmails.push({ to: msg.to, subject: msg.subject })
+    return true
+  }),
+}))
+
+import { fetchDigestCandidates, runDailyDigest } from '@/lib/notifications/daily-digest'
+
+/**
+ * Cap-forcing tests for the daily digest (issue #548).
+ *
+ * The point of these is that they FAIL on a small dataset read without
+ * pagination — the fake server below clamps every response to `serverCap`
+ * rows exactly as PostgREST's "Max rows" does (`supabase/config.toml:18`),
+ * while still reporting the true `count`. Every fixture here is deliberately
+ * several times larger than the cap, so a single unpaged read cannot possibly
+ * see all of it. `requestsFor()` asserts the cap was genuinely exercised
+ * rather than accidentally avoided.
+ *
+ * The two behaviours under test are not "a total is slightly off": a truncated
+ * preferences read EMAILS STUDENTS WHO TURNED EMAIL OFF, and a truncated
+ * idempotency read RE-SENDS a digest the tenant already received.
+ */
+
+interface Row {
+  [column: string]: unknown
+}
+
+const TENANT = '00000000-0000-0000-0000-0000000000aa'
+/** 17:30 UTC — the default send hour (17), and not the nudge hour (20). */
+const NOW = new Date('2026-07-14T17:30:00Z')
+
+/** Deterministic, ordered uuids so keyset paging has something real to sort. */
+const userId = (n: number) => `00000000-0000-0000-0000-${String(n).padStart(12, '0')}`
+const emailFor = (n: number) => `student${n}@example.com`
+
+/**
+ * An in-memory PostgREST with a row cap.
+ *
+ * Supports the slice of the API the digest uses: select/eq/in/order/range with
+ * `count: 'exact'`, `metadata->>key` json accessors, insert, and the
+ * keyset-paginated candidates RPC. `serverCap` clamps every response — ranged
+ * ones included, which is the whole trap: a short page is NOT the end of the
+ * relation.
+ */
+function makeServer(options: {
+  serverCap: number
+  candidates: Row[]
+  preferences?: Row[]
+  tenants?: Row[]
+  notifications?: Row[]
+  failPreferences?: boolean
+}) {
+  const db: Record<string, Row[]> = {
+    tenants: options.tenants ?? [{ id: TENANT, name: 'Cap School', slug: 'cap' }],
+    tenant_settings: [],
+    notification_templates: [],
+    notification_preferences: options.preferences ?? [],
+    notifications: options.notifications ?? [],
+    user_notifications: [],
+  }
+  const requests: Record<string, number> = {}
+  let nextId = 10_000
+
+  const value = (row: Row, column: string): unknown => {
+    const json = column.match(/^(\w+)->>(\w+)$/)
+    if (json) return (row[json[1]] as Record<string, unknown> | null)?.[json[2]]
+    return row[column]
+  }
+
+  function builder(table: string) {
+    const filters: Array<(r: Row) => boolean> = []
+    const orderBy: Array<{ column: string; ascending: boolean }> = []
+    let from = 0
+    let to = Number.MAX_SAFE_INTEGER
+
+    const run = () => {
+      requests[table] = (requests[table] ?? 0) + 1
+      let rows = db[table].filter((r) => filters.every((f) => f(r)))
+      for (const { column, ascending } of [...orderBy].reverse()) {
+        rows = [...rows].sort((a, b) => {
+          const [x, y] = [value(a, column), value(b, column)]
+          const cmp = x === y ? 0 : (x as number | string) < (y as number | string) ? -1 : 1
+          return ascending ? cmp : -cmp
+        })
+      }
+      const count = rows.length
+      // The cap applies to the ranged window, not to the relation.
+      const data = rows.slice(from, to + 1).slice(0, options.serverCap)
+      return { data, error: null, count }
+    }
+
+    const api = {
+      select: () => api,
+      eq: (column: string, v: unknown) => {
+        filters.push((r) => value(r, column) === v)
+        return api
+      },
+      in: (column: string, values: unknown[]) => {
+        filters.push((r) => values.includes(value(r, column)))
+        return api
+      },
+      or: () => api,
+      order: (column: string, opts?: { ascending?: boolean }) => {
+        orderBy.push({ column, ascending: opts?.ascending !== false })
+        return api
+      },
+      range: (f: number, t: number) => {
+        from = f
+        to = t
+        return api
+      },
+      then: (resolve: (v: unknown) => unknown) => Promise.resolve(run()).then(resolve),
+    }
+    return api
+  }
+
+  const client = {
+    from(table: string) {
+      if (table === 'notification_preferences' && options.failPreferences) {
+        return {
+          select: () => ({
+            in: () => ({
+              order: () => ({
+                range: () => ({
+                  then: (resolve: (v: unknown) => unknown) =>
+                    Promise.resolve({ data: null, error: { message: 'connection reset' }, count: null }).then(resolve),
+                }),
+              }),
+            }),
+          }),
+        }
+      }
+      return {
+        ...builder(table),
+        insert(row: Row) {
+          const stored = { id: nextId++, ...row }
+          db[table].push(stored)
+          const result = { data: { id: stored.id }, error: null }
+          return {
+            select: () => ({ single: async () => result }),
+            then: (resolve: (v: unknown) => unknown) => Promise.resolve({ data: null, error: null }).then(resolve),
+          }
+        },
+      }
+    },
+
+    /** Keyset-paginated candidates, clamped by the same cap. */
+    async rpc(_fn: string, args: { _after_tenant_id: string | null; _after_user_id: string | null; _limit: number }) {
+      requests.rpc = (requests.rpc ?? 0) + 1
+      const sorted = [...options.candidates].sort((a, b) =>
+        `${a.tenant_id}${a.user_id}` < `${b.tenant_id}${b.user_id}` ? -1 : 1
+      )
+      const after = args._after_tenant_id ? `${args._after_tenant_id}${args._after_user_id}` : null
+      const remaining = after ? sorted.filter((r) => `${r.tenant_id}${r.user_id}` > after) : sorted
+      return { data: remaining.slice(0, Math.min(args._limit, options.serverCap)), error: null }
+    },
+  }
+
+  return { client: client as unknown as SupabaseClient, db, requestsFor: (t: string) => requests[t] ?? 0 }
+}
+
+/** `n` students, all with review cards due, so all are digest recipients. */
+function candidates(n: number, tenant = TENANT): Row[] {
+  return Array.from({ length: n }, (_, i) => ({
+    tenant_id: tenant,
+    user_id: userId(i),
+    email: emailFor(i),
+    full_name: `Student ${i}`,
+    due_cards: 3,
+    goals_pending: 0,
+    current_streak: 0,
+    last_activity_date: null,
+  }))
+}
+
+const CAP = 7
+const STUDENTS = 40
+
+beforeEach(() => {
+  sentEmails.length = 0
+})
+
+describe('fetchDigestCandidates', () => {
+  it('#548: reads every candidate when the server caps each page far below the ask', async () => {
+    const { client, requestsFor } = makeServer({ serverCap: CAP, candidates: candidates(STUDENTS) })
+    const rows = await fetchDigestCandidates(client)
+    expect(rows).toHaveLength(STUDENTS)
+    // The cap was real: 40 rows at 7 per response cannot be one request.
+    expect(requestsFor('rpc')).toBeGreaterThan(1)
+    // And no row was seen twice — the keyset advanced strictly.
+    expect(new Set(rows.map((r) => r.user_id)).size).toBe(STUDENTS)
+  })
+
+  it('stops on an empty page, not a short one', async () => {
+    // Every page here is short (cap 7 < the 500 asked for). Treating short as
+    // "exhausted" would return 7 of 40 — the exact #548 failure.
+    const { client } = makeServer({ serverCap: CAP, candidates: candidates(STUDENTS) })
+    await expect(fetchDigestCandidates(client)).resolves.toHaveLength(STUDENTS)
+  })
+
+  it('returns an empty set without looping when there are no candidates', async () => {
+    const { client, requestsFor } = makeServer({ serverCap: CAP, candidates: [] })
+    await expect(fetchDigestCandidates(client)).resolves.toEqual([])
+    expect(requestsFor('rpc')).toBe(1)
+  })
+
+  it('surfaces an RPC error instead of silently digesting nobody', async () => {
+    const client = { rpc: async () => ({ data: null, error: { message: 'permission denied' } }) }
+    await expect(fetchDigestCandidates(client as unknown as SupabaseClient)).rejects.toThrow('permission denied')
+  })
+})
+
+describe('runDailyDigest past the row cap', () => {
+  it('#548: sends to every candidate, not just the first capped page', async () => {
+    const { client, requestsFor } = makeServer({ serverCap: CAP, candidates: candidates(STUDENTS) })
+    const result = await runDailyDigest(client, NOW)
+
+    expect(result.errors).toEqual([])
+    expect(result.digestsSent).toBe(STUDENTS)
+    expect(result.emailsSent).toBe(STUDENTS)
+    expect(sentEmails).toHaveLength(STUDENTS)
+    // Proof the cap was genuinely in play: 40 candidates could not have
+    // arrived in one 7-row response.
+    expect(requestsFor('rpc')).toBeGreaterThan(1)
+  })
+
+  it('#548 acceptance: a second run the same tenant-local day sends ZERO additional emails', async () => {
+    const server = makeServer({ serverCap: CAP, candidates: candidates(STUDENTS) })
+    const first = await runDailyDigest(server.client, NOW)
+    expect(first.digestsSent).toBe(STUDENTS)
+    expect(sentEmails).toHaveLength(STUDENTS)
+
+    // 40 notification rows now exist for this (tenant, kind, day). Read
+    // unpaged, the idempotency check would see only 7 of them and re-send to
+    // the other 33 — a cron retry duplicating a day's digests.
+    sentEmails.length = 0
+    const second = await runDailyDigest(server.client, NOW)
+
+    expect(second.errors).toEqual([])
+    expect(second.digestsSent).toBe(0)
+    expect(second.emailsSent).toBe(0)
+    expect(second.skippedAlreadySent).toBe(STUDENTS)
+    expect(sentEmails).toEqual([])
+    expect(server.requestsFor('notifications')).toBeGreaterThan(1)
+  })
+
+  it('#548 acceptance: a student with email disabled is not emailed, even past the cap', async () => {
+    // Index 30 sits well beyond the 7-row cap, so an unpaged preferences read
+    // never sees this row and `resolveChannels(undefined)` defaults them back
+    // to email:true — opting out would be silently reversed by truncation.
+    const optedOut = 30
+    const preferences = Array.from({ length: STUDENTS }, (_, i) => ({
+      id: i,
+      user_id: userId(i),
+      in_app_enabled: true,
+      email_enabled: i !== optedOut,
+      email_frequency: 'immediate',
+    }))
+    const { client, requestsFor } = makeServer({ serverCap: CAP, candidates: candidates(STUDENTS), preferences })
+
+    const result = await runDailyDigest(client, NOW)
+
+    expect(result.errors).toEqual([])
+    // The preference read really was capped — 40 rows over 7-row responses.
+    expect(requestsFor('notification_preferences')).toBeGreaterThan(1)
+    expect(sentEmails.map((e) => e.to)).not.toContain(emailFor(optedOut))
+    expect(result.emailsSent).toBe(STUDENTS - 1)
+    // Still gets the in-app notification — only the email channel was declined.
+    expect(result.digestsSent).toBe(STUDENTS)
+  })
+
+  it('#548: honours email_frequency "never" past the cap as well', async () => {
+    const silent = 35
+    const preferences = Array.from({ length: STUDENTS }, (_, i) => ({
+      id: i,
+      user_id: userId(i),
+      in_app_enabled: true,
+      email_enabled: true,
+      email_frequency: i === silent ? 'never' : 'immediate',
+    }))
+    const { client } = makeServer({ serverCap: CAP, candidates: candidates(STUDENTS), preferences })
+
+    const result = await runDailyDigest(client, NOW)
+    expect(sentEmails.map((e) => e.to)).not.toContain(emailFor(silent))
+    expect(result.emailsSent).toBe(STUDENTS - 1)
+  })
+
+  it('skips the tenant rather than emailing everyone when the preferences read fails', async () => {
+    // Falling through with an empty preferences map would mean "nobody has
+    // opted out" — the failure mode must be sending nothing, not sending all.
+    const { client } = makeServer({ serverCap: CAP, candidates: candidates(STUDENTS), failPreferences: true })
+    const result = await runDailyDigest(client, NOW)
+
+    expect(result.digestsSent).toBe(0)
+    expect(sentEmails).toEqual([])
+    expect(result.errors.join(' ')).toMatch(/preferences read failed/)
+  })
+
+  it('spans multiple tenants, each read completely', async () => {
+    const other = '00000000-0000-0000-0000-0000000000bb'
+    const { client } = makeServer({
+      serverCap: CAP,
+      candidates: [...candidates(STUDENTS), ...candidates(STUDENTS, other)],
+      tenants: [
+        { id: TENANT, name: 'Cap School', slug: 'cap' },
+        { id: other, name: 'Other School', slug: 'other' },
+      ],
+    })
+
+    const result = await runDailyDigest(client, NOW)
+    expect(result.tenantsConsidered).toBe(2)
+    expect(result.tenantsProcessed).toBe(2)
+    expect(result.digestsSent).toBe(STUDENTS * 2)
+  })
+})

--- a/tests/unit/fetch-all-rows-in.test.ts
+++ b/tests/unit/fetch-all-rows-in.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+import { chunkIds, fetchAllRowsIn, IN_FILTER_CHUNK_SIZE } from '@/lib/supabase/fetch-all-rows-in'
+
+/**
+ * `.in()` lookups have two independent ceilings (issue #548): the response row
+ * cap that `fetchAllRows` handles, and the request URL length that only
+ * chunking handles. These cover the chunking half and the composition of both.
+ */
+
+/** A fake PostgREST that only knows rows whose id is in the requested chunk. */
+function serverOver(rows: Array<{ id: number }>, options: { serverCap?: number } = {}) {
+  const requests: Array<{ ids: number[]; from: number; to: number }> = []
+  const page = async (chunk: number[], from: number, to: number) => {
+    requests.push({ ids: chunk, from, to })
+    const matching = rows.filter((r) => chunk.includes(r.id))
+    let slice = matching.slice(from, to + 1)
+    if (options.serverCap != null) slice = slice.slice(0, options.serverCap)
+    return { data: slice, error: null, count: matching.length }
+  }
+  return { page, requests }
+}
+
+const rowsUpTo = (n: number) => Array.from({ length: n }, (_, i) => ({ id: i }))
+const idsUpTo = (n: number) => Array.from({ length: n }, (_, i) => i)
+
+describe('chunkIds', () => {
+  it('splits into fixed-size chunks preserving order', () => {
+    expect(chunkIds([1, 2, 3, 4, 5], 2)).toEqual([[1, 2], [3, 4], [5]])
+  })
+
+  it('returns a single chunk when the list is shorter than the size', () => {
+    expect(chunkIds([1, 2], 10)).toEqual([[1, 2]])
+  })
+
+  it('returns nothing for an empty list', () => {
+    expect(chunkIds([], 10)).toEqual([])
+  })
+
+  it('rejects a chunk size below 1 rather than looping forever', () => {
+    expect(() => chunkIds([1], 0)).toThrow(/size must be >= 1/)
+  })
+
+  it('defaults to a size that keeps the query string well inside gateway limits', () => {
+    // 200 uuids ≈ 10KB encoded — the assertion is on the guarantee, not the number.
+    expect(IN_FILTER_CHUNK_SIZE).toBeLessThanOrEqual(250)
+  })
+})
+
+describe('fetchAllRowsIn', () => {
+  it('makes no request at all for an empty id list', async () => {
+    const { page, requests } = serverOver(rowsUpTo(10))
+    await expect(fetchAllRowsIn('t', [], page)).resolves.toEqual([])
+    expect(requests).toHaveLength(0)
+  })
+
+  it('splits a long id list across several requests and returns every row', async () => {
+    const { page, requests } = serverOver(rowsUpTo(1000))
+    const rows = await fetchAllRowsIn('t', idsUpTo(1000), page, 100)
+    expect(rows).toHaveLength(1000)
+    // 10 chunks, each confirmed by a trailing empty page (the chunk is an exact
+    // multiple of nothing here — it is short, so one request each).
+    expect(requests.map((r) => r.ids.length)).toEqual(Array(10).fill(100))
+  })
+
+  it('collapses duplicate ids instead of spending URL budget on them', async () => {
+    const { page, requests } = serverOver(rowsUpTo(5))
+    const rows = await fetchAllRowsIn('t', [1, 1, 1, 2, 2, 3], page, 100)
+    expect(rows).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }])
+    expect(requests[0].ids).toEqual([1, 2, 3])
+  })
+
+  it('#548: pages WITHIN a chunk when the server caps the response', async () => {
+    // Both ceilings at once: 400 ids is too many for one URL, and the server
+    // returns at most 30 rows per response. Neither chunking nor paging alone
+    // returns all 400 — the id at index 399 is only reachable through both.
+    const { page, requests } = serverOver(rowsUpTo(400), { serverCap: 30 })
+    const rows = await fetchAllRowsIn('t', idsUpTo(400), page, 100)
+    expect(rows).toHaveLength(400)
+    expect(rows.at(-1)).toEqual({ id: 399 })
+    // 4 chunks × (100/30 rounded up, plus the confirming short page).
+    expect(requests.length).toBeGreaterThan(4)
+  })
+
+  it('propagates the completeness assertion rather than returning a short set', async () => {
+    // A server that reports 100 rows but will only ever hand back 10 is the
+    // failure `fetchAllRows` exists to make loud; chunking must not swallow it.
+    const stuck = async () => ({ data: [] as Array<{ id: number }>, error: null, count: 100 })
+    await expect(fetchAllRowsIn('t', idsUpTo(50), stuck, 100)).rejects.toThrow(/incomplete read/)
+  })
+
+  it('surfaces a page error with the relation name', async () => {
+    const failing = async () => ({ data: null, error: { message: 'boom' }, count: null })
+    await expect(fetchAllRowsIn('prefs', [1], failing)).rejects.toThrow(/fetchAllRows\(prefs\).*boom/)
+  })
+})

--- a/tests/unit/unbounded-read-guard.test.ts
+++ b/tests/unit/unbounded-read-guard.test.ts
@@ -1,0 +1,272 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Review guard against the next unbounded sweep (issue #548).
+ *
+ * PostgREST caps every response at the API "Max rows" setting and returns the
+ * capped result as an ordinary 200 (`supabase/config.toml:18`). Truncation is
+ * therefore invisible: `#533` found it after a school was underpaid, `#548`
+ * after finding that a truncated preferences read emails students who opted
+ * out. Neither was caught by a test, because on a development dataset every
+ * one of these reads is complete.
+ *
+ * So the check has to be static. This walks the source tree, pulls out every
+ * PostgREST chain against a table whose row count grows with usage, and fails
+ * on any that reads without bounding itself. New violations fail; the ones
+ * that already existed are listed in `KNOWN_UNBOUNDED` with a reason, so the
+ * baseline is a ratchet rather than a blanket.
+ *
+ * A chain counts as bounded if it pages (`.range(`, which is what
+ * `fetchAllRows`/`fetchAllRowsIn` callers use), asks for one row
+ * (`.single(`/`.maybeSingle(`), takes a fixed slice (`.limit(`), or wants only
+ * a count (`head: true`).
+ */
+
+const ROOTS = ['app', 'lib', 'components']
+const SOURCE_EXTENSIONS = ['.ts', '.tsx']
+
+/**
+ * Tables whose row count grows with tenant activity — one row per sale, per
+ * enrolment, per notification. These are the ones where "it works locally"
+ * says nothing at all about production.
+ */
+const UNBOUNDED_PRONE_TABLES = [
+  'transactions',
+  'payouts',
+  'notifications',
+  'notification_preferences',
+  'user_notifications',
+  'subscriptions',
+  'platform_subscriptions',
+  'entitlements',
+  'enrollments',
+  'tenants',
+]
+
+const BOUNDING_TOKENS = ['.range(', '.single(', '.maybeSingle(', '.limit(', 'head: true']
+
+/**
+ * Pre-existing reads, recorded when the guard was added. Each is `file::table`.
+ *
+ * Two kinds, and the distinction matters:
+ *  - `scoped` — filtered to one user, one course or one row, so the result set
+ *    is bounded by something other than luck.
+ *  - `gap` — genuinely unbounded platform- or tenant-wide sweeps, the same
+ *    class of bug as #533/#548 and not yet fixed. Tracked in epic #540; listed
+ *    here so they are visible rather than forgotten.
+ *
+ * Fixing one means deleting its line — the test fails on a stale entry, so the
+ * list cannot quietly rot.
+ */
+const KNOWN_UNBOUNDED: Record<string, string> = {
+  // scoped: a single user's own rows
+  'app/[locale]/dashboard/student/billing/page.tsx::transactions': 'scoped — one user’s own purchases',
+  'app/[locale]/dashboard/student/billing/page.tsx::subscriptions': 'scoped — one user’s own subscriptions',
+  'app/[locale]/dashboard/student/courses/page.tsx::enrollments': 'scoped — one user’s enrolments',
+  'app/[locale]/dashboard/student/page.tsx::enrollments': 'scoped — one user’s enrolments',
+  'app/[locale]/dashboard/student/progress/page.tsx::enrollments': 'scoped — one user’s enrolments',
+  'app/[locale]/dashboard/admin/users/[userId]/page.tsx::enrollments': 'scoped — one user’s enrolments',
+  'lib/hooks/use-course-access.ts::entitlements': 'scoped — one user’s entitlements',
+  'lib/services/course-access.ts::entitlements': 'scoped — one user’s entitlements',
+  'lib/payments/subscription-guard.ts::subscriptions': 'scoped — one user’s subscriptions',
+
+  // scoped: one course (large, but bounded by a course roster)
+  'app/[locale]/dashboard/teacher/courses/[courseId]/page.tsx::enrollments': 'scoped — one course roster',
+  'app/[locale]/dashboard/teacher/courses/[courseId]/certificates/page.tsx::enrollments': 'scoped — one course roster',
+  'app/actions/teacher/courses.ts::enrollments': 'scoped — one course roster',
+  'app/actions/admin/notifications.ts::enrollments': 'scoped — one course roster',
+
+  // gap: tenant- or platform-wide sweeps, #533 class, not in #548's scope
+  'app/[locale]/dashboard/admin/analytics/page.tsx::transactions': 'gap #540 — tenant-wide, summed',
+  'app/[locale]/dashboard/admin/analytics/page.tsx::enrollments': 'gap #540 — tenant-wide, counted',
+  'app/[locale]/dashboard/admin/page.tsx::transactions': 'gap #540 — tenant-wide, summed',
+  'app/[locale]/dashboard/admin/courses/page.tsx::enrollments': 'gap #540 — tenant-wide, counted',
+  'app/[locale]/dashboard/admin/enrollments/page.tsx::enrollments': 'gap #540 — tenant-wide listing',
+  'app/[locale]/dashboard/admin/users/page.tsx::enrollments': 'gap #540 — tenant-wide, counted',
+  'app/[locale]/dashboard/admin/subscriptions/page.tsx::subscriptions': 'gap #540 — tenant-wide listing',
+  'app/[locale]/dashboard/admin/transactions/page.tsx::transactions': 'gap #540 — tenant-wide listing',
+  'app/[locale]/dashboard/admin/tenants/page.tsx::tenants': 'gap #540 — platform-wide listing',
+  'app/[locale]/dashboard/teacher/page.tsx::enrollments': 'gap #540 — tenant-wide, counted',
+  'app/actions/admin/binance-personal.ts::transactions': 'gap #540 — tenant-wide reconcile list',
+  'app/api/cron/binance-personal-reconcile/route.ts::transactions': 'gap #540 — platform-wide cron queue',
+  'app/api/cron/expire-subscriptions/route.ts::subscriptions': 'gap #540 — platform-wide cron queue',
+  'app/api/cron/expire-platform-subscriptions/route.ts::platform_subscriptions': 'gap #540 — platform-wide cron queue',
+  'app/api/stripe/webhook/route.ts::transactions': 'gap #540 — platform-wide pending scan',
+}
+
+/** Every source file under the scanned roots. */
+function sourceFiles(): string[] {
+  const out: string[] = []
+  for (const root of ROOTS) {
+    let entries: string[]
+    try {
+      entries = readdirSync(root, { recursive: true }) as string[]
+    } catch {
+      continue
+    }
+    for (const entry of entries) {
+      const path = join(root, entry)
+      if (SOURCE_EXTENSIONS.some((ext) => path.endsWith(ext))) out.push(path)
+    }
+  }
+  return out
+}
+
+/**
+ * Pull out each `.from('table')…` chain as raw text.
+ *
+ * The chain runs until the expression ends: a bracket that closes something
+ * opened outside it, a `,`/`;` at depth zero, or a newline whose next
+ * non-space character is not `.` (so a broken-up fluent chain stays one
+ * chain). Crude next to a real parser, and deliberately so — it only has to be
+ * good enough to spot a `.select()` that never bounds itself.
+ */
+export function extractChains(source: string): Array<{ table: string; text: string }> {
+  const chains: Array<{ table: string; text: string }> = []
+  const fromCall = /\.from\(\s*['"]([a-z_]+)['"]\s*\)/g
+  let match: RegExpExecArray | null
+
+  while ((match = fromCall.exec(source))) {
+    let index = match.index + match[0].length
+    let depth = 0
+    let end = index
+
+    while (index < source.length) {
+      const char = source[index]
+      if ('([{'.includes(char)) depth++
+      else if (')]}'.includes(char)) {
+        if (depth === 0) break
+        depth--
+      } else if (depth === 0 && (char === ';' || char === ',')) break
+      else if (depth === 0 && char === '\n') {
+        const rest = source.slice(index + 1)
+        const indent = rest.match(/^[ \t]*/)![0].length
+        if (rest[indent] !== '.') break
+      }
+      index++
+      end = index
+    }
+    chains.push({ table: match[1], text: source.slice(match.index, end) })
+  }
+  return chains
+}
+
+/** A read against a growth table that bounds itself in none of the accepted ways. */
+export function isUnboundedRead(chain: { table: string; text: string }): boolean {
+  if (!UNBOUNDED_PRONE_TABLES.includes(chain.table)) return false
+  if (!chain.text.includes('.select(')) return false
+  return !BOUNDING_TOKENS.some((token) => chain.text.includes(token))
+}
+
+function scanRepository(): Map<string, string[]> {
+  const found = new Map<string, string[]>()
+  for (const file of sourceFiles()) {
+    for (const chain of extractChains(readFileSync(file, 'utf8'))) {
+      if (!isUnboundedRead(chain)) continue
+      const key = `${file}::${chain.table}`
+      found.set(key, [...(found.get(key) ?? []), chain.text.replace(/\s+/g, ' ').slice(0, 120)])
+    }
+  }
+  return found
+}
+
+describe('unbounded read guard', () => {
+  it('finds no unbounded read that is not already accounted for', () => {
+    const offenders = [...scanRepository().entries()]
+      .filter(([key]) => !(key in KNOWN_UNBOUNDED))
+      .map(([key, samples]) => `${key}\n      ${samples[0]}`)
+
+    expect(
+      offenders,
+      'New unbounded read on a growth table. PostgREST silently caps it at the API row ' +
+        'limit, so any total computed from it is wrong and no error is raised. Page it with ' +
+        'fetchAllRows (or fetchAllRowsIn for .in() lookups) plus a primary-key .order(), or ' +
+        'bound it with .limit()/.single(). If it is genuinely scoped, add it to ' +
+        'KNOWN_UNBOUNDED with the reason.'
+    ).toEqual([])
+  })
+
+  it('keeps the known-unbounded list honest — no entry that no longer applies', () => {
+    const live = scanRepository()
+    const stale = Object.keys(KNOWN_UNBOUNDED).filter((key) => !live.has(key))
+    expect(stale, 'Fixed (or moved) — delete these lines from KNOWN_UNBOUNDED.').toEqual([])
+  })
+
+  it('#548: the reads this issue fixed no longer register as unbounded', () => {
+    const live = scanRepository()
+    const fixed = [
+      'app/[locale]/dashboard/admin/payouts/page.tsx::payouts',
+      'app/[locale]/dashboard/teacher/revenue/page.tsx::transactions',
+      'app/actions/admin/revenue.ts::transactions',
+      'app/actions/platform/billing-health.ts::tenants',
+      'app/actions/platform/billing-health.ts::platform_subscriptions',
+      'lib/notifications/daily-digest.ts::notification_preferences',
+      'lib/notifications/daily-digest.ts::notifications',
+      'lib/notifications/daily-digest.ts::tenants',
+      'app/api/cron/solana-reconcile/route.ts::transactions',
+      'app/api/cron/solana-pull/route.ts::subscriptions',
+    ]
+    expect(fixed.filter((key) => live.has(key))).toEqual([])
+  })
+})
+
+/**
+ * The guard is worthless if the extractor quietly stops matching anything —
+ * a scan that finds nothing looks identical to a clean repository.
+ */
+describe('unbounded read guard — the detector itself', () => {
+  it('flags a bare tenant-wide select', () => {
+    const [chain] = extractChains(`
+      const { data } = await supabase
+        .from('transactions')
+        .select('amount')
+        .eq('tenant_id', tenantId)
+    `)
+    expect(chain.table).toBe('transactions')
+    expect(isUnboundedRead(chain)).toBe(true)
+  })
+
+  it.each(BOUNDING_TOKENS)('accepts a read bounded by %s', (token) => {
+    const call = token === 'head: true' ? ".select('*', { count: 'exact', head: true })" : `.select('*')${token})`
+    const [chain] = extractChains(`await supabase.from('transactions')${call}`)
+    expect(isUnboundedRead(chain)).toBe(false)
+  })
+
+  it('ignores tables that do not grow with usage', () => {
+    const [chain] = extractChains(`await supabase.from('plans').select('*')`)
+    expect(isUnboundedRead(chain)).toBe(false)
+  })
+
+  it('ignores a write that never reads rows back', () => {
+    const [chain] = extractChains(`await supabase.from('transactions').update({ status: 'failed' }).eq('id', id)`)
+    expect(isUnboundedRead(chain)).toBe(false)
+  })
+
+  it('keeps a chain broken across lines together', () => {
+    const [chain] = extractChains(`
+      await supabase
+        .from('payouts')
+        .select('amount')
+        .eq('tenant_id', t)
+        .limit(10)
+    `)
+    expect(isUnboundedRead(chain)).toBe(false)
+  })
+
+  it('stops at the end of the expression rather than swallowing the next statement', () => {
+    const [first] = extractChains(`
+      const a = await supabase.from('transactions').select('amount')
+      const b = await supabase.from('payouts').select('amount').limit(1)
+    `)
+    // Without a boundary the `.limit(1)` below would mark this one bounded.
+    expect(first.text).not.toContain('limit')
+    expect(isUnboundedRead(first)).toBe(true)
+  })
+
+  it('actually walks the repository — the scan is not silently empty', () => {
+    expect(sourceFiles().length).toBeGreaterThan(100)
+    expect(scanRepository().size).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
Closes #548. Part of EPIC #540, §3.5.

## The problem

PostgREST caps every response at the API "Max rows" limit (`supabase/config.toml:18`, same default on the hosted project) and returns the capped result as an ordinary `200`. Truncation is indistinguishable from a complete read. #533 shipped `lib/supabase/fetch-all-rows.ts` but wired it to only two call sites; nine reads were left unbounded.

Seven of them fail as a wrong number. **Two fail as wrong user-visible behaviour**, which is why this is worth the diff:

| Read | What truncation actually does |
|---|---|
| `daily-digest.ts` — `notification_preferences` | `resolveChannels(undefined)` reads a missing row as the schema default `{ inApp: true, email: true }`, so **every student the short read dropped gets emailed — including the ones who turned email off**. |
| `daily-digest.ts` — the idempotency read | One notification row is written per recipient, so past the cap it truncates and **a cron retry re-sends the day's digests**, inverting the module's documented "re-runs never double-send" guarantee precisely when a retry happens. |

## What changed

**Nine reads paged**, each with `{ count: 'exact' }` and a primary-key `.order()` — an unordered `.range()` window is not a stable page, so that ordering is load-bearing, not cosmetic. Where a natural sort already existed (`created_at`) the PK is added as a tiebreaker rather than replacing it, so display order is unchanged.

- `dashboard/admin/payouts/page.tsx` · `dashboard/teacher/revenue/page.tsx` · `actions/admin/revenue.ts`
- `actions/platform/billing-health.ts` (all five reads)
- `api/cron/solana-reconcile` · `api/cron/solana-pull` — these are work queues, so `fetchAllRows` throwing means a short queue can no longer masquerade as a finished one
- `lib/notifications/daily-digest.ts` (candidates, tenants, settings, preferences, idempotency)

**`get_daily_digest_candidates` now paginates** (`20260726140000`). It could not be fixed from the caller side: a SETOF function with no `ORDER BY` gives `.range()` nothing stable to window over, and offers no exact count to verify against. It takes a keyset cursor on `(tenant_id, user_id)` — UNIQUE via `tenant_users_unique`, so a total order with no ties — plus `ORDER BY` and a clamped `LIMIT`. Keyset rather than `LIMIT/OFFSET` because the candidate set is computed live from `review_cards`/`study_goals` and shifts under a multi-second sweep, which is exactly when OFFSET skips and repeats rows. Every parameter defaults, so the old zero-arg call still resolves.

The caller stops on an **empty** page, never a short one. A short page is ambiguous between "end of the set" and "the row cap clamped us below what we asked for" — reading it as "done" is the original bug in a new place.

**`lib/supabase/fetch-all-rows-in.ts` (new)** for `.in()` lookups. These have a second, independent ceiling on the *request* side: a few hundred uuids overflow the gateway's URL limit, and paging the response cannot help with a request that is never made. It chunks the ids and reads each chunk through `fetchAllRows`, so both ceilings are covered. `fetch-all-rows.ts` itself is untouched, as the issue asks.

**A failed preferences read now skips the tenant** instead of continuing with an empty map. "Nobody has opted out" is the worst possible reading of "the read failed".

## Verification — cap-forced, not "it works locally"

A test that passes on a development dataset proves nothing here, because on a development dataset every unpaged read is already complete. Both layers force the cap.

**Live, against real PostgREST** (`scripts/qa-548-cap-forcing.mts`) — row cap lowered to 5, seeded to 37 transactions / 23 payouts / 37 candidates:

```
0. The cap is real (unpaged reads must come back short)
  PASS  unpaged transactions rows returned — got 5, expected 5
  PASS  ...while count reports the true total — got 37, expected 37
  PASS  unpaged candidates RPC rows returned — got 5, expected 5
1. transaction sweep      PASS rows 37/37   PASS summed revenue 370/370
2. payout ledger          PASS rows 23/23   PASS summed "Total paid" 69/69
3. candidates RPC         PASS 37/37        PASS every candidate distinct
4. chunked .in() prefs    PASS 37/37
  PASS  paged read sees the opted-out student
  PASS  unpaged read would have MISSED them
```

Step 0 re-proves the cap is biting on every run — otherwise a green result would only mean the override failed to apply. Fixture and cap were torn down afterwards; `config.toml` is unmodified in the diff.

> The cap was forced with `ALTER ROLE authenticator SET pgrst.db_max_rows = '5'; NOTIFY pgrst, 'reload config';` — the live-equivalent of the `config.toml` knob, adopted without restarting the local stack that sibling worktrees share. The `config.toml` line it corresponds to is documented in the script header.

**In unit tests** — a fake PostgREST that clamps every response to 7 rows over a 40-student fixture. The decisive check: reverting the fix fails 6 of them with exactly the expected numbers.

```
× sends to every candidate            → expected 7 to be 40
× second run sends ZERO more emails   → expected 7 to be 40
× student with email disabled         → the opted-out student was emailed
× spans multiple tenants              → expected 1 to be 2
```

Covers both acceptance criteria directly: a second run in the same tenant-local day sends **zero** additional emails, and a student with `email: false` is not emailed even when the candidate set exceeds the cap.

## Guard against the next one

`tests/unit/unbounded-read-guard.test.ts` statically extracts every PostgREST chain against a table whose row count grows with usage and fails on any that never bounds itself. Pre-existing sites are recorded in `KNOWN_UNBOUNDED` as a ratchet, split into `scoped` (bounded by one user or one course) and `gap` (real tenant/platform-wide sweeps still outstanding under #540 — the admin analytics and dashboard revenue sums, the admin listings, and three more cron queues). A stale entry also fails the test, so the list cannot rot as things get fixed. The detector has its own tests, because a scan that silently stops matching looks exactly like a clean repository.

## Out of scope, deliberately

`rollover_all_leagues`' tenant loop is untouched — it runs entirely in PL/pgSQL and never crosses PostgREST, so the cap does not apply.

## Note for the reviewer

The migration is applied to **local only**. Cloud needs `supabase db push` before this ships, or the digest cron will call the RPC with three arguments it does not have.

## Gates

| | |
|---|---|
| `npm run typecheck` | clean |
| `npm run lint` | clean on every changed file |
| `npm run build` | compiled successfully |
| `npm run test:unit` | **446/446** (was 411 on this branch point; issue quotes 370 from the older `146a8cfa`) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0185GrowMKwTrLQE1it2HNGN