### PR TITLE
feat(mcp): widget UX polish — i18n, colour semantics, CTAs, dead payload data, card alignment (#570)

### DIFF
--- a/mcp-server/docs/WIDGET_DEMO_DATA.md
+++ b/mcp-server/docs/WIDGET_DEMO_DATA.md
@@ -78,6 +78,37 @@ Two constraints worth knowing before you touch this:
 Preview any widget under a fake school with the `brand` argument on the demo
 tools: `none` (default), `ocean`, `sunset`, `forest`.
 
+> Until #570 this argument did nothing. `src/tools/demo.ts` computed the brand
+> and named it in the output text but never attached it to the result's
+> `_meta`, so every "branded" preview rendered the platform violet. It now
+> passes it through `widget({ metadata })`, the same sideband the real server
+> uses.
+
+## Language
+
+Widget chrome is en/es. The language comes from the host —
+`useWidget().locale`, a BCP 47 tag (SEP-1865 `HostContext.locale`) — and
+`resources/shared/i18n.tsx` turns it into a string table plus `Intl`
+formatters. Only strings the widget owns are translated; course titles, lesson
+titles and tags come out of the database in the school's own language and are
+rendered verbatim.
+
+The preview harness supplies **no** host locale, so everything would otherwise
+render at the `"en"` default and the Spanish half would never be reviewable.
+Pass `lang=es` (or `en`) to any demo tool to pin it:
+
+```bash
+npx mcp-use client screenshot --mcp http://localhost:3000/mcp \
+  --tool lms_demo_school_overview variant=default lang=es \
+  --width 1100 --height 800 --theme dark --output es.png
+```
+
+That rides the same `_meta` channel as branding (`lms/locale`, see
+`src/locale.ts`). Nothing in production sets it — the host stays the source of
+truth. The fixtures are deliberately Spanish, so `lang=es` is the combination
+that matches a real school, and `lang=en` next to Spanish content is the
+mismatch #570 was filed about.
+
 ## Editing fixtures
 
 Fixtures must satisfy each widget's own `propsSchema`. When you change a widget

--- a/mcp-server/resources/course-catalog/widget.tsx
+++ b/mcp-server/resources/course-catalog/widget.tsx
@@ -7,6 +7,7 @@ import {
   type WidgetMetadata,
 } from "mcp-use/react";
 import { Brand } from "../shared/branding";
+import { useFormat, useStrings } from "../shared/i18n";
 import { z } from "zod";
 
 // ── Schema ──────────────────────────────────────────────────────────────────
@@ -21,6 +22,10 @@ const courseSchema = z.object({
   enrolled: z.boolean(),
   has_access: z.boolean(),
   covered_by_plan: z.boolean(),
+  // Cheapest active product covering this course. `null` = not individually
+  // for sale. Optional so a payload from an older server still validates.
+  price: z.number().nullable().optional(),
+  currency: z.string().nullable().optional(),
 });
 
 const propsSchema = z.object({
@@ -41,6 +46,44 @@ export const widgetMetadata: WidgetMetadata = {
 };
 
 type Props = z.infer<typeof propsSchema>;
+
+// ── Strings ──────────────────────────────────────────────────────────────────
+
+const STRINGS = {
+  en: {
+    loading: "Browsing catalog…",
+    title: "Course Catalog",
+    summary: (n: number, s: string) => `${s} published course${n === 1 ? "" : "s"}`,
+    subscriptionActive: " · subscription active",
+    empty: "No published courses found",
+    lessons: (n: number, s: string) => `${s} lesson${n === 1 ? "" : "s"}`,
+    enrolled: "✓ Enrolled",
+    // One verb for "get into this course", whichever entitlement gets you in.
+    start: "Start course",
+    enrolling: "Enrolling…",
+    getAccess: "Get access",
+    notInPlan: "Not in your plan",
+    free: "Free",
+    enrollFailed: (title: string) => `Could not enroll in "${title}". Please try again.`,
+  },
+  es: {
+    loading: "Explorando el catálogo…",
+    title: "Catálogo de cursos",
+    summary: (n: number, s: string) =>
+      `${s} ${n === 1 ? "curso publicado" : "cursos publicados"}`,
+    subscriptionActive: " · suscripción activa",
+    empty: "No se encontraron cursos publicados",
+    lessons: (n: number, s: string) => `${s} ${n === 1 ? "lección" : "lecciones"}`,
+    enrolled: "✓ Inscrito",
+    start: "Empezar curso",
+    enrolling: "Inscribiendo…",
+    getAccess: "Obtener acceso",
+    notInPlan: "No incluido en tu plan",
+    free: "Gratis",
+    enrollFailed: (title: string) =>
+      `No se pudo inscribir en "${title}". Inténtalo de nuevo.`,
+  },
+};
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -72,6 +115,8 @@ export default function CourseCatalog() {
   const [enrolledIds, setEnrolledIds] = useState<Set<number>>(new Set());
   const [enrollError, setEnrollError] = useState<string | null>(null);
   const dark = theme === "dark";
+  const t = useStrings(STRINGS);
+  const fmt = useFormat();
 
   if (isPending) {
     return (
@@ -80,7 +125,7 @@ export default function CourseCatalog() {
         <div className={dark ? "dark" : ""}>
           <div className="bg-zinc-50 p-10 text-center font-sans text-zinc-400 dark:bg-zinc-950 dark:text-zinc-500">
             <div className="mx-auto mb-3 size-9 animate-spin rounded-full border-[3px] border-zinc-200 border-t-[var(--brand-600)] dark:border-zinc-800 dark:border-t-[var(--brand-400)]" />
-            <p className="m-0 text-sm">Browsing catalog…</p>
+            <p className="m-0 text-sm">{t.loading}</p>
           </div>
         </div>
       </McpUseProvider>
@@ -102,7 +147,7 @@ export default function CourseCatalog() {
           );
         },
         onError: () =>
-          setEnrollError(`Could not enroll in "${title}". Please try again.`),
+          setEnrollError(t.enrollFailed(title)),
         onSettled: () => {
           setPendingIds((prev) => {
             const next = new Set(prev);
@@ -121,11 +166,11 @@ export default function CourseCatalog() {
         <div className="mx-auto max-w-[820px] bg-zinc-50 p-6 font-sans dark:bg-zinc-950">
           <div className="mb-4.5 flex flex-wrap items-baseline justify-between gap-2">
             <h1 className="m-0 text-[22px] font-bold tracking-tight text-zinc-900 dark:text-zinc-100">
-              Course Catalog
+              {t.title}
             </h1>
             <span className="text-[13px] text-zinc-500 dark:text-zinc-400">
-              {total} published course{total === 1 ? "" : "s"}
-              {has_subscription ? " · subscription active" : ""}
+              {t.summary(total, fmt.number(total))}
+              {has_subscription ? t.subscriptionActive : ""}
             </span>
           </div>
 
@@ -142,44 +187,66 @@ export default function CourseCatalog() {
             <div className="rounded-xl border border-zinc-200 bg-white p-10 text-center dark:border-zinc-800 dark:bg-zinc-900">
               <div className="mb-2 text-[32px]">📚</div>
               <p className="m-0 text-[15px] font-semibold text-zinc-900 dark:text-zinc-100">
-                No published courses found
+                {t.empty}
               </p>
             </div>
           ) : (
-            <div className="grid grid-cols-[repeat(auto-fill,minmax(230px,1fr))] gap-3.5">
+            /*
+              Four named rows — media, heading, tags, footer — declared on the
+              grid and adopted by every card via `grid-rows-subgrid`. Optional
+              blocks then collapse *in step*: a card with no description or no
+              tags leaves a short row rather than a hole, and the tag rows and
+              footers line up across the row instead of floating to wherever
+              each card's own content happened to end. When no card in a row
+              has a thumbnail the media row collapses to nothing, which is why
+              the placeholder below can simply not be rendered.
+            */
+            <div className="grid grid-cols-[repeat(auto-fill,minmax(230px,1fr))] grid-rows-[auto_auto_auto_auto] gap-3.5">
               {courses.map((course) => {
                 const tags = normalizeTags(course.tags).slice(0, 3);
+                const owned = course.enrolled || enrolledIds.has(course.id);
+                const canEnter = course.covered_by_plan || course.has_access;
+                const price = course.price ?? null;
+                const priceLabel =
+                  price === null
+                    ? null
+                    : price === 0
+                      ? t.free
+                      : fmt.currency(price, course.currency);
+
                 return (
                   <div
                     key={course.id}
-                    className="flex flex-col overflow-hidden rounded-xl border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900"
+                    className="row-span-4 grid grid-rows-subgrid overflow-hidden rounded-xl border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900"
                   >
-                    {/* Thumbnail */}
-                    <div
-                      className="flex h-24 items-center justify-center bg-zinc-100 bg-cover bg-center text-[28px] dark:bg-zinc-800"
-                      style={
-                        course.thumbnail_url
-                          ? { backgroundImage: `url(${course.thumbnail_url})` }
-                          : undefined
-                      }
-                    >
-                      {!course.thumbnail_url && "📖"}
+                    {/*
+                      A 96px grey block with a book emoji on every card carried
+                      no information and cost more vertical space than the title
+                      it sat above. With no image there is simply no media row.
+                    */}
+                    {course.thumbnail_url ? (
+                      <div
+                        className="h-24 bg-zinc-100 bg-cover bg-center dark:bg-zinc-800"
+                        style={{ backgroundImage: `url(${course.thumbnail_url})` }}
+                      />
+                    ) : (
+                      <div />
+                    )}
+
+                    <div className="px-3.5 pt-3.5">
+                      <div className="text-[14.5px] leading-[1.3] font-semibold text-zinc-900 dark:text-zinc-100">
+                        {course.title}
+                      </div>
+                      {course.description && (
+                        <div className="mt-1 line-clamp-2 text-xs leading-[1.45] text-zinc-400 dark:text-zinc-500">
+                          {course.description}
+                        </div>
+                      )}
                     </div>
 
-                    <div className="flex flex-1 flex-col gap-2 p-3.5">
-                      <div>
-                        <div className="text-[14.5px] leading-[1.3] font-semibold text-zinc-900 dark:text-zinc-100">
-                          {course.title}
-                        </div>
-                        {course.description && (
-                          <div className="mt-1 line-clamp-2 text-xs leading-[1.45] text-zinc-400 dark:text-zinc-500">
-                            {course.description}
-                          </div>
-                        )}
-                      </div>
-
+                    <div className="px-3.5">
                       {tags.length > 0 && (
-                        <div className="flex flex-wrap gap-[5px]">
+                        <div className="flex flex-wrap gap-[5px] pt-2">
                           {tags.map((tag) => (
                             <span
                               key={tag}
@@ -190,34 +257,71 @@ export default function CourseCatalog() {
                           ))}
                         </div>
                       )}
+                    </div>
 
-                      <div className="mt-auto flex items-center justify-between gap-2">
-                        <span className="text-[11.5px] text-zinc-400 dark:text-zinc-500">
-                          {course.lesson_count} lesson
-                          {course.lesson_count === 1 ? "" : "s"}
-                        </span>
-                        {course.enrolled || enrolledIds.has(course.id) ? (
-                          <span className="rounded-full bg-green-100 px-[9px] py-[3px] text-[11px] font-bold text-green-600 dark:bg-green-900 dark:text-green-400">
-                            ✓ Enrolled
-                          </span>
-                        ) : course.covered_by_plan ? (
-                          <button
-                            onClick={() => handleEnroll(course.id, course.title)}
-                            disabled={pendingIds.has(course.id)}
-                            className="cursor-pointer rounded-full border-none bg-[var(--brand-600)] px-2.5 py-[3px] text-[11px] font-bold text-white disabled:cursor-default disabled:opacity-60 dark:bg-[var(--brand-400)]"
-                          >
-                            {pendingIds.has(course.id) ? "Enrolling…" : "Enroll"}
-                          </button>
-                        ) : course.has_access ? (
-                          <span className="rounded-full bg-[var(--brand-100)] px-[9px] py-[3px] text-[11px] font-bold text-[var(--brand-600)] dark:bg-[var(--brand-950)] dark:text-[var(--brand-400)]">
-                            Access
-                          </span>
-                        ) : (
-                          <span className="text-[11px] text-zinc-400 dark:text-zinc-500">
-                            Not in plan
+                    <div className="flex items-center justify-between gap-2 px-3.5 pt-2 pb-3.5">
+                      <span className="min-w-0 text-[11.5px] text-zinc-400 dark:text-zinc-500">
+                        {t.lessons(course.lesson_count, fmt.number(course.lesson_count))}
+                        {/* Price only where it changes a decision — once the
+                            student is in, what it would have cost is noise. */}
+                        {!owned && !canEnter && priceLabel && (
+                          <span className="ml-1.5 font-semibold text-zinc-900 dark:text-zinc-100">
+                            · {priceLabel}
                           </span>
                         )}
-                      </div>
+                      </span>
+
+                      {owned ? (
+                        <span className="shrink-0 rounded-full bg-green-100 px-[9px] py-[3px] text-[11px] font-bold text-green-600 dark:bg-green-900 dark:text-green-400">
+                          {t.enrolled}
+                        </span>
+                      ) : course.covered_by_plan ? (
+                        <button
+                          onClick={() => handleEnroll(course.id, course.title)}
+                          disabled={pendingIds.has(course.id)}
+                          className="shrink-0 cursor-pointer rounded-full border-none bg-[var(--brand-600)] px-2.5 py-[3px] text-[11px] font-bold text-white disabled:cursor-default disabled:opacity-60 dark:bg-[var(--brand-400)] dark:text-zinc-950"
+                        >
+                          {pendingIds.has(course.id) ? t.enrolling : t.start}
+                        </button>
+                      ) : course.has_access ? (
+                        /*
+                          Already entitled but not enrolled — `lms_enroll_in_course`
+                          only accepts plan-covered courses, so this opens the
+                          course instead of enrolling. Different call, same act
+                          as far as the student is concerned, so the same label.
+                        */
+                        <button
+                          onClick={() =>
+                            sendFollowUpMessage(
+                              `Open the course "${course.title}" with lms_get_course_content so I can start it.`
+                            )
+                          }
+                          className="shrink-0 cursor-pointer rounded-full border-none bg-[var(--brand-600)] px-2.5 py-[3px] text-[11px] font-bold text-white dark:bg-[var(--brand-400)] dark:text-zinc-950"
+                        >
+                          {t.start}
+                        </button>
+                      ) : priceLabel ? (
+                        /*
+                          The old dead end: "Not in plan" in grey, on the only
+                          cards where the student still had a decision to make.
+                          Purchases complete in the app, so this hands off to the
+                          assistant rather than pretending to check out here.
+                        */
+                        <button
+                          onClick={() =>
+                            sendFollowUpMessage(
+                              `I want access to the course "${course.title}". What are my options — can I buy it or upgrade my plan?`
+                            )
+                          }
+                          className="shrink-0 cursor-pointer rounded-full border border-[var(--brand-600)] bg-transparent px-2.5 py-[3px] text-[11px] font-bold text-[var(--brand-600)] dark:border-[var(--brand-400)] dark:text-[var(--brand-400)]"
+                        >
+                          {t.getAccess}
+                        </button>
+                      ) : (
+                        <span className="shrink-0 text-[11px] text-zinc-400 dark:text-zinc-500">
+                          {t.notInPlan}
+                        </span>
+                      )}
                     </div>
                   </div>
                 );

--- a/mcp-server/resources/course-dashboard/widget.tsx
+++ b/mcp-server/resources/course-dashboard/widget.tsx
@@ -6,6 +6,7 @@ import {
   type WidgetMetadata,
 } from "mcp-use/react";
 import { Brand } from "../shared/branding";
+import { useFormat, useStrings } from "../shared/i18n";
 import { z } from "zod";
 
 // ── Schema ──────────────────────────────────────────────────────────────────
@@ -39,6 +40,96 @@ export const widgetMetadata: WidgetMetadata = {
 };
 
 type Props = z.infer<typeof propsSchema>;
+
+// ── Strings ──────────────────────────────────────────────────────────────────
+
+const STRINGS = {
+  en: {
+    loading: "Loading courses…",
+    // Filter-tab / heading label for a status. The underlying filter VALUE
+    // ("all"/"published"/"draft"/"archived") stays English and drives the
+    // actual filtering — only this rendered word changes with locale.
+    filterLabel: (filter: string): string => {
+      switch (filter) {
+        case "all":
+          return "All";
+        case "published":
+          return "Published";
+        case "draft":
+          return "Draft";
+        case "archived":
+          return "Archived";
+        default:
+          return filter.charAt(0).toUpperCase() + filter.slice(1);
+      }
+    },
+    heading: (filter: string): string => {
+      switch (filter) {
+        case "all":
+          return "All Courses";
+        case "published":
+          return "Published Courses";
+        case "draft":
+          return "Draft Courses";
+        case "archived":
+          return "Archived Courses";
+        default:
+          return `${filter.charAt(0).toUpperCase()}${filter.slice(1)} Courses`;
+      }
+    },
+    totalCount: (n: number, count: string) => `${count} course${n === 1 ? "" : "s"} total`,
+    status: {
+      published: "Published",
+      draft: "Draft",
+      archived: "Archived",
+    } as Record<string, string>,
+    emptyFiltered: "No courses match this filter",
+    lessons: (n: number, count: string) => `${count} lesson${n === 1 ? "" : "s"}`,
+    enrolled: (count: string) => `${count} enrolled`,
+  },
+  es: {
+    loading: "Cargando cursos…",
+    filterLabel: (filter: string): string => {
+      switch (filter) {
+        case "all":
+          return "Todos";
+        case "published":
+          return "Publicados";
+        case "draft":
+          return "Borrador";
+        case "archived":
+          return "Archivados";
+        default:
+          return filter;
+      }
+    },
+    heading: (filter: string): string => {
+      switch (filter) {
+        case "all":
+          return "Todos los cursos";
+        case "published":
+          return "Cursos publicados";
+        case "draft":
+          return "Cursos en borrador";
+        case "archived":
+          return "Cursos archivados";
+        default:
+          return `Cursos: ${filter}`;
+      }
+    },
+    totalCount: (n: number, count: string) =>
+      `${count} ${n === 1 ? "curso" : "cursos"} en total`,
+    status: {
+      published: "Publicado",
+      draft: "Borrador",
+      archived: "Archivado",
+    } as Record<string, string>,
+    emptyFiltered: "Ningún curso coincide con este filtro",
+    lessons: (n: number, count: string) =>
+      `${count} ${n === 1 ? "lección" : "lecciones"}`,
+    enrolled: (count: string) => `${count} inscritos`,
+  },
+};
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -75,6 +166,8 @@ export default function CourseDashboard() {
   const [activeFilter, setActiveFilter] = useState<string>("all");
 
   const dark = theme === "dark";
+  const t = useStrings(STRINGS);
+  const fmt = useFormat();
 
   if (isPending) {
     return (
@@ -83,7 +176,7 @@ export default function CourseDashboard() {
         <div className={dark ? "dark" : ""}>
           <div className="bg-zinc-50 p-10 text-center font-sans text-zinc-400 dark:bg-zinc-950 dark:text-zinc-500">
             <div className="mx-auto mb-3 size-9 animate-spin rounded-full border-[3px] border-zinc-200 border-t-[var(--brand-600)] dark:border-zinc-800 dark:border-t-[var(--brand-400)]" />
-            <p className="m-0 text-sm">Loading courses…</p>
+            <p className="m-0 text-sm">{t.loading}</p>
           </div>
         </div>
       </McpUseProvider>
@@ -96,9 +189,6 @@ export default function CourseDashboard() {
       ? props.courses
       : props.courses.filter((c) => c.status === activeFilter);
 
-  const labelForFilter =
-    activeFilter === "all" ? "All" : activeFilter.charAt(0).toUpperCase() + activeFilter.slice(1);
-
   return (
     <McpUseProvider autoSize>
       <Brand />
@@ -108,10 +198,10 @@ export default function CourseDashboard() {
           <div className="mb-5 flex flex-wrap items-center justify-between gap-3">
             <div>
               <h2 className="m-0 text-xl font-semibold tracking-tight text-zinc-900 dark:text-zinc-100">
-                {labelForFilter} Courses
+                {t.heading(activeFilter)}
               </h2>
               <p className="mt-0.5 mb-0 text-[13px] text-zinc-500 dark:text-zinc-400">
-                {props.total} course{props.total !== 1 ? "s" : ""} total
+                {t.totalCount(props.total, fmt.number(props.total))}
               </p>
             </div>
 
@@ -129,7 +219,7 @@ export default function CourseDashboard() {
                         : "border-zinc-200 bg-transparent font-normal text-zinc-500 dark:border-zinc-800 dark:text-zinc-400"
                     }`}
                   >
-                    {s.charAt(0).toUpperCase() + s.slice(1)}
+                    {t.filterLabel(s)}
                   </button>
                 );
               })}
@@ -140,18 +230,25 @@ export default function CourseDashboard() {
           {filtered.length === 0 && (
             <div className="p-12 text-center text-zinc-400 dark:text-zinc-500">
               <div className="mb-3 text-4xl">📚</div>
-              <p className="m-0 text-sm">No courses match this filter</p>
+              <p className="m-0 text-sm">{t.emptyFiltered}</p>
             </div>
           )}
 
-          {/* Card grid */}
-          <div className="grid grid-cols-[repeat(auto-fill,minmax(260px,1fr))] gap-4">
+          {/*
+            Card grid, three shared rows: heading, body (description + tags),
+            footer. Each card adopts them with `grid-rows-subgrid`, so a course
+            with no description or no tags — "Diseño de APIs REST" in the
+            fixture — leaves a short row instead of a hole, and every card's
+            stats bar sits on the same line as its neighbours' rather than
+            wherever that card's own content happened to run out.
+          */}
+          <div className="grid grid-cols-[repeat(auto-fill,minmax(260px,1fr))] grid-rows-[auto_auto_auto_auto] gap-4">
             {filtered.map((course) => {
               const tags = normalizeTags(course.tags);
               return (
                 <div
                   key={course.id}
-                  className="flex flex-col gap-2.5 rounded-xl border border-zinc-200 bg-white p-[18px] transition-shadow duration-150 dark:border-zinc-800 dark:bg-zinc-900"
+                  className="row-span-4 grid grid-rows-subgrid gap-2.5 rounded-xl border border-zinc-200 bg-white p-[18px] transition-shadow duration-150 dark:border-zinc-800 dark:bg-zinc-900"
                 >
                   {/* Title + status */}
                   <div className="flex items-start justify-between gap-2">
@@ -163,43 +260,49 @@ export default function CourseDashboard() {
                         course.status
                       )}`}
                     >
-                      {course.status}
+                      {t.status[course.status.toLowerCase()] ?? course.status}
                     </span>
                   </div>
 
-                  {/* Description */}
-                  {course.description && (
-                    <p className="m-0 line-clamp-2 text-[13px] leading-normal text-zinc-500 dark:text-zinc-400">
-                      {course.description}
-                    </p>
-                  )}
+                  {/* Description — its own row, so a card without one leaves a
+                      short row rather than dragging the tags up out of line
+                      with the rest of the row. */}
+                  <div>
+                    {course.description && (
+                      <p className="m-0 line-clamp-2 text-[13px] leading-normal text-zinc-500 dark:text-zinc-400">
+                        {course.description}
+                      </p>
+                    )}
+                  </div>
 
-                  {/* Tags */}
-                  {tags.length > 0 && (
-                    <div className="flex flex-wrap gap-1">
-                      {tags.slice(0, 4).map((tag) => (
-                        <span
-                          key={tag}
-                          className="rounded-md bg-zinc-100 px-[7px] py-0.5 text-[11px] text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300"
-                        >
-                          {tag}
-                        </span>
-                      ))}
-                      {tags.length > 4 && (
-                        <span className="rounded-md bg-zinc-100 px-[7px] py-0.5 text-[11px] text-zinc-400 dark:bg-zinc-800 dark:text-zinc-500">
-                          +{tags.length - 4}
-                        </span>
-                      )}
-                    </div>
-                  )}
+                  {/* Tags — own row, so every card's tags share a baseline. */}
+                  <div>
+                    {tags.length > 0 && (
+                      <div className="flex flex-wrap gap-1">
+                        {tags.slice(0, 4).map((tag) => (
+                          <span
+                            key={tag}
+                            className="rounded-md bg-zinc-100 px-[7px] py-0.5 text-[11px] text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300"
+                          >
+                            {tag}
+                          </span>
+                        ))}
+                        {tags.length > 4 && (
+                          <span className="rounded-md bg-zinc-100 px-[7px] py-0.5 text-[11px] text-zinc-400 dark:bg-zinc-800 dark:text-zinc-500">
+                            +{tags.length - 4}
+                          </span>
+                        )}
+                      </div>
+                    )}
+                  </div>
 
                   {/* Stats */}
-                  <div className="mt-auto flex gap-3.5 border-t border-zinc-200 pt-2 dark:border-zinc-800">
+                  <div className="flex gap-3.5 border-t border-zinc-200 pt-2 dark:border-zinc-800">
                     <span className="text-xs text-zinc-400 dark:text-zinc-500">
-                      📖 {course.lesson_count} lesson{course.lesson_count !== 1 ? "s" : ""}
+                      📖 {t.lessons(course.lesson_count, fmt.number(course.lesson_count))}
                     </span>
                     <span className="text-xs text-zinc-400 dark:text-zinc-500">
-                      👥 {course.enrollment_count} enrolled
+                      👥 {t.enrolled(fmt.number(course.enrollment_count))}
                     </span>
                   </div>
                 </div>

--- a/mcp-server/resources/course-detail/widget.tsx
+++ b/mcp-server/resources/course-detail/widget.tsx
@@ -7,6 +7,7 @@ import {
   type WidgetMetadata,
 } from "mcp-use/react";
 import { Brand } from "../shared/branding";
+import { useFormat, useStrings } from "../shared/i18n";
 import { z } from "zod";
 
 // ── Schema ──────────────────────────────────────────────────────────────────
@@ -55,6 +56,59 @@ export const widgetMetadata: WidgetMetadata = {
 
 type Props = z.infer<typeof propsSchema>;
 
+// ── Strings ──────────────────────────────────────────────────────────────────
+
+const STRINGS = {
+  en: {
+    loading: "Loading course…",
+    status: {
+      published: "Published",
+      draft: "Draft",
+      archived: "Archived",
+    } as Record<string, string>,
+    enrolled: (n: string) => `${n} enrolled`,
+    created: (d: string) => `Created ${d}`,
+    sequential: "Sequential",
+    loadStats: "Load stats",
+    loadingStats: "Loading stats…",
+    statActiveEnrollments: "Active enrollments",
+    statPublishedLessons: "Published lessons",
+    statCompletionRate: "Completion rate",
+    statExams: "Exams",
+    statSubmissions: "Submissions",
+    statAvgScore: "Avg score",
+    lessonsHeading: (n: string) => `Lessons (${n})`,
+    noLessons: "No lessons yet.",
+    examsHeading: (n: string) => `Exams (${n})`,
+    noExams: "No exams yet.",
+    minutes: (n: string) => `${n} min`,
+  },
+  es: {
+    loading: "Cargando curso…",
+    status: {
+      published: "Publicado",
+      draft: "Borrador",
+      archived: "Archivado",
+    } as Record<string, string>,
+    enrolled: (n: string) => `${n} inscritos`,
+    created: (d: string) => `Creado el ${d}`,
+    sequential: "Secuencial",
+    loadStats: "Cargar estadísticas",
+    loadingStats: "Cargando estadísticas…",
+    statActiveEnrollments: "Inscripciones activas",
+    statPublishedLessons: "Lecciones publicadas",
+    statCompletionRate: "Tasa de finalización",
+    statExams: "Exámenes",
+    statSubmissions: "Entregas",
+    statAvgScore: "Nota media",
+    lessonsHeading: (n: string) => `Lecciones (${n})`,
+    noLessons: "Todavía no hay lecciones.",
+    examsHeading: (n: string) => `Exámenes (${n})`,
+    noExams: "Todavía no hay exámenes.",
+    minutes: (n: string) => `${n} min`,
+  },
+};
+
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
 function statusPill(status: string): string {
@@ -67,19 +121,6 @@ function statusPill(status: string): string {
       return "bg-[var(--brand-50)] text-[var(--brand-600)] dark:bg-[var(--brand-950)] dark:text-[var(--brand-400)]";
     default:
       return "bg-amber-100 text-amber-600 dark:bg-amber-950 dark:text-amber-400";
-  }
-}
-
-function formatDate(s: string | null): string {
-  if (!s) return "—";
-  try {
-    return new Date(s).toLocaleDateString(undefined, {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-    });
-  } catch {
-    return s;
   }
 }
 
@@ -112,6 +153,8 @@ export default function CourseDetail() {
   } = useCallTool<{ course_id: number }>("lms_get_course_stats");
 
   const dark = theme === "dark";
+  const t = useStrings(STRINGS);
+  const fmt = useFormat();
 
   if (isPending) {
     return (
@@ -120,7 +163,7 @@ export default function CourseDetail() {
         <div className={dark ? "dark" : ""}>
           <div className="bg-zinc-50 p-10 text-center font-sans text-zinc-400 dark:bg-zinc-950 dark:text-zinc-500">
             <div className="mx-auto mb-3 size-9 animate-spin rounded-full border-[3px] border-zinc-200 border-t-[var(--brand-600)] dark:border-zinc-800 dark:border-t-[var(--brand-400)]" />
-            <p className="m-0 text-sm">Loading course…</p>
+            <p className="m-0 text-sm">{t.loading}</p>
           </div>
         </div>
       </McpUseProvider>
@@ -129,6 +172,7 @@ export default function CourseDetail() {
 
   const { course, lessons, exams } = props;
   const stats = parseCourseStats(statsData?.structuredContent);
+  const statusLabel = (status: string) => t.status[status.toLowerCase()] ?? status;
 
   const handleLoadStats = () => {
     setStatsVisible(true);
@@ -151,7 +195,7 @@ export default function CourseDetail() {
                   course.status
                 )}`}
               >
-                {course.status}
+                {statusLabel(course.status)}
               </span>
             </div>
 
@@ -163,13 +207,13 @@ export default function CourseDetail() {
 
             <div className="mb-3.5 flex flex-wrap gap-4">
               <span className="text-[13px] text-zinc-400 dark:text-zinc-500">
-                👥 {course.enrollment_count} enrolled
+                👥 {t.enrolled(fmt.number(course.enrollment_count))}
               </span>
               <span className="text-[13px] text-zinc-400 dark:text-zinc-500">
-                📅 Created {formatDate(course.created_at)}
+                📅 {t.created(fmt.date(course.created_at))}
               </span>
               {course.require_sequential_completion && (
-                <span className="text-[13px] text-zinc-400 dark:text-zinc-500">🔒 Sequential</span>
+                <span className="text-[13px] text-zinc-400 dark:text-zinc-500">🔒 {t.sequential}</span>
               )}
             </div>
 
@@ -183,29 +227,50 @@ export default function CourseDetail() {
                   : "bg-transparent"
               }`}
             >
-              {statsLoading ? "Loading stats…" : "Load stats"}
+              {statsLoading ? t.loadingStats : t.loadStats}
             </button>
 
             {/* Stats row */}
             {statsVisible && stats && (
               <div className="mt-3.5 grid grid-cols-[repeat(auto-fill,minmax(120px,1fr))] gap-3 rounded-[10px] border border-green-200 bg-green-50 p-3.5 dark:border-green-900 dark:bg-green-950">
                 {[
-                  { label: "Active enrollments", value: stats.active_enrollments },
-                  { label: "Published lessons", value: stats.published_lessons },
                   {
-                    label: "Completion rate",
+                    label: t.statActiveEnrollments,
                     value:
-                      stats.lesson_completion_rate != null
-                        ? `${Math.round(stats.lesson_completion_rate)}%`
+                      stats.active_enrollments != null
+                        ? fmt.number(stats.active_enrollments)
                         : undefined,
                   },
-                  { label: "Exams", value: stats.exam_count },
-                  { label: "Submissions", value: stats.submission_count },
                   {
-                    label: "Avg score",
+                    label: t.statPublishedLessons,
+                    value:
+                      stats.published_lessons != null
+                        ? fmt.number(stats.published_lessons)
+                        : undefined,
+                  },
+                  {
+                    label: t.statCompletionRate,
+                    value:
+                      stats.lesson_completion_rate != null
+                        ? fmt.percent(Math.round(stats.lesson_completion_rate))
+                        : undefined,
+                  },
+                  {
+                    label: t.statExams,
+                    value: stats.exam_count != null ? fmt.number(stats.exam_count) : undefined,
+                  },
+                  {
+                    label: t.statSubmissions,
+                    value:
+                      stats.submission_count != null
+                        ? fmt.number(stats.submission_count)
+                        : undefined,
+                  },
+                  {
+                    label: t.statAvgScore,
                     value:
                       stats.average_score != null
-                        ? `${Math.round(stats.average_score)}%`
+                        ? fmt.percent(Math.round(stats.average_score))
                         : undefined,
                   },
                 ]
@@ -227,12 +292,12 @@ export default function CourseDetail() {
           {/* Lessons */}
           <div className="mb-4 rounded-xl border border-zinc-200 bg-white p-[18px] dark:border-zinc-800 dark:bg-zinc-900">
             <h3 className="mt-0 mb-3.5 text-[15px] font-semibold text-zinc-900 dark:text-zinc-100">
-              Lessons ({lessons.length})
+              {t.lessonsHeading(fmt.number(lessons.length))}
             </h3>
 
             {lessons.length === 0 ? (
               <p className="m-0 text-[13px] text-zinc-400 dark:text-zinc-500">
-                No lessons yet.
+                {t.noLessons}
               </p>
             ) : (
               <div className="flex flex-col gap-2">
@@ -245,7 +310,7 @@ export default function CourseDetail() {
                       className="flex items-center gap-2.5 rounded-lg bg-zinc-100 px-2.5 py-2 dark:bg-zinc-800"
                     >
                       <span className="flex h-6 min-w-6 shrink-0 items-center justify-center rounded-full bg-[var(--brand-50)] text-[11px] font-bold text-[var(--brand-600)] dark:bg-[var(--brand-950)] dark:text-[var(--brand-400)]">
-                        {lesson.sequence}
+                        {fmt.number(lesson.sequence)}
                       </span>
                       <span className="flex-1 text-[13px] font-medium text-zinc-900 dark:text-zinc-100">
                         {lesson.title}
@@ -255,7 +320,7 @@ export default function CourseDetail() {
                           lesson.status
                         )}`}
                       >
-                        {lesson.status}
+                        {statusLabel(lesson.status)}
                       </span>
                     </div>
                   ))}
@@ -266,12 +331,12 @@ export default function CourseDetail() {
           {/* Exams */}
           <div className="rounded-xl border border-zinc-200 bg-white p-[18px] dark:border-zinc-800 dark:bg-zinc-900">
             <h3 className="mt-0 mb-3.5 text-[15px] font-semibold text-zinc-900 dark:text-zinc-100">
-              Exams ({exams.length})
+              {t.examsHeading(fmt.number(exams.length))}
             </h3>
 
             {exams.length === 0 ? (
               <p className="m-0 text-[13px] text-zinc-400 dark:text-zinc-500">
-                No exams yet.
+                {t.noExams}
               </p>
             ) : (
               <div className="flex flex-col gap-2">
@@ -284,11 +349,11 @@ export default function CourseDetail() {
                       {exam.title}
                     </span>
                     <span className="text-xs text-zinc-400 dark:text-zinc-500">
-                      ⏱ {exam.duration} min
+                      ⏱ {t.minutes(fmt.number(exam.duration))}
                     </span>
                     {exam.date && (
                       <span className="text-xs text-zinc-400 dark:text-zinc-500">
-                        📅 {formatDate(exam.date)}
+                        📅 {fmt.date(exam.date)}
                       </span>
                     )}
                     <span
@@ -296,7 +361,7 @@ export default function CourseDetail() {
                         exam.status
                       )}`}
                     >
-                      {exam.status}
+                      {statusLabel(exam.status)}
                     </span>
                   </div>
                 ))}

--- a/mcp-server/resources/exam-readiness/widget.tsx
+++ b/mcp-server/resources/exam-readiness/widget.tsx
@@ -5,6 +5,7 @@ import {
   type WidgetMetadata,
 } from "mcp-use/react";
 import { Brand } from "../shared/branding";
+import { useFormat, useStrings } from "../shared/i18n";
 import { z } from "zod";
 
 // Props produced by lms_get_exam_readiness (Epic #348 Phase 3, #358).
@@ -58,6 +59,47 @@ export const widgetMetadata: WidgetMetadata = {
 
 type Props = z.infer<typeof propsSchema>;
 
+const STRINGS = {
+  en: {
+    title: (course: string) => `Exam readiness — ${course}`,
+    noSignal: "No signal yet",
+    noSignalHint: "Take a practice quiz to calibrate your readiness.",
+    startDiagnostic: "Start a diagnostic quiz",
+    examHistory: "Exam history",
+    practice: "Practice",
+    lessons: (done: string, total: string) => `Lessons ${done}/${total}`,
+    na: "n/a",
+    noTopics:
+      "No per-topic history yet — practice quizzes and exam attempts will show up here.",
+    practiceThis: "Practice this",
+    focusHere: "Focus here first",
+    today: "today",
+  },
+  es: {
+    title: (course: string) => `Preparación para el examen — ${course}`,
+    noSignal: "Sin datos todavía",
+    noSignalHint:
+      "Haz un cuestionario de práctica para calibrar tu preparación.",
+    startDiagnostic: "Empezar un cuestionario de diagnóstico",
+    examHistory: "Historial de exámenes",
+    practice: "Práctica",
+    lessons: (done: string, total: string) => `Lecciones ${done}/${total}`,
+    na: "n/d",
+    noTopics:
+      "Todavía no hay historial por tema: los cuestionarios de práctica y los intentos de examen aparecerán aquí.",
+    practiceThis: "Practicar esto",
+    focusHere: "Empieza por aquí",
+    today: "hoy",
+  },
+};
+
+/**
+ * At or above this, a topic is "solid": it still gets a practice link, but a
+ * quiet one. The whole point of the report is what to fix first, and six
+ * equally loud buttons answer that question with "everything".
+ */
+const SOLID_AT = 80;
+
 // Fixed score buckets → Tailwind class strings (pass ≥80, warn ≥60, fail <60)
 const bandText = (v: number) =>
   v >= 80
@@ -84,6 +126,8 @@ export default function ExamReadiness() {
   const { props, isPending, sendFollowUpMessage } = useWidget<Props>();
   const theme = useWidgetTheme();
   const dark = theme === "dark";
+  const t = useStrings(STRINGS);
+  const fmt = useFormat();
 
   if (isPending) {
     return (
@@ -101,23 +145,37 @@ export default function ExamReadiness() {
   const { course_title, exam, readiness, components, formula, topics, lessons } =
     props;
 
-  const examDate = exam?.exam_date
-    ? new Date(exam.exam_date).toLocaleDateString(undefined, {
-        month: "short",
-        day: "numeric",
-        year: "numeric",
-      })
-    : null;
+  const examDate = exam?.exam_date ? fmt.date(exam.exam_date) : null;
+
+  /**
+   * How long the student actually has. `exam_date` was in the payload but only
+   * ever printed as a calendar date, which makes the reader do the subtraction
+   * — and the answer to "how much time do I have" is the reason to look at this
+   * panel at all. Counted in whole days so a 09:00 exam tomorrow reads
+   * "tomorrow" rather than "in 0 days".
+   */
+  const daysLeft = exam?.exam_date ? fmt.daysUntil(exam.exam_date) : null;
+  const countdown =
+    daysLeft === null ? null : daysLeft === 0 ? t.today : fmt.relativeDays(daysLeft);
+  // A week out is when it stops being trivia and starts being pressure.
+  const urgent = daysLeft !== null && daysLeft >= 0 && daysLeft <= 7;
 
   const componentChips: Array<{ label: string; value: number | null; weight: number }> = [
-    { label: "Exam history", value: components.exam_history, weight: components.weights.exam_history },
-    { label: "Practice", value: components.practice, weight: components.weights.practice },
+    { label: t.examHistory, value: components.exam_history, weight: components.weights.exam_history },
+    { label: t.practice, value: components.practice, weight: components.weights.practice },
     {
-      label: `Lessons ${lessons.completed}/${lessons.total}`,
+      label: t.lessons(fmt.number(lessons.completed), fmt.number(lessons.total)),
       value: components.lesson_coverage,
       weight: components.weights.lesson_coverage,
     },
   ];
+
+  /**
+   * Weakest first. The payload arrives in whatever order the server assembled
+   * it, which put the 12% topic last and buried the single most useful line in
+   * the report. Sorted on a copy — `topics` is props and must not be mutated.
+   */
+  const rankedTopics = [...topics].sort((a, b) => a.mastery - b.mastery);
 
   return (
     <McpUseProvider autoSize>
@@ -126,12 +184,24 @@ export default function ExamReadiness() {
         <div className="mx-auto max-w-[720px] bg-zinc-50 p-6 font-sans dark:bg-zinc-950">
           <div className="mb-4">
             <h2 className="m-0 text-lg font-bold text-zinc-900 dark:text-zinc-100">
-              Exam readiness — {course_title}
+              {t.title(course_title)}
             </h2>
             {exam && (
               <p className="mt-1 mb-0 text-[13px] text-zinc-500 dark:text-zinc-400">
                 {exam.title}
                 {examDate ? ` · ${examDate}` : ""}
+                {countdown ? " · " : ""}
+                {countdown && (
+                  <span
+                    className={
+                      urgent
+                        ? "font-semibold text-amber-600 dark:text-amber-400"
+                        : undefined
+                    }
+                  >
+                    {countdown}
+                  </span>
+                )}
               </p>
             )}
           </div>
@@ -140,10 +210,10 @@ export default function ExamReadiness() {
             <div className="rounded-xl border border-zinc-200 bg-white p-10 text-center dark:border-zinc-800 dark:bg-zinc-900">
               <div className="mb-2 text-3xl">🧭</div>
               <p className="m-0 text-[15px] font-semibold text-zinc-900 dark:text-zinc-100">
-                No signal yet
+                {t.noSignal}
               </p>
               <p className="mt-1.5 mb-0 text-[13px] text-zinc-400 dark:text-zinc-500">
-                Take a practice quiz to calibrate your readiness.
+                {t.noSignalHint}
               </p>
               <button
                 onClick={() =>
@@ -153,7 +223,7 @@ export default function ExamReadiness() {
                 }
                 className="mt-4 cursor-pointer rounded-lg border-none bg-[var(--brand-600)] px-4 py-2 text-[13px] font-semibold text-white dark:bg-[var(--brand-400)]"
               >
-                Start a diagnostic quiz
+                {t.startDiagnostic}
               </button>
             </div>
           ) : (
@@ -177,7 +247,7 @@ export default function ExamReadiness() {
                             : "text-zinc-900 dark:text-zinc-100"
                         }`}
                       >
-                        {c.label}: {c.value === null ? "n/a" : c.value}
+                        {c.label}: {c.value === null ? t.na : c.value}
                         {c.value !== null && c.weight > 0
                           ? ` (${Math.round(c.weight * 100)}%)`
                           : ""}
@@ -191,49 +261,79 @@ export default function ExamReadiness() {
               {topics.length === 0 ? (
                 <div className="rounded-xl border border-zinc-200 bg-white p-6 text-center dark:border-zinc-800 dark:bg-zinc-900">
                   <p className="m-0 text-[13px] text-zinc-400 dark:text-zinc-500">
-                    No per-topic history yet — practice quizzes and exam attempts will
-                    show up here.
+                    {t.noTopics}
                   </p>
                 </div>
               ) : (
                 <div className="flex flex-col gap-2.5">
-                  {topics.map((t, i) => (
-                    <div
-                      key={`${t.label}-${i}`}
-                      className="rounded-[10px] border border-zinc-200 bg-white px-4 py-3 dark:border-zinc-800 dark:bg-zinc-900"
-                    >
-                      <div className="mb-1.5 flex items-center justify-between gap-3">
-                        <span className="overflow-hidden text-sm font-semibold text-ellipsis whitespace-nowrap text-zinc-900 dark:text-zinc-100">
-                          {t.source === "exam" ? "📄 " : "✏️ "}
-                          {t.label}
-                        </span>
-                        <div className="flex shrink-0 items-center gap-2.5">
-                          <span className={`text-[13px] font-bold ${bandText(t.mastery)}`}>
-                            {t.mastery}
+                  {rankedTopics.map((topic, i) => {
+                    const solid = topic.mastery >= SOLID_AT;
+                    // The first row is the weakest topic in the course, which
+                    // is the one thing this whole report exists to say.
+                    const weakest = i === 0 && !solid;
+                    return (
+                      <div
+                        key={`${topic.label}-${topic.source}`}
+                        className={`rounded-[10px] border bg-white px-4 py-3 dark:bg-zinc-900 ${
+                          weakest
+                            ? "border-red-300 dark:border-red-900"
+                            : "border-zinc-200 dark:border-zinc-800"
+                        }`}
+                      >
+                        <div className="mb-1.5 flex items-center justify-between gap-3">
+                          <span className="flex min-w-0 items-center gap-2">
+                            <span className="overflow-hidden text-sm font-semibold text-ellipsis whitespace-nowrap text-zinc-900 dark:text-zinc-100">
+                              {topic.source === "exam" ? "📄 " : "✏️ "}
+                              {topic.label}
+                            </span>
+                            {weakest && (
+                              <span className="shrink-0 rounded-md bg-red-50 px-[7px] py-px text-[10.5px] font-bold text-red-600 dark:bg-red-950 dark:text-red-400">
+                                {t.focusHere}
+                              </span>
+                            )}
                           </span>
-                          <button
-                            onClick={() =>
-                              sendFollowUpMessage(
-                                `Generate a practice quiz on "${t.label}" with lms_practice_quiz — focus on my misses. (Course: ${course_title})`
-                              )
-                            }
-                            className="cursor-pointer rounded-md border border-[var(--brand-600)] bg-transparent px-2.5 py-1 text-xs font-semibold text-[var(--brand-600)] dark:border-[var(--brand-400)] dark:text-[var(--brand-400)]"
-                          >
-                            Practice this
-                          </button>
+                          <div className="flex shrink-0 items-center gap-2.5">
+                            <span
+                              className={`text-[13px] font-bold ${bandText(topic.mastery)}`}
+                            >
+                              {topic.mastery}
+                            </span>
+                            {/*
+                              Same action either way; only the volume changes.
+                              A mastered topic keeps its practice link so it is
+                              still reachable, but it stops competing with the
+                              topics that actually need the time.
+                            */}
+                            <button
+                              onClick={() =>
+                                sendFollowUpMessage(
+                                  `Generate a practice quiz on "${topic.label}" with lms_practice_quiz — focus on my misses. (Course: ${course_title})`
+                                )
+                              }
+                              className={
+                                solid
+                                  ? "cursor-pointer border-none bg-transparent px-1 py-1 text-xs font-medium text-zinc-400 underline underline-offset-2 dark:text-zinc-500"
+                                  : "cursor-pointer rounded-md border border-[var(--brand-600)] bg-transparent px-2.5 py-1 text-xs font-semibold text-[var(--brand-600)] dark:border-[var(--brand-400)] dark:text-[var(--brand-400)]"
+                              }
+                            >
+                              {t.practiceThis}
+                            </button>
+                          </div>
                         </div>
+                        <div className="mb-1.5 h-1.5 overflow-hidden rounded-[3px] bg-zinc-100 dark:bg-zinc-800">
+                          <div
+                            className={`h-full rounded-[3px] ${bandFill(topic.mastery)}`}
+                            style={{
+                              width: `${Math.max(0, Math.min(100, topic.mastery))}%`,
+                            }}
+                          />
+                        </div>
+                        <p className="m-0 text-xs text-zinc-400 dark:text-zinc-500">
+                          {topic.evidence}
+                        </p>
                       </div>
-                      <div className="mb-1.5 h-1.5 overflow-hidden rounded-[3px] bg-zinc-100 dark:bg-zinc-800">
-                        <div
-                          className={`h-full rounded-[3px] ${bandFill(t.mastery)}`}
-                          style={{ width: `${Math.max(0, Math.min(100, t.mastery))}%` }}
-                        />
-                      </div>
-                      <p className="m-0 text-xs text-zinc-400 dark:text-zinc-500">
-                        {t.evidence}
-                      </p>
-                    </div>
-                  ))}
+                    );
+                  })}
                 </div>
               )}
             </>

--- a/mcp-server/resources/exam-submissions/widget.tsx
+++ b/mcp-server/resources/exam-submissions/widget.tsx
@@ -7,6 +7,7 @@ import {
   type WidgetMetadata,
 } from "mcp-use/react";
 import { Brand } from "../shared/branding";
+import { useFormat, useStrings } from "../shared/i18n";
 import { z } from "zod";
 import { Markdown } from "../shared/markdown";
 
@@ -38,6 +39,57 @@ export const widgetMetadata: WidgetMetadata = {
 
 type Props = z.infer<typeof propsSchema>;
 
+// ── Strings ──────────────────────────────────────────────────────────────────
+
+const STRINGS = {
+  en: {
+    loading: "Loading submissions…",
+    heading: (id: number) => `Exam #${id} — Submissions`,
+    subtitle: (n: number, count: string) =>
+      `${count} submission${n === 1 ? "" : "s"} · Click a row to see details`,
+    colStudent: "Student",
+    colScore: "Score",
+    colDate: "Date",
+    colStatus: "Status",
+    empty: "No submissions yet",
+    loadingDetails: "Loading details…",
+    detailScore: "Score",
+    detailReviewStatus: "Review status",
+    detailFeedback: "Feedback",
+    noDetail: "No additional detail available.",
+    reviewStatus: {
+      approved: "Approved",
+      graded: "Graded",
+      rejected: "Rejected",
+      failed: "Failed",
+      pending: "Pending",
+    } as Record<string, string>,
+  },
+  es: {
+    loading: "Cargando entregas…",
+    heading: (id: number) => `Examen n.º ${id} — Entregas`,
+    subtitle: (n: number, count: string) =>
+      `${count} ${n === 1 ? "entrega" : "entregas"} · Haz clic en una fila para ver los detalles`,
+    colStudent: "Estudiante",
+    colScore: "Nota",
+    colDate: "Fecha",
+    colStatus: "Estado",
+    empty: "Todavía no hay entregas",
+    loadingDetails: "Cargando detalles…",
+    detailScore: "Nota",
+    detailReviewStatus: "Estado de revisión",
+    detailFeedback: "Comentarios",
+    noDetail: "No hay más detalles disponibles.",
+    reviewStatus: {
+      approved: "Aprobada",
+      graded: "Calificada",
+      rejected: "Rechazada",
+      failed: "Suspendida",
+      pending: "Pendiente",
+    } as Record<string, string>,
+  },
+};
+
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
 function reviewPill(status: string | null): { bg: string; text: string } {
@@ -60,18 +112,6 @@ function reviewPill(status: string | null): { bg: string; text: string } {
         bg: "bg-amber-100 dark:bg-amber-950",
         text: "text-amber-600 dark:text-amber-400",
       };
-  }
-}
-
-function formatDate(s: string): string {
-  try {
-    return new Date(s).toLocaleDateString(undefined, {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-    });
-  } catch {
-    return s;
   }
 }
 
@@ -101,6 +141,8 @@ export default function ExamSubmissions() {
   );
 
   const dark = theme === "dark";
+  const t = useStrings(STRINGS);
+  const fmt = useFormat();
 
   if (isPending) {
     return (
@@ -109,7 +151,7 @@ export default function ExamSubmissions() {
         <div className={dark ? "dark" : ""}>
           <div className="bg-zinc-50 p-10 text-center font-sans text-zinc-400 dark:bg-zinc-950 dark:text-zinc-500">
             <div className="mx-auto mb-3 size-9 animate-spin rounded-full border-[3px] border-zinc-200 border-t-[var(--brand-600)] dark:border-zinc-800 dark:border-t-[var(--brand-400)]" />
-            <p className="m-0 text-sm">Loading submissions…</p>
+            <p className="m-0 text-sm">{t.loading}</p>
           </div>
         </div>
       </McpUseProvider>
@@ -117,6 +159,11 @@ export default function ExamSubmissions() {
   }
 
   const { submissions, total, exam_id } = props;
+
+  const reviewLabel = (status: string | null): string => {
+    const key = (status ?? "pending").toLowerCase();
+    return t.reviewStatus[key] ?? status ?? "pending";
+  };
 
   const handleRowClick = async (id: number) => {
     if (expandedId === id) {
@@ -148,10 +195,10 @@ export default function ExamSubmissions() {
           {/* Header */}
           <div className="mb-4">
             <h2 className="m-0 text-lg font-semibold tracking-tight text-zinc-900 dark:text-zinc-100">
-              Exam #{exam_id} — Submissions
+              {t.heading(exam_id)}
             </h2>
             <p className="mt-0.5 mb-0 text-[13px] text-zinc-500 dark:text-zinc-400">
-              {total} submission{total !== 1 ? "s" : ""} · Click a row to see details
+              {t.subtitle(total, fmt.number(total))}
             </p>
           </div>
 
@@ -159,7 +206,7 @@ export default function ExamSubmissions() {
           <div className="overflow-x-auto overflow-y-hidden rounded-xl border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
             {/* Header row */}
             <div className="grid min-w-[480px] grid-cols-[minmax(140px,1fr)_80px_120px_100px] border-b border-zinc-200 bg-zinc-100 px-4 py-[9px] dark:border-zinc-800 dark:bg-zinc-800">
-              {["Student", "Score", "Date", "Status"].map((col) => (
+              {[t.colStudent, t.colScore, t.colDate, t.colStatus].map((col) => (
                 <span
                   key={col}
                   className="text-[11px] font-bold tracking-wider text-zinc-400 uppercase dark:text-zinc-500"
@@ -173,7 +220,7 @@ export default function ExamSubmissions() {
             {submissions.length === 0 && (
               <div className="p-10 text-center text-zinc-400 dark:text-zinc-500">
                 <div className="mb-2.5 text-3xl">📋</div>
-                <p className="m-0 text-sm">No submissions yet</p>
+                <p className="m-0 text-sm">{t.empty}</p>
               </div>
             )}
 
@@ -210,16 +257,16 @@ export default function ExamSubmissions() {
                       {sub.student_name}
                     </span>
                     <span className="text-[13px] font-semibold text-zinc-900 dark:text-zinc-100">
-                      {sub.score != null ? `${sub.score}%` : "—"}
+                      {fmt.percent(sub.score)}
                     </span>
                     <span className="text-xs text-zinc-500 dark:text-zinc-400">
-                      {formatDate(sub.submission_date)}
+                      {fmt.date(sub.submission_date)}
                     </span>
                     <span className="inline-flex items-center">
                       <span
                         className={`rounded-lg px-2 py-0.5 text-[11px] font-semibold ${pill.bg} ${pill.text}`}
                       >
-                        {sub.review_status ?? "pending"}
+                        {reviewLabel(sub.review_status)}
                       </span>
                     </span>
                   </div>
@@ -235,7 +282,7 @@ export default function ExamSubmissions() {
                     >
                       {isLoadingThis ? (
                         <p className="m-0 text-[13px] text-zinc-400 dark:text-zinc-500">
-                          Loading details…
+                          {t.loadingDetails}
                         </p>
                       ) : detail ? (
                         <div className="flex flex-col gap-2">
@@ -243,24 +290,24 @@ export default function ExamSubmissions() {
                             {detail.score != null && (
                               <div>
                                 <span className="block text-[11px] text-zinc-400 dark:text-zinc-500">
-                                  Score
+                                  {t.detailScore}
                                 </span>
                                 <span className="text-xl font-bold text-[var(--brand-600)] dark:text-[var(--brand-400)]">
-                                  {detail.score}%
+                                  {fmt.percent(detail.score)}
                                 </span>
                               </div>
                             )}
                             {detail.review_status && (
                               <div>
                                 <span className="block text-[11px] text-zinc-400 dark:text-zinc-500">
-                                  Review status
+                                  {t.detailReviewStatus}
                                 </span>
                                 <span
                                   className={`text-[13px] font-semibold ${
                                     reviewPill(detail.review_status).text
                                   }`}
                                 >
-                                  {detail.review_status}
+                                  {reviewLabel(detail.review_status)}
                                 </span>
                               </div>
                             )}
@@ -268,7 +315,7 @@ export default function ExamSubmissions() {
                           {detail.feedback && (
                             <div>
                               <span className="mb-1 block text-[11px] text-zinc-400 dark:text-zinc-500">
-                                Feedback
+                                {t.detailFeedback}
                               </span>
                               <Markdown
                                 content={detail.feedback}
@@ -280,7 +327,7 @@ export default function ExamSubmissions() {
                         </div>
                       ) : (
                         <p className="m-0 text-[13px] text-zinc-400 dark:text-zinc-500">
-                          No additional detail available.
+                          {t.noDetail}
                         </p>
                       )}
                     </div>

--- a/mcp-server/resources/gamification-profile/widget.tsx
+++ b/mcp-server/resources/gamification-profile/widget.tsx
@@ -5,6 +5,7 @@ import {
   type WidgetMetadata,
 } from "mcp-use/react";
 import { Brand } from "../shared/branding";
+import { useFormat, useStrings } from "../shared/i18n";
 import { z } from "zod";
 
 // ── Schema ──────────────────────────────────────────────────────────────────
@@ -49,6 +50,59 @@ export const widgetMetadata: WidgetMetadata = {
 
 type Props = z.infer<typeof propsSchema>;
 
+// ── Strings ──────────────────────────────────────────────────────────────────
+
+const STRINGS = {
+  en: {
+    loading: "Loading your progress…",
+    emptyTitle: "No XP yet",
+    emptyHint: "Complete a lesson to start earning XP and unlocking achievements.",
+    level: (n: string) => `Level ${n}`,
+    xpTotal: (n: string) => `${n} XP total`,
+    xpToLevel: (xp: string, level: string) => `${xp} XP to level ${level}`,
+    maxLevel: "Max level reached 🎉",
+    coins: "Coins",
+    streak: "Streak",
+    bestStreak: "Best streak",
+    rank: "Rank",
+    rankValue: (rank: string, participants: string) => `#${rank} of ${participants}`,
+    days: (n: string) => `${n}d`,
+    achievements: (n: string) => `Achievements (${n})`,
+    noAchievements: "No achievements earned yet — keep learning!",
+    tier: {
+      gold: "Gold",
+      silver: "Silver",
+      bronze: "Bronze",
+      platinum: "Platinum",
+      diamond: "Diamond",
+    } as Record<string, string>,
+  },
+  es: {
+    loading: "Cargando tu progreso…",
+    emptyTitle: "Todavía no tienes XP",
+    emptyHint: "Completa una lección para empezar a ganar XP y desbloquear logros.",
+    level: (n: string) => `Nivel ${n}`,
+    xpTotal: (n: string) => `${n} XP en total`,
+    xpToLevel: (xp: string, level: string) => `${xp} XP para el nivel ${level}`,
+    maxLevel: "Nivel máximo alcanzado 🎉",
+    coins: "Monedas",
+    streak: "Racha",
+    bestStreak: "Mejor racha",
+    rank: "Posición",
+    rankValue: (rank: string, participants: string) => `N.º ${rank} de ${participants}`,
+    days: (n: string) => `${n} d`,
+    achievements: (n: string) => `Logros (${n})`,
+    noAchievements: "Todavía no has ganado logros — ¡sigue aprendiendo!",
+    tier: {
+      gold: "Oro",
+      silver: "Plata",
+      bronze: "Bronce",
+      platinum: "Platino",
+      diamond: "Diamante",
+    } as Record<string, string>,
+  },
+};
+
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
 function tierClass(tier: string | null): string {
@@ -67,18 +121,14 @@ function tierClass(tier: string | null): string {
   }
 }
 
-function formatDate(iso: string): string {
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return iso;
-  return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
-}
-
 // ── Component ────────────────────────────────────────────────────────────────
 
 export default function GamificationProfile() {
   const { props, isPending } = useWidget<Props>();
   const theme = useWidgetTheme();
   const dark = theme === "dark";
+  const t = useStrings(STRINGS);
+  const fmt = useFormat();
 
   if (isPending) {
     return (
@@ -87,7 +137,7 @@ export default function GamificationProfile() {
         <div className={dark ? "dark" : ""}>
           <div className="bg-zinc-50 p-10 text-center font-sans text-zinc-400 dark:bg-zinc-950 dark:text-zinc-500">
             <div className="mx-auto mb-3 size-9 animate-spin rounded-full border-[3px] border-zinc-200 border-t-[var(--brand-600)] dark:border-zinc-800 dark:border-t-[var(--brand-400)]" />
-            <p className="m-0 text-sm">Loading your progress…</p>
+            <p className="m-0 text-sm">{t.loading}</p>
           </div>
         </div>
       </McpUseProvider>
@@ -103,10 +153,10 @@ export default function GamificationProfile() {
             <div className="rounded-xl border border-zinc-200 bg-white p-10 text-center dark:border-zinc-800 dark:bg-zinc-900">
               <div className="mb-2 text-[32px]">⚡</div>
               <p className="m-0 text-[15px] font-semibold text-zinc-900 dark:text-zinc-100">
-                No XP yet
+                {t.emptyTitle}
               </p>
               <p className="mt-1.5 mb-0 text-[13px] text-zinc-400 dark:text-zinc-500">
-                Complete a lesson to start earning XP and unlocking achievements.
+                {t.emptyHint}
               </p>
             </div>
           </div>
@@ -125,13 +175,16 @@ export default function GamificationProfile() {
       : 100;
 
   const stats: Array<{ label: string; value: string; icon: string }> = [
-    { icon: "🪙", label: "Coins", value: String(props.coins) },
-    { icon: "🔥", label: "Streak", value: `${props.current_streak}d` },
-    { icon: "🏆", label: "Best streak", value: `${props.longest_streak}d` },
+    { icon: "🪙", label: t.coins, value: fmt.number(props.coins) },
+    { icon: "🔥", label: t.streak, value: t.days(fmt.number(props.current_streak)) },
+    { icon: "🏆", label: t.bestStreak, value: t.days(fmt.number(props.longest_streak)) },
     {
       icon: "📊",
-      label: "Rank",
-      value: props.rank !== null ? `#${props.rank} of ${props.participants}` : "—",
+      label: t.rank,
+      value:
+        props.rank !== null
+          ? t.rankValue(fmt.number(props.rank), fmt.number(props.participants))
+          : "—",
     },
   ];
 
@@ -148,11 +201,11 @@ export default function GamificationProfile() {
               </div>
               <div className="min-w-0">
                 <div className="text-lg font-bold tracking-tight text-zinc-900 dark:text-zinc-100">
-                  Level {props.level}
+                  {t.level(fmt.number(props.level))}
                   {props.level_title ? ` · ${props.level_title}` : ""}
                 </div>
                 <div className="mt-0.5 text-[13px] text-zinc-500 dark:text-zinc-400">
-                  {props.total_xp.toLocaleString()} XP total
+                  {t.xpTotal(fmt.number(props.total_xp))}
                 </div>
               </div>
             </div>
@@ -168,13 +221,12 @@ export default function GamificationProfile() {
               {props.next_level && props.xp_needed !== null ? (
                 <>
                   <span>
-                    {props.xp_needed.toLocaleString()} XP to level{" "}
-                    {props.next_level.level}
+                    {t.xpToLevel(fmt.number(props.xp_needed), fmt.number(props.next_level.level))}
                   </span>
-                  <span className="tabular-nums">{levelPct}%</span>
+                  <span className="tabular-nums">{fmt.percent(levelPct)}</span>
                 </>
               ) : (
-                <span>Max level reached 🎉</span>
+                <span>{t.maxLevel}</span>
               )}
             </div>
           </div>
@@ -201,44 +253,49 @@ export default function GamificationProfile() {
           <div className="overflow-hidden rounded-xl border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
             <div className="border-b border-zinc-200 px-4 py-3 dark:border-zinc-800">
               <span className="text-[13px] font-semibold text-zinc-900 dark:text-zinc-100">
-                Achievements ({props.achievements.length})
+                {t.achievements(fmt.number(props.achievements.length))}
               </span>
             </div>
 
             {props.achievements.length === 0 ? (
               <div className="p-6 text-center text-[13px] text-zinc-400 dark:text-zinc-500">
-                No achievements earned yet — keep learning!
+                {t.noAchievements}
               </div>
             ) : (
-              <div className="grid grid-cols-[repeat(auto-fill,minmax(210px,1fr))] gap-2.5 p-3.5">
+              /*
+                Three shared rows — title, description, footer — so an
+                achievement with no description ("Buena gente" in the fixture)
+                collapses that row instead of leaving a gap above its badge,
+                and every tier badge and date sits on the same baseline across
+                the row.
+              */
+              <div className="grid grid-cols-[repeat(auto-fill,minmax(210px,1fr))] grid-rows-[auto_auto_auto] gap-2.5 p-3.5">
                 {props.achievements.map((a) => (
                   <div
                     key={a.slug + a.earned_at}
-                    className="rounded-[10px] border border-zinc-200 p-3 dark:border-zinc-800"
+                    className="row-span-3 grid grid-rows-subgrid gap-1.5 rounded-[10px] border border-zinc-200 p-3 dark:border-zinc-800"
                   >
-                    <div className="mb-1.5 flex items-center gap-2">
+                    <div className="flex items-center gap-2">
                       <span className="text-xl">{a.icon ?? "🏅"}</span>
                       <span className="text-[13px] leading-tight font-semibold text-zinc-900 dark:text-zinc-100">
                         {a.title}
                       </span>
                     </div>
-                    {a.description && (
-                      <div className="mb-2 text-[11.5px] leading-[1.45] text-zinc-400 dark:text-zinc-500">
-                        {a.description}
-                      </div>
-                    )}
+                    <div className="text-[11.5px] leading-[1.45] text-zinc-400 dark:text-zinc-500">
+                      {a.description}
+                    </div>
                     <div className="flex items-center justify-between gap-1.5">
                       {a.tier ? (
                         <span
                           className={`rounded-lg px-2 py-0.5 text-[10.5px] font-bold capitalize ${tierClass(a.tier)}`}
                         >
-                          {a.tier}
+                          {t.tier[a.tier.toLowerCase()] ?? a.tier}
                         </span>
                       ) : (
                         <span />
                       )}
                       <span className="text-[11px] text-zinc-400 dark:text-zinc-500">
-                        {formatDate(a.earned_at)}
+                        {fmt.date(a.earned_at)}
                       </span>
                     </div>
                   </div>

--- a/mcp-server/resources/my-exam-results/widget.tsx
+++ b/mcp-server/resources/my-exam-results/widget.tsx
@@ -6,6 +6,7 @@ import {
   type WidgetMetadata,
 } from "mcp-use/react";
 import { Brand } from "../shared/branding";
+import { useFormat, useStrings } from "../shared/i18n";
 import { z } from "zod";
 import { Markdown } from "../shared/markdown";
 
@@ -41,19 +42,48 @@ export const widgetMetadata: WidgetMetadata = {
 
 type Props = z.infer<typeof propsSchema>;
 
+// ── Strings ──────────────────────────────────────────────────────────────────
+
+const STRINGS = {
+  en: {
+    loading: "Loading your exam results…",
+    title: "My Exam Results",
+    subtitle: (n: number, count: string) => `${count} submission${n === 1 ? "" : "s"}`,
+    avgScore: (avg: string) => ` · ${avg} avg score`,
+    emptyTitle: "No exam submissions yet",
+    emptyHint: "Your scores and feedback will appear here after you take an exam.",
+    hideFeedback: "Hide feedback ▲",
+    showFeedback: "Feedback ▼",
+    reviewStatus: {
+      approved: "Approved",
+      graded: "Graded",
+      rejected: "Rejected",
+      failed: "Failed",
+      pending: "Pending",
+    } as Record<string, string>,
+  },
+  es: {
+    loading: "Cargando tus resultados de examen…",
+    title: "Mis resultados de exámenes",
+    subtitle: (n: number, count: string) => `${count} ${n === 1 ? "entrega" : "entregas"}`,
+    avgScore: (avg: string) => ` · nota media ${avg}`,
+    emptyTitle: "Todavía no hay entregas de examen",
+    emptyHint: "Tus notas y comentarios aparecerán aquí después de realizar un examen.",
+    hideFeedback: "Ocultar comentarios ▲",
+    showFeedback: "Comentarios ▼",
+    reviewStatus: {
+      approved: "Aprobada",
+      graded: "Calificada",
+      rejected: "Rechazada",
+      failed: "Suspendida",
+      pending: "Pendiente",
+    } as Record<string, string>,
+  },
+};
+
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
 const PASS_THRESHOLD = 70;
-
-function formatDate(iso: string): string {
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return iso;
-  return d.toLocaleDateString(undefined, {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-  });
-}
 
 // ── Component ────────────────────────────────────────────────────────────────
 
@@ -63,6 +93,8 @@ export default function MyExamResults() {
   const [expanded, setExpanded] = useState<Set<number>>(new Set());
 
   const dark = theme === "dark";
+  const t = useStrings(STRINGS);
+  const fmt = useFormat();
 
   if (isPending) {
     return (
@@ -71,7 +103,7 @@ export default function MyExamResults() {
         <div className={dark ? "dark" : ""}>
           <div className="bg-zinc-50 p-10 text-center font-sans text-zinc-400 dark:bg-zinc-950 dark:text-zinc-500">
             <div className="mx-auto mb-3 size-9 animate-spin rounded-full border-[3px] border-zinc-200 border-t-[var(--brand-600)] dark:border-zinc-800 dark:border-t-[var(--brand-400)]" />
-            <p className="m-0 text-sm">Loading your exam results…</p>
+            <p className="m-0 text-sm">{t.loading}</p>
           </div>
         </div>
       </McpUseProvider>
@@ -96,12 +128,12 @@ export default function MyExamResults() {
         <div className="mx-auto max-w-[760px] bg-zinc-50 p-6 font-sans dark:bg-zinc-950">
           <div className="mb-[18px] flex flex-wrap items-baseline justify-between gap-2">
             <h1 className="m-0 text-[22px] font-bold tracking-tight text-zinc-900 dark:text-zinc-100">
-              My Exam Results
+              {t.title}
             </h1>
             <span className="text-[13px] text-zinc-500 dark:text-zinc-400">
-              {total} submission{total === 1 ? "" : "s"}
+              {t.subtitle(total, fmt.number(total))}
               {average_score !== null
-                ? ` · ${Math.round(average_score)} avg score`
+                ? t.avgScore(fmt.number(Math.round(average_score)))
                 : ""}
             </span>
           </div>
@@ -110,10 +142,10 @@ export default function MyExamResults() {
             <div className="rounded-xl border border-zinc-200 bg-white p-10 text-center dark:border-zinc-800 dark:bg-zinc-900">
               <div className="mb-2 text-3xl">📝</div>
               <p className="m-0 text-[15px] font-semibold text-zinc-900 dark:text-zinc-100">
-                No exam submissions yet
+                {t.emptyTitle}
               </p>
               <p className="mt-1.5 mb-0 text-[13px] text-zinc-400 dark:text-zinc-500">
-                Your scores and feedback will appear here after you take an exam.
+                {t.emptyHint}
               </p>
             </div>
           ) : (
@@ -165,14 +197,16 @@ export default function MyExamResults() {
                         </div>
                         <div className="mt-0.5 text-xs text-zinc-400 dark:text-zinc-500">
                           {r.course_title ? `${r.course_title} · ` : ""}
-                          {formatDate(r.submitted_at)}
-                          {r.review_status ? ` · ${r.review_status}` : ""}
+                          {fmt.date(r.submitted_at)}
+                          {r.review_status
+                            ? ` · ${t.reviewStatus[r.review_status.toLowerCase()] ?? r.review_status}`
+                            : ""}
                         </div>
                       </div>
 
                       {r.feedback && (
                         <span className="shrink-0 text-xs font-semibold text-[var(--brand-600)] dark:text-[var(--brand-400)]">
-                          {isOpen ? "Hide feedback ▲" : "Feedback ▼"}
+                          {isOpen ? t.hideFeedback : t.showFeedback}
                         </span>
                       )}
                     </div>

--- a/mcp-server/resources/my-learning/widget.tsx
+++ b/mcp-server/resources/my-learning/widget.tsx
@@ -5,6 +5,7 @@ import {
   type WidgetMetadata,
 } from "mcp-use/react";
 import { Brand } from "../shared/branding";
+import { useFormat, useStrings } from "../shared/i18n";
 import { z } from "zod";
 
 // ── Schema ──────────────────────────────────────────────────────────────────
@@ -46,12 +47,42 @@ export const widgetMetadata: WidgetMetadata = {
 
 type Props = z.infer<typeof propsSchema>;
 
+// ── Strings ──────────────────────────────────────────────────────────────────
+
+const STRINGS = {
+  en: {
+    loading: "Loading your courses…",
+    title: "My Learning",
+    summary: (n: number, count: string, avg: string) =>
+      `${count} course${n === 1 ? "" : "s"} · ${avg} average progress`,
+    emptyTitle: "No enrolled courses yet",
+    emptyHint: "Browse the catalog to find your first course.",
+    lessonsDone: (done: string, total: string) => `${done}/${total} lessons completed`,
+    complete: "✓ Course complete",
+    resume: (seq: string, title: string) => `Continue · Lesson ${seq}: ${title}`,
+  },
+  es: {
+    loading: "Cargando tus cursos…",
+    title: "Mi aprendizaje",
+    summary: (n: number, count: string, avg: string) =>
+      `${count} ${n === 1 ? "curso" : "cursos"} · ${avg} de progreso medio`,
+    emptyTitle: "Todavía no tienes cursos",
+    emptyHint: "Explora el catálogo para encontrar tu primer curso.",
+    lessonsDone: (done: string, total: string) =>
+      `${done}/${total} lecciones completadas`,
+    complete: "✓ Curso completado",
+    resume: (seq: string, title: string) => `Continuar · Lección ${seq}: ${title}`,
+  },
+};
+
 // ── Component ────────────────────────────────────────────────────────────────
 
 export default function MyLearning() {
-  const { props, isPending } = useWidget<Props>();
+  const { props, isPending, sendFollowUpMessage } = useWidget<Props>();
   const theme = useWidgetTheme();
   const dark = theme === "dark";
+  const t = useStrings(STRINGS);
+  const fmt = useFormat();
 
   if (isPending) {
     return (
@@ -60,7 +91,7 @@ export default function MyLearning() {
         <div className={dark ? "dark" : ""}>
           <div className="bg-zinc-50 p-10 text-center font-sans text-zinc-400 dark:bg-zinc-950 dark:text-zinc-500">
             <div className="mx-auto mb-3 size-9 animate-spin rounded-full border-[3px] border-zinc-200 border-t-[var(--brand-600)] dark:border-zinc-800 dark:border-t-[var(--brand-400)]" />
-            <p className="m-0 text-sm">Loading your courses…</p>
+            <p className="m-0 text-sm">{t.loading}</p>
           </div>
         </div>
       </McpUseProvider>
@@ -77,11 +108,10 @@ export default function MyLearning() {
           {/* Header */}
           <div className="mb-4 flex flex-wrap items-baseline justify-between gap-2">
             <h1 className="m-0 text-[22px] font-bold tracking-tight text-zinc-900 dark:text-zinc-100">
-              My Learning
+              {t.title}
             </h1>
             <span className="text-[13px] text-zinc-500 dark:text-zinc-400">
-              {total} course{total === 1 ? "" : "s"} · {average_progress}%
-              average progress
+              {t.summary(total, fmt.number(total), fmt.percent(average_progress))}
             </span>
           </div>
 
@@ -89,10 +119,10 @@ export default function MyLearning() {
             <div className="rounded-xl border border-zinc-200 bg-white p-10 text-center dark:border-zinc-800 dark:bg-zinc-900">
               <div className="mb-2 text-3xl">🎓</div>
               <p className="m-0 text-[15px] font-semibold text-zinc-900 dark:text-zinc-100">
-                No enrolled courses yet
+                {t.emptyTitle}
               </p>
               <p className="mt-1.5 mb-0 text-[13px] text-zinc-400 dark:text-zinc-500">
-                Browse the catalog to find your first course.
+                {t.emptyHint}
               </p>
             </div>
           ) : (
@@ -140,18 +170,35 @@ export default function MyLearning() {
 
                     <div className="flex flex-wrap items-center justify-between gap-3">
                       <span className="text-xs text-zinc-500 dark:text-zinc-400">
-                        {course.lessons_completed}/{course.lessons_total} lessons
-                        completed
+                        {t.lessonsDone(
+                          fmt.number(course.lessons_completed),
+                          fmt.number(course.lessons_total)
+                        )}
                       </span>
                       {done ? (
                         <span className="text-xs font-semibold text-green-600 dark:text-green-400">
-                          ✓ Course complete
+                          {t.complete}
                         </span>
                       ) : course.next_lesson ? (
-                        <span className="rounded-lg bg-zinc-100 px-2 py-0.5 text-xs text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">
-                          Next: Lesson {course.next_lesson.sequence} ·{" "}
-                          {course.next_lesson.title}
-                        </span>
+                        /*
+                          Getting the student back into the lesson is the entire
+                          job of this card, and it used to be a grey pill that
+                          looked like a caption. It is the primary action, so it
+                          is now the only thing on the card that looks like one.
+                        */
+                        <button
+                          onClick={() =>
+                            sendFollowUpMessage(
+                              `Open lesson ${course.next_lesson!.id} ("${course.next_lesson!.title}") from "${course.title}" with lms_view_lesson.`
+                            )
+                          }
+                          className="max-w-full cursor-pointer truncate rounded-lg border-none bg-[var(--brand-600)] px-3 py-1.5 text-xs font-semibold text-white dark:bg-[var(--brand-400)] dark:text-zinc-950"
+                        >
+                          {t.resume(
+                            fmt.number(course.next_lesson.sequence),
+                            course.next_lesson.title
+                          )}
+                        </button>
                       ) : null}
                     </div>
                   </div>

--- a/mcp-server/resources/practice-player/widget.tsx
+++ b/mcp-server/resources/practice-player/widget.tsx
@@ -7,6 +7,7 @@ import {
   type WidgetMetadata,
 } from "mcp-use/react";
 import { Brand } from "../shared/branding";
+import { useStrings } from "../shared/i18n";
 import { z } from "zod";
 
 // ── Schema ──────────────────────────────────────────────────────────────────
@@ -63,6 +64,75 @@ type Question = z.infer<typeof questionSchema>;
 // match → right-item per left-item, order → arranged items.
 type Answer = number | boolean | string | Record<string, string> | string[];
 
+// ── Strings ──────────────────────────────────────────────────────────────────
+
+const STRINGS = {
+  en: {
+    loading: "Setting up practice…",
+    noQuestions: (topic: string) =>
+      `No practice questions could be generated for “${topic}”. Ask the tutor to try a different topic or lesson.`,
+    practice: "Practice",
+    mixedPractice: "Mixed practice",
+    mixedBanner:
+      "Mixed practice: questions jump between topics on purpose. It feels harder — that's the point: it measurably improves long-term retention.",
+    questionOf: (current: number, total: number) => `Question ${current} of ${total}`,
+    trueLabel: "True",
+    falseLabel: "False",
+    noAnswer: "(no answer)",
+    freeTextPlaceholder: "Write your answer — the tutor will grade it",
+    fillBlankPlaceholder: "Type your answer",
+    matchHint: "Tap an item on the left, then its match on the right.",
+    orderHint: "Arrange with the ↑ / ↓ buttons.",
+    moveUp: (item: string) => `Move "${item}" up`,
+    moveDown: (item: string) => `Move "${item}" down`,
+    back: "Back",
+    next: "Next",
+    finish: "Finish",
+    answersSent: "Answers sent",
+    scoreCorrect: (correct: number, total: number) => `${correct}/${total} correct`,
+    freeTextSentSuffix:
+      " — your free-text answers went to the tutor for grading.",
+    recordingSuffix: " — recording your attempt…",
+    recordedSuffix: " — attempt recorded. The tutor will pick it up from here.",
+    yourAnswer: "Your answer: ",
+    correctLabel: " · Correct: ",
+    awaitingGrading: " · Awaiting tutor grading",
+  },
+  es: {
+    loading: "Preparando la práctica…",
+    noQuestions: (topic: string) =>
+      `No se pudieron generar preguntas de práctica para “${topic}”. Pídele al tutor que pruebe con otro tema o lección.`,
+    practice: "Práctica",
+    mixedPractice: "Práctica mixta",
+    mixedBanner:
+      "Práctica mezclada: las preguntas saltan entre temas a propósito. Se siente más difícil — esa es la idea: mejora de forma comprobada la retención a largo plazo.",
+    questionOf: (current: number, total: number) => `Pregunta ${current} de ${total}`,
+    trueLabel: "Verdadero",
+    falseLabel: "Falso",
+    noAnswer: "(sin respuesta)",
+    freeTextPlaceholder: "Escribe tu respuesta — el tutor la calificará",
+    fillBlankPlaceholder: "Escribe tu respuesta",
+    matchHint: "Toca un elemento de la izquierda y luego su pareja a la derecha.",
+    orderHint: "Ordena con los botones ↑ / ↓.",
+    moveUp: (item: string) => `Subir "${item}"`,
+    moveDown: (item: string) => `Bajar "${item}"`,
+    back: "Atrás",
+    next: "Siguiente",
+    finish: "Finalizar",
+    answersSent: "Respuestas enviadas",
+    scoreCorrect: (correct: number, total: number) => `${correct}/${total} correctas`,
+    freeTextSentSuffix:
+      " — tus respuestas de texto libre se enviaron al tutor para su calificación.",
+    recordingSuffix: " — registrando tu intento…",
+    recordedSuffix: " — intento registrado. El tutor lo retomará desde aquí.",
+    yourAnswer: "Tu respuesta: ",
+    correctLabel: " · Correcta: ",
+    awaitingGrading: " · Esperando la calificación del tutor",
+  },
+};
+
+type Strings = typeof STRINGS.en;
+
 // ── Grading (closed types only) ─────────────────────────────────────────────
 
 function isCorrect(q: Question, answer: Answer | undefined): boolean | null {
@@ -95,12 +165,12 @@ function isCorrect(q: Question, answer: Answer | undefined): boolean | null {
   }
 }
 
-function expectedAnswerText(q: Question): string {
+function expectedAnswerText(q: Question, t: Strings): string {
   switch (q.type) {
     case "multiple_choice":
       return q.options?.[q.correct as number] ?? "";
     case "true_false":
-      return q.correct ? "True" : "False";
+      return q.correct ? t.trueLabel : t.falseLabel;
     case "fill_blank":
       return Array.isArray(q.correct) ? q.correct[0] : String(q.correct ?? "");
     case "match":
@@ -112,13 +182,13 @@ function expectedAnswerText(q: Question): string {
   }
 }
 
-function answerText(q: Question, answer: Answer | undefined): string {
-  if (answer === undefined) return "(no answer)";
+function answerText(q: Question, answer: Answer | undefined, t: Strings): string {
+  if (answer === undefined) return t.noAnswer;
   switch (q.type) {
     case "multiple_choice":
       return q.options?.[answer as number] ?? String(answer);
     case "true_false":
-      return answer ? "True" : "False";
+      return answer ? t.trueLabel : t.falseLabel;
     case "match":
       return Object.entries(answer as Record<string, string>)
         .map(([l, r]) => `${l} → ${r}`)
@@ -129,24 +199,6 @@ function answerText(q: Question, answer: Answer | undefined): string {
       return String(answer);
   }
 }
-
-// mcp-server widgets have no i18n layer; the mixed-practice explainer is the
-// one string the issue (#393) requires in en/es, so pick by browser locale.
-const IS_ES =
-  typeof navigator !== "undefined" &&
-  (navigator.language || "").toLowerCase().startsWith("es");
-
-const MIXED_COPY = IS_ES
-  ? {
-      pill: "Práctica mixta",
-      banner:
-        "Práctica mezclada: las preguntas saltan entre temas a propósito. Se siente más difícil — esa es la idea: mejora de forma comprobada la retención a largo plazo.",
-    }
-  : {
-      pill: "Mixed practice",
-      banner:
-        "Mixed practice: questions jump between topics on purpose. It feels harder — that's the point: it measurably improves long-term retention.",
-    };
 
 /** Deterministic-enough shuffle for presentation (never mutates the input). */
 function shuffled<T>(items: T[]): T[] {
@@ -187,6 +239,7 @@ const inputClass =
 export default function PracticePlayer() {
   const { props, isPending, sendFollowUpMessage } = useWidget<Props>();
   const theme = useWidgetTheme();
+  const t = useStrings(STRINGS);
   const { callTool: recordAttempt, isPending: isRecording } = useCallTool(
     "lms_record_practice_attempt"
   );
@@ -225,7 +278,7 @@ export default function PracticePlayer() {
         <Brand />
         <div className={dark ? "dark" : ""}>
           <div className="bg-zinc-50 p-10 text-center font-sans text-zinc-400 dark:bg-zinc-950 dark:text-zinc-500">
-            Setting up practice…
+            {t.loading}
           </div>
         </div>
       </McpUseProvider>
@@ -240,8 +293,7 @@ export default function PracticePlayer() {
         <Brand />
         <div className={dark ? "dark" : ""}>
           <div className="bg-zinc-50 p-10 text-center font-sans text-sm text-zinc-400 dark:bg-zinc-950 dark:text-zinc-500">
-            No practice questions could be generated for “{topic}”. Ask the
-            tutor to try a different topic or lesson.
+            {t.noQuestions(topic)}
           </div>
         </div>
       </McpUseProvider>
@@ -282,7 +334,7 @@ export default function PracticePlayer() {
       prompt: x.prompt,
       type: x.type,
       ...(x.topic ? { topic: x.topic } : {}),
-      answer: answerText(x, effectiveAnswer(x)),
+      answer: answerText(x, effectiveAnswer(x), t),
       correct: isCorrect(x, effectiveAnswer(x)),
     }));
 
@@ -360,15 +412,15 @@ export default function PracticePlayer() {
         <div className={dark ? "dark" : ""}>
           <div className={containerClass}>
             <h2 className="m-0 mb-1 text-xl text-zinc-900 dark:text-zinc-100">
-              {hasFreeText ? "Answers sent" : `${correctCount}/${closedTotal} correct`}
+              {hasFreeText ? t.answersSent : t.scoreCorrect(correctCount, closedTotal)}
             </h2>
             <p className="m-0 mb-4 text-[13px] text-zinc-500 dark:text-zinc-400">
               {topic}
               {hasFreeText
-                ? " — your free-text answers went to the tutor for grading."
+                ? t.freeTextSentSuffix
                 : isRecording
-                  ? " — recording your attempt…"
-                  : " — attempt recorded. The tutor will pick it up from here."}
+                  ? t.recordingSuffix
+                  : t.recordedSuffix}
             </p>
             {results.map(({ q: rq, correct }) => (
               <div
@@ -385,11 +437,12 @@ export default function PracticePlayer() {
                   {correct === null ? "✍️" : correct ? "✓" : "✗"} {rq.prompt}
                 </div>
                 <div className="text-zinc-500 dark:text-zinc-400">
-                  Your answer: {answerText(rq, effectiveAnswer(rq))}
+                  {t.yourAnswer}
+                  {answerText(rq, effectiveAnswer(rq), t)}
                   {correct === false && (
-                    <> · Correct: {expectedAnswerText(rq)}</>
+                    <>{t.correctLabel}{expectedAnswerText(rq, t)}</>
                   )}
-                  {correct === null && <> · Awaiting tutor grading</>}
+                  {correct === null && <>{t.awaitingGrading}</>}
                 </div>
                 {correct !== null && rq.explanation && (
                   <div className="mt-1 text-[12.5px] leading-[1.5] text-zinc-600 dark:text-zinc-300">
@@ -414,12 +467,12 @@ export default function PracticePlayer() {
           <div className="mb-3.5 flex flex-wrap items-center justify-between gap-2">
             <span className="rounded-lg bg-[var(--brand-50)] px-2 py-0.5 text-[11px] font-bold text-[var(--brand-600)] dark:bg-[var(--brand-950)] dark:text-[var(--brand-400)]">
               {isMixed
-                ? `${MIXED_COPY.pill} · ${q.topic ?? topic}`
-                : `Practice · ${topic}`}
+                ? `${t.mixedPractice} · ${q.topic ?? topic}`
+                : `${t.practice} · ${topic}`}
             </span>
             <div
               className="flex gap-[5px]"
-              aria-label={`Question ${index + 1} of ${questions.length}`}
+              aria-label={t.questionOf(index + 1, questions.length)}
             >
               {questions.map((dot, i) => (
                 <span
@@ -438,7 +491,7 @@ export default function PracticePlayer() {
 
           {isMixed && index === 0 && (
             <p className="m-0 mb-3.5 rounded-[10px] border border-[var(--brand-200)] bg-[var(--brand-50)] px-3 py-2 text-[12.5px] leading-[1.5] text-[var(--brand-900)] dark:border-[var(--brand-900)] dark:bg-[var(--brand-950)] dark:text-[var(--brand-200)]">
-              {MIXED_COPY.banner}
+              {t.mixedBanner}
             </p>
           )}
 
@@ -462,7 +515,7 @@ export default function PracticePlayer() {
                   onClick={() => setAnswer(v)}
                   className={choiceClass(answer === v, "flex-1 text-center")}
                 >
-                  {v ? "True" : "False"}
+                  {v ? t.trueLabel : t.falseLabel}
                 </button>
               ))}
             </div>
@@ -474,7 +527,7 @@ export default function PracticePlayer() {
                 value={(answer as string) ?? ""}
                 onChange={(e) => setAnswer(e.target.value)}
                 rows={5}
-                placeholder="Write your answer — the tutor will grade it"
+                placeholder={t.freeTextPlaceholder}
                 className={`${inputClass} resize-y [font-family:inherit]`}
               />
             ) : (
@@ -482,7 +535,7 @@ export default function PracticePlayer() {
                 type="text"
                 value={(answer as string) ?? ""}
                 onChange={(e) => setAnswer(e.target.value)}
-                placeholder="Type your answer"
+                placeholder={t.fillBlankPlaceholder}
                 className={inputClass}
               />
             )
@@ -491,7 +544,7 @@ export default function PracticePlayer() {
           {q.type === "match" && (
             <div>
               <p className="m-0 mb-2 text-xs text-zinc-400 dark:text-zinc-500">
-                Tap an item on the left, then its match on the right.
+                {t.matchHint}
               </p>
               <div className="flex gap-3">
                 <div className="flex-1">
@@ -545,7 +598,7 @@ export default function PracticePlayer() {
           {q.type === "order" && (
             <div>
               <p className="m-0 mb-2 text-xs text-zinc-400 dark:text-zinc-500">
-                Arrange with the ↑ / ↓ buttons.
+                {t.orderHint}
               </p>
               {(((answer as string[]) ?? initialOrders[q.id]) ?? []).map(
                 (item, i, arr) => (
@@ -555,7 +608,7 @@ export default function PracticePlayer() {
                   >
                     <span className="flex-1">{item}</span>
                     <button
-                      aria-label={`Move "${item}" up`}
+                      aria-label={t.moveUp(item)}
                       disabled={i === 0}
                       onClick={() => {
                         const next = [...arr];
@@ -567,7 +620,7 @@ export default function PracticePlayer() {
                       ↑
                     </button>
                     <button
-                      aria-label={`Move "${item}" down`}
+                      aria-label={t.moveDown(item)}
                       disabled={i === arr.length - 1}
                       onClick={() => {
                         const next = [...arr];
@@ -591,7 +644,7 @@ export default function PracticePlayer() {
               disabled={index === 0}
               className="cursor-pointer rounded-[10px] border border-zinc-200 bg-transparent px-4.5 py-[9px] text-[13.5px] font-semibold text-zinc-500 disabled:cursor-default disabled:opacity-40 dark:border-zinc-800 dark:text-zinc-400"
             >
-              Back
+              {t.back}
             </button>
             <button
               onClick={() => {
@@ -605,7 +658,7 @@ export default function PracticePlayer() {
               disabled={!answeredCurrent}
               className={`${primaryBtnClass} disabled:cursor-default disabled:opacity-50`}
             >
-              {isLast ? "Finish" : "Next"}
+              {isLast ? t.finish : t.next}
             </button>
           </div>
         </div>

--- a/mcp-server/resources/school-overview/widget.tsx
+++ b/mcp-server/resources/school-overview/widget.tsx
@@ -5,6 +5,8 @@ import {
   type WidgetMetadata,
 } from "mcp-use/react";
 import { Brand } from "../shared/branding";
+import { useFormat, useStrings } from "../shared/i18n";
+import { NEUTRAL_TEXT, barClass, textClass } from "../shared/severity";
 import { z } from "zod";
 
 // ── Schema ──────────────────────────────────────────────────────────────────
@@ -52,6 +54,68 @@ export const widgetMetadata: WidgetMetadata = {
 type Props = z.infer<typeof propsSchema>;
 type Course = z.infer<typeof courseSchema>;
 
+// ── Strings ──────────────────────────────────────────────────────────────────
+
+const STRINGS = {
+  en: {
+    loading: "Crunching school stats…",
+    subtitle: "School overview",
+    courses: "Courses",
+    students: "Students",
+    publishedLessons: "Published lessons",
+    avgCompletion: "Avg completion",
+    avgExamScore: "Avg exam score",
+    atRisk: "At-risk students",
+    // States the rule the number is actually computed from
+    // (analytics.ts: active enrollment + course has published lessons +
+    // zero completions), replacing a hardcoded "active · 0 lessons done"
+    // that described nothing.
+    atRiskRule: "active enrollments · 0 lessons done",
+    published: (n: number) => `${n} published`,
+    draft: (n: number) => `${n} draft`,
+    archived: (n: number) => `${n} archived`,
+    activeEnrollments: (n: string) => `${n} active enrollments`,
+    submissions: (n: string) => `${n} submissions`,
+    coursesHeading: (n: string) => `Courses (${n})`,
+    enrolled: "enrolled",
+    lessons: (n: number, s: string) => `${s} lesson${n === 1 ? "" : "s"}`,
+    examAvg: "exam avg",
+    noCourses: "No courses yet.",
+    status: {
+      published: "published",
+      draft: "draft",
+      archived: "archived",
+    } as Record<string, string>,
+  },
+  es: {
+    loading: "Calculando estadísticas…",
+    subtitle: "Resumen de la escuela",
+    courses: "Cursos",
+    students: "Estudiantes",
+    publishedLessons: "Lecciones publicadas",
+    avgCompletion: "Finalización media",
+    avgExamScore: "Nota media de exámenes",
+    atRisk: "Estudiantes en riesgo",
+    atRiskRule: "inscripciones activas · 0 lecciones",
+    // Spanish agrees in number, so these cannot be a bare suffix.
+    published: (n: number) => `${n} ${n === 1 ? "publicado" : "publicados"}`,
+    draft: (n: number) => `${n} en borrador`,
+    archived: (n: number) => `${n} ${n === 1 ? "archivado" : "archivados"}`,
+    activeEnrollments: (n: string) => `${n} inscripciones activas`,
+    submissions: (n: string) => `${n} entregas`,
+    coursesHeading: (n: string) => `Cursos (${n})`,
+    enrolled: "inscritos",
+    lessons: (n: number, s: string) => `${s} ${n === 1 ? "lección" : "lecciones"}`,
+    examAvg: "nota media",
+    noCourses: "Todavía no hay cursos.",
+    status: {
+      published: "publicado",
+      draft: "borrador",
+      archived: "archivado",
+    } as Record<string, string>,
+  },
+};
+
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
 function statusPill(status: string): string {
@@ -61,17 +125,19 @@ function statusPill(status: string): string {
     case "draft":
       return "bg-zinc-100 text-zinc-600 dark:bg-zinc-700 dark:text-zinc-400";
     case "archived":
-      return "bg-indigo-100 text-indigo-700 dark:bg-indigo-950 dark:text-indigo-300";
+      return "bg-zinc-200 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300";
     default:
       return "bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300";
   }
 }
 
-function completionColor(pct: number): string {
-  if (pct >= 80) return "bg-green-600 dark:bg-green-400";
-  if (pct >= 40) return "bg-[var(--brand-600)] dark:bg-[var(--brand-400)]";
-  if (pct > 0) return "bg-amber-600 dark:bg-amber-400";
-  return "bg-zinc-300 dark:bg-zinc-600";
+/**
+ * Completion has no meaning for a course with nothing published to complete —
+ * that is "no data", not 0%. Passing `null` keeps those bars neutral instead of
+ * painting an empty draft course as a failing one.
+ */
+function completionOf(c: Course): number | null {
+  return c.published_lessons > 0 ? c.completion_rate : null;
 }
 
 // ── Component ────────────────────────────────────────────────────────────────
@@ -80,6 +146,8 @@ export default function SchoolOverview() {
   const { props, isPending } = useWidget<Props>();
   const theme = useWidgetTheme();
   const dark = theme === "dark";
+  const t = useStrings(STRINGS);
+  const fmt = useFormat();
 
   if (isPending) {
     return (
@@ -88,7 +156,7 @@ export default function SchoolOverview() {
         <div className={dark ? "dark" : ""}>
           <div className="bg-zinc-50 p-10 text-center font-sans text-zinc-400 dark:bg-zinc-950 dark:text-zinc-500">
             <div className="mx-auto mb-3 size-9 animate-spin rounded-full border-[3px] border-zinc-200 border-t-[var(--brand-600)] dark:border-zinc-800 dark:border-t-[var(--brand-400)]" />
-            <p className="m-0 text-sm">Crunching school stats…</p>
+            <p className="m-0 text-sm">{t.loading}</p>
           </div>
         </div>
       </McpUseProvider>
@@ -96,6 +164,20 @@ export default function SchoolOverview() {
   }
 
   const { school, courses } = props;
+
+  /**
+   * "3 published · 2 draft" under a total of 6 — the archived courses were
+   * simply left out, so the parts visibly failed to sum to the number directly
+   * above them. Build the caption from whichever buckets are non-empty; the
+   * three are exhaustive, so it now always adds up.
+   */
+  const breakdown = [
+    school.courses_published > 0 ? t.published(school.courses_published) : null,
+    school.courses_draft > 0 ? t.draft(school.courses_draft) : null,
+    school.courses_archived > 0 ? t.archived(school.courses_archived) : null,
+  ]
+    .filter(Boolean)
+    .join(" · ");
 
   const kpi = (
     label: string,
@@ -133,38 +215,43 @@ export default function SchoolOverview() {
               {school.name}
             </h2>
             <div className="mt-0.5 text-[13px] text-zinc-400 dark:text-zinc-500">
-              School overview
+              {t.subtitle}
             </div>
           </div>
 
           {/* KPI grid */}
           <div className="mb-[22px] grid grid-cols-[repeat(auto-fill,minmax(150px,1fr))] gap-3">
+            {/*
+              Accent rule: a number is coloured only when it is a verdict —
+              something a school can be doing well or badly at. Counts of
+              courses, students and lessons are facts, so they stay neutral.
+              Previously completion was brand-violet and at-risk was red with
+              the other four plain, which read as if those two had been singled
+              out for an unstated reason.
+            */}
+            {kpi(t.courses, fmt.number(school.courses_total), breakdown || undefined)}
             {kpi(
-              "Courses",
-              String(school.courses_total),
-              `${school.courses_published} published · ${school.courses_draft} draft`
+              t.students,
+              fmt.number(school.students),
+              t.activeEnrollments(fmt.number(school.active_enrollments))
             )}
+            {kpi(t.publishedLessons, fmt.number(school.published_lessons))}
             {kpi(
-              "Students",
-              String(school.students),
-              `${school.active_enrollments} active enrollments`
-            )}
-            {kpi("Published lessons", String(school.published_lessons))}
-            {kpi(
-              "Avg completion",
-              `${school.completion_rate}%`,
+              t.avgCompletion,
+              fmt.percent(school.completion_rate),
               undefined,
-              "text-[var(--brand-600)] dark:text-[var(--brand-400)]"
+              textClass(school.completion_rate)
             )}
             {kpi(
-              "Avg exam score",
-              school.avg_exam_score == null ? "—" : `${school.avg_exam_score}%`,
-              `${school.exam_submissions} submissions`
+              t.avgExamScore,
+              fmt.percent(school.avg_exam_score),
+              t.submissions(fmt.number(school.exam_submissions)),
+              textClass(school.avg_exam_score)
             )}
             {kpi(
-              "At-risk students",
-              String(school.at_risk_students),
-              "active · 0 lessons done",
+              t.atRisk,
+              fmt.number(school.at_risk_students),
+              t.atRiskRule,
               school.at_risk_students > 0
                 ? "text-red-600 dark:text-red-400"
                 : undefined
@@ -173,7 +260,7 @@ export default function SchoolOverview() {
 
           {/* Per-course breakdown */}
           <h3 className="mt-0 mb-3 text-sm font-semibold text-zinc-900 dark:text-zinc-100">
-            Courses ({courses.length})
+            {t.coursesHeading(fmt.number(courses.length))}
           </h3>
 
           <div className="flex flex-col gap-2">
@@ -191,42 +278,41 @@ export default function SchoolOverview() {
                     <span
                       className={`shrink-0 rounded-[7px] px-[7px] py-px text-[10.5px] font-semibold ${statusPill(c.status)}`}
                     >
-                      {c.status}
+                      {t.status[c.status.toLowerCase()] ?? c.status}
                     </span>
                   </div>
                   <div className="h-1.5 overflow-hidden rounded-[3px] bg-zinc-100 dark:bg-zinc-800">
                     <div
-                      className={`h-full rounded-[3px] ${completionColor(c.completion_rate)}`}
+                      className={`h-full rounded-[3px] ${barClass(completionOf(c))}`}
                       style={{ width: `${c.completion_rate}%` }}
                     />
                   </div>
                 </div>
 
                 <div className="min-w-16 shrink-0 text-right">
-                  <div className="text-sm font-bold text-zinc-900 dark:text-zinc-100">
-                    {c.active_enrollments}
+                  <div className={`text-sm font-bold ${NEUTRAL_TEXT}`}>
+                    {fmt.number(c.active_enrollments)}
                   </div>
                   <div className="text-[11px] text-zinc-400 dark:text-zinc-500">
-                    enrolled
+                    {t.enrolled}
                   </div>
                 </div>
 
                 <div className="min-w-14 shrink-0 text-right">
-                  <div className="text-sm font-bold text-zinc-900 dark:text-zinc-100">
-                    {c.completion_rate}%
+                  <div className={`text-sm font-bold ${textClass(completionOf(c))}`}>
+                    {completionOf(c) === null ? "—" : fmt.percent(c.completion_rate)}
                   </div>
                   <div className="text-[11px] text-zinc-400 dark:text-zinc-500">
-                    {c.published_lessons} lesson
-                    {c.published_lessons === 1 ? "" : "s"}
+                    {t.lessons(c.published_lessons, fmt.number(c.published_lessons))}
                   </div>
                 </div>
 
                 <div className="min-w-14 shrink-0 text-right">
-                  <div className="text-sm font-bold text-zinc-900 dark:text-zinc-100">
-                    {c.exam_avg == null ? "—" : `${c.exam_avg}%`}
+                  <div className={`text-sm font-bold ${textClass(c.exam_avg)}`}>
+                    {fmt.percent(c.exam_avg)}
                   </div>
                   <div className="text-[11px] text-zinc-400 dark:text-zinc-500">
-                    exam avg
+                    {t.examAvg}
                   </div>
                 </div>
               </div>
@@ -234,7 +320,7 @@ export default function SchoolOverview() {
 
             {courses.length === 0 && (
               <p className="m-0 p-6 text-center text-[13px] text-zinc-400 dark:text-zinc-500">
-                No courses yet.
+                {t.noCourses}
               </p>
             )}
           </div>

--- a/mcp-server/resources/shared/i18n.tsx
+++ b/mcp-server/resources/shared/i18n.tsx
@@ -1,0 +1,213 @@
+import { useMemo } from "react";
+import { useWidget } from "mcp-use/react";
+
+/**
+ * Widget-side i18n — the strings a widget owns, and every number/date it prints.
+ *
+ * WHY THIS EXISTS
+ *   Course content comes out of the database in the school's own language, but
+ *   every string the *widget* owns was hardcoded English ("True"/"False",
+ *   "Back"/"Next", "Save grade", "last active"), and dates were formatted with
+ *   an implicit `en-US`. A Spanish course rendered a Spanish lesson title above
+ *   an English button and a `Jul 24, 2026` date. en/es is a product
+ *   requirement, so the widget half has to follow the content.
+ *
+ * WHERE THE LOCALE COMES FROM
+ *   `useWidget().locale` — a BCP 47 tag the host supplies (SEP-1865
+ *   `HostContext.locale` / `window.openai.locale`). There is no locale column
+ *   anywhere in the LMS schema, so the host is the only source of truth; the
+ *   `_meta` override below exists for previewing, not as a second opinion.
+ *
+ * WHAT IS DELIBERATELY *NOT* TRANSLATED
+ *   Anything that came out of the database — course titles, lesson titles,
+ *   descriptions, tag names, student names. Those are already in the school's
+ *   language and must be rendered verbatim.
+ */
+
+/**
+ * `_meta` key a tool may set to force a widget's language.
+ *
+ * The only production reason to set this would be a school whose content
+ * language differs from the reader's chat client; nothing sets it today. It
+ * exists so the offline fixture preview can render Spanish at all: the headless
+ * screenshot harness (`scripts/shoot-demo-widgets.sh`) renders through the
+ * mcp-use dev inspector, which supplies no host locale, so every widget would
+ * otherwise be pinned to the `"en"` default and the Spanish path would have no
+ * committed evidence. Keep in sync with `LOCALE_META_KEY` in `src/locale.ts`.
+ */
+export const LOCALE_META_KEY = "lms/locale";
+
+/** The languages the LMS ships. Mirrors the app's own `en`/`es` routing. */
+export type Lang = "en" | "es";
+
+const FALLBACK: Lang = "en";
+
+/**
+ * Reduce a BCP 47 tag to a language we have strings for.
+ *
+ * `es-419` (Latin American Spanish) and `es-ES` both collapse to `es` — the
+ * user base spans LATAM and Spain and the widget strings are neutral between
+ * them. Anything we do not ship falls back to English rather than rendering a
+ * key.
+ */
+export function normalizeLang(tag: string | null | undefined): Lang {
+  const base = String(tag ?? "")
+    .trim()
+    .toLowerCase()
+    .split(/[-_]/)[0];
+  return base === "es" ? "es" : FALLBACK;
+}
+
+/** Read the raw host context this widget was rendered with. */
+function useLocaleContext(): { lang: Lang; intlLocale: string; timeZone?: string } {
+  const { locale, timeZone, metadata } = useWidget<Record<string, unknown>>();
+  const meta = metadata as Record<string, unknown> | null | undefined;
+  const override = meta?.[LOCALE_META_KEY];
+  const tag = typeof override === "string" && override ? override : locale;
+  const lang = normalizeLang(tag);
+
+  return useMemo(() => {
+    // Keep the region when it agrees with the language we resolved: `es-419`
+    // and `en-GB` format dates and numbers better than a bare `es`/`en`. When
+    // they disagree (host says `fr-FR`, we fell back to English) the region
+    // would format in the wrong convention, so drop it.
+    const full = String(tag ?? "");
+    const intlLocale = normalizeLang(full) === lang && full ? full : lang;
+    return { lang, intlLocale, timeZone: timeZone || undefined };
+  }, [tag, lang, timeZone]);
+}
+
+/** The language this widget should render its own strings in. */
+export function useLang(): Lang {
+  return useLocaleContext().lang;
+}
+
+/**
+ * Pick this widget's string table.
+ *
+ * Each widget declares its own table next to the component — the strings are
+ * few, they are specific to that widget, and keeping them local means a widget
+ * can be read in one file. Both branches are the same shape, so a missing
+ * Spanish string is a type error rather than a fallback at runtime.
+ *
+ * @example
+ *   const S = { en: { next: "Next" }, es: { next: "Siguiente" } };
+ *   const t = useStrings(S);
+ *   <button>{t.next}</button>
+ */
+export function useStrings<T>(table: Record<Lang, T>): T {
+  return table[useLang()];
+}
+
+export interface Formatters {
+  /** The resolved BCP 47 tag actually handed to `Intl`. */
+  locale: string;
+  /** `24 jul 2026` / `Jul 24, 2026` — a calendar date with no time. */
+  date: (value: string | number | Date | null | undefined) => string;
+  /** Same, spelled out: `24 de julio de 2026` / `July 24, 2026`. */
+  dateLong: (value: string | number | Date | null | undefined) => string;
+  /** Date plus wall-clock time in the host's timezone. */
+  dateTime: (value: string | number | Date | null | undefined) => string;
+  /** Grouped integer/decimal: `1.234,5` / `1,234.5`. */
+  number: (value: number | null | undefined, opts?: Intl.NumberFormatOptions) => string;
+  /** A 0–100 progress value as a percent: `64 %` / `64%`. */
+  percent: (value: number | null | undefined) => string;
+  /** Money in its own currency: `$29.00` / `29,00 US$`. */
+  currency: (value: number | null | undefined, currency?: string | null) => string;
+  /** `in 5 days` / `dentro de 5 días`, `yesterday` / `ayer`. */
+  relativeDays: (days: number) => string;
+  /** Whole days from now until `value`; negative when past. `null` if unparseable. */
+  daysUntil: (value: string | number | Date | null | undefined) => number | null;
+}
+
+function toDate(value: string | number | Date | null | undefined): Date | null {
+  if (value === null || value === undefined || value === "") return null;
+  const d = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+/**
+ * `Intl` formatters bound to the host's locale and timezone.
+ *
+ * Memoised per locale: constructing an `Intl.DateTimeFormat` is the expensive
+ * part, and widgets format one per row.
+ *
+ * Every formatter renders an em dash for null/unparseable input rather than
+ * `Invalid Date` or `NaN%` — a missing value is a normal state in these
+ * payloads (an unscheduled exam, an ungraded submission).
+ */
+export function useFormat(): Formatters {
+  const { intlLocale, timeZone } = useLocaleContext();
+
+  return useMemo(() => {
+    const EMPTY = "—";
+    const dateFmt = new Intl.DateTimeFormat(intlLocale, {
+      day: "numeric",
+      month: "short",
+      year: "numeric",
+      timeZone,
+    });
+    const dateLongFmt = new Intl.DateTimeFormat(intlLocale, {
+      day: "numeric",
+      month: "long",
+      year: "numeric",
+      timeZone,
+    });
+    const dateTimeFmt = new Intl.DateTimeFormat(intlLocale, {
+      day: "numeric",
+      month: "short",
+      year: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+      timeZone,
+    });
+    const relFmt = new Intl.RelativeTimeFormat(intlLocale, { numeric: "auto" });
+
+    const fmtDate =
+      (f: Intl.DateTimeFormat) => (value: string | number | Date | null | undefined) => {
+        const d = toDate(value);
+        return d ? f.format(d) : EMPTY;
+      };
+
+    const daysUntil = (value: string | number | Date | null | undefined): number | null => {
+      const d = toDate(value);
+      if (!d) return null;
+      // Compare calendar days, not elapsed milliseconds: an exam at 09:00
+      // tomorrow is "in 1 day", not "in 0 days" because it is 15 hours away.
+      const startOfDay = (x: Date) =>
+        Date.UTC(x.getFullYear(), x.getMonth(), x.getDate());
+      const MS_PER_DAY = 86_400_000;
+      return Math.round((startOfDay(d) - startOfDay(new Date())) / MS_PER_DAY);
+    };
+
+    return {
+      locale: intlLocale,
+      date: fmtDate(dateFmt),
+      dateLong: fmtDate(dateLongFmt),
+      dateTime: fmtDate(dateTimeFmt),
+      number: (value, opts) =>
+        typeof value === "number" && Number.isFinite(value)
+          ? new Intl.NumberFormat(intlLocale, opts).format(value)
+          : EMPTY,
+      percent: (value) =>
+        typeof value === "number" && Number.isFinite(value)
+          ? // The payloads carry 0–100, not 0–1, so this is a formatted number
+            // with a unit rather than `style: "percent"` (which would multiply).
+            new Intl.NumberFormat(intlLocale, {
+              style: "unit",
+              unit: "percent",
+              maximumFractionDigits: 0,
+            }).format(value)
+          : EMPTY,
+      currency: (value, currency) =>
+        typeof value === "number" && Number.isFinite(value)
+          ? new Intl.NumberFormat(intlLocale, {
+              style: "currency",
+              currency: (currency || "USD").toUpperCase(),
+            }).format(value)
+          : EMPTY,
+      relativeDays: (days) => relFmt.format(days, "day"),
+      daysUntil,
+    };
+  }, [intlLocale, timeZone]);
+}

--- a/mcp-server/resources/shared/severity.tsx
+++ b/mcp-server/resources/shared/severity.tsx
@@ -1,0 +1,78 @@
+/**
+ * The one status ramp every widget shares.
+ *
+ * WHY THIS EXISTS
+ *   Two widgets each carried a private copy of "percent → colour"
+ *   (`completionColor` in school-overview, `progressColor` in
+ *   student-progress-roster). Both ran amber → **brand** → green, which put the
+ *   school's brand colour in the middle of a severity scale: on the default
+ *   palette a 64% bar rendered violet, and violet is the accent colour used all
+ *   over these widgets for things that carry no status at all. One colour, two
+ *   meanings — and the reader has to know which is which.
+ *
+ *   The epic (#571) already settled the rule: "Accents theme, status colours
+ *   (red/amber/green) deliberately do not." So status is red/amber/green only,
+ *   brand stays out of it, and a school that themes its widgets orange does not
+ *   end up with an orange bar that reads as a warning.
+ *
+ *   The two copies had also already drifted — at exactly 0% one returned zinc
+ *   and the other red — which is the usual argument for having one of these
+ *   instead of two.
+ *
+ * NO DATA vs A REAL ZERO
+ *   These are different and they must not look the same. A draft course with no
+ *   lessons has nothing to complete (neutral); a student enrolled for a month
+ *   who has completed nothing is at 0% and that is the worst case (red).
+ *   Callers say which they mean by passing `null` for "no denominator" rather
+ *   than coercing it to 0.
+ */
+
+/** Severity band, worst to best. `none` means "nothing to measure". */
+export type Band = "none" | "bad" | "warn" | "good";
+
+/** Percentage (0–100) → band. `null`/`undefined` is "no data", not zero. */
+export function band(pct: number | null | undefined): Band {
+  if (pct === null || pct === undefined || !Number.isFinite(pct)) return "none";
+  if (pct >= 80) return "good";
+  if (pct >= 40) return "warn";
+  return "bad";
+}
+
+/** Fill colour for a progress bar. */
+export function barClass(pct: number | null | undefined): string {
+  switch (band(pct)) {
+    case "good":
+      return "bg-green-600 dark:bg-green-400";
+    case "warn":
+      return "bg-amber-500 dark:bg-amber-400";
+    case "bad":
+      return "bg-red-600 dark:bg-red-400";
+    default:
+      return "bg-zinc-300 dark:bg-zinc-600";
+  }
+}
+
+/** Text colour for a number that carries the same status as its bar. */
+export function textClass(pct: number | null | undefined): string {
+  switch (band(pct)) {
+    case "good":
+      return "text-green-600 dark:text-green-400";
+    case "warn":
+      return "text-amber-600 dark:text-amber-400";
+    case "bad":
+      return "text-red-600 dark:text-red-400";
+    default:
+      return "text-zinc-400 dark:text-zinc-500";
+  }
+}
+
+/**
+ * Neutral text colour, for numbers that are *facts* rather than *verdicts*.
+ *
+ * The KPI tiles previously coloured two of six numbers with no stated rule
+ * (completion violet, at-risk red; students, courses, lessons and exam average
+ * left plain), which reads as though those two were singled out for a reason.
+ * The rule now is: colour means "this is good or bad". A count of students is
+ * neither, so it stays neutral and the coloured tiles mean something.
+ */
+export const NEUTRAL_TEXT = "text-zinc-900 dark:text-zinc-100";

--- a/mcp-server/resources/student-progress-roster/widget.tsx
+++ b/mcp-server/resources/student-progress-roster/widget.tsx
@@ -6,6 +6,8 @@ import {
   type WidgetMetadata,
 } from "mcp-use/react";
 import { Brand } from "../shared/branding";
+import { useFormat, useStrings } from "../shared/i18n";
+import { NEUTRAL_TEXT, barClass, textClass } from "../shared/severity";
 import { z } from "zod";
 
 // ── Schema ──────────────────────────────────────────────────────────────────
@@ -51,28 +53,44 @@ export const widgetMetadata: WidgetMetadata = {
 type Props = z.infer<typeof propsSchema>;
 type Student = z.infer<typeof studentSchema>;
 
+// ── Strings ──────────────────────────────────────────────────────────────────
+
+const STRINGS = {
+  en: {
+    loading: "Loading roster…",
+    roster: (n: number, s: string) =>
+      `Student roster · ${s} published lesson${n === 1 ? "" : "s"}`,
+    students: "Students",
+    avgProgress: "Avg progress",
+    atRisk: "At risk",
+    atRiskOnlyOn: "✓ At risk only",
+    atRiskOnlyOff: "Show at risk only",
+    atRiskBadge: "AT RISK",
+    lessons: (done: string, total: string) => `${done}/${total} lessons`,
+    exams: (n: number, s: string) => `${s} exam${n === 1 ? "" : "s"}`,
+    lastActive: "last active",
+    noAtRisk: "No at-risk students. 🎉",
+    noStudents: "No students enrolled.",
+  },
+  es: {
+    loading: "Cargando lista…",
+    roster: (n: number, s: string) =>
+      `Lista de estudiantes · ${s} ${n === 1 ? "lección publicada" : "lecciones publicadas"}`,
+    students: "Estudiantes",
+    avgProgress: "Progreso medio",
+    atRisk: "En riesgo",
+    atRiskOnlyOn: "✓ Solo en riesgo",
+    atRiskOnlyOff: "Ver solo en riesgo",
+    atRiskBadge: "EN RIESGO",
+    lessons: (done: string, total: string) => `${done}/${total} lecciones`,
+    exams: (n: number, s: string) => `${s} ${n === 1 ? "examen" : "exámenes"}`,
+    lastActive: "última actividad",
+    noAtRisk: "Ningún estudiante en riesgo. 🎉",
+    noStudents: "No hay estudiantes inscritos.",
+  },
+};
+
 // ── Helpers ──────────────────────────────────────────────────────────────────
-
-function relativeDate(s: string | null): string {
-  if (!s) return "—";
-  try {
-    return new Date(s).toLocaleDateString(undefined, {
-      month: "short",
-      day: "numeric",
-      year: "numeric",
-    });
-  } catch {
-    return s;
-  }
-}
-
-function progressColor(pct: number | null): string {
-  if (pct == null) return "bg-zinc-300 dark:bg-zinc-600";
-  if (pct >= 80) return "bg-green-600 dark:bg-green-400";
-  if (pct >= 40) return "bg-[var(--brand-600)] dark:bg-[var(--brand-400)]";
-  if (pct > 0) return "bg-amber-600 dark:bg-amber-400";
-  return "bg-red-600 dark:bg-red-400";
-}
 
 function initials(name: string | null, id: string): string {
   if (name) {
@@ -88,6 +106,8 @@ export default function StudentProgressRoster() {
   const { props, isPending } = useWidget<Props>();
   const theme = useWidgetTheme();
   const dark = theme === "dark";
+  const t = useStrings(STRINGS);
+  const fmt = useFormat();
   const [atRiskOnly, setAtRiskOnly] = useState(false);
 
   if (isPending) {
@@ -97,7 +117,7 @@ export default function StudentProgressRoster() {
         <div className={dark ? "dark" : ""}>
           <div className="bg-zinc-50 p-10 text-center font-sans text-zinc-400 dark:bg-zinc-950 dark:text-zinc-500">
             <div className="mx-auto mb-3 size-9 animate-spin rounded-full border-[3px] border-zinc-200 border-t-[var(--brand-600)] dark:border-zinc-800 dark:border-t-[var(--brand-400)]" />
-            <p className="m-0 text-sm">Loading roster…</p>
+            <p className="m-0 text-sm">{t.loading}</p>
           </div>
         </div>
       </McpUseProvider>
@@ -133,22 +153,26 @@ export default function StudentProgressRoster() {
               {course.title}
             </h2>
             <div className="mt-0.5 text-[13px] text-zinc-400 dark:text-zinc-500">
-              Student roster · {course.published_lessons} published lesson
-              {course.published_lessons === 1 ? "" : "s"}
+              {t.roster(
+                course.published_lessons,
+                fmt.number(course.published_lessons)
+              )}
             </div>
           </div>
 
           {/* Summary */}
           <div className="my-3.5 flex w-fit gap-6 rounded-xl border border-zinc-200 bg-white px-[18px] py-3.5 dark:border-zinc-800 dark:bg-zinc-900">
-            {stat("Students", String(summary.total))}
+            {/* Same accent rule as school-overview: counts are facts and stay
+                neutral; only the numbers that read as good or bad get colour. */}
+            {stat(t.students, fmt.number(summary.total))}
             {stat(
-              "Avg progress",
-              `${summary.avg_progress}%`,
-              "text-[var(--brand-600)] dark:text-[var(--brand-400)]"
+              t.avgProgress,
+              fmt.percent(summary.avg_progress),
+              textClass(summary.avg_progress)
             )}
             {stat(
-              "At risk",
-              String(summary.at_risk),
+              t.atRisk,
+              fmt.number(summary.at_risk),
               summary.at_risk > 0 ? "text-red-600 dark:text-red-400" : undefined
             )}
           </div>
@@ -163,7 +187,7 @@ export default function StudentProgressRoster() {
                   : "border-zinc-200 bg-transparent text-zinc-500 dark:border-zinc-800 dark:text-zinc-400"
               }`}
             >
-              {atRiskOnly ? "✓ At risk only" : "Show at risk only"}
+              {atRiskOnly ? t.atRiskOnlyOn : t.atRiskOnlyOff}
             </button>
           )}
 
@@ -194,7 +218,7 @@ export default function StudentProgressRoster() {
                       </span>
                       {s.at_risk && (
                         <span className="shrink-0 rounded-md bg-red-50 px-[7px] py-px text-[10.5px] font-bold text-red-600 dark:bg-red-950 dark:text-red-400">
-                          AT RISK
+                          {t.atRiskBadge}
                         </span>
                       )}
                       {s.status !== "active" && (
@@ -205,7 +229,7 @@ export default function StudentProgressRoster() {
                     </div>
                     <div className="h-1.5 overflow-hidden rounded-[3px] bg-zinc-100 dark:bg-zinc-800">
                       <div
-                        className={`h-full rounded-[3px] transition-[width] duration-300 ${progressColor(pct)}`}
+                        className={`h-full rounded-[3px] transition-[width] duration-300 ${barClass(pct)}`}
                         style={{ width: `${pct ?? 0}%` }}
                       />
                     </div>
@@ -213,29 +237,32 @@ export default function StudentProgressRoster() {
 
                   {/* Metrics */}
                   <div className="min-w-14 shrink-0 text-right">
-                    <div className="text-sm font-bold text-zinc-900 dark:text-zinc-100">
-                      {pct == null ? "—" : `${pct}%`}
+                    <div className={`text-sm font-bold ${textClass(pct)}`}>
+                      {fmt.percent(pct)}
                     </div>
                     <div className="text-[11px] text-zinc-400 dark:text-zinc-500">
-                      {s.completed_lessons}/{course.published_lessons} lessons
+                      {t.lessons(
+                        fmt.number(s.completed_lessons),
+                        fmt.number(course.published_lessons)
+                      )}
                     </div>
                   </div>
 
                   <div className="min-w-16 shrink-0 text-right">
-                    <div className="text-sm font-bold text-zinc-900 dark:text-zinc-100">
-                      {s.exam_avg == null ? "—" : `${s.exam_avg}%`}
+                    <div className={`text-sm font-bold ${textClass(s.exam_avg)}`}>
+                      {fmt.percent(s.exam_avg)}
                     </div>
                     <div className="text-[11px] text-zinc-400 dark:text-zinc-500">
-                      {s.exam_count} exam{s.exam_count === 1 ? "" : "s"}
+                      {t.exams(s.exam_count, fmt.number(s.exam_count))}
                     </div>
                   </div>
 
                   <div className="min-w-20 shrink-0 text-right">
-                    <div className="text-xs text-zinc-500 dark:text-zinc-400">
-                      {relativeDate(s.last_active)}
+                    <div className={`text-xs ${NEUTRAL_TEXT}`}>
+                      {fmt.date(s.last_active)}
                     </div>
                     <div className="text-[11px] text-zinc-400 dark:text-zinc-500">
-                      last active
+                      {t.lastActive}
                     </div>
                   </div>
                 </div>
@@ -244,7 +271,7 @@ export default function StudentProgressRoster() {
 
             {visible.length === 0 && (
               <p className="m-0 p-6 text-center text-[13px] text-zinc-400 dark:text-zinc-500">
-                {atRiskOnly ? "No at-risk students. 🎉" : "No students enrolled."}
+                {atRiskOnly ? t.noAtRisk : t.noStudents}
               </p>
             )}
           </div>

--- a/mcp-server/resources/study-plan/widget.tsx
+++ b/mcp-server/resources/study-plan/widget.tsx
@@ -7,6 +7,7 @@ import {
   type WidgetMetadata,
 } from "mcp-use/react";
 import { Brand } from "../shared/branding";
+import { useFormat, useStrings } from "../shared/i18n";
 import { z } from "zod";
 
 // Props produced by lms_get_study_plan (Epic #348 Phase 4, #359).
@@ -52,20 +53,73 @@ export const widgetMetadata: WidgetMetadata = {
 type Props = z.infer<typeof propsSchema>;
 type Goal = Props["goals"][number];
 
-const KIND_META: Record<Goal["kind"], { label: string; icon: string }> = {
-  lesson: { label: "Lessons", icon: "📖" },
-  practice: { label: "Practice", icon: "✏️" },
-  review: { label: "Review", icon: "🔁" },
-  exam_prep: { label: "Exam prep", icon: "📄" },
-  custom: { label: "Other", icon: "🎯" },
+const KIND_ICON: Record<Goal["kind"], string> = {
+  lesson: "📖",
+  practice: "✏️",
+  review: "🔁",
+  exam_prep: "📄",
+  custom: "🎯",
 };
 const KIND_ORDER: Goal["kind"][] = ["lesson", "practice", "review", "exam_prep", "custom"];
+
+const STRINGS = {
+  en: {
+    kinds: {
+      lesson: "Lessons",
+      practice: "Practice",
+      review: "Review",
+      exam_prep: "Exam prep",
+      custom: "Other",
+    } as Record<Goal["kind"], string>,
+    weekOf: (d: string) => `Week of ${d}`,
+    noGoals: "No goals yet this week",
+    goalsDone: (done: string, total: string) => `${done} of ${total} goals done`,
+    requiredLeft: (n: string) => ` · ${n} required left`,
+    flashcardsDue: (n: string) => ` · ${n} flashcards due`,
+    weekCompleteAll: "Week complete — every goal done!",
+    weekCompleteRequired: "Week complete — all required goals done!",
+    saveError: "Could not save that goal — it has been unchecked. Try again.",
+    nothingPlanned: "Nothing planned yet",
+    upNext: "Up next",
+    openLesson: "Open",
+    planWeek: "Plan my week",
+    required: "Required",
+    planNextWeek: "Plan next week with me",
+  },
+  es: {
+    kinds: {
+      lesson: "Lecciones",
+      practice: "Práctica",
+      review: "Repaso",
+      exam_prep: "Preparación de examen",
+      custom: "Otros",
+    } as Record<Goal["kind"], string>,
+    weekOf: (d: string) => `Semana del ${d}`,
+    noGoals: "Sin objetivos esta semana",
+    goalsDone: (done: string, total: string) =>
+      `${done} de ${total} objetivos completados`,
+    requiredLeft: (n: string) => ` · faltan ${n} obligatorios`,
+    flashcardsDue: (n: string) => ` · ${n} tarjetas pendientes`,
+    weekCompleteAll: "¡Semana completa: todos los objetivos hechos!",
+    weekCompleteRequired: "¡Semana completa: todos los obligatorios hechos!",
+    saveError:
+      "No se pudo guardar el objetivo: se ha desmarcado. Inténtalo de nuevo.",
+    nothingPlanned: "Todavía no hay nada planificado",
+    upNext: "A continuación",
+    openLesson: "Abrir",
+    planWeek: "Planificar mi semana",
+    required: "Obligatorio",
+    planNextWeek: "Planifica conmigo la próxima semana",
+  },
+};
 
 export default function StudyPlan() {
   const { props, isPending, sendFollowUpMessage } = useWidget<Props>();
   const { callTool } = useCallTool("lms_complete_study_goal");
   const theme = useWidgetTheme();
   const dark = theme === "dark";
+  const t = useStrings(STRINGS);
+  const fmt = useFormat();
 
   // Optimistic check-off: goal ids marked done locally while the tool runs.
   const [checked, setChecked] = useState<Set<number>>(new Set());
@@ -96,11 +150,9 @@ export default function StudyPlan() {
   const weekComplete =
     goals.length > 0 && (requiredGoals.length > 0 ? requiredLeft === 0 : allDone);
 
-  const weekLabel = new Date(`${week_start}T00:00:00Z`).toLocaleDateString(undefined, {
-    month: "short",
-    day: "numeric",
-    timeZone: "UTC",
-  });
+  // week_start is a bare calendar date; pin it to UTC so it does not slip a day
+  // for readers west of the meridian.
+  const weekLabel = fmt.date(`${week_start}T00:00:00Z`);
 
   const check = (g: Goal) => {
     if (isDone(g)) return;
@@ -125,6 +177,49 @@ export default function StudyPlan() {
   // Progress ring geometry (SVG circle, r=26).
   const R = 26;
   const CIRC = 2 * Math.PI * R;
+
+  /**
+   * "What do I do now" — the lessons the server already worked out and sent.
+   *
+   * `context.next_lessons` was only ever rendered inside the no-goals branch,
+   * so the moment a student had a plan at all (the normal case, and both the
+   * `default` and `done` fixtures) the payload was fetched and thrown away.
+   * It is the one thing on this panel that answers "now what", so it renders
+   * whenever it is non-empty, and each row opens its lesson.
+   */
+  const upNext =
+    context.next_lessons.length === 0 ? null : (
+      <div className="mb-4">
+        <p className="m-0 mb-1.5 text-[11px] font-bold tracking-[1px] text-zinc-400 uppercase dark:text-zinc-500">
+          🧭 {t.upNext}
+        </p>
+        <div className="flex flex-col gap-1.5">
+          {context.next_lessons.slice(0, 3).map((l) => (
+            <button
+              key={l.lesson_id}
+              onClick={() =>
+                sendFollowUpMessage(
+                  `Open lesson ${l.lesson_id} ("${l.lesson_title}") from "${l.course_title}" with lms_view_lesson.`
+                )
+              }
+              className="flex w-full cursor-pointer items-center gap-2.5 rounded-[10px] border border-zinc-200 bg-white px-3.5 py-2.5 text-left dark:border-zinc-800 dark:bg-zinc-900"
+            >
+              <span className="min-w-0 flex-1">
+                <span className="block truncate text-sm text-zinc-900 dark:text-zinc-100">
+                  {l.lesson_title}
+                </span>
+                <span className="block truncate text-[11px] text-zinc-400 dark:text-zinc-500">
+                  {l.course_title}
+                </span>
+              </span>
+              <span className="shrink-0 text-xs font-semibold text-[var(--brand-600)] dark:text-[var(--brand-400)]">
+                {t.openLesson} →
+              </span>
+            </button>
+          ))}
+        </div>
+      </div>
+    );
 
   return (
     <McpUseProvider autoSize>
@@ -168,14 +263,16 @@ export default function StudyPlan() {
             </svg>
             <div className="min-w-0 flex-1">
               <h2 className="m-0 text-[17px] font-bold text-zinc-900 dark:text-zinc-100">
-                Week of {weekLabel}
+                {t.weekOf(weekLabel)}
               </h2>
               <p className="mt-1 mb-0 text-[13px] text-zinc-500 dark:text-zinc-400">
                 {goals.length === 0
-                  ? "No goals yet this week"
-                  : `${doneCount} of ${goals.length} goals done`}
-                {requiredLeft > 0 ? ` · ${requiredLeft} required left` : ""}
-                {context.due_reviews > 0 ? ` · ${context.due_reviews} flashcards due` : ""}
+                  ? t.noGoals
+                  : t.goalsDone(fmt.number(doneCount), fmt.number(goals.length))}
+                {requiredLeft > 0 ? t.requiredLeft(fmt.number(requiredLeft)) : ""}
+                {context.due_reviews > 0
+                  ? t.flashcardsDue(fmt.number(context.due_reviews))
+                  : ""}
               </p>
             </div>
           </div>
@@ -184,16 +281,14 @@ export default function StudyPlan() {
             <div className="mb-4 flex items-center gap-2.5 rounded-xl border border-green-600 bg-green-100 px-4.5 py-3.5 dark:border-green-400 dark:bg-green-900">
               <span className="text-[22px]">🎉</span>
               <span className="text-sm font-bold text-green-600 dark:text-green-400">
-                {allDone
-                  ? "Week complete — every goal done!"
-                  : "Week complete — all required goals done!"}
+                {allDone ? t.weekCompleteAll : t.weekCompleteRequired}
               </span>
             </div>
           )}
 
           {saveError && (
             <div className="mb-3 rounded-[10px] bg-red-50 px-[13px] py-[9px] text-[13px] text-red-700 dark:bg-red-950 dark:text-red-400">
-              Could not save that goal — it has been unchecked. Try again.
+              {t.saveError}
             </div>
           )}
 
@@ -201,17 +296,8 @@ export default function StudyPlan() {
             <div className="mb-4 rounded-xl border border-zinc-200 bg-white p-8 text-center dark:border-zinc-800 dark:bg-zinc-900">
               <div className="mb-2 text-3xl">🗓️</div>
               <p className="m-0 text-[15px] font-semibold text-zinc-900 dark:text-zinc-100">
-                Nothing planned yet
+                {t.nothingPlanned}
               </p>
-              {context.next_lessons.length > 0 && (
-                <p className="mt-2 mb-0 text-[13px] text-zinc-500 dark:text-zinc-400">
-                  Up next:{" "}
-                  {context.next_lessons
-                    .slice(0, 3)
-                    .map((l) => `"${l.lesson_title}" (${l.course_title})`)
-                    .join(" · ")}
-                </p>
-              )}
               <button
                 onClick={() =>
                   sendFollowUpMessage(
@@ -220,7 +306,7 @@ export default function StudyPlan() {
                 }
                 className="mt-4 cursor-pointer rounded-lg border-none bg-[var(--brand-600)] px-4 py-2 text-[13px] font-semibold text-white dark:bg-[var(--brand-400)]"
               >
-                Plan my week
+                {t.planWeek}
               </button>
             </div>
           ) : (
@@ -228,7 +314,7 @@ export default function StudyPlan() {
               {KIND_ORDER.filter((k) => goals.some((g) => g.kind === k)).map((kind) => (
                 <div key={kind}>
                   <p className="m-0 mb-1.5 text-[11px] font-bold tracking-[1px] text-zinc-400 uppercase dark:text-zinc-500">
-                    {KIND_META[kind].icon} {KIND_META[kind].label}
+                    {KIND_ICON[kind]} {t.kinds[kind]}
                   </p>
                   <div className="flex flex-col gap-1.5">
                     {goals
@@ -272,7 +358,7 @@ export default function StudyPlan() {
                                     : "bg-amber-100 text-amber-700 dark:bg-amber-950 dark:text-amber-400"
                                 }`}
                               >
-                                Required
+                                {t.required}
                               </span>
                             )}
                           </button>
@@ -284,6 +370,8 @@ export default function StudyPlan() {
             </div>
           )}
 
+          {upNext}
+
           {goals.length > 0 && (
             <button
               onClick={() =>
@@ -293,7 +381,7 @@ export default function StudyPlan() {
               }
               className="cursor-pointer rounded-lg border border-[var(--brand-600)] bg-transparent px-4 py-2 text-[13px] font-semibold text-[var(--brand-600)] dark:border-[var(--brand-400)] dark:text-[var(--brand-400)]"
             >
-              Plan next week with me
+              {t.planNextWeek}
             </button>
           )}
         </div>

--- a/mcp-server/resources/submission-grader/widget.tsx
+++ b/mcp-server/resources/submission-grader/widget.tsx
@@ -7,6 +7,7 @@ import {
   type WidgetMetadata,
 } from "mcp-use/react";
 import { Brand } from "../shared/branding";
+import { useFormat, useStrings } from "../shared/i18n";
 import { z } from "zod";
 import { Markdown } from "../shared/markdown";
 
@@ -65,45 +66,89 @@ export const widgetMetadata: WidgetMetadata = {
 
 type Props = z.infer<typeof propsSchema>;
 
+// ── Strings ──────────────────────────────────────────────────────────────────
+
+const STRINGS = {
+  en: {
+    loading: "Loading submission…",
+    scoreLabel: "Score (0–100)",
+    aiPoints: "AI points:",
+    gradedCount: (graded: string, total: string) => `${graded}/${total} graded`,
+    feedbackLabel: "Feedback to student",
+    feedbackPlaceholder: "Write overall feedback…",
+    saving: "Saving…",
+    saved: "Saved ✓",
+    saveGrade: "Save grade",
+    saveFailed: "Save failed",
+    submitted: "submitted",
+    studentAnswer: "Student answer",
+    noAnswer: "(no answer)",
+    correct: "Correct",
+    incorrect: "Incorrect",
+    aiFeedback: "AI feedback",
+    confidenceSuffix: (pct: string) => ` (${pct} confidence)`,
+    points: (earned: string, possible: string) => `${earned}/${possible} pts`,
+    question: (n: number) => `Q${n}`,
+    status: {
+      teacher_reviewed: "Teacher reviewed",
+      ai_reviewed: "AI reviewed",
+      pending_teacher_review: "Awaiting review",
+      pending: "Pending",
+    } as Record<string, string>,
+  },
+  es: {
+    loading: "Cargando entrega…",
+    scoreLabel: "Nota (0–100)",
+    aiPoints: "Puntos de la IA:",
+    gradedCount: (graded: string, total: string) => `${graded}/${total} calificadas`,
+    feedbackLabel: "Comentarios para el estudiante",
+    feedbackPlaceholder: "Escribe comentarios generales…",
+    saving: "Guardando…",
+    saved: "Guardado ✓",
+    saveGrade: "Guardar nota",
+    saveFailed: "Error al guardar",
+    submitted: "entregado el",
+    studentAnswer: "Respuesta del estudiante",
+    noAnswer: "(sin respuesta)",
+    correct: "Correcta",
+    incorrect: "Incorrecta",
+    aiFeedback: "Comentarios de la IA",
+    confidenceSuffix: (pct: string) => ` (confianza: ${pct})`,
+    points: (earned: string, possible: string) => `${earned}/${possible} pts`,
+    question: (n: number) => `P${n}`,
+    status: {
+      teacher_reviewed: "Revisado por el profesor",
+      ai_reviewed: "Revisado por IA",
+      pending_teacher_review: "Pendiente de revisión",
+      pending: "Pendiente",
+    } as Record<string, string>,
+  },
+};
+
+type Strings = typeof STRINGS.en;
+
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
-function statusPill(status: string): { classes: string; label: string } {
-  const map: Record<string, { classes: string; label: string }> = {
+function statusPill(status: string, t: Strings): { classes: string; label: string } {
+  const map: Record<string, { classes: string }> = {
     teacher_reviewed: {
       classes:
         "bg-green-100 text-green-600 dark:bg-green-900 dark:text-green-400",
-      label: "Teacher reviewed",
     },
     ai_reviewed: {
       classes:
         "bg-[var(--brand-50)] text-[var(--brand-600)] dark:bg-[var(--brand-950)] dark:text-[var(--brand-400)]",
-      label: "AI reviewed",
     },
     pending_teacher_review: {
       classes:
         "bg-amber-100 text-amber-600 dark:bg-amber-950 dark:text-amber-400",
-      label: "Awaiting review",
     },
     pending: {
       classes: "bg-zinc-100 text-zinc-500 dark:bg-zinc-700 dark:text-zinc-400",
-      label: "Pending",
     },
   };
-  return map[status] ?? map.pending;
-}
-
-function formatDate(s: string): string {
-  try {
-    return new Date(s).toLocaleString(undefined, {
-      month: "short",
-      day: "numeric",
-      year: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-    });
-  } catch {
-    return s;
-  }
+  const entry = map[status] ?? map.pending;
+  return { classes: entry.classes, label: t.status[status] ?? t.status.pending };
 }
 
 // ── Component ────────────────────────────────────────────────────────────────
@@ -112,6 +157,8 @@ export default function SubmissionGrader() {
   const { props, isPending } = useWidget<Props>();
   const theme = useWidgetTheme();
   const dark = theme === "dark";
+  const t = useStrings(STRINGS);
+  const fmt = useFormat();
 
   const [score, setScore] = useState<string | null>(null);
   const [feedback, setFeedback] = useState<string | null>(null);
@@ -133,7 +180,7 @@ export default function SubmissionGrader() {
         <div className={dark ? "dark" : ""}>
           <div className="bg-zinc-50 p-10 text-center font-sans text-zinc-400 dark:bg-zinc-950 dark:text-zinc-500">
             <div className="mx-auto mb-3 size-9 animate-spin rounded-full border-[3px] border-zinc-200 border-t-[var(--brand-600)] dark:border-zinc-800 dark:border-t-[var(--brand-400)]" />
-            <p className="m-0 text-sm">Loading submission…</p>
+            <p className="m-0 text-sm">{t.loading}</p>
           </div>
         </div>
       </McpUseProvider>
@@ -142,7 +189,7 @@ export default function SubmissionGrader() {
 
   const { submission, questions, summary } = props;
   const status = localStatus ?? submission.review_status;
-  const pill = statusPill(status);
+  const pill = statusPill(status, t);
 
   const scoreVal = score ?? (submission.score != null ? String(submission.score) : "");
   const feedbackVal = feedback ?? submission.feedback ?? "";
@@ -178,7 +225,7 @@ export default function SubmissionGrader() {
                 {studentName}
               </h2>
               <div className="mt-0.5 text-[13px] text-zinc-400 dark:text-zinc-500">
-                {submission.exam_title} · submitted {formatDate(submission.date)}
+                {submission.exam_title} · {t.submitted} {fmt.dateTime(submission.date)}
               </div>
             </div>
             <span
@@ -193,7 +240,7 @@ export default function SubmissionGrader() {
             <div className="flex flex-wrap items-end gap-[18px]">
               <label className="block">
                 <span className="mb-1.5 block text-xs font-semibold text-zinc-500 dark:text-zinc-400">
-                  Score (0–100)
+                  {t.scoreLabel}
                 </span>
                 <input
                   type="number"
@@ -207,23 +254,29 @@ export default function SubmissionGrader() {
               </label>
 
               <div className="pb-2 text-[13px] text-zinc-400 dark:text-zinc-500">
-                AI points:{" "}
+                {t.aiPoints}{" "}
                 <strong className="text-zinc-900 dark:text-zinc-100">
-                  {summary.total_points_earned}
-                  {summary.total_points_possible ? ` / ${summary.total_points_possible}` : ""}
+                  {fmt.number(summary.total_points_earned)}
+                  {summary.total_points_possible
+                    ? ` / ${fmt.number(summary.total_points_possible)}`
+                    : ""}
                 </strong>{" "}
-                · {summary.graded_count}/{summary.question_count} graded
+                ·{" "}
+                {t.gradedCount(
+                  fmt.number(summary.graded_count),
+                  fmt.number(summary.question_count)
+                )}
               </div>
             </div>
 
             <label className="mt-3.5 block">
               <span className="mb-1.5 block text-xs font-semibold text-zinc-500 dark:text-zinc-400">
-                Feedback to student
+                {t.feedbackLabel}
               </span>
               <textarea
                 value={feedbackVal}
                 onChange={(e) => setFeedback(e.target.value)}
-                placeholder="Write overall feedback…"
+                placeholder={t.feedbackPlaceholder}
                 className="box-border h-[90px] w-full resize-y rounded-lg border border-zinc-200 bg-zinc-100 p-2.5 text-[13.5px] leading-normal text-zinc-900 [font-family:inherit] dark:border-zinc-800 dark:bg-zinc-800 dark:text-zinc-100"
               />
             </label>
@@ -239,14 +292,14 @@ export default function SubmissionGrader() {
                 } ${saving ? "cursor-not-allowed opacity-70" : "cursor-pointer"}`}
               >
                 {saving
-                  ? "Saving…"
+                  ? t.saving
                   : status === "teacher_reviewed" && !dirty
-                    ? "Saved ✓"
-                    : "Save grade"}
+                    ? t.saved
+                    : t.saveGrade}
               </button>
               {saveFailed && (
                 <span className="text-[13px] text-red-600 dark:text-red-400">
-                  {saveError instanceof Error ? saveError.message : "Save failed"}
+                  {saveError instanceof Error ? saveError.message : t.saveFailed}
                 </span>
               )}
             </div>
@@ -261,13 +314,13 @@ export default function SubmissionGrader() {
                   ? {
                       classes:
                         "bg-green-100 text-green-600 dark:bg-green-900 dark:text-green-400",
-                      label: "Correct",
+                      label: t.correct,
                     }
                   : correct === false
                     ? {
                         classes:
                           "bg-red-100 text-red-600 dark:bg-red-950 dark:text-red-400",
-                        label: "Incorrect",
+                        label: t.incorrect,
                       }
                     : null;
               return (
@@ -278,7 +331,7 @@ export default function SubmissionGrader() {
                   <div className="mb-2 flex items-start justify-between gap-2.5">
                     <div className="flex items-baseline gap-2">
                       <span className="text-xs font-bold text-[var(--brand-600)] dark:text-[var(--brand-400)]">
-                        Q{i + 1}
+                        {t.question(i + 1)}
                       </span>
                       <span className="text-[11px] text-zinc-400 dark:text-zinc-500">
                         {q.type.replace(/_/g, " ")}
@@ -287,7 +340,10 @@ export default function SubmissionGrader() {
                     <div className="flex shrink-0 items-center gap-2">
                       {q.points_possible != null && (
                         <span className="text-xs font-semibold text-zinc-900 dark:text-zinc-100">
-                          {q.points_earned ?? 0}/{q.points_possible} pts
+                          {t.points(
+                            fmt.number(q.points_earned ?? 0),
+                            fmt.number(q.points_possible)
+                          )}
                         </span>
                       )}
                       {badge && (
@@ -330,11 +386,11 @@ export default function SubmissionGrader() {
                     }`}
                   >
                     <div className="mb-0.5 text-[11px] text-zinc-400 dark:text-zinc-500">
-                      Student answer
+                      {t.studentAnswer}
                     </div>
                     <div className="text-[13.5px] break-words whitespace-pre-wrap text-zinc-900 dark:text-zinc-100">
                       {q.student_answer ?? (
-                        <em className="text-zinc-400 dark:text-zinc-500">(no answer)</em>
+                        <em className="text-zinc-400 dark:text-zinc-500">{t.noAnswer}</em>
                       )}
                     </div>
                   </div>
@@ -343,9 +399,11 @@ export default function SubmissionGrader() {
                   {q.ai_feedback && (
                     <div className="text-[12.5px] leading-normal text-zinc-500 dark:text-zinc-400">
                       <span className="font-semibold">
-                        AI feedback
+                        {t.aiFeedback}
                         {q.ai_confidence != null &&
-                          ` (${Math.round(q.ai_confidence * 100)}% confidence)`}
+                          t.confidenceSuffix(
+                            fmt.percent(Math.round(q.ai_confidence * 100))
+                          )}
                       </span>
                       <Markdown content={q.ai_feedback} dark={dark} fontSize={12.5} />
                     </div>

--- a/mcp-server/src/demo-data.ts
+++ b/mcp-server/src/demo-data.ts
@@ -653,6 +653,8 @@ export const WIDGET_DEMOS: WidgetDemo[] = [
               enrolled: true,
               has_access: true,
               covered_by_plan: true,
+              price: 49,
+              currency: "usd",
             },
             {
               id: 102,
@@ -664,6 +666,8 @@ export const WIDGET_DEMOS: WidgetDemo[] = [
               enrolled: true,
               has_access: true,
               covered_by_plan: true,
+              price: 39,
+              currency: "usd",
             },
             {
               id: 103,
@@ -675,6 +679,8 @@ export const WIDGET_DEMOS: WidgetDemo[] = [
               enrolled: false,
               has_access: true,
               covered_by_plan: true,
+              price: 45,
+              currency: "usd",
             },
             {
               id: 107,
@@ -688,6 +694,8 @@ export const WIDGET_DEMOS: WidgetDemo[] = [
               // Sold separately: on a plan, but this one is not covered.
               has_access: false,
               covered_by_plan: false,
+              price: 89,
+              currency: "usd",
             },
             {
               id: 108,
@@ -699,6 +707,9 @@ export const WIDGET_DEMOS: WidgetDemo[] = [
               enrolled: false,
               has_access: true,
               covered_by_plan: false,
+              // A $0 product: free, but still a product.
+              price: 0,
+              currency: "usd",
             },
             {
               id: 109,
@@ -710,6 +721,9 @@ export const WIDGET_DEMOS: WidgetDemo[] = [
               enrolled: false,
               has_access: false,
               covered_by_plan: false,
+              // No active product covers it — nothing to sell, so no CTA.
+              price: null,
+              currency: null,
             },
           ],
         },
@@ -732,6 +746,8 @@ export const WIDGET_DEMOS: WidgetDemo[] = [
               enrolled: false,
               has_access: false,
               covered_by_plan: false,
+              price: 49,
+              currency: "usd",
             },
             {
               id: 108,
@@ -743,6 +759,8 @@ export const WIDGET_DEMOS: WidgetDemo[] = [
               enrolled: true,
               has_access: true,
               covered_by_plan: false,
+              price: 0,
+              currency: "usd",
             },
             {
               id: 109,
@@ -754,6 +772,8 @@ export const WIDGET_DEMOS: WidgetDemo[] = [
               enrolled: false,
               has_access: false,
               covered_by_plan: false,
+              price: 129,
+              currency: "usd",
             },
           ],
         },

--- a/mcp-server/src/locale.ts
+++ b/mcp-server/src/locale.ts
@@ -1,0 +1,22 @@
+/**
+ * Server-side half of widget language selection.
+ *
+ * Widgets normally take their language from the host: `useWidget().locale` is a
+ * BCP 47 tag the MCP client supplies (SEP-1865 `HostContext.locale`). There is
+ * no locale column anywhere in the LMS schema, so the host is the source of
+ * truth and nothing in production overrides it.
+ *
+ * This key exists so a tool *can* pin a widget's language when it has a better
+ * answer than the host. Today the only caller is the dev-only demo tool, which
+ * needs it because the headless preview harness supplies no host locale at all:
+ * without an override every fixture renders English and the Spanish half of the
+ * widget strings has no way to be seen or reviewed.
+ *
+ * Keep in sync with `LOCALE_META_KEY` in `resources/shared/i18n.tsx`.
+ */
+export const LOCALE_META_KEY = "lms/locale";
+
+/** Languages the widgets ship strings for. Mirrors the app's `en`/`es` routing. */
+export const SUPPORTED_LANGS = ["en", "es"] as const;
+
+export type Lang = (typeof SUPPORTED_LANGS)[number];

--- a/mcp-server/src/tools/demo.ts
+++ b/mcp-server/src/tools/demo.ts
@@ -3,6 +3,7 @@ import type { MCPServer } from "mcp-use/server";
 import { widget, text } from "mcp-use/server";
 import { WIDGET_DEMOS } from "../demo-data.js";
 import { BRANDING_META_KEY, type TenantBranding } from "../branding.js";
+import { LOCALE_META_KEY, SUPPORTED_LANGS } from "../locale.js";
 
 /**
  * Fake schools to preview tenant theming with.
@@ -74,6 +75,12 @@ export function registerDemoTools(server: MCPServer): void {
             .describe(
               "Preview the widget with a fake school's brand colour. 'none' (default) uses the platform palette."
             ),
+          lang: z
+            .enum(SUPPORTED_LANGS)
+            .optional()
+            .describe(
+              "Render the widget's own strings in this language. Normally the host supplies the locale; the preview harness does not, so it defaults to 'en'. The fixtures are Spanish, so 'es' is what a real school looks like."
+            ),
         }),
         annotations: {
           readOnlyHint: true,
@@ -87,17 +94,28 @@ export function registerDemoTools(server: MCPServer): void {
           invoked: `${demo.widget} demo ready`,
         },
       },
-      async (input: { variant?: string; brand?: string }) => {
+      async (input: { variant?: string; brand?: string; lang?: string }) => {
         const chosen =
           demo.variants.find((v) => v.id === input.variant) ?? demo.variants[0];
         const branding = DEMO_BRANDS[input.brand ?? "none"] ?? null;
 
+        // `_meta` is the same sideband the real server uses for branding
+        // (`brandWidgetResult` in register.ts), which these tools deliberately
+        // sit in front of. It has to be built here or it never reaches the
+        // widget: until now this handler computed `branding`, named it in the
+        // output text and then dropped it, so `brand=ocean|sunset|forest` — a
+        // documented feature — themed nothing at all.
+        const metadata: Record<string, unknown> = {};
+        if (branding) metadata[BRANDING_META_KEY] = branding;
+        if (input.lang) metadata[LOCALE_META_KEY] = input.lang;
+
         const result = widget({
           props: chosen.props,
+          metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
           output: text(
             `[DEMO FIXTURE — not real data] ${demo.widget} · ${chosen.id}: ${chosen.label}${
               branding ? ` · brand: ${branding.name} (${branding.primary_color})` : ""
-            }\n\n${chosen.output}`
+            }${input.lang ? ` · lang: ${input.lang}` : ""}\n\n${chosen.output}`
           ),
         });
 

--- a/mcp-server/src/tools/student.ts
+++ b/mcp-server/src/tools/student.ts
@@ -737,17 +737,82 @@ export function registerStudentTools(server: MCPServer) {
           }
         }
 
-        const courses = (coursesRes.data ?? []).map((c) => ({
-          id: c.course_id,
-          title: c.title,
-          description: c.description,
-          thumbnail_url: c.thumbnail_url,
-          tags: c.tags,
-          lesson_count: lessonCounts.get(c.course_id as number) ?? 0,
-          enrolled: enrolledSet.has(c.course_id),
-          has_access: accessible.has(c.course_id) || enrolledSet.has(c.course_id),
-          covered_by_plan: planCovered.has(c.course_id),
-        }));
+        /**
+         * What a course costs to buy outright.
+         *
+         * The catalog had no price at any layer — not in the query, not in the
+         * payload, not on the card — so a student looking at a course they are
+         * not entitled to had no way to learn what it would take to get it.
+         *
+         * A course can be sold under several products (`product_courses` is
+         * many-to-many, and `.single()` on it is a known trap), so this takes
+         * the cheapest active one and presents it as a "from" price. RLS
+         * already limits `products` to `status = 'active'`, but the filter is
+         * explicit here for the same reason every tenant filter is.
+         */
+        const priceByCourse = new Map<
+          number,
+          { price: number; currency: string | null }
+        >();
+        if (catalogCourseIds.length > 0) {
+          const { data: productRows, error: productErr } = await supabase
+            .from("product_courses")
+            .select("course_id, products!inner(price, currency, status)")
+            .eq("tenant_id", tenantId)
+            .in("course_id", catalogCourseIds)
+            .eq("products.status", "active");
+
+          // Pricing is decoration on a catalog listing: if it fails, the cards
+          // render without it rather than the whole catalog 500ing.
+          if (!productErr) {
+            type EmbeddedProduct = {
+              price: number | string | null;
+              currency: string | null;
+            };
+            const rows = (productRows ?? []) as unknown as Array<{
+              course_id: number;
+              // PostgREST types a joined table as an array even when the FK
+              // makes it to-one, and the runtime shape follows the FK. Accept
+              // both rather than betting on one.
+              products: EmbeddedProduct | EmbeddedProduct[] | null;
+            }>;
+
+            for (const row of rows) {
+              const embedded = row.products;
+              if (!embedded) continue;
+              const products = Array.isArray(embedded) ? embedded : [embedded];
+              for (const product of products) {
+                const price = Number(product?.price);
+                if (!Number.isFinite(price)) continue;
+                const best = priceByCourse.get(row.course_id);
+                if (!best || price < best.price) {
+                  priceByCourse.set(row.course_id, {
+                    price,
+                    currency: product.currency ?? null,
+                  });
+                }
+              }
+            }
+          }
+        }
+
+        const courses = (coursesRes.data ?? []).map((c) => {
+          const priced = priceByCourse.get(c.course_id as number) ?? null;
+          return {
+            id: c.course_id,
+            title: c.title,
+            description: c.description,
+            thumbnail_url: c.thumbnail_url,
+            tags: c.tags,
+            lesson_count: lessonCounts.get(c.course_id as number) ?? 0,
+            enrolled: enrolledSet.has(c.course_id),
+            has_access: accessible.has(c.course_id) || enrolledSet.has(c.course_id),
+            covered_by_plan: planCovered.has(c.course_id),
+            // null = not individually for sale (no active product covers it).
+            price: priced ? priced.price : null,
+            currency: priced ? priced.currency : null,
+          };
+        });
 
         return widget({
           props: {


### PR DESCRIPTION
## What

The seven polish items from #570, plus one bug found in the tooling they needed. None of these were broken output — each one worked and read badly.

Closes #570

## Why

Per item, and what turned out to be true rather than what the issue assumed:

**1. Widgets were English-only next to Spanish content.** Every string a widget owned was hardcoded, and every date went through `toLocaleDateString(undefined, …)`, which is the *reader's browser* locale rather than the school's. New `resources/shared/i18n.tsx` exposes `useLang` / `useStrings` / `useFormat`, driven by `useWidget().locale` (the BCP 47 tag the host supplies per SEP-1865) and `timeZone`. All 13 widgets with user-visible chrome now carry an en/es table, typed `Record<Lang, T>` so a missing Spanish string is a compile error rather than a runtime fallback. Every `toLocale*` call site is gone. `practice-player` had a hand-rolled `navigator.language` sniff for one string; it now uses the shared hook.

Only widget-owned strings are translated. Course titles, lesson titles, student names and tags come out of the database in the school's own language and are rendered verbatim.

**2. Brand purple was a mid value on a red→green scale.** `completionColor` (school-overview) and `progressColor` (student-progress-roster) were the same function copied twice, both running amber → **brand** → green. They collapse into `resources/shared/severity.tsx` on red/amber/green with brand removed — the rule #571 already states ("Accents theme, status colours deliberately do not").

The two copies had already drifted: at exactly 0% one returned zinc and the other red. That forced the real question, so "no data" is now `null` and distinct from a real zero — a draft course with nothing to complete reads neutral instead of being painted as a failing one.

Also in scope, from the same item: KPI tiles get a stated rule (colour marks a *verdict*; counts of courses and students are facts and stay neutral), and the `3 published · 2 draft` caption gains the missing archived bucket so the parts sum to the 6 shown above them.

> **Not in the issue, fixed anyway:** the at-risk tile's caption was the hardcoded string `"active · 0 lessons done"` — not derived from anything. The real rule (`analytics.ts`) is *active enrollment + course has published lessons + zero completions*, so the caption now says that. Flagging separately because it was wrong output, not polish. Related: that number counts enrollment **pairs**, not distinct students, while the tile is labelled "At-risk students". I left the label alone — changing what it counts is #568's territory — but the caption now discloses the unit.

**3. exam-readiness buried the thing to act on.** Topics render weakest-first, the weakest is marked, the practice CTA drops to a quiet link on already-mastered topics so it stops competing, and days-until-exam is rendered from `exam.exam_date` (counted in calendar days, so a 09:00 exam tomorrow reads "tomorrow", not "in 0 days").

**4. my-learning's next lesson is now a button.** It is the card's actual job, and it was a grey pill in the footer.

**5. course-catalog had no price to render.** Not "not displayed" — not present. `lms_browse_catalog` selected `course_id, title, description, thumbnail_url, tags, created_at` and never asked for one. It now joins `product_courses` → `products` and reports the cheapest active product per course (a course can be sold under several, so this aggregates rather than `.single()`-ing). `Enroll`/`Access` collapse into one verb, `Not in plan` becomes a real path instead of a grey dead end, and the 96px `📖` placeholder is dropped when there is no thumbnail rather than reserving space for nothing.

**6. study-plan's `next_lessons` was dropped in the common case.** Slight correction to the issue: it *was* rendered — inside the `goals.length === 0` branch only. So the moment a student had a plan at all, the payload was fetched and thrown away. Same fix, aimed at the case you actually see.

**7. Null fields broke card-row alignment.** course-dashboard, course-catalog and gamification-profile give their cards a shared row grid via `grid-rows-subgrid`, so a null description or an absent tag row collapses without pushing the tags and footers out of line with the neighbouring cards.

### Drive-by: `brand=` never worked

The demo tools' documented `brand=ocean|sunset|forest` argument themed nothing. `src/tools/demo.ts` computed the branding, named it in the output text, and never attached it to the result — `BRANDING_META_KEY` was an unused import. It now goes through `widget({ metadata })`, the same `_meta` sideband the real server uses.

I fixed it because I needed that channel: the headless preview harness supplies **no** host locale, so `useWidget().locale` falls back to `"en"` and the Spanish path would have had no evidence at all. The demo tools now take `lang=en|es` over the same sideband. Nothing in production sets it; the host stays the source of truth. Documented in `docs/WIDGET_DEMO_DATA.md`.

## How to QA

No migration, no seed data, no login — this is all offline against committed fixtures.

```bash
cd mcp-server && npm install
MCP_DEMO_WIDGETS=1 npm run dev
# inspector: http://localhost:3000/inspector?autoConnect=http%3A%2F%2Flocalhost%3A3000%2Fmcp
```

Then, per item — every one has a named fixture:

1. **i18n** — run `lms_demo_school_overview` with `variant=default`, then again with `lang=es`. The fixtures are Spanish, so `lang=es` is what a real school looks like and the default is the mismatch the issue is about. Dates and numbers should follow (`4 ago 2026`, `54 %`).
2. **Colour** — `lms_demo_school_overview` and `lms_demo_student_progress_roster`, `variant=default`. No violet in any bar; 68% is amber, 22% is red, 91% is green. Drafts with 0 lessons are grey with `—`, not red 0%. The Courses tile should read `3 published · 2 draft · 1 archived` and sum to 6.
3. **exam-readiness** — `variant=default`. Topics run 12 → 88, the 12% "Compilador de React" is first and flagged, "Server components" (88) has a quiet link, and the header shows a countdown.
4. **my-learning** — `variant=default`. The next lesson is a filled primary button.
5. **course-catalog** — `variant=subscriber`. Prices on the cards you cannot yet access, one verb on every CTA, `Get access` where `Not in plan` used to be a dead end, and no book-emoji blocks. `variant=no-plan` for the unsubscribed case.
6. **study-plan** — `variant=default` (i.e. *with* goals, where it used to be dropped). An "Up next" block with an `Open →` per lesson.
7. **Alignment** — `lms_demo_course_dashboard variant=default` ("Diseño de APIs REST" has no description) and `lms_demo_gamification_profile variant=default` ("Buena gente" has no description and no tier). Tag rows and footers should sit on one line across each row.
8. **The drive-by** — any demo tool with `brand=forest`. It should render green. On `master` it renders violet.

Whole set at once, both themes:

```bash
./scripts/shoot-demo-widgets.sh dark     # → mcp-server/demo-shots/dark/
./scripts/shoot-demo-widgets.sh light
```

## Screenshots / GIF

Posted as a comment below — before/after for each item, dark and light, plus the Spanish render.

## Checklist

- [x] `npm run typecheck` and `npm run test:unit` pass — in `mcp-server`: `tsc --noEmit` clean, `vitest run` 39/39
- [x] `npm run build` passes — `mcp-use build`, 18 widgets built, type check passed
- [x] Every new tenant-scoped query filters by `tenant_id` (or the table genuinely has no such column) — the new `product_courses` query filters `tenant_id` and is explicit about `products.status = 'active'` on top of the RLS policy that already enforces it
- [x] Tested with every relevant role (student / teacher / admin) — see below
- [x] Loading and error states handled — pending branches translated too; the price lookup degrades to no price rather than failing the catalog
- [x] New UI strings added to both `messages/en.json` and `messages/es.json` — **n/a**, and worth being explicit: MCP widgets render in a host iframe and never load `next-intl`, which is exactly why they had no i18n. Their strings live in per-widget tables next to the component.
- [ ] Migration — none.

### On the role checkbox, honestly

The widgets are covered per role by their fixtures, which is what this issue's "done when" asks for, and the tool-policy split is unchanged. What I did **not** do is exercise `lms_browse_catalog` against a live tenant with real `products` rows — the price join is the one change here that touches a database query, and offline fixtures cannot prove it. The RLS policies allow it (`"Anyone can view active products"` is `TO anon, authenticated USING (status = 'active')`, and `product_courses` is `USING (true)`), and it fails soft — a query error leaves cards priceless rather than breaking the catalog. But a reviewer with a seeded tenant should confirm a real price appears.

### Notes for the reviewer

- **`submission-grader` also has changes in #574** (issue #567, in flight). I only touched its strings and date formatting, but expect a conflict there for whichever lands second.
- `my-learning`'s progress bars are still brand-coloured, deliberately. That widget never had a red→green ramp — it is brand for in-progress and green for complete, a two-state accent rather than a severity scale, so item 2's rule does not apply to it.
- The `lang` `_meta` override is a preview affordance, not a second config surface. Nothing in production sets it, and there is no locale column anywhere in the schema to set it from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bs69mfRZXog8KPM1n626RA
