### PR TITLE
fix(ci): unbreak the MCP server deploy — exclude tests from the prod build

### DIFF
--- a/mcp-server/tsconfig.json
+++ b/mcp-server/tsconfig.json
@@ -20,5 +20,8 @@
     }
   },
   "include": ["index.ts", "src/**/*", "resources/**/*", "server.ts", ".mcp-use/**/*.d.ts"],
-  "exclude": ["node_modules", "dist"]
+  // Test files are excluded from the build: `vitest` resolves from the repo
+  // root's node_modules here, but the Docker image copies only mcp-server/,
+  // so compiling them fails the production build with TS2307.
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.test.tsx"]
 }


### PR DESCRIPTION
## What

The last three pushes to `master` (#578, #576, #575) all failed `deploy-mcp.yml`. The production MCP image has not been rebuilt since — prod is running a stale MCP server.

## Root cause

The Docker build runs `mcp-use build`, which type-checks everything in the tsconfig `include`, test files included:

```
src/branding.test.ts(1,38): error TS2307: Cannot find module 'vitest' or its corresponding type declarations.
src/tools/flashcards.test.ts(104,91): error TS7006: Parameter 'rating' implicitly has an 'any' type.
src/tools/practice.test.ts(1,38): error TS2307: Cannot find module 'vitest' ...
```

`mcp-server` has its own `vitest.config.ts` but does not declare `vitest` as a dependency — locally the import resolves by walking up into the repo root's `node_modules`. `mcp-server/Dockerfile` copies only `mcp-server/`, so inside the image there is no root to walk up to.

It first broke in f93a762a (#572), which added the three test files.

## Fix

Exclude `**/*.test.ts(x)` from `mcp-server/tsconfig.json`. Test files should not be compiled into `dist` regardless, and this is preferable to shipping vitest into the production image.

## QA

- `docker build` of `mcp-server/Dockerfile` locally: ✅ `Type check passed!`, 18 widgets built, image exported (fails on `master` with the errors above)
- `npx vitest run` in `mcp-server`: ✅ 5 files, 66 tests passing — the tests still run, they are only excluded from the build

## Follow-up (not in this PR)

`vitest` is an undeclared dependency of `mcp-server`; `npm test` there only works because of root hoisting. Worth declaring, but that means touching `mcp-server/package-lock.json`, which is out of scope for a deploy hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJ4dqwXuyKUPtg11ni5BSb