### PR TITLE
fix(editor): stop the add-block palette from being clipped by the viewport

### DIFF
--- a/components/teacher/block-editor/add-block-menu.tsx
+++ b/components/teacher/block-editor/add-block-menu.tsx
@@ -91,6 +91,10 @@ interface AddBlockMenuProps {
   position?: 'top' | 'inline' | 'between'
 }
 
+// The palette is taller than the room most triggers leave on screen; PopoverContent
+// caps itself at `--available-height` and scrolls, so all 23 blocks stay reachable.
+const PALETTE_POPOVER_CLASS = 'w-[360px] p-3'
+
 export function AddBlockMenu({ onSelect, position = 'inline' }: AddBlockMenuProps) {
   const [open, setOpen] = useState(false)
 
@@ -111,7 +115,7 @@ export function AddBlockMenu({ onSelect, position = 'inline' }: AddBlockMenuProp
             <IconPlus className="h-3 w-3" />
           </PopoverTrigger>
         </div>
-        <PopoverContent align="center" side="bottom" className="w-[340px] p-3" sideOffset={4}>
+        <PopoverContent align="center" side="bottom" className={PALETTE_POPOVER_CLASS} sideOffset={4}>
           <BlockPalette onSelect={handleSelect} />
         </PopoverContent>
       </Popover>
@@ -128,7 +132,7 @@ export function AddBlockMenu({ onSelect, position = 'inline' }: AddBlockMenuProp
           <IconPlus className="h-4 w-4" />
           Añadir bloque
         </PopoverTrigger>
-        <PopoverContent align="center" side="bottom" className="w-[340px] p-3" sideOffset={4}>
+        <PopoverContent align="center" side="bottom" className={PALETTE_POPOVER_CLASS} sideOffset={4}>
           <BlockPalette onSelect={handleSelect} />
         </PopoverContent>
       </Popover>
@@ -144,7 +148,7 @@ export function AddBlockMenu({ onSelect, position = 'inline' }: AddBlockMenuProp
       >
         <IconPlus className="h-4 w-4" />
       </PopoverTrigger>
-      <PopoverContent align="end" side="bottom" className="w-[340px] p-3" sideOffset={4}>
+      <PopoverContent align="end" side="bottom" className={PALETTE_POPOVER_CLASS} sideOffset={4}>
         <BlockPalette onSelect={handleSelect} />
       </PopoverContent>
     </Popover>
@@ -159,7 +163,7 @@ function BlockPalette({ onSelect }: { onSelect: (type: BlockType) => void }) {
     <div className="space-y-3">
       {BLOCK_GROUPS.map((group) => (
         <div key={group.label}>
-          <p className="mb-1.5 px-1 text-[10px] font-semibold uppercase tracking-widest text-muted-foreground/60">
+          <p className="mb-1.5 px-1 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
             {group.label}
           </p>
           <div className="grid grid-cols-3 gap-1.5">
@@ -181,7 +185,7 @@ function BlockPalette({ onSelect }: { onSelect: (type: BlockType) => void }) {
                   <div className={cn('flex h-8 w-8 items-center justify-center rounded-md', iconData.bg)}>
                     <Icon className={cn('h-4 w-4', iconData.color)} />
                   </div>
-                  <span className="text-[11px] font-medium leading-tight text-muted-foreground group-hover:text-foreground">
+                  <span className="text-xs font-medium leading-tight text-foreground/80 group-hover:text-foreground">
                     {meta?.label || type}
                   </span>
                 </button>

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -37,7 +37,7 @@ function PopoverContent({
         <PopoverPrimitive.Popup
           data-slot="popover-content"
           className={cn(
-            "z-50 flex w-72 origin-(--transform-origin) flex-col gap-4 rounded-lg bg-popover p-2.5 text-xs text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            "z-50 flex max-h-(--available-height) w-72 origin-(--transform-origin) flex-col gap-4 overflow-y-auto overscroll-contain rounded-lg bg-popover p-2.5 text-xs text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
             className
           )}
           {...props}


### PR DESCRIPTION
## Problem

In the teacher lesson editor (**Contenido** tab), clicking **Añadir bloque** opens a palette listing 23 block types across 5 groups — roughly **875px tall**. `PopoverContent` had no height cap and no scroll, so on a normal desktop viewport the bottom of the list was simply cut off: the **Separador** block was completely unreachable and the last **Estructura** row sat half off-screen.

Measured on a 1440×800 viewport with the lower "Añadir bloque" trigger: popup bottom at **880px** vs a **800px** viewport → **80px of blocks with no way to reach them**.

## Root cause

`components/ui/popover.tsx` was the only base-ui overlay primitive in the repo missing the height treatment its siblings already have — `select.tsx`, `dropdown-menu.tsx` and `combobox.tsx` all use `max-h-(--available-height)` + `overflow-y-auto` (base-ui sets `--available-height` on the positioner). So any popover taller than the space around its trigger overflowed the viewport. `lesson-component-picker.tsx` has the same latent bug.

## Changes

- `components/ui/popover.tsx` — add `max-h-(--available-height) overflow-y-auto overscroll-contain`, matching the other overlay primitives. Fixes every over-tall popover, not just this one.
- `components/teacher/block-editor/add-block-menu.tsx` — readability pass on the palette, since the user also reported it was hard to read:
  - item labels `text-[11px]` muted → `text-xs` at `text-foreground/80` (the 11px muted-on-popover pairing was below comfortable contrast)
  - group headings `text-[10px]` at `text-muted-foreground/60` → `text-[11px]` at full `text-muted-foreground`
  - popover width `340px` → `360px` so the larger labels still fit 3 columns

## Verification

- `npm run typecheck` — clean
- `npm run build` — passes
- `npx eslint` on both changed files — clean
- Browser-verified at 1440×800 as `creator@codeacademy.com` on `/es/dashboard/teacher/courses/2001/lessons/2001`:
  - **before** (cap disabled at runtime to reproduce): popup bottom `880px`, 80px clipped, "Separador" invisible
  - **after**: `max-height: 774px` = reported available height, popup bottom `780px` (inside the viewport), `scrollHeight 874 > clientHeight 774` → scrolls, and **Separador** is reachable

## QA script

1. `npm run dev`, sign in as `creator@codeacademy.com` / `password123` at `code-academy.lvh.me:3000`
2. Open a lesson: `/es/dashboard/teacher/courses/2001/lessons/2001` → **Contenido** tab
3. Click the lower **Añadir bloque** button (the one near the bottom of the page)
4. The palette should end inside the viewport and scroll internally — scroll to the bottom and confirm **Separador** under **ESTRUCTURA** is fully visible and clickable
5. Repeat with the small `+` inserter that appears when hovering between two blocks
6. Sanity-check the notification bell popover still renders normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MVN1bVpXJQ2CT7nv4acFRz