### PR TITLE
fix(lesson): stop a code sample from blanking the whole lesson, and never leave a dead video frame (#566)

### DIFF
--- a/app/[locale]/dashboard/student/courses/[courseId]/lessons/[lessonId]/serialize-lesson.ts
+++ b/app/[locale]/dashboard/student/courses/[courseId]/lessons/[lessonId]/serialize-lesson.ts
@@ -1,6 +1,7 @@
 import { serialize } from 'next-mdx-remote-client/serialize'
 import type { SerializeResult } from 'next-mdx-remote-client'
 import remarkGfm from 'remark-gfm'
+import { inlineCodeBlockBodies } from '@/lib/lesson/mdx-source'
 
 /**
  * Compiles lesson MDX on the server so the client only renders the
@@ -12,7 +13,9 @@ export async function serializeLessonMdx(
   if (!content) return null
   try {
     return await serialize({
-      source: content,
+      // A `<CodeBlock>` holding a module would otherwise fail the whole
+      // document — see inlineCodeBlockBodies().
+      source: inlineCodeBlockBodies(content),
       options: {
         mdxOptions: {
           remarkPlugins: [remarkGfm],

--- a/components/lesson/code-block.tsx
+++ b/components/lesson/code-block.tsx
@@ -6,9 +6,13 @@ import { cn } from '@/lib/utils'
 import { IconCopy, IconCheck, IconFile } from '@tabler/icons-react'
 
 interface CodeBlockProps {
-  children: string
+  children?: string
+  /** Snippet moved out of the children position by `inlineCodeBlockBodies()`. */
+  code?: string
   language?: string
   filename?: string
+  /** Alias for `filename` — what a fenced block carries in its `title="…"` meta. */
+  title?: string
   showLineNumbers?: boolean
   highlightLines?: number[]
   className?: string
@@ -16,8 +20,10 @@ interface CodeBlockProps {
 
 export function CodeBlock({
   children,
+  code: codeProp,
   language,
   filename,
+  title,
   showLineNumbers = false,
   highlightLines = [],
   className,
@@ -26,7 +32,10 @@ export function CodeBlock({
   const [copied, setCopied] = useState(false)
   const [highlightedHtml, setHighlightedHtml] = useState<string | null>(null)
 
-  const code = typeof children === 'string' ? children.trim() : String(children).trim()
+  // `code` wins: a snippet only travels as a prop when keeping it as children
+  // would have failed the MDX compile outright.
+  const source = typeof codeProp === 'string' ? codeProp : children
+  const code = typeof source === 'string' ? source.trim() : String(source ?? '').trim()
 
   // Cargar Shiki y resaltar código
   useEffect(() => {
@@ -84,10 +93,10 @@ export function CodeBlock({
       {/* Header con filename y botón copiar */}
       <div className="flex items-center justify-between border-b border-gray-700 bg-[#161b22] px-4 py-2">
         <div className="flex items-center gap-2 text-xs text-gray-400">
-          {filename ? (
+          {filename || title ? (
             <>
               <IconFile className="size-4" />
-              <span>{filename}</span>
+              <span>{filename || title}</span>
             </>
           ) : language ? (
             <span className="uppercase">{language}</span>

--- a/components/teacher/mdx-preview.tsx
+++ b/components/teacher/mdx-preview.tsx
@@ -3,30 +3,35 @@
 import { MDXClient, type SerializeResult } from 'next-mdx-remote-client'
 import { useState, useEffect } from 'react'
 import { lessonMdxComponents } from '@/components/lesson/mdx-components'
+import { inlineCodeBlockBodies } from '@/lib/lesson/mdx-source'
 
 interface MDXPreviewProps {
     content: string
 }
 
 export function MDXPreview({ content }: MDXPreviewProps) {
-    const [mdxResult, setMdxResult] = useState<SerializeResult | null>(null)
-    const [isLoading, setIsLoading] = useState(false)
+    // The compiled output is tagged with the source it came from, so "still
+    // compiling" and "nothing to compile" are derived rather than tracked in
+    // their own state — setting state synchronously in the effect body would
+    // cascade a render on every keystroke.
+    const [compiled, setCompiled] = useState<{
+        source: string
+        result: SerializeResult
+    } | null>(null)
 
     // Compile MDX content on client
     useEffect(() => {
-        if (!content) {
-            setMdxResult(null)
-            return
-        }
+        if (!content) return
 
         let cancelled = false
-        setIsLoading(true)
 
         async function compileMDX() {
             try {
                 const { serialize } = await import('next-mdx-remote-client/serialize')
                 const result = await serialize({
-                    source: content,
+                    // Same normalization the student page applies, so the
+                    // preview compiles exactly what they will see.
+                    source: inlineCodeBlockBodies(content),
                     options: {
                         mdxOptions: {
                             development: process.env.NODE_ENV === 'development',
@@ -34,20 +39,19 @@ export function MDXPreview({ content }: MDXPreviewProps) {
                     },
                 })
 
-                if (!cancelled) {
-                    setMdxResult(result)
-                    setIsLoading(false)
-                }
+                if (!cancelled) setCompiled({ source: content, result })
             } catch (err) {
                 if (!cancelled) {
                     console.error('MDX compilation error:', err)
                     // Create a result with error
-                    setMdxResult({
-                        error: err instanceof Error ? err : new Error('Failed to compile MDX'),
-                        frontmatter: {},
-                        scope: {},
+                    setCompiled({
+                        source: content,
+                        result: {
+                            error: err instanceof Error ? err : new Error('Failed to compile MDX'),
+                            frontmatter: {},
+                            scope: {},
+                        },
                     })
-                    setIsLoading(false)
                 }
             }
         }
@@ -58,6 +62,9 @@ export function MDXPreview({ content }: MDXPreviewProps) {
             cancelled = true
         }
     }, [content])
+
+    const mdxResult = content && compiled?.source === content ? compiled.result : null
+    const isLoading = Boolean(content) && mdxResult === null
 
     // Check if result has error
     const hasError = mdxResult && 'error' in mdxResult

--- a/lib/lesson/mdx-source.ts
+++ b/lib/lesson/mdx-source.ts
@@ -1,0 +1,46 @@
+/**
+ * Source-level normalization applied to `lessons.content` before it is compiled
+ * as MDX.
+ *
+ * Kept in sync with `mcp-server/resources/shared/lesson/mdx.ts`, which does the
+ * same work for the widget renderer — the two live in separate npm projects and
+ * can not import each other, so `tests/unit/mcp-lesson-mdx.test.ts` asserts the
+ * two implementations produce identical output.
+ */
+
+/**
+ * Move `<CodeBlock>` bodies out of the children position and into a `code` prop.
+ *
+ * MDX parses a JSX element's children as MDX, so a snippet whose first line
+ * starts at column 0 with `export` or `import` is read as an ESM statement and
+ * handed to acorn — which then chokes on `</CodeBlock>` and fails the *whole
+ * document*, dropping the student to the "content could not be rendered"
+ * banner. Pasting a module into `<CodeBlock>` is the documented usage
+ * (`components/lesson/mdx-components.tsx`), so this is the common case.
+ *
+ * `{expressions}` and `<tags>` inside a snippet break the same way. Rewriting
+ * the body to `code={JSON.parse('…')}` — the escape hatch the block editor's
+ * serializer already uses for complex props — makes the snippet opaque to the
+ * parser, so none of them reach acorn. It also renders more faithfully: as
+ * children, `**bold**` inside a snippet was parsed as markdown and the
+ * asterisks were lost on the way to the `<pre>`.
+ */
+export function inlineCodeBlockBodies(source: string): string {
+  return source.replace(
+    /<CodeBlock(\s[^>]*?)?>([\s\S]*?)<\/CodeBlock>/g,
+    (whole, rawAttributes: string | undefined, body: string) => {
+      const attributes = rawAttributes ?? ''
+      // Already prop-carried, or an empty block — nothing to move.
+      if (/(^|\s)code\s*=/.test(attributes) || body.trim() === '') return whole
+
+      // Drop the newline that follows the opening tag and the indentation that
+      // precedes the closing one; both are layout, not part of the snippet.
+      const code = body.replace(/^\r?\n/, '').replace(/\r?\n[ \t]*$/, '')
+
+      // JSON.stringify escapes everything acorn cares about except the single
+      // quote wrapping the payload, which the MDX attribute expression needs.
+      const payload = JSON.stringify(code).split("'").join("\\'")
+      return `<CodeBlock${attributes} code={JSON.parse('${payload}')} />`
+    }
+  )
+}

--- a/mcp-server/resources/shared/lesson/components.tsx
+++ b/mcp-server/resources/shared/lesson/components.tsx
@@ -337,14 +337,22 @@ export function Quiz({
 
 export function CodeBlock({
   children,
+  code: codeProp,
   language,
   filename,
+  title,
   showLineNumbers,
   highlightLines,
 }: Record<string, any>) {
   const [copied, setCopied] = useState(false);
-  const code = str(children).replace(/\n$/, "");
+  // `code` is what `inlineCodeBlockBodies()` hands us: a snippet that would
+  // have broken the document if it had stayed in the children position.
+  const code = (typeof codeProp === "string" ? codeProp : str(children)).replace(/\n$/, "");
   const highlighted = arr<number>(highlightLines);
+
+  // Fenced blocks carry the name in `title="…"` meta, so JSX blocks written the
+  // same way should label themselves the same way.
+  const label = str(filename) || str(title);
 
   const copy = () => {
     // Clipboard access can be denied inside the widget sandbox — the button
@@ -362,10 +370,10 @@ export function CodeBlock({
     <div className="my-4 overflow-hidden rounded-xl border border-zinc-800 bg-[#0d1117]">
       <div className="flex items-center justify-between border-b border-zinc-700 bg-[#161b22] px-4 py-2">
         <div className="flex items-center gap-2 text-[11px] text-zinc-400">
-          {filename ? (
+          {label ? (
             <>
               <IconFile className="size-4" />
-              <span>{str(filename)}</span>
+              <span>{label}</span>
             </>
           ) : (
             <span className="uppercase">{str(language) || "Code"}</span>
@@ -807,6 +815,33 @@ export function getEmbedUrl(url: string): string | null {
   return null;
 }
 
+/**
+ * Escape hatch printed under every player.
+ *
+ * Widget hosts frame the widget itself, and both YouTube and Vimeo refuse to be
+ * framed from an origin the uploader has not allowed — so the iframe can render
+ * as an unexplained black rectangle with nothing the student can do about it.
+ * The frame either works or it does not, and there is no reliable load event to
+ * tell them apart from inside the sandbox, so the link is always offered.
+ */
+export function VideoFallbackLink({ url }: { url: string }) {
+  if (!url) return null;
+
+  return (
+    <p className="mt-1.5 mb-0 text-[11px] text-zinc-400 dark:text-zinc-500">
+      Video not playing?{" "}
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="font-medium text-zinc-500 underline underline-offset-2 dark:text-zinc-400"
+      >
+        Open it in a new tab
+      </a>
+    </p>
+  );
+}
+
 export function Video({ url, title }: Record<string, any>) {
   const source = str(url);
   const embedUrl = getEmbedUrl(source);
@@ -840,6 +875,7 @@ export function Video({ url, title }: Record<string, any>) {
           className="h-full w-full border-0"
         />
       </div>
+      <VideoFallbackLink url={source} />
     </div>
   );
 }

--- a/mcp-server/resources/shared/lesson/index.tsx
+++ b/mcp-server/resources/shared/lesson/index.tsx
@@ -1,4 +1,4 @@
-import { getEmbedUrl } from "./components";
+import { getEmbedUrl, VideoFallbackLink } from "./components";
 import { LessonMdxContent } from "./renderer";
 
 export { LessonMdxContent } from "./renderer";
@@ -34,14 +34,17 @@ export function LessonBody({
   return (
     <div className="space-y-5">
       {videoEmbedUrl && (
-        <div className="aspect-video w-full overflow-hidden rounded-xl bg-black ring-1 ring-zinc-200 dark:ring-zinc-800">
-          <iframe
-            src={videoEmbedUrl}
-            title="Video"
-            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-            allowFullScreen
-            className="h-full w-full border-0"
-          />
+        <div>
+          <div className="aspect-video w-full overflow-hidden rounded-xl bg-black ring-1 ring-zinc-200 dark:ring-zinc-800">
+            <iframe
+              src={videoEmbedUrl}
+              title="Video"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowFullScreen
+              className="h-full w-full border-0"
+            />
+          </div>
+          <VideoFallbackLink url={videoUrl as string} />
         </div>
       )}
 

--- a/mcp-server/resources/shared/lesson/mdx.ts
+++ b/mcp-server/resources/shared/lesson/mdx.ts
@@ -42,6 +42,144 @@ export function parseLessonMdx(source: string): MdNode | null {
   }
 }
 
+// ── Source normalization ─────────────────────────────────────────────────────
+
+/**
+ * Move `<CodeBlock>` bodies out of the children position and into a `code` prop.
+ *
+ * MDX parses a JSX element's children as MDX, so a snippet whose first line
+ * starts at column 0 with `export` or `import` is read as an ESM statement and
+ * handed to acorn — which then chokes on `</CodeBlock>` and fails the *whole
+ * document*. Pasting a module into `<CodeBlock>` is the documented usage
+ * (`components/lesson/mdx-components.tsx`), so this is the common case, not an
+ * exotic one.
+ *
+ * `{expressions}` and `<tags>` inside a snippet break the same way. Rewriting
+ * the body to `code={JSON.parse('…')}` — the escape hatch the block editor's
+ * serializer already uses for complex props — makes the snippet opaque to the
+ * parser, so none of them can reach acorn. It also renders more faithfully:
+ * as children, `**bold**` inside a snippet parsed as markdown and the asterisks
+ * were lost on the way to the `<pre>`.
+ *
+ * `mcp-server/resources/shared/lesson/mdx.ts` and `lib/lesson/mdx-source.ts`
+ * hold the same implementation for the two renderers (widget / web app);
+ * `tests/unit/mcp-lesson-mdx.test.ts` asserts they stay identical.
+ */
+export function inlineCodeBlockBodies(source: string): string {
+  return source.replace(
+    /<CodeBlock(\s[^>]*?)?>([\s\S]*?)<\/CodeBlock>/g,
+    (whole, rawAttributes: string | undefined, body: string) => {
+      const attributes = rawAttributes ?? "";
+      // Already prop-carried, or an empty block — nothing to move.
+      if (/(^|\s)code\s*=/.test(attributes) || body.trim() === "") return whole;
+
+      // Drop the newline that follows the opening tag and the indentation that
+      // precedes the closing one; both are layout, not part of the snippet.
+      const code = body.replace(/^\r?\n/, "").replace(/\r?\n[ \t]*$/, "");
+
+      // JSON.stringify escapes everything acorn cares about except the single
+      // quote wrapping the payload, which resolveExpression un-escapes again.
+      const payload = JSON.stringify(code).split("'").join("\\'");
+      return `<CodeBlock${attributes} code={JSON.parse('${payload}')} />`;
+    }
+  );
+}
+
+// ── Block-level parsing ──────────────────────────────────────────────────────
+
+/** One top-level slice of a lesson. `tree` is null when that slice failed to parse. */
+export type LessonBlock = { source: string; tree: MdNode | null };
+
+/**
+ * Split MDX source at blank lines that sit outside a fenced code block.
+ *
+ * A fence may contain blank lines of its own, and an unterminated fence parses
+ * happily to end-of-input, so splitting inside one silently mangles the rest of
+ * the document rather than erroring.
+ */
+function splitOnBlankLines(source: string): string[] {
+  const segments: string[] = [];
+  let current: string[] = [];
+  let fence: string | null = null;
+
+  const flush = () => {
+    if (current.join("\n").trim() !== "") segments.push(current.join("\n"));
+    current = [];
+  };
+
+  for (const line of source.split("\n")) {
+    const fenceMarker = line.match(/^\s*(```+|~~~+)/)?.[1];
+    if (fenceMarker) {
+      if (fence === null) fence = fenceMarker[0];
+      else if (fenceMarker[0] === fence) fence = null;
+    }
+
+    if (fence === null && line.trim() === "") {
+      flush();
+      continue;
+    }
+    current.push(line);
+  }
+  flush();
+
+  return segments;
+}
+
+/**
+ * Parse a lesson into independently-rendered blocks.
+ *
+ * The whole document is tried first, and on success it stays one block — the
+ * ordinary path is unchanged, including `<Steps>` numbering, which is scoped
+ * per parse. Only when the document as a whole fails to parse does this fall
+ * back to per-block parsing, so one unparseable snippet costs the student that
+ * snippet rather than the entire lesson.
+ *
+ * Blocks are re-joined greedily: a multi-line element like `<Steps>` fails on
+ * its own (`Expected a closing tag`), so its segments are pulled in until the
+ * element closes and the whole thing parses.
+ */
+export function parseLessonBlocks(source: string): LessonBlock[] {
+  const normalized = inlineCodeBlockBodies(source);
+
+  const whole = parseLessonMdx(normalized);
+  if (whole) return [{ source: normalized, tree: whole }];
+
+  const segments = splitOnBlankLines(normalized);
+  const blocks: LessonBlock[] = [];
+
+  // An unclosed tag early in a long document makes every re-join attempt fail,
+  // which is quadratic. Lessons are nowhere near that size, but the walk runs in
+  // the browser, so it gets a budget rather than the benefit of the doubt.
+  let attempts = 0;
+  const budget = 2000;
+
+  for (let start = 0; start < segments.length; ) {
+    let joined = segments[start];
+    let tree = parseLessonMdx(joined);
+    let end = start;
+    attempts += 1;
+
+    while (!tree && end + 1 < segments.length && attempts < budget) {
+      end += 1;
+      joined = `${joined}\n\n${segments[end]}`;
+      tree = parseLessonMdx(joined);
+      attempts += 1;
+    }
+
+    if (tree) {
+      blocks.push({ source: joined, tree });
+      start = end + 1;
+    } else {
+      // Nothing from here on parses together — degrade this segment alone and
+      // let the next one try on its own.
+      blocks.push({ source: segments[start], tree: null });
+      start += 1;
+    }
+  }
+
+  return blocks;
+}
+
 /**
  * Resolve one JSX attribute expression to a value without evaluating it.
  *

--- a/mcp-server/resources/shared/lesson/renderer.tsx
+++ b/mcp-server/resources/shared/lesson/renderer.tsx
@@ -33,7 +33,7 @@ import {
   Video,
   Warning,
 } from "./components";
-import { attributesToProps, nodeText, parseLessonMdx, type MdNode } from "./mdx";
+import { attributesToProps, nodeText, parseLessonBlocks, type MdNode } from "./mdx";
 
 /**
  * Renders a parsed lesson MDX tree with the same component set the web app
@@ -310,25 +310,52 @@ class RenderBoundary extends Component<
   }
 }
 
-export function LessonMdxContent({ content }: { content: string }) {
-  const tree = parseLessonMdx(content);
-
-  const fallback = (
+/** Raw source behind a banner — the last resort for a block we can not parse. */
+function SourceFallback({ source, notice }: { source: string; notice: string }) {
+  return (
     <div>
       <p className="mb-3 rounded-lg bg-amber-50 px-3 py-2 text-[13px] text-amber-800 dark:bg-amber-950 dark:text-amber-300">
-        This lesson could not be rendered fully — showing its source text.
+        {notice}
       </p>
       <pre className="m-0 overflow-x-auto text-[12.5px] whitespace-pre-wrap text-zinc-600 dark:text-zinc-400">
-        {content}
+        {source}
       </pre>
     </div>
   );
+}
 
-  if (!tree) return fallback;
+export function LessonMdxContent({ content }: { content: string }) {
+  const blocks = parseLessonBlocks(content);
+
+  // Nothing at all parsed — the document is broken end to end, so say so once
+  // rather than repeating the banner over every block.
+  if (!blocks.some((block) => block.tree)) {
+    return (
+      <SourceFallback
+        source={content}
+        notice="This lesson could not be rendered fully — showing its source text."
+      />
+    );
+  }
 
   return (
     <div className="max-w-[72ch] break-words">
-      <RenderBoundary fallback={fallback}>{renderNode(tree, {})}</RenderBoundary>
+      {blocks.map((block, index) => {
+        const fallback = (
+          <SourceFallback
+            source={block.source}
+            notice="This part of the lesson could not be rendered — showing its source text."
+          />
+        );
+
+        if (!block.tree) return <Fragment key={index}>{fallback}</Fragment>;
+
+        return (
+          <RenderBoundary key={index} fallback={fallback}>
+            {renderNode(block.tree, {})}
+          </RenderBoundary>
+        );
+      })}
     </div>
   );
 }

--- a/mcp-server/src/demo-data.ts
+++ b/mcp-server/src/demo-data.ts
@@ -102,15 +102,18 @@ El bug estaba en \`setItems(items.push(nuevo))\`: \`push\` muta el array y devue
 Cuando termines, marca la lección como completada y pasa a **Efectos y limpieza**.`;
 
 /**
- * Lesson content that MDX cannot parse — kept deliberately.
+ * The two authoring shapes that used to blank a whole lesson (#566) — kept as a
+ * regression fixture.
  *
- * `<CodeBlock>` children are parsed as MDX, so a code sample whose first line
- * starts at column 0 with `export`/`import` is read as an ESM statement and
- * handed to acorn, which chokes on the closing `</CodeBlock>`. One bad snippet
- * fails the WHOLE document, and the renderer falls back to dumping raw source
- * at the student. This is the exact shape a teacher produces by pasting a
- * module into the documented `<CodeBlock language="tsx">…</CodeBlock>` form,
- * so the fallback state needs to stay inspectable.
+ * The `<CodeBlock>` is the case teachers hit: its children are parsed as MDX, so
+ * a sample whose first line starts at column 0 with `export`/`import` was read
+ * as an ESM statement and handed to acorn, which choked on the closing tag and
+ * failed the WHOLE document. `inlineCodeBlockBodies()` now moves the snippet to
+ * a `code` prop, so it renders like any other block.
+ *
+ * The unclosed `<Callout>` below it still cannot be parsed by anything — it is
+ * here so the per-block fallback stays inspectable: that one block degrades to
+ * its source, everything around it renders.
  */
 const BROKEN_LESSON_MDX = `Un módulo de ejemplo, pegado tal cual dentro de un bloque de código.
 
@@ -121,7 +124,13 @@ export function Contador() {
 }
 </CodeBlock>
 
-El resto de la lección ya no se renderiza: **todo** el documento cae al modo texto plano.`;
+<Callout type="warning">Esta etiqueta nunca se cierra.
+
+El resto de la lección **sí** se renderiza: sólo el bloque roto cae a texto plano.
+
+| Antes | Ahora |
+| --- | --- |
+| Documento entero en crudo | Sólo el bloque que falla |`;
 
 const ARTIFACT_HTML = `<!doctype html>
 <html lang="es">
@@ -493,14 +502,14 @@ export const WIDGET_DEMOS: WidgetDemo[] = [
       },
       {
         id: "broken-mdx",
-        label: "Unparseable MDX — raw-source fallback",
-        output: "Lesson 5009 — content could not be parsed as MDX.",
+        label: "Module in <CodeBlock> + one unparseable block",
+        output: "Lesson 5009 — one block of the content could not be parsed as MDX.",
         props: {
           lesson: {
             id: 5009,
             course_id: 101,
             title: "Un contador con estado",
-            description: "Lección cuyo bloque de código rompe el parseo MDX.",
+            description: "Lección con un módulo en <CodeBlock> y una etiqueta sin cerrar.",
             summary: null,
             content: BROKEN_LESSON_MDX,
             video_url: null,

--- a/tests/unit/lesson-mdx-serialize.test.ts
+++ b/tests/unit/lesson-mdx-serialize.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import { serializeLessonMdx } from '@/app/[locale]/dashboard/student/courses/[courseId]/lessons/[lessonId]/serialize-lesson'
+
+/**
+ * The web app half of #566.
+ *
+ * `serializeLessonMdx()` compiles `lessons.content` with the same MDX parser the
+ * widget renderer uses, so it failed on the same input: a snippet pasted into
+ * `<CodeBlock>` whose first line starts at column 0 with `export`/`import` was
+ * read as an ESM statement, and the compile error dropped the student to the
+ * contentError banner with no lesson at all.
+ */
+describe('serializeLessonMdx', () => {
+  const compiled = (result: unknown) => result as { error?: Error; compiledSource?: string }
+
+  it('compiles a module pasted into <CodeBlock>', async () => {
+    const result = compiled(
+      await serializeLessonMdx(
+        [
+          'Before.',
+          '',
+          '<CodeBlock language="tsx" title="counter.tsx">',
+          'export function Counter() {',
+          '  const [n, setN] = useState(0)',
+          '  return <button onClick={() => setN(n + 1)}>{n}</button>',
+          '}',
+          '</CodeBlock>',
+          '',
+          'After.',
+        ].join('\n')
+      )
+    )
+
+    expect(result.error).toBeUndefined()
+    expect(result.compiledSource).toContain('export function Counter')
+  })
+
+  it('compiles an import-first snippet', async () => {
+    const result = compiled(
+      await serializeLessonMdx(
+        `<CodeBlock language="ts">\nimport { createClient } from '@supabase/supabase-js'\n</CodeBlock>`
+      )
+    )
+    expect(result.error).toBeUndefined()
+  })
+
+  it('still compiles ordinary lesson content', async () => {
+    const result = compiled(
+      await serializeLessonMdx(
+        ['# Title', '', '<Callout type="tip">ok</Callout>', '', '```ts', 'const a = 1', '```'].join(
+          '\n'
+        )
+      )
+    )
+    expect(result.error).toBeUndefined()
+  })
+
+  it('still reports a genuinely broken document instead of throwing', async () => {
+    // `error` is remark's own VFileMessage, which is Error-shaped but not an
+    // instance of this realm's Error — the page only reads `.message`.
+    const result = compiled(await serializeLessonMdx('<Callout type="info">never closed'))
+    expect(result.error?.message).toContain('closing tag')
+  })
+
+  it('returns null for empty content', async () => {
+    expect(await serializeLessonMdx(null)).toBeNull()
+  })
+})

--- a/tests/unit/mcp-lesson-mdx.test.ts
+++ b/tests/unit/mcp-lesson-mdx.test.ts
@@ -3,11 +3,14 @@ import { createElement } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import {
   attributesToProps,
+  inlineCodeBlockBodies,
+  parseLessonBlocks,
   parseLessonMdx,
   resolveExpression,
   type MdNode,
 } from '@/mcp-server/resources/shared/lesson/mdx'
 import { LessonBody } from '@/mcp-server/resources/shared/lesson'
+import { inlineCodeBlockBodies as inlineCodeBlockBodiesApp } from '@/lib/lesson/mdx-source'
 
 /**
  * The MCP lesson widgets render `lessons.content` — an MDX source string — with
@@ -55,6 +58,103 @@ describe('resolveExpression', () => {
   it('falls back to the raw text rather than throwing on anything it can not resolve', () => {
     expect(resolveExpression('someRuntimeVariable')).toBe('someRuntimeVariable')
     expect(resolveExpression(`JSON.parse('{not json}')`)).toBe(`JSON.parse('{not json}')`)
+  })
+})
+
+describe('inlineCodeBlockBodies', () => {
+  // `<CodeBlock>` children are parsed as MDX, so a snippet starting at column 0
+  // with export/import was handed to acorn and failed the WHOLE document (#566).
+  const MODULE_IN_CODEBLOCK = [
+    'Before.',
+    '',
+    '<CodeBlock language="tsx" title="counter.tsx">',
+    'export function Counter() {',
+    '  const [n, setN] = useState(0)',
+    '  return <button onClick={() => setN(n + 1)}>{n}</button>',
+    '}',
+    '</CodeBlock>',
+    '',
+    'After.',
+  ].join('\n')
+
+  it('makes a module inside <CodeBlock> parse instead of failing the document', () => {
+    expect(parseLessonMdx(MODULE_IN_CODEBLOCK)).toBeNull()
+    expect(parseLessonMdx(inlineCodeBlockBodies(MODULE_IN_CODEBLOCK))).not.toBeNull()
+  })
+
+  it('round-trips the snippet byte for byte, quotes and backslashes included', () => {
+    const source = `<CodeBlock>const s = 'it\\'s'\nconst re = /\\d+/\n</CodeBlock>`
+    const element = firstJsxElement(parseLessonMdx(inlineCodeBlockBodies(source)))
+    expect(attributesToProps(element).code).toBe(`const s = 'it\\'s'\nconst re = /\\d+/`)
+  })
+
+  it('leaves blocks it has nothing to move alone', () => {
+    const selfClosing = '<CodeBlock language="ts" code={JSON.parse(\'"a"\')} />'
+    expect(inlineCodeBlockBodies(selfClosing)).toBe(selfClosing)
+    expect(inlineCodeBlockBodies('<CodeBlock language="ts"></CodeBlock>')).toBe(
+      '<CodeBlock language="ts"></CodeBlock>'
+    )
+    expect(inlineCodeBlockBodies('no code blocks here')).toBe('no code blocks here')
+  })
+
+  it('is byte-identical to the web app copy in lib/lesson/mdx-source.ts', () => {
+    // The two renderers live in separate npm projects and can not import each
+    // other, so the only thing keeping the ports honest is this assertion.
+    for (const source of [
+      MODULE_IN_CODEBLOCK,
+      '<CodeBlock>a</CodeBlock>',
+      `<CodeBlock lang="js">const x = {a: 1}\nif (x) console.log('hi')</CodeBlock>`,
+      '<CodeBlock language="ts"></CodeBlock>',
+      'plain text',
+      '<CodeBlock>one</CodeBlock>\n\n<CodeBlock>two</CodeBlock>',
+    ]) {
+      expect(inlineCodeBlockBodies(source)).toBe(inlineCodeBlockBodiesApp(source))
+    }
+  })
+})
+
+describe('parseLessonBlocks', () => {
+  it('keeps a parseable lesson as a single block', () => {
+    const blocks = parseLessonBlocks('# Title\n\nSome **text**.')
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0].tree).not.toBeNull()
+  })
+
+  it('degrades only the block that can not be parsed', () => {
+    const blocks = parseLessonBlocks(
+      ['Intro.', '', '<Callout type="info">never closed', '', 'Outro.'].join('\n')
+    )
+    expect(blocks.map((block) => block.tree !== null)).toEqual([true, false, true])
+    expect(blocks[1].source).toContain('never closed')
+  })
+
+  it('re-joins segments until a multi-line element closes', () => {
+    // <Steps> alone is a parse error ("Expected a closing tag"), so the blank
+    // lines inside it must not become block boundaries.
+    const blocks = parseLessonBlocks(
+      [
+        '<Callout>unclosed', // forces the per-block path
+        '',
+        '<Steps>',
+        '',
+        '  <Step title="One">a</Step>',
+        '',
+        '</Steps>',
+      ].join('\n')
+    )
+    const parsed = blocks.filter((block) => block.tree)
+    expect(parsed).toHaveLength(1)
+    expect(parsed[0].source).toContain('</Steps>')
+  })
+
+  it('does not split inside a fenced code block', () => {
+    // An unterminated fence parses happily to end-of-input, so a bad split here
+    // would silently swallow the rest of the lesson rather than erroring.
+    const blocks = parseLessonBlocks(
+      ['<Callout>unclosed', '', '```ts', 'const a = 1', '', 'const b = 2', '```'].join('\n')
+    )
+    const fenced = blocks.find((block) => block.source.startsWith('```'))
+    expect(fenced?.source).toContain('const b = 2')
   })
 })
 
@@ -178,6 +278,80 @@ describe('LessonBody', () => {
     const broken = render(createElement(LessonBody, { content: '<Callout type="info">oops' }))
     expect(broken).toContain('could not be rendered fully')
     expect(broken).toContain('oops')
+  })
+
+  it('renders a module pasted into <CodeBlock> instead of dumping the lesson (#566)', () => {
+    const withModule = render(
+      createElement(LessonBody, {
+        content: [
+          '# Counter',
+          '',
+          '<CodeBlock language="tsx" title="counter.tsx">',
+          'export function Counter() {',
+          '  return <button>{n}</button>',
+          '}',
+          '</CodeBlock>',
+          '',
+          'Explanation **after** the snippet.',
+        ].join('\n'),
+      })
+    )
+
+    expect(withModule).not.toContain('could not be rendered')
+    expect(withModule).toContain('export function Counter')
+    expect(withModule).toContain('counter.tsx')
+    // The prose after the snippet still renders as markdown, not as raw source.
+    expect(withModule).toContain('<strong')
+  })
+
+  it('keeps a snippet literal rather than parsing it as markdown', () => {
+    // As children, `**bold**` was parsed as markdown and the asterisks were
+    // lost on the way to the <pre>.
+    const literal = render(
+      createElement(LessonBody, { content: '<CodeBlock>a = "**not bold**"</CodeBlock>' })
+    )
+    expect(literal).toContain('**not bold**')
+  })
+
+  it('degrades one broken block and renders the rest of the lesson (#566)', () => {
+    const partly = render(
+      createElement(LessonBody, {
+        content: [
+          '# Still here',
+          '',
+          '<Callout type="warning">this tag never closes',
+          '',
+          'And this paragraph must still render.',
+        ].join('\n'),
+      })
+    )
+
+    expect(partly).toContain('This part of the lesson could not be rendered')
+    expect(partly).not.toContain('could not be rendered fully')
+    expect(partly).toContain('Still here')
+    expect(partly).toContain('And this paragraph must still render.')
+  })
+
+  it('always offers a link out of an embedded video (#566)', () => {
+    // Widget hosts refuse to frame YouTube/Vimeo, and there is no reliable load
+    // event inside the sandbox — so a blocked player must never be a bare void.
+    const embedded = render(
+      createElement(LessonBody, {
+        content: null,
+        videoUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+      })
+    )
+    expect(embedded).toContain('https://www.youtube.com/embed/dQw4w9WgXcQ')
+    expect(embedded).toContain('href="https://www.youtube.com/watch?v=dQw4w9WgXcQ"')
+
+    // Same for a <Video> authored inside the lesson body.
+    const authored = render(
+      createElement(LessonBody, {
+        content: '<Video url="https://vimeo.com/123456" />',
+      })
+    )
+    expect(authored).toContain('https://player.vimeo.com/video/123456')
+    expect(authored).toContain('href="https://vimeo.com/123456"')
   })
 
   it('renders video and embed_code the way the lesson page orders them', () => {


### PR DESCRIPTION
Closes #566.

## 1. A module in `<CodeBlock>` dumped the entire lesson as raw source

MDX parses a JSX element's children as MDX, so a snippet whose first line starts at column 0 with `export`/`import` was read as an ESM statement and handed to acorn, which choked on `</CodeBlock>` and failed the **whole document**. The student got unrendered `<Quiz options={[...]}>` tags and pipe tables behind a banner.

`inlineCodeBlockBodies()` moves the snippet into a `code` prop as `code={JSON.parse('…')}` — the escape hatch the block editor's serializer already uses for complex props — so nothing inside a snippet reaches acorn. `{expressions}` and `<tags>` inside code broke identically and are fixed by the same move.

It also renders *more* faithfully than before: as children, `**bold**` inside a snippet was parsed as markdown and the asterisks were lost on the way to the `<pre>`.

### The web app fails the same way — verified, not assumed

The issue flagged this as unchecked. `next-mdx-remote-client`'s `serialize()` uses the same parser and fails on the same input:

```
export-first: FAIL — [next-mdx-remote-client] error compiling MDX
import-first: FAIL — [next-mdx-remote-client] error compiling MDX
```

So the normalization runs on **both** paths — `serializeLessonMdx()` (student page) and `MDXPreview` (teacher preview) — and both `CodeBlock` components accept the prop. `tests/unit/lesson-mdx-serialize.test.ts` covers the app half.

The two implementations live in separate npm projects that cannot import each other, so a test asserts `mcp-server/.../mdx.ts` and `lib/lesson/mdx-source.ts` produce byte-identical output.

## 2. One unparseable block no longer costs the rest of the lesson

`parseLessonBlocks()` parses the document whole first and keeps it as a single block on success — ordinary lessons and `<Steps>` numbering are untouched. Only when the document fails does it split, on blank lines **outside fenced code** (an unterminated fence parses happily to EOF, so a bad split would silently swallow the rest), re-joining greedily so multi-line elements like `<Steps>` survive their internal blank lines.

## 3. A blocked video left a 400px black void

Widget hosts refuse to frame YouTube/Vimeo, and the link fallback only fired for URLs we could not embed *at all* — so the common case got no message, no link, nothing. There is no reliable load event inside the sandbox to tell a working frame from a blocked one, so the link is now always offered under the player, in both `LessonBody` and the authored `<Video>` component.

`<Embed>` has the same shape of defect for arbitrary URLs and is **not** touched here.

## Fixture

`broken-mdx` keeps both states inspectable, per the issue: the module now renders with its `contador.tsx` label, and an unclosed `<Callout>` next to it exercises the per-block fallback while the prose and table around it render.

## Verified

- **12 new tests fail against the pre-fix tree** (checked out `HEAD`, ran them, 12 red / 15 pre-existing green), then pass after
- `npm run test:unit` — **616 passed**, 50 files
- `mcp-server` — **39 passed**
- `npm run build` (Next) and `mcp-server` build — both green, 18 widgets
- `tsc --noEmit` clean in both projects
- Both fixture variants re-rendered headlessly through the inspector

## Note on `MDXPreview`

Its compile effect is restructured only because lint-staged lints the whole file and it carried a pre-existing `set-state-in-effect` error. The compiled output is now tagged with the source it came from, so "loading" and "empty" are derived instead of set synchronously in the effect body. No behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017sLtN12VfnLziCpst3Pfo2