### PR TITLE
feat(exercises): show students their past AI task results, legibly (#581)

### DIFF
--- a/app/[locale]/dashboard/student/courses/[courseId]/exercises/[exerciseId]/page.tsx
+++ b/app/[locale]/dashboard/student/courses/[courseId]/exercises/[exerciseId]/page.tsx
@@ -5,6 +5,8 @@ import { requireCourseAccess, requireRowInCourse } from '@/lib/services/course-a
 import { getTranslations } from 'next-intl/server'
 import { EXTERNAL_EXERCISE_TYPES } from '@/lib/checkpoints/types'
 import { getCheckpointLinkedExerciseIds } from '@/lib/checkpoints/load'
+import { toLatestEvaluation, type LatestExerciseEvaluation } from '@/lib/exercises/latest-evaluation'
+import ExerciseResultSummary from '@/components/exercises/exercise-result-summary'
 import type { SpeechEvaluation } from '@/lib/speech/types'
 
 import dynamic from 'next/dynamic'
@@ -171,14 +173,22 @@ export default async function ExercisePage({ params }: PageProps) {
 
     // Fetch evaluation history from unified exercise_evaluations table
     let submissionHistory: { id: number; ai_evaluation: SpeechEvaluation | null; score: number | null; status: string; media_url: string; created_at: string; duration_seconds: number | null }[] = []
+    // Newest graded attempt, replayed to the student when they come back to a
+    // finished exercise. Derived from the same rows as submissionHistory — the
+    // artifact/essay engines write here too, their results were just never read.
+    let latestEvaluation: LatestExerciseEvaluation | null = null
     try {
-        const { data: evaluations } = await supabase
+        const { data: evaluations, error: evaluationsError } = await supabase
             .from('exercise_evaluations')
             .select('id, score, passed, ai_result, ai_metrics, engine_type, attempt_number, created_at')
             .eq('exercise_id', parseInt(exerciseId))
             .eq('user_id', userId)
             .eq('tenant_id', tenantId)
             .order('created_at', { ascending: false })
+
+        // PostgREST reports failures in `error`, not by throwing, so without this
+        // the catch below never fires and a broken query looks like "no attempts".
+        if (evaluationsError) console.error('Error fetching exercise evaluations:', evaluationsError)
 
         // Map to legacy format for AudioExercise component compatibility
         submissionHistory = (evaluations ?? []).map(ev => ({
@@ -192,8 +202,11 @@ export default async function ExercisePage({ params }: PageProps) {
                 (ev.ai_metrics as unknown as { duration_seconds?: number | null } | null)
                     ?.duration_seconds ?? null,
         }))
-    } catch {
+
+        latestEvaluation = toLatestEvaluation(evaluations?.[0] ?? null)
+    } catch (err) {
         // RLS or table access may fail — gracefully degrade
+        console.error('Error fetching exercise evaluations:', err)
     }
 
     const exerciseConfig = exercise.exercise_config as unknown as {
@@ -267,6 +280,33 @@ export default async function ExercisePage({ params }: PageProps) {
         </>
     ) : null
 
+    // Code challenges are graded by their own test runner and never write an
+    // exercise_evaluations row, so their reviewable record is the completion.
+    const codeCompletion = exercise.exercise_completions?.[0] as
+        | { score?: number | null; completed_at?: string | null }
+        | undefined
+
+    const resultSummary = latestEvaluation ? (
+        <ExerciseResultSummary
+            score={latestEvaluation.score}
+            passed={latestEvaluation.passed}
+            feedback={latestEvaluation.feedback}
+            strengths={latestEvaluation.strengths}
+            improvements={latestEvaluation.improvements}
+            attemptNumber={latestEvaluation.attemptNumber}
+            completedAt={latestEvaluation.createdAt}
+            passingScore={passingScore}
+        />
+    ) : null
+
+    const codeResultSummary = codeCompletion ? (
+        <ExerciseResultSummary
+            score={codeCompletion.score ?? null}
+            passed
+            completedAt={codeCompletion.completed_at ?? null}
+        />
+    ) : null
+
     const chatComponent = (
         <ExerciseChat
             apiEndpoint="/api/chat/exercises/student"
@@ -287,6 +327,7 @@ export default async function ExercisePage({ params }: PageProps) {
                     isExerciseCompleted={isExerciseCompleted}
                     studentId={userId}
                     courseId={courseId}
+                    resultSummary={codeResultSummary}
                 >
                     <CodeChallengeWrapper
                         exercise={exercise}
@@ -325,6 +366,18 @@ export default async function ExercisePage({ params }: PageProps) {
                     isExerciseCompleted={isExerciseCompleted}
                     passingScore={passingScore}
                     isExerciseCompletedSection={otherExercisesSection}
+                    initialEvaluation={
+                        latestEvaluation
+                            ? {
+                                  score: latestEvaluation.score ?? 0,
+                                  feedback: latestEvaluation.feedback ?? '',
+                                  passed: latestEvaluation.passed,
+                                  strengths: latestEvaluation.strengths,
+                                  improvements: latestEvaluation.improvements,
+                                  passingScore,
+                              }
+                            : null
+                    }
                 />
             ) : exercise.exercise_type === 'audio_evaluation' ? (
                 <AudioExercise
@@ -355,6 +408,7 @@ export default async function ExercisePage({ params }: PageProps) {
                     profile={profile}
                     studentId={userId}
                     isExerciseCompletedSection={otherExercisesSection}
+                    resultSummary={resultSummary}
                 >
                     {chatComponent}
                 </EssayExercise>

--- a/components/exercises/artifact-exercise.tsx
+++ b/components/exercises/artifact-exercise.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef, useCallback, useEffect } from 'react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import ExerciseResultSummary from '@/components/exercises/exercise-result-summary'
 import { cn } from '@/lib/utils'
 import Markdown from 'react-markdown'
 import { useTranslations } from 'next-intl'
@@ -16,7 +17,6 @@ import {
   IconSparkles,
   IconLoader2,
   IconAlertTriangle,
-  IconTarget,
   IconArrowRight,
   IconTrophy,
   IconCode,
@@ -40,6 +40,9 @@ interface ArtifactExerciseProps {
   isExerciseCompleted: boolean
   passingScore: number
   isExerciseCompletedSection?: React.ReactNode
+  /** Last graded attempt from exercise_evaluations. The route has always written
+   * one; it was simply never read back, so reloading the page lost the feedback. */
+  initialEvaluation?: EvaluationResult | null
 }
 
 interface EvaluationResult {
@@ -58,6 +61,7 @@ export default function ArtifactExercise({
   isExerciseCompleted,
   passingScore,
   isExerciseCompletedSection,
+  initialEvaluation = null,
 }: ArtifactExerciseProps) {
   const t = useTranslations('exercises.artifact')
   const tAudio = useTranslations('exercises.audio')
@@ -68,7 +72,7 @@ export default function ArtifactExercise({
 
   const iframeRef = useRef<HTMLIFrameElement>(null)
   const [submitState, setSubmitState] = useState<SubmitState>('idle')
-  const [evaluation, setEvaluation] = useState<EvaluationResult | null>(null)
+  const [evaluation, setEvaluation] = useState<EvaluationResult | null>(initialEvaluation)
   const [passed, setPassed] = useState<boolean>(isExerciseCompleted)
   const [errorMsg, setErrorMsg] = useState<string | null>(null)
   const [rateLimited, setRateLimited] = useState(false)
@@ -303,98 +307,32 @@ export default function ArtifactExercise({
               </div>
             )}
 
-            {/* Evaluation result */}
-            {evaluation && submitState === 'done' && (
-              <div className="rounded-xl border bg-card p-5 space-y-5">
-                <h3 className="text-sm font-semibold flex items-center gap-2">
-                  <IconSparkles size={16} className="text-primary" />
-                  {tAudio('aiFeedback')}
-                </h3>
+            {/* Evaluation result — also shown for a restored prior attempt, whose
+                submitState is still 'idle' because nothing was submitted this visit. */}
+            {/* One result card across every engine. This block used to be a
+                near-copy of ExerciseResultSummary that printed the score over
+                the PASS MARK, twice: "62 / 70" reads as 89% when 62 is a fail. */}
+            {evaluation && submitState !== 'evaluating' && (
+              <div className="space-y-4">
+                <ExerciseResultSummary
+                  score={evaluation.score}
+                  passed={evaluation.passed}
+                  feedback={evaluation.feedback}
+                  strengths={evaluation.strengths}
+                  improvements={evaluation.improvements}
+                  // The API response carries its own threshold; the prop is the
+                  // fallback for a restored attempt that predates that field.
+                  passingScore={evaluation.passingScore ?? passingScore}
+                />
 
-                {/* Score */}
-                <div className="flex items-center justify-between">
-                  <div className="flex items-baseline gap-3">
-                    <div className="flex items-baseline gap-1">
-                      <span className={cn(
-                        'text-4xl font-black tabular-nums tracking-tight',
-                        evaluation.passed ? 'text-emerald-600 dark:text-emerald-400' : 'text-foreground'
-                      )}>
-                        {evaluation.score}
-                      </span>
-                      <span className="text-lg font-bold text-muted-foreground/60">/</span>
-                      <span className="text-lg font-bold text-primary tabular-nums">{evaluation.passingScore}</span>
-                    </div>
-                  </div>
-                  <Badge className={cn(
-                    'font-bold text-xs px-3 py-1',
-                    evaluation.passed
-                      ? 'bg-emerald-500 text-white'
-                      : 'bg-amber-500/10 text-amber-700 border-amber-500/30'
-                  )}>
-                    {evaluation.passed ? t('passed') : t('failed')}
-                  </Badge>
-                </div>
-
-                {/* Feedback */}
-                <p className="text-sm text-foreground/80 leading-relaxed">{evaluation.feedback}</p>
-
-                {/* Strengths */}
-                {evaluation.strengths.length > 0 && (
-                  <div>
-                    <p className="text-xs font-bold uppercase tracking-widest text-emerald-600 dark:text-emerald-400 mb-2">
-                      {t('strengths')}
-                    </p>
-                    <ul className="space-y-1.5">
-                      {evaluation.strengths.map((s, i) => (
-                        <li key={i} className="flex items-start gap-2 text-sm text-foreground/80">
-                          <span className="mt-0.5 shrink-0 text-emerald-500">+</span>
-                          {s}
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                )}
-
-                {/* Improvements */}
-                {evaluation.improvements.length > 0 && (
-                  <div>
-                    <p className="text-xs font-bold uppercase tracking-widest text-amber-600 dark:text-amber-400 mb-2">
-                      {t('improvements')}
-                    </p>
-                    <ul className="space-y-1.5">
-                      {evaluation.improvements.map((imp, i) => (
-                        <li key={i} className="flex items-start gap-2 text-sm text-foreground/80">
-                          <span className="mt-0.5 shrink-0 text-amber-500">-</span>
-                          {imp}
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                )}
-
-                {/* Try again */}
                 {!evaluation.passed && !rateLimited && (
-                  <div className="rounded-2xl border-2 border-primary/15 bg-gradient-to-br from-primary/[0.04] to-primary/[0.01] p-5">
-                    <div className="flex items-center justify-between mb-4">
-                      <div className="flex items-baseline gap-1">
-                        <span className="text-2xl font-black tabular-nums tracking-tight text-foreground">
-                          {evaluation.score}
-                        </span>
-                        <span className="text-sm font-bold text-muted-foreground/60">/</span>
-                        <span className="text-sm font-bold text-primary tabular-nums">{evaluation.passingScore}</span>
-                      </div>
-                      <div className="rounded-full border-2 border-primary/20 bg-primary/5 p-2">
-                        <IconTarget size={18} className="text-primary" />
-                      </div>
-                    </div>
-                    <Button
-                      onClick={handleTryAgain}
-                      className="w-full gap-2.5 h-11 text-sm font-bold tracking-wide"
-                    >
-                      {t('tryAgain')}
-                      <IconArrowRight size={16} className="ml-auto opacity-60" />
-                    </Button>
-                  </div>
+                  <Button
+                    onClick={handleTryAgain}
+                    className="w-full gap-2.5 h-11 text-sm font-semibold tracking-wide"
+                  >
+                    {t('tryAgain')}
+                    <IconArrowRight size={16} className="ml-auto opacity-60" />
+                  </Button>
                 )}
               </div>
             )}

--- a/components/exercises/code-exercise.tsx
+++ b/components/exercises/code-exercise.tsx
@@ -12,12 +12,15 @@ interface CodeExerciseProps {
     studentId: string;
     courseId: string;
     children: ReactNode;
+    /** Prior completion record, shown when the student returns to a solved challenge. */
+    resultSummary?: ReactNode;
 }
 
 export default function CodeExercise({
     exercise,
     isExerciseCompleted,
     children,
+    resultSummary,
 }: CodeExerciseProps) {
     return (
         <div className="space-y-6 pb-20">
@@ -41,6 +44,8 @@ export default function CodeExercise({
                     </div>
                 </div>
             </motion.div>
+
+            {resultSummary}
 
             <Tabs defaultValue="environment" className="space-y-4">
                 <TabsList className="bg-muted/50 p-1">

--- a/components/exercises/essay-exercise.tsx
+++ b/components/exercises/essay-exercise.tsx
@@ -16,6 +16,8 @@ interface EssayExerciseProps {
     studentId: string;
     children: ReactNode;
     isExerciseCompletedSection?: ReactNode;
+    /** Last graded attempt, shown above the chat when the student returns. */
+    resultSummary?: ReactNode;
 }
 
 const difficultyConfig: Record<string, { label: string; color: string; icon: typeof IconFlame }> = {
@@ -40,6 +42,7 @@ export default function EssayExercise({
     isExerciseCompleted,
     children,
     isExerciseCompletedSection,
+    resultSummary,
 }: EssayExerciseProps) {
     const difficulty = difficultyConfig[exercise.difficulty_level] || difficultyConfig.easy;
     const DifficultyIcon = difficulty.icon;
@@ -94,6 +97,14 @@ export default function EssayExercise({
                 transition={{ duration: 0.35, delay: 0.1 }}
                 className="grid grid-cols-1 lg:grid-cols-12 gap-4 sm:gap-6"
             >
+                {/* Last graded attempt — first for a returning student, and
+                    deliberately OUTSIDE the sticky chat column: adding it there
+                    pushed that column past the viewport height, and `sticky`
+                    stops pinning once the element is taller than its scrollport. */}
+                {resultSummary && (
+                    <div className="lg:col-span-12 order-first">{resultSummary}</div>
+                )}
+
                 {/* Instructions */}
                 <div className="lg:col-span-4 order-1">
                     <div className="rounded-xl sm:rounded-2xl border sm:border-2 border-primary/10 bg-gradient-to-b from-primary/[0.03] to-transparent overflow-hidden">

--- a/components/exercises/exercise-result-summary.tsx
+++ b/components/exercises/exercise-result-summary.tsx
@@ -1,0 +1,180 @@
+'use client'
+
+import { useTranslations, useLocale } from 'next-intl'
+import { IconArrowNarrowRight, IconCheck, IconSparkles, IconTarget } from '@tabler/icons-react'
+import { cn } from '@/lib/utils'
+import { Badge } from '@/components/ui/badge'
+
+interface ExerciseResultSummaryProps {
+  score: number | null
+  passed: boolean
+  /** Absent for engines that record a completion but no AI feedback (code). */
+  feedback?: string | null
+  strengths?: string[]
+  improvements?: string[]
+  attemptNumber?: number | null
+  completedAt?: string | null
+  passingScore?: number
+  className?: string
+}
+
+/** Prose measure. The design law caps body text at 65-75ch; the card sits in a
+ * `lg:col-span-8` column that is otherwise wide enough to run past 85ch. */
+const PROSE = 'max-w-[68ch] break-words'
+
+/**
+ * The student's last graded attempt on a standalone exercise, shown when they
+ * come back to it. Previously every one of these engines held its result in
+ * component state only, so returning to a finished exercise showed a bare
+ * "Completed" badge and the feedback they had already earned was gone.
+ */
+export default function ExerciseResultSummary({
+  score,
+  passed,
+  feedback,
+  strengths = [],
+  improvements = [],
+  attemptNumber,
+  completedAt,
+  passingScore,
+  className,
+}: ExerciseResultSummaryProps) {
+  const t = useTranslations('exercises.result')
+  const tAudio = useTranslations('exercises.audio')
+  const tArtifact = useTranslations('exercises.artifact')
+  const locale = useLocale()
+
+  const meta = [
+    typeof attemptNumber === 'number' ? tAudio('attempt', { number: attemptNumber }) : null,
+    typeof passingScore === 'number' ? t('passMark', { score: passingScore }) : null,
+    completedAt
+      ? tAudio('completedOn', {
+          date: new Date(completedAt).toLocaleDateString(locale, {
+            month: 'long',
+            day: 'numeric',
+            year: 'numeric',
+          }),
+        })
+      : null,
+  ].filter(Boolean)
+
+  return (
+    <section
+      className={cn(
+        'rounded-xl border p-5 space-y-5',
+        passed
+          ? 'border-emerald-500/30 bg-emerald-500/[0.04]'
+          : 'border-amber-500/30 bg-amber-500/[0.04]',
+        className
+      )}
+      aria-label={t('title')}
+    >
+      {/* Stacks below sm: at 390px the metadata line is squeezed to ~160px by
+          the score block, which cannot shrink (the badge is whitespace-nowrap). */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
+        <div className="min-w-0">
+          <h3 className="font-semibold text-sm flex items-center gap-2">
+            {passed ? (
+              <IconCheck size={16} className="text-emerald-700 dark:text-emerald-400 shrink-0" />
+            ) : (
+              <IconTarget size={16} className="text-amber-700 dark:text-amber-400 shrink-0" />
+            )}
+            {t('title')}
+          </h3>
+          {meta.length > 0 && (
+            <p className="text-xs text-muted-foreground mt-1">{meta.join(' · ')}</p>
+          )}
+        </div>
+
+        <div className="flex items-center gap-3 shrink-0">
+          {score !== null && (
+            <div className="flex items-baseline gap-1">
+              <span
+                className={cn(
+                  'text-2xl font-bold tabular-nums tracking-tight',
+                  passed ? 'text-emerald-700 dark:text-emerald-400' : 'text-foreground'
+                )}
+              >
+                {Math.round(score)}
+              </span>
+              {/* Denominator is the scale, not the pass mark — every engine
+                  clamps to 0-100, so "88 / 70" would read as 88 out of 70. */}
+              <span className="text-sm font-medium text-muted-foreground">/ 100</span>
+            </div>
+          )}
+          <Badge
+            className={cn(
+              'font-semibold px-2.5',
+              passed
+                ? 'bg-emerald-700 text-white dark:bg-emerald-400 dark:text-emerald-950'
+                : 'bg-amber-500/10 text-amber-800 dark:text-amber-300 border-amber-500/40'
+            )}
+          >
+            {passed ? tArtifact('passed') : tArtifact('failed')}
+          </Badge>
+        </div>
+      </div>
+
+      {feedback && (
+        <div className="space-y-2">
+          {/* The label is foreground, not `text-primary`: primary is overridden
+              per tenant, so small text in it cannot be guaranteed to clear AA
+              (the default hue measured 3.35:1 in dark). The icon keeps the
+              accent — non-text UI only needs 3:1. */}
+          <p className="text-xs font-semibold flex items-center gap-1.5">
+            <IconSparkles size={13} className="text-primary" aria-hidden="true" />
+            {tAudio('aiFeedback')}
+          </p>
+          <p className={cn('text-sm leading-relaxed whitespace-pre-wrap', PROSE)}>{feedback}</p>
+        </div>
+      )}
+
+      {strengths.length > 0 && (
+        <div>
+          <p className="text-xs font-semibold text-emerald-700 dark:text-emerald-400 mb-2">
+            {tAudio('strengths')}
+          </p>
+          <ul className="space-y-1.5">
+            {strengths.map((item, i) => (
+              <li key={i} className={cn('flex items-start gap-2 text-sm', PROSE)}>
+                <IconCheck
+                  size={14}
+                  className="mt-1 shrink-0 text-emerald-700 dark:text-emerald-400"
+                  aria-hidden="true"
+                />
+                {item}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {improvements.length > 0 && (
+        <div>
+          <p className="text-xs font-semibold text-amber-700 dark:text-amber-400 mb-2">
+            {tAudio('improvements')}
+          </p>
+          <ul className="space-y-1.5">
+            {improvements.map((item, i) => (
+              // An arrow, not a minus: these are next steps, not deductions.
+              <li key={i} className={cn('flex items-start gap-2 text-sm', PROSE)}>
+                <IconArrowNarrowRight
+                  size={14}
+                  className="mt-1 shrink-0 text-amber-700 dark:text-amber-400"
+                  aria-hidden="true"
+                />
+                {item}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {!feedback && strengths.length === 0 && improvements.length === 0 && (
+        // Code challenges are graded by their test runner and store no feedback.
+        // Say so, rather than leaving an unexplained empty card.
+        <p className={cn('text-sm text-muted-foreground', PROSE)}>{t('noFeedbackRecorded')}</p>
+      )}
+    </section>
+  )
+}

--- a/components/lesson/checkpoints/checkpoint-exercise-renderer.tsx
+++ b/components/lesson/checkpoints/checkpoint-exercise-renderer.tsx
@@ -3,7 +3,14 @@
 import { useState } from 'react'
 import Link from 'next/link'
 import { useTranslations } from 'next-intl'
-import { IconCheck, IconX, IconLoader2, IconExternalLink, IconRefresh } from '@tabler/icons-react'
+import {
+  IconCheck,
+  IconX,
+  IconLoader2,
+  IconExternalLink,
+  IconRefresh,
+  IconTarget,
+} from '@tabler/icons-react'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
@@ -14,6 +21,7 @@ import {
   EXTERNAL_EXERCISE_TYPES,
   type CheckpointAnswer,
   type CheckpointAttemptResult,
+  type ClientCheckpointQuestion,
 } from '@/lib/checkpoints/types'
 import type { LessonCheckpointClientData } from '@/lib/checkpoints/load'
 
@@ -69,6 +77,73 @@ async function postAttempt(checkpointId: number, body: unknown): Promise<Attempt
   }
 }
 
+/**
+ * Rebuild a displayable result from the attempt persisted in
+ * `lesson_checkpoint_attempts`, so a student who reloads the lesson still sees
+ * the AI's feedback and their own answer rather than only a score badge.
+ *
+ * `attemptId` is not part of the stored summary and nothing in the display uses
+ * it. `canRetryAi` is the checkpoint-level half of the server's gate — the plan
+ * and monthly quotas stay server-enforced and surface as `aiUnavailable` on the
+ * next submit, so this is an affordance hint, never the authority.
+ */
+function restoredResult(checkpoint: LessonCheckpointClientData): CheckpointAttemptResult | null {
+  const attempt = checkpoint.latestAttempt
+  if (!attempt) return null
+  return {
+    attemptId: 0,
+    attemptNumber: attempt.attemptNumber,
+    evaluatorType: attempt.evaluatorType,
+    completed: attempt.completed,
+    passed: attempt.passed,
+    score: attempt.score,
+    feedback: attempt.feedback,
+    nextStepHint: attempt.nextStepHint,
+    perQuestion: attempt.perQuestion,
+    aiUnavailable: attempt.aiUnavailable,
+    canRetryAi:
+      attempt.evaluatorType === 'ai' &&
+      attempt.passed === false &&
+      checkpoint.attemptCount < checkpoint.maxAiAttempts,
+  }
+}
+
+/**
+ * Render the correct answer the way the student saw the options, not the way it
+ * is stored. `correctValue` is an index for multiple choice and a boolean for
+ * true/false, so printing it raw told a student "Incorrect — 1".
+ */
+function correctValueLabel(
+  question: ClientCheckpointQuestion,
+  value: string | number | boolean,
+  t: ReturnType<typeof useTranslations<'components.checkpoints'>>
+): string {
+  if (question.type === 'multiple_choice' && typeof value === 'number') {
+    return question.options?.[value] ?? String(value)
+  }
+  if (typeof value === 'boolean') return value ? t('trueLabel') : t('falseLabel')
+  return String(value)
+}
+
+/**
+ * The student's own submitted text, shown alongside the feedback it earned.
+ *
+ * Deliberately borderless: with a border and a pale fill it was visually the
+ * same object as the retry Textarea directly below it, so the read-only record
+ * of a past answer read as an editable field.
+ */
+function SubmittedAnswer({ text }: { text: string }) {
+  const t = useTranslations('components.checkpoints')
+  return (
+    <div className="space-y-1.5">
+      <p className="text-xs font-medium text-muted-foreground">{t('yourAnswer')}</p>
+      <p className="max-w-[68ch] whitespace-pre-wrap break-words rounded-lg bg-muted/60 p-3 text-sm">
+        {text}
+      </p>
+    </div>
+  )
+}
+
 export function CheckpointExerciseRenderer({ checkpoint }: CheckpointExerciseRendererProps) {
   const { exercise } = checkpoint
   const isClosed =
@@ -81,9 +156,18 @@ export function CheckpointExerciseRenderer({ checkpoint }: CheckpointExerciseRen
   return <TextCheckpointForm checkpoint={checkpoint} />
 }
 
-function ResultAlert({ result }: { result: CheckpointAttemptResult }) {
+function ResultAlert({
+  result,
+  maxAttempts,
+}: {
+  result: CheckpointAttemptResult
+  /** Only meaningful for AI-graded checkpoints that allow more than one try. */
+  maxAttempts?: number
+}) {
   const t = useTranslations('components.checkpoints')
   const positive = result.passed !== false
+  const showAttempts =
+    result.evaluatorType === 'ai' && maxAttempts !== undefined && maxAttempts > 1
   return (
     <div
       className={cn(
@@ -94,17 +178,31 @@ function ResultAlert({ result }: { result: CheckpointAttemptResult }) {
       )}
       role="status"
     >
-      <div className="flex items-center gap-2 font-semibold">
-        {positive ? <IconCheck className="size-4" /> : <IconX className="size-4" />}
+      {/* Wraps: "Puntuación: 64 / 100" plus "Intento 1 de 3" runs past 320px. */}
+      <div className="flex flex-wrap items-center gap-x-2 gap-y-1 font-semibold">
+        {positive ? (
+          <IconCheck className="size-4 shrink-0" />
+        ) : (
+          <IconTarget className="size-4 shrink-0" />
+        )}
+        {/* Same grammar as the standalone exercise card: a score out of 100,
+            never over the pass mark. */}
         {result.score !== null
-          ? t('scoreLabel', { score: Math.round(result.score) })
+          ? t('scoreOutOf', { score: Math.round(result.score) })
           : result.passed
             ? t('passed')
             : t('notPassed')}
+        {showAttempts && (
+          <span className="ml-auto text-xs font-normal text-muted-foreground">
+            {t('attemptCounter', { attempt: result.attemptNumber, total: maxAttempts })}
+          </span>
+        )}
       </div>
-      {result.feedback && <p className="text-foreground/80">{result.feedback}</p>}
+      {result.feedback && (
+        <p className="max-w-[68ch] break-words text-foreground/80">{result.feedback}</p>
+      )}
       {result.nextStepHint && (
-        <p className="text-xs text-muted-foreground">
+        <p className="max-w-[68ch] break-words text-xs text-muted-foreground">
           <span className="font-medium">{t('nextStep')}:</span> {result.nextStepHint}
         </p>
       )}
@@ -120,13 +218,17 @@ function ClosedCheckpointForm({ checkpoint }: CheckpointExerciseRendererProps) {
   const ctx = useCheckpoints()
   const recordResult = ctx?.recordResult
   const questions = checkpoint.exercise.questions ?? []
-  const [answers, setAnswers] = useState<Record<string, string | number | boolean>>({})
+  const [answers, setAnswers] = useState<Record<string, string | number | boolean>>(
+    () => checkpoint.latestAttempt?.submittedAnswers ?? {}
+  )
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   // Seed from the provider: this form remounts whenever the provider updates
   // (the MDX tree is recreated), so local-only state would lose the feedback.
+  // Falling back to the persisted attempt is what makes the graded answers and
+  // per-question explanations survive a page reload, not just a remount.
   const [result, setResult] = useState<CheckpointAttemptResult | null>(
-    () => ctx?.getResult(checkpoint.id) ?? null
+    () => ctx?.getResult(checkpoint.id) ?? restoredResult(checkpoint)
   )
 
   const allAnswered = questions.every((q) => answers[q.id] !== undefined)
@@ -146,7 +248,7 @@ function ClosedCheckpointForm({ checkpoint }: CheckpointExerciseRendererProps) {
       return
     }
     setResult(res.data)
-    recordResult?.(checkpoint.id, res.data)
+    recordResult?.(checkpoint.id, res.data, { answers })
   }
 
   function handleRetry() {
@@ -174,9 +276,12 @@ function ClosedCheckpointForm({ checkpoint }: CheckpointExerciseRendererProps) {
                 disabled={result !== null}
               >
                 {(q.options ?? []).map((opt, optIdx) => (
+                  // items-start, not items-center: a two-line option pushed the
+                  // radio to the vertical middle of the wrapped text. py-1 also
+                  // lifts the tap target off the 20px text line height.
                   <label
                     key={optIdx}
-                    className="flex items-center gap-2 text-sm cursor-pointer"
+                    className="flex items-start gap-2 py-1 text-sm cursor-pointer"
                   >
                     <RadioGroupItem value={String(optIdx)} />
                     {opt}
@@ -209,7 +314,7 @@ function ClosedCheckpointForm({ checkpoint }: CheckpointExerciseRendererProps) {
             {q.type === 'fill_in_the_blank' && (
               <input
                 type="text"
-                className="flex h-8 w-full rounded-md border border-input bg-input/20 px-2 text-sm outline-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/30 disabled:cursor-not-allowed disabled:opacity-50"
+                className="flex h-10 w-full rounded-md border border-input bg-input/20 px-2 text-base outline-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/30 disabled:cursor-not-allowed disabled:opacity-50 sm:h-8 sm:text-sm"
                 placeholder={t('fillBlankPlaceholder')}
                 value={typeof answers[q.id] === 'string' ? (answers[q.id] as string) : ''}
                 disabled={result !== null}
@@ -231,7 +336,7 @@ function ClosedCheckpointForm({ checkpoint }: CheckpointExerciseRendererProps) {
                 <span>
                   {pq.correct ? t('correct') : t('incorrect')}
                   {!pq.correct && pq.correctValue !== null && (
-                    <> — {String(pq.correctValue)}</>
+                    <> — {correctValueLabel(q, pq.correctValue, t)}</>
                   )}
                   {pq.explanation && <span className="block text-muted-foreground">{pq.explanation}</span>}
                 </span>
@@ -242,7 +347,7 @@ function ClosedCheckpointForm({ checkpoint }: CheckpointExerciseRendererProps) {
       })}
 
       {error && <p className="text-xs text-destructive">{error}</p>}
-      {result && <ResultAlert result={result} />}
+      {result && <ResultAlert result={result} maxAttempts={checkpoint.maxAiAttempts} />}
 
       <div>
         {result === null ? (
@@ -269,8 +374,12 @@ function TextCheckpointForm({ checkpoint }: CheckpointExerciseRendererProps) {
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [result, setResult] = useState<CheckpointAttemptResult | null>(
-    () => ctx?.getResult(checkpoint.id) ?? null
+    () => ctx?.getResult(checkpoint.id) ?? restoredResult(checkpoint)
   )
+  // The graded answer comes from the attempt row, not from `text` — this form
+  // remounts on every provider update, so local input state is already gone by
+  // the time the feedback renders, and is empty outright after a reload.
+  const submittedText = result === null ? null : (checkpoint.latestAttempt?.submittedText ?? null)
 
   async function handleSubmit() {
     if (!text.trim()) return
@@ -284,7 +393,7 @@ function TextCheckpointForm({ checkpoint }: CheckpointExerciseRendererProps) {
       return
     }
     setResult(res.data)
-    recordResult?.(checkpoint.id, res.data)
+    recordResult?.(checkpoint.id, res.data, { text })
   }
 
   function handleRetry() {
@@ -296,6 +405,15 @@ function TextCheckpointForm({ checkpoint }: CheckpointExerciseRendererProps) {
 
   return (
     <div className="space-y-3">
+      {/* Answer, then the grade for that answer, then the retry field. The
+          empty Textarea used to sit between the two, so the feedback was
+          separated from the text it was feedback about. */}
+      {submittedText && <SubmittedAnswer text={submittedText} />}
+
+      {result && <ResultAlert result={result} maxAttempts={checkpoint.maxAiAttempts} />}
+
+      {error && <p className="text-xs text-destructive">{error}</p>}
+
       {result === null || canRetry ? (
         <Textarea
           value={text}
@@ -303,20 +421,31 @@ function TextCheckpointForm({ checkpoint }: CheckpointExerciseRendererProps) {
           placeholder={t('textPlaceholder')}
           disabled={submitting}
           rows={5}
+          // 16px on phones: iOS Safari zooms the whole page when a focused
+          // field is under 16px, which throws the student out of the lesson.
+          className="text-base sm:text-sm"
         />
       ) : null}
 
-      {error && <p className="text-xs text-destructive">{error}</p>}
-      {result && <ResultAlert result={result} />}
-
       <div>
         {result === null ? (
-          <Button size="sm" disabled={!text.trim() || submitting} onClick={handleSubmit}>
+          <Button
+            size="sm"
+            className="h-9 sm:h-6"
+            disabled={!text.trim() || submitting}
+            onClick={handleSubmit}
+          >
             {submitting && <IconLoader2 className="size-3.5 animate-spin" />}
             {submitting ? t('submitting') : t('submit')}
           </Button>
         ) : canRetry ? (
-          <Button size="sm" variant="outline" disabled={submitting || !text.trim()} onClick={handleSubmit}>
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-9 sm:h-6"
+            disabled={submitting || !text.trim()}
+            onClick={handleSubmit}
+          >
             {submitting && <IconLoader2 className="size-3.5 animate-spin" />}
             <IconRefresh className="size-3.5" />
             {t('retry')}
@@ -325,7 +454,7 @@ function TextCheckpointForm({ checkpoint }: CheckpointExerciseRendererProps) {
       </div>
       {result && !canRetry && (
         <div>
-          <Button size="sm" variant="ghost" onClick={handleRetry}>
+          <Button size="sm" variant="ghost" className="h-9 sm:h-6" onClick={handleRetry}>
             {t('review')}
           </Button>
         </div>
@@ -340,18 +469,8 @@ function ExternalCheckpointForm({ checkpoint }: CheckpointExerciseRendererProps)
   const [syncing, setSyncing] = useState(false)
   const [notCompleted, setNotCompleted] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [result, setResult] = useState<CheckpointAttemptResult | null>(() =>
-    ctx?.getResult(checkpoint.id) ??
-    (checkpoint.latestAttempt
-      ? {
-          attemptId: 0,
-          attemptNumber: checkpoint.latestAttempt.attemptNumber,
-          evaluatorType: checkpoint.latestAttempt.evaluatorType,
-          completed: checkpoint.latestAttempt.completed,
-          passed: checkpoint.latestAttempt.passed,
-          score: checkpoint.latestAttempt.score,
-        }
-      : null)
+  const [result, setResult] = useState<CheckpointAttemptResult | null>(
+    () => ctx?.getResult(checkpoint.id) ?? restoredResult(checkpoint)
   )
 
   const exerciseHref = ctx

--- a/components/lesson/checkpoints/checkpoints-provider.tsx
+++ b/components/lesson/checkpoints/checkpoints-provider.tsx
@@ -2,14 +2,25 @@
 
 import { createContext, useContext, useState, type ReactNode } from 'react'
 import type { LessonCheckpointClientData } from '@/lib/checkpoints/load'
-import type { CheckpointAttemptResult } from '@/lib/checkpoints/types'
+import {
+  shouldAutoExpandCheckpoint,
+  type CheckpointAttemptResult,
+  type SubmittedCheckpointResponse,
+} from '@/lib/checkpoints/types'
 
 export interface CheckpointsContextValue {
   /** Initial checkpoint data merged with any results recorded this session. */
   checkpoints: LessonCheckpointClientData[]
   courseId: number
   getCheckpoint: (checkpointId: number) => LessonCheckpointClientData | undefined
-  recordResult: (checkpointId: number, result: CheckpointAttemptResult) => void
+  /** `submitted` is the student's own answer; it is not part of the server's
+   * grading response, so the form hands it over to keep `latestAttempt` a
+   * complete mirror of what a page reload would restore. */
+  recordResult: (
+    checkpointId: number,
+    result: CheckpointAttemptResult,
+    submitted?: SubmittedCheckpointResponse
+  ) => void
   /** Full result of the last attempt made THIS session (incl. per-question
    * feedback). Lives here, not in the card, because the MDX tree remounts on
    * every provider update and would otherwise drop the feedback on submit. */
@@ -39,11 +50,13 @@ export function CheckpointsProvider({
   children,
 }: CheckpointsProviderProps) {
   const [results, setResults] = useState<Record<number, CheckpointAttemptResult>>({})
+  const [submissions, setSubmissions] = useState<Record<number, SubmittedCheckpointResponse>>({})
   const [expandedIds, setExpandedIds] = useState<Record<number, boolean>>({})
 
   const checkpoints = initialCheckpoints.map((cp) => {
     const result = results[cp.id]
     if (!result) return cp
+    const submitted = submissions[cp.id] ?? {}
     return {
       ...cp,
       attemptCount: result.attemptNumber,
@@ -53,6 +66,12 @@ export function CheckpointsProvider({
         passed: result.passed,
         score: result.score,
         evaluatorType: result.evaluatorType,
+        feedback: result.feedback,
+        nextStepHint: result.nextStepHint,
+        perQuestion: result.perQuestion,
+        aiUnavailable: result.aiUnavailable,
+        submittedText: submitted.text,
+        submittedAnswers: submitted.answers,
       },
     }
   })
@@ -61,16 +80,30 @@ export function CheckpointsProvider({
     return checkpoints.find((cp) => cp.id === checkpointId)
   }
 
-  function recordResult(checkpointId: number, result: CheckpointAttemptResult) {
+  function recordResult(
+    checkpointId: number,
+    result: CheckpointAttemptResult,
+    submitted?: SubmittedCheckpointResponse
+  ) {
     setResults((prev) => ({ ...prev, [checkpointId]: result }))
+    if (submitted) setSubmissions((prev) => ({ ...prev, [checkpointId]: submitted }))
   }
 
   function getResult(checkpointId: number) {
     return results[checkpointId] ?? null
   }
 
+  /**
+   * Collapsed by default, EXCEPT when the student has a graded attempt they did
+   * not pass. That is the one case where the card holds something they need to
+   * act on — the AI's feedback and next-step hint — and leaving it behind a
+   * chevron meant a returning student saw only a score chip. An explicit
+   * toggle still wins, so they can close it.
+   */
   function isExpanded(checkpointId: number) {
-    return expandedIds[checkpointId] === true
+    const stored = expandedIds[checkpointId]
+    if (stored !== undefined) return stored
+    return shouldAutoExpandCheckpoint(getCheckpoint(checkpointId)?.latestAttempt)
   }
 
   function setExpanded(checkpointId: number, expanded: boolean) {

--- a/components/lesson/checkpoints/lesson-checkpoint.tsx
+++ b/components/lesson/checkpoints/lesson-checkpoint.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useTranslations } from 'next-intl'
-import { IconChevronDown, IconCircleCheck, IconFlag } from '@tabler/icons-react'
+import { IconChevronDown, IconCircleCheck, IconFlag, IconTarget } from '@tabler/icons-react'
 import { cn } from '@/lib/utils'
 import { Badge } from '@/components/ui/badge'
 import { useCheckpoints } from './checkpoints-provider'
@@ -32,6 +32,10 @@ export function LessonCheckpoint({ checkpointId }: LessonCheckpointProps) {
   const setExpanded = (value: boolean) => ctx.setExpanded(numericId, value)
 
   const isCompleted = checkpoint.latestAttempt?.completed === true
+  // A failed attempt is still `completed`, so completion alone must not drive
+  // the tone: a green tick over "Score: 64%" against a pass mark of 70 told the
+  // student they had passed. `passed` is null for engines that do not grade.
+  const didNotPass = isCompleted && checkpoint.latestAttempt?.passed === false
   const title = checkpoint.label || checkpoint.exercise.title
 
   return (
@@ -46,10 +50,20 @@ export function LessonCheckpoint({ checkpointId }: LessonCheckpointProps) {
           <div
             className={cn(
               'flex size-7 shrink-0 items-center justify-center rounded-full',
-              isCompleted ? 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400' : 'bg-primary/10 text-primary'
+              didNotPass
+                ? 'bg-amber-500/10 text-amber-700 dark:text-amber-400'
+                : isCompleted
+                  ? 'bg-emerald-500/10 text-emerald-700 dark:text-emerald-400'
+                  : 'bg-primary/10 text-primary'
             )}
           >
-            {isCompleted ? <IconCircleCheck className="size-4" /> : <IconFlag className="size-4" />}
+            {didNotPass ? (
+              <IconTarget className="size-4" />
+            ) : isCompleted ? (
+              <IconCircleCheck className="size-4" />
+            ) : (
+              <IconFlag className="size-4" />
+            )}
           </div>
           <div className="min-w-0">
             <p className="text-sm font-semibold truncate">{title}</p>
@@ -60,7 +74,13 @@ export function LessonCheckpoint({ checkpointId }: LessonCheckpointProps) {
                 </Badge>
               )}
               {isCompleted && (
-                <Badge variant="secondary" className="text-[0.625rem]">
+                <Badge
+                  variant="secondary"
+                  className={cn(
+                    'text-[0.625rem]',
+                    didNotPass && 'bg-amber-500/10 text-amber-800 dark:text-amber-300'
+                  )}
+                >
                   {checkpoint.latestAttempt?.score !== null && checkpoint.latestAttempt?.score !== undefined
                     ? t('scoreLabel', { score: Math.round(checkpoint.latestAttempt.score) })
                     : t('completedBadge')}

--- a/lib/checkpoints/load.ts
+++ b/lib/checkpoints/load.ts
@@ -1,10 +1,13 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 import {
   parseCheckpointQuestions,
+  parseStoredEvaluation,
+  parseStoredResponse,
   toClientCheckpointQuestions,
   type CheckpointEvaluatorType,
   type CheckpointPlacement,
   type ClientCheckpointExercise,
+  type PerQuestionResult,
 } from './types'
 
 export interface CheckpointAttemptSummary {
@@ -13,6 +16,15 @@ export interface CheckpointAttemptSummary {
   passed: boolean | null
   score: number | null
   evaluatorType: CheckpointEvaluatorType
+  /** Graded feedback, restored from the attempt row so a student returning to a
+   * finished checkpoint re-reads the AI's message instead of a bare score badge. */
+  feedback?: string
+  nextStepHint?: string
+  perQuestion?: PerQuestionResult[]
+  aiUnavailable?: boolean
+  /** The student's own answer, so they can see what they were graded on. */
+  submittedText?: string
+  submittedAnswers?: Record<string, string | number | boolean>
 }
 
 /** Everything the student lesson needs to render one checkpoint. Client-safe:
@@ -72,7 +84,9 @@ export async function loadLessonCheckpoints(
 
   const { data: attempts } = await adminClient
     .from('lesson_checkpoint_attempts')
-    .select('checkpoint_id, attempt_number, completed, passed, score, evaluator_type')
+    .select(
+      'checkpoint_id, attempt_number, completed, passed, score, evaluator_type, response, evaluation'
+    )
     .eq('user_id', args.userId)
     .eq('lesson_id', args.lessonId)
     .order('attempt_number', { ascending: false })
@@ -85,12 +99,19 @@ export async function loadLessonCheckpoints(
       (countByCheckpoint.get(attempt.checkpoint_id) ?? 0) + 1
     )
     if (!latestByCheckpoint.has(attempt.checkpoint_id)) {
+      // Mapped field by field, not spread: the parsers return the response's own
+      // vocabulary (`text`/`answers`), which a spread would silently drop here
+      // rather than fail to type-check.
+      const submitted = parseStoredResponse(attempt.response)
       latestByCheckpoint.set(attempt.checkpoint_id, {
         attemptNumber: attempt.attempt_number,
         completed: attempt.completed,
         passed: attempt.passed,
         score: attempt.score === null ? null : Number(attempt.score),
         evaluatorType: attempt.evaluator_type as CheckpointEvaluatorType,
+        ...parseStoredEvaluation(attempt.evaluation),
+        submittedText: submitted.text,
+        submittedAnswers: submitted.answers,
       })
     }
   }

--- a/lib/checkpoints/types.ts
+++ b/lib/checkpoints/types.ts
@@ -94,6 +94,98 @@ export interface CheckpointAttemptResult {
   canRetryAi?: boolean
 }
 
+/** What the student submitted, restored from lesson_checkpoint_attempts.response. */
+export interface SubmittedCheckpointResponse {
+  /** Free-text answer (essay/discussion checkpoints). */
+  text?: string
+  /** Closed-question answers keyed by question id. */
+  answers?: Record<string, string | number | boolean>
+}
+
+/** Client-visible slice of lesson_checkpoint_attempts.evaluation. */
+export interface StoredCheckpointEvaluation {
+  feedback?: string
+  nextStepHint?: string
+  perQuestion?: PerQuestionResult[]
+  aiUnavailable?: boolean
+}
+
+/**
+ * Restore the student's own answer from the stored `response` jsonb. The attempt
+ * route writes one of three shapes — `{ text }`, `{ answers }`, or `{ source }`
+ * for external syncs — and this is free-form jsonb, so anything unrecognised
+ * yields "nothing to show" rather than being trusted into the UI.
+ */
+export function parseStoredResponse(raw: unknown): SubmittedCheckpointResponse {
+  if (!raw || typeof raw !== 'object') return {}
+  const row = raw as Record<string, unknown>
+  if (typeof row.text === 'string') return { text: row.text }
+  if (!Array.isArray(row.answers)) return {}
+  const answers: Record<string, string | number | boolean> = {}
+  for (const item of row.answers) {
+    if (!item || typeof item !== 'object') continue
+    const answer = item as Record<string, unknown>
+    if (typeof answer.questionId !== 'string') continue
+    const value = answer.value
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+      answers[answer.questionId] = value
+    }
+  }
+  return Object.keys(answers).length > 0 ? { answers } : {}
+}
+
+/**
+ * Restore the graded feedback from the stored `evaluation` jsonb — the AI shape
+ * (`feedback` / `next_step_hint`), the deterministic shape (`per_question`), or
+ * the fallback shape (`fallback_reason`, meaning the answer was recorded but no
+ * AI feedback exists). External-sync attempts carry only ids and yield nothing.
+ */
+export function parseStoredEvaluation(raw: unknown): StoredCheckpointEvaluation {
+  if (!raw || typeof raw !== 'object') return {}
+  const row = raw as Record<string, unknown>
+  const parsed: StoredCheckpointEvaluation = {}
+  if (typeof row.feedback === 'string') parsed.feedback = row.feedback
+  if (typeof row.next_step_hint === 'string') parsed.nextStepHint = row.next_step_hint
+  if (typeof row.fallback_reason === 'string') parsed.aiUnavailable = true
+  if (Array.isArray(row.per_question)) {
+    const perQuestion: PerQuestionResult[] = []
+    for (const item of row.per_question) {
+      if (!item || typeof item !== 'object') continue
+      const entry = item as Record<string, unknown>
+      if (typeof entry.questionId !== 'string' || typeof entry.correct !== 'boolean') continue
+      const correctValue = entry.correctValue
+      perQuestion.push({
+        questionId: entry.questionId,
+        correct: entry.correct,
+        correctValue:
+          typeof correctValue === 'string' ||
+          typeof correctValue === 'number' ||
+          typeof correctValue === 'boolean'
+            ? correctValue
+            : null,
+        explanation: typeof entry.explanation === 'string' ? entry.explanation : undefined,
+      })
+    }
+    if (perQuestion.length > 0) parsed.perQuestion = perQuestion
+  }
+  return parsed
+}
+
+/**
+ * Should a checkpoint card open on its own when the lesson loads?
+ *
+ * Only for a graded attempt the student did NOT pass: that is the one state
+ * holding something to act on (the AI's feedback and next-step hint), and
+ * collapsing it meant a returning student saw a score chip and nothing else.
+ * A passed attempt stays collapsed — it is a receipt, not a task — and an
+ * ungraded one (`passed === null`, e.g. an external sync) has nothing to show.
+ */
+export function shouldAutoExpandCheckpoint(
+  attempt: { completed: boolean; passed: boolean | null } | null | undefined
+): boolean {
+  return attempt?.completed === true && attempt.passed === false
+}
+
 /** Client-safe view of the linked exercise for rendering a checkpoint. */
 export interface ClientCheckpointExercise {
   id: number

--- a/lib/exercises/latest-evaluation.ts
+++ b/lib/exercises/latest-evaluation.ts
@@ -1,0 +1,72 @@
+/**
+ * Restoring the last graded attempt on a standalone exercise.
+ *
+ * Every AI engine writes to `exercise_evaluations`, but `ai_result` is free-form
+ * jsonb whose shape depends on the writer: the artifact route stores
+ * `{feedback, strengths, improvements}`, the chat tool stores `{feedback}` only,
+ * and the media route stores a full SpeechEvaluation. This pulls out the parts
+ * every engine agrees on so a returning student can re-read how they did.
+ *
+ * Coding challenges deliberately have no entry here — they are graded by their
+ * own test runner and produce an `exercise_completions` row with no feedback, so
+ * there is nothing to restore beyond the completion itself.
+ */
+
+/** The last graded attempt, normalized across engines. */
+export interface LatestExerciseEvaluation {
+  id: number
+  score: number | null
+  passed: boolean
+  attemptNumber: number | null
+  createdAt: string
+  feedback: string | null
+  strengths: string[]
+  improvements: string[]
+}
+
+/** Row shape this module consumes — the columns the exercise page selects. */
+export interface ExerciseEvaluationRow {
+  id: number | string
+  score: number | null
+  passed: boolean | null
+  ai_result: unknown
+  attempt_number?: number | null
+  created_at: string
+}
+
+function stringList(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return []
+  return raw.filter((item): item is string => typeof item === 'string' && item.trim() !== '')
+}
+
+export function parseExerciseAiResult(raw: unknown): {
+  feedback: string | null
+  strengths: string[]
+  improvements: string[]
+} {
+  if (!raw || typeof raw !== 'object') {
+    return { feedback: null, strengths: [], improvements: [] }
+  }
+  const result = raw as Record<string, unknown>
+  return {
+    feedback: typeof result.feedback === 'string' && result.feedback.trim() !== '' ? result.feedback : null,
+    strengths: stringList(result.strengths),
+    improvements: stringList(result.improvements),
+  }
+}
+
+/** Newest row → displayable result. Returns null when there is nothing graded. */
+export function toLatestEvaluation(
+  row: ExerciseEvaluationRow | null | undefined
+): LatestExerciseEvaluation | null {
+  if (!row) return null
+  const parsed = parseExerciseAiResult(row.ai_result)
+  return {
+    id: Number(row.id),
+    score: row.score === null ? null : Number(row.score),
+    passed: row.passed === true,
+    attemptNumber: row.attempt_number ?? null,
+    createdAt: row.created_at,
+    ...parsed,
+  }
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -3946,8 +3946,11 @@
       "requiredBadge": "Required",
       "completedBadge": "Completed",
       "scoreLabel": "Score: {score}%",
+      "scoreOutOf": "Score: {score} / 100",
       "passed": "Passed",
       "notPassed": "Not passed yet",
+      "yourAnswer": "Your answer",
+      "attemptCounter": "Attempt {attempt} of {total}",
       "correct": "Correct",
       "incorrect": "Incorrect",
       "nextStep": "Next step",
@@ -5213,6 +5216,11 @@
       "improvements": "Areas to Improve",
       "tryAgain": "Try Again",
       "rateLimited": "Too many submissions. Please wait a moment before trying again."
+    },
+    "result": {
+      "title": "Your last result",
+      "noFeedbackRecorded": "This exercise is graded automatically, so there is no written feedback to review.",
+      "passMark": "Pass mark {score}"
     },
     "audio": {
       "title": "Audio Exercise",

--- a/messages/es.json
+++ b/messages/es.json
@@ -3791,8 +3791,11 @@
       "requiredBadge": "Obligatorio",
       "completedBadge": "Completado",
       "scoreLabel": "Puntaje: {score}%",
+      "scoreOutOf": "Puntaje: {score} / 100",
       "passed": "Aprobado",
       "notPassed": "Aún no aprobado",
+      "yourAnswer": "Tu respuesta",
+      "attemptCounter": "Intento {attempt} de {total}",
       "correct": "Correcto",
       "incorrect": "Incorrecto",
       "nextStep": "Siguiente paso",
@@ -5206,6 +5209,11 @@
       "improvements": "Áreas de Mejora",
       "tryAgain": "Intentar de Nuevo",
       "rateLimited": "Demasiadas entregas. Por favor espera un momento antes de intentar de nuevo."
+    },
+    "result": {
+      "title": "Tu último resultado",
+      "noFeedbackRecorded": "Este ejercicio se califica automáticamente, así que no hay comentarios escritos para revisar.",
+      "passMark": "Nota mínima {score}"
     },
     "audio": {
       "title": "Ejercicio de Audio",

--- a/tests/unit/checkpoint-attempt-restore.test.ts
+++ b/tests/unit/checkpoint-attempt-restore.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect } from 'vitest'
+
+import {
+  parseStoredEvaluation,
+  parseStoredResponse,
+  shouldAutoExpandCheckpoint,
+} from '../../lib/checkpoints/types'
+
+/**
+ * Pins the restore path that lets a student re-read a finished lesson task.
+ *
+ * The AI feedback was always written to lesson_checkpoint_attempts.evaluation,
+ * but the loader never selected the column, so returning to a completed
+ * checkpoint showed a bare score badge and nothing else. These parsers are what
+ * turn those two free-form jsonb columns back into displayable feedback.
+ *
+ * Contract:
+ *   - The four shapes the attempt route writes (deterministic / ai / fallback /
+ *     external sync) each restore exactly what they carry, and nothing more.
+ *   - jsonb is free-form: anything unrecognised yields "nothing to show"
+ *     rather than being trusted into the UI. Never throws.
+ */
+
+describe('parseStoredEvaluation', () => {
+  it('restores AI feedback and the next-step hint', () => {
+    expect(
+      parseStoredEvaluation({
+        feedback: 'Good grasp of the base case.',
+        next_step_hint: 'Try tracing the call stack.',
+        meets_expectations: true,
+      })
+    ).toEqual({
+      feedback: 'Good grasp of the base case.',
+      nextStepHint: 'Try tracing the call stack.',
+    })
+  })
+
+  it('restores deterministic per-question results', () => {
+    const parsed = parseStoredEvaluation({
+      correct_count: 1,
+      total: 2,
+      per_question: [
+        { questionId: 'q1', correct: true, correctValue: 1, explanation: 'B is correct' },
+        { questionId: 'q2', correct: false, correctValue: null },
+      ],
+    })
+    expect(parsed.perQuestion).toEqual([
+      { questionId: 'q1', correct: true, correctValue: 1, explanation: 'B is correct' },
+      { questionId: 'q2', correct: false, correctValue: null, explanation: undefined },
+    ])
+    expect(parsed.feedback).toBeUndefined()
+  })
+
+  it('flags a fallback attempt as AI-unavailable', () => {
+    // The answer was recorded but never graded — the student must be told that,
+    // not shown an unexplained empty result.
+    expect(parseStoredEvaluation({ fallback_reason: 'provider_error' })).toEqual({
+      aiUnavailable: true,
+    })
+  })
+
+  it('yields nothing for an external-sync attempt', () => {
+    expect(
+      parseStoredEvaluation({ synced_evaluation_id: 7, synced_completion_id: null })
+    ).toEqual({})
+  })
+
+  it('drops malformed per-question entries instead of throwing', () => {
+    const parsed = parseStoredEvaluation({
+      per_question: [
+        { questionId: 'q1', correct: true, correctValue: 'a' },
+        { questionId: 42, correct: true },
+        { correct: true },
+        { questionId: 'q4', correct: 'yes' },
+        null,
+        'nope',
+      ],
+    })
+    expect(parsed.perQuestion).toEqual([
+      { questionId: 'q1', correct: true, correctValue: 'a', explanation: undefined },
+    ])
+  })
+
+  it('omits perQuestion entirely when every entry is malformed', () => {
+    expect(parseStoredEvaluation({ per_question: [{ bogus: true }] })).toEqual({})
+  })
+
+  it('tolerates null, primitives and wrong types', () => {
+    expect(parseStoredEvaluation(null)).toEqual({})
+    expect(parseStoredEvaluation(undefined)).toEqual({})
+    expect(parseStoredEvaluation('feedback')).toEqual({})
+    expect(parseStoredEvaluation({ feedback: 12, next_step_hint: [] })).toEqual({})
+  })
+})
+
+describe('parseStoredResponse', () => {
+  it('restores a free-text answer', () => {
+    expect(parseStoredResponse({ text: 'Recursion is when a function calls itself.' })).toEqual({
+      text: 'Recursion is when a function calls itself.',
+    })
+  })
+
+  it('restores closed answers keyed by question id', () => {
+    expect(
+      parseStoredResponse({
+        answers: [
+          { questionId: 'q1', value: 1 },
+          { questionId: 'q2', value: true },
+          { questionId: 'q3', value: 'photosynthesis' },
+        ],
+      })
+    ).toEqual({ answers: { q1: 1, q2: true, q3: 'photosynthesis' } })
+  })
+
+  it('preserves a falsy answer rather than dropping it', () => {
+    // `false` and `0` are real answers to true/false and multiple-choice
+    // questions — a truthiness check here would blank the first option.
+    expect(
+      parseStoredResponse({
+        answers: [
+          { questionId: 'q1', value: false },
+          { questionId: 'q2', value: 0 },
+          { questionId: 'q3', value: '' },
+        ],
+      })
+    ).toEqual({ answers: { q1: false, q2: 0, q3: '' } })
+  })
+
+  it('yields nothing for an external-sync response', () => {
+    expect(parseStoredResponse({ source: 'exercise_evaluations' })).toEqual({})
+  })
+
+  it('drops malformed answer entries instead of throwing', () => {
+    expect(
+      parseStoredResponse({
+        answers: [
+          { questionId: 'q1', value: 1 },
+          { questionId: 'q2', value: { nested: true } },
+          { value: 3 },
+          null,
+        ],
+      })
+    ).toEqual({ answers: { q1: 1 } })
+  })
+
+  it('tolerates null, primitives and wrong types', () => {
+    expect(parseStoredResponse(null)).toEqual({})
+    expect(parseStoredResponse(undefined)).toEqual({})
+    expect(parseStoredResponse('text')).toEqual({})
+    expect(parseStoredResponse({ text: 99 })).toEqual({})
+    expect(parseStoredResponse({ answers: 'q1' })).toEqual({})
+    expect(parseStoredResponse({ answers: [] })).toEqual({})
+  })
+})
+
+describe('shouldAutoExpandCheckpoint', () => {
+  /**
+   * Restoring the feedback is worthless if it stays behind a closed chevron.
+   * The card opens itself only for the state that asks something of the
+   * student; everything else stays collapsed so a long lesson does not unfurl.
+   */
+  it('opens a graded attempt the student did not pass', () => {
+    expect(shouldAutoExpandCheckpoint({ completed: true, passed: false })).toBe(true)
+  })
+
+  it('leaves a passed attempt collapsed — it is a receipt, not a task', () => {
+    expect(shouldAutoExpandCheckpoint({ completed: true, passed: true })).toBe(false)
+  })
+
+  it('leaves an ungraded attempt collapsed', () => {
+    // `passed` is null for external syncs, which carry no feedback to read.
+    expect(shouldAutoExpandCheckpoint({ completed: true, passed: null })).toBe(false)
+  })
+
+  it('leaves an unattempted or incomplete checkpoint collapsed', () => {
+    expect(shouldAutoExpandCheckpoint({ completed: false, passed: false })).toBe(false)
+    expect(shouldAutoExpandCheckpoint(null)).toBe(false)
+    expect(shouldAutoExpandCheckpoint(undefined)).toBe(false)
+  })
+})

--- a/tests/unit/exercise-latest-evaluation.test.ts
+++ b/tests/unit/exercise-latest-evaluation.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest'
+
+import {
+  parseExerciseAiResult,
+  toLatestEvaluation,
+} from '../../lib/exercises/latest-evaluation'
+
+/**
+ * Pins the restore path for standalone exercises (artifact / essay).
+ *
+ * `exercise_evaluations.ai_result` is free-form jsonb and each engine writes a
+ * different shape: the artifact route writes {feedback, strengths, improvements},
+ * the chat tool writes {feedback} alone, the media route writes a full
+ * SpeechEvaluation. Contract:
+ *   - Take the fields every engine agrees on; ignore the rest.
+ *   - Never throw on a shape that has not been seen before.
+ *   - Blank strings and non-string list entries are dropped, so the UI never
+ *     renders an empty bullet or an empty "AI feedback" heading.
+ */
+
+describe('parseExerciseAiResult', () => {
+  it('reads the full artifact shape', () => {
+    expect(
+      parseExerciseAiResult({
+        feedback: 'Solid state handling.',
+        strengths: ['Clear naming', 'Good edge cases'],
+        improvements: ['Extract the reducer'],
+      })
+    ).toEqual({
+      feedback: 'Solid state handling.',
+      strengths: ['Clear naming', 'Good edge cases'],
+      improvements: ['Extract the reducer'],
+    })
+  })
+
+  it('reads the chat-tool shape, which has feedback only', () => {
+    expect(parseExerciseAiResult({ feedback: 'Well argued.' })).toEqual({
+      feedback: 'Well argued.',
+      strengths: [],
+      improvements: [],
+    })
+  })
+
+  it('treats a blank or missing feedback string as no feedback', () => {
+    // An empty string would otherwise render an "AI Feedback" heading over nothing.
+    expect(parseExerciseAiResult({ feedback: '   ' }).feedback).toBeNull()
+    expect(parseExerciseAiResult({ feedback: 42 }).feedback).toBeNull()
+    expect(parseExerciseAiResult({}).feedback).toBeNull()
+  })
+
+  it('drops non-string and blank list entries', () => {
+    expect(
+      parseExerciseAiResult({
+        strengths: ['Real', '', '   ', 7, null, { a: 1 }],
+        improvements: 'not a list',
+      })
+    ).toEqual({ feedback: null, strengths: ['Real'], improvements: [] })
+  })
+
+  it('tolerates null, primitives and unknown engine shapes', () => {
+    const empty = { feedback: null, strengths: [], improvements: [] }
+    expect(parseExerciseAiResult(null)).toEqual(empty)
+    expect(parseExerciseAiResult(undefined)).toEqual(empty)
+    expect(parseExerciseAiResult('feedback')).toEqual(empty)
+    // A SpeechEvaluation from the media engine carries none of these keys.
+    expect(parseExerciseAiResult({ transcript: 'hi', wpm: 120 })).toEqual(empty)
+  })
+})
+
+describe('toLatestEvaluation', () => {
+  const row = {
+    id: '12',
+    score: 82,
+    passed: true,
+    ai_result: { feedback: 'Nice work.', strengths: ['Clear'], improvements: [] },
+    attempt_number: 2,
+    created_at: '2026-07-27T10:00:00.000Z',
+  }
+
+  it('normalizes a graded row', () => {
+    expect(toLatestEvaluation(row)).toEqual({
+      id: 12,
+      score: 82,
+      passed: true,
+      attemptNumber: 2,
+      createdAt: '2026-07-27T10:00:00.000Z',
+      feedback: 'Nice work.',
+      strengths: ['Clear'],
+      improvements: [],
+    })
+  })
+
+  it('returns null when there is no graded attempt', () => {
+    expect(toLatestEvaluation(null)).toBeNull()
+    expect(toLatestEvaluation(undefined)).toBeNull()
+  })
+
+  it('treats a null `passed` as not passed rather than as truthy', () => {
+    expect(toLatestEvaluation({ ...row, passed: null })?.passed).toBe(false)
+  })
+
+  it('keeps a null score null instead of coercing it to zero', () => {
+    // Number(null) is 0 — that would report an ungraded attempt as a hard zero.
+    expect(toLatestEvaluation({ ...row, score: null })?.score).toBeNull()
+  })
+
+  it('tolerates a missing attempt_number', () => {
+    const withoutAttempt = { ...row }
+    delete (withoutAttempt as Partial<typeof row>).attempt_number
+    expect(toLatestEvaluation(withoutAttempt)?.attemptNumber).toBeNull()
+  })
+})


### PR DESCRIPTION
Closes #581.

A student who came back to a finished lesson checkpoint or standalone exercise saw a bare score badge. **The AI's feedback was never missing** — it has always been written to `lesson_checkpoint_attempts.evaluation` and `exercise_evaluations.ai_result`. The loaders just never read those columns back, and every engine held its result in component state that a reload discarded. This was a display gap, not a storage gap.

This PR restores it, then fixes what an `/impeccable critique` found wrong with how it read.

## Walkthrough

Same student, two surfaces: the standalone essay they passed, then the in-lesson checkpoint they did not. 390px.

![Walkthrough](https://raw.githubusercontent.com/guillermoscript/lms-front/master/docs/screenshots/581-walkthrough.gif?v=1)

## Restoring the result

| Mobile · 390px | Desktop · 1440px |
|---|---|
| ![essay mobile](https://raw.githubusercontent.com/guillermoscript/lms-front/master/docs/screenshots/581-essay-mobile.png?v=1) | ![essay desktop](https://raw.githubusercontent.com/guillermoscript/lms-front/master/docs/screenshots/581-essay-desktop.png?v=1) |

- `loadLessonCheckpoints` now selects `response` and `evaluation`. Defensive parsers turn those two free-form jsonb columns back into the student's own answer plus the feedback, next-step hint and per-question explanations. Four writer shapes exist (ai / deterministic / fallback / external sync); anything unrecognised yields "nothing to show" rather than being trusted into the UI.
- **The standalone exercise page needed no new query.** Artifact and essay rows were already in the `exercise_evaluations` result set fetched for the audio/video history, and were simply never passed to their components.
- Per-question feedback rendered `correctValue` raw, so a multiple-choice miss read **"Incorrect — 1"** — the option *index*. It now maps to option text, and booleans to localized true/false.
- **Coding challenges write no evaluation row at all.** They are graded by their test runner and store a hardcoded completion, so there is nothing to replay. The card says so explicitly instead of rendering an empty result. That is a storage gap and out of scope here.

## Making it legible

Verified live at 390×844 and 1440×900, light and dark, `/en` and `/es`, on cold loads.

**Accessibility.** Six WCAG AA text-contrast failures in light and four in dark, measured canvas-sampled over the real composited background. All now clear; 14/14 elements pass in both themes.

| Element | Was | Now |
|---|---|---|
| `PASSED` badge, white on `emerald-500` | 2.47 | ✅ |
| `/ 100`, `text-muted-foreground/60` | 2.31 light / 3.29 dark | ✅ |
| `STRENGTHS` / `AREAS TO IMPROVE` | 3.65 / 3.20 | ✅ |
| `+` / `-` list markers | 2.47 / 2.13 | ✅ |
| `AI FEEDBACK`, `text-primary` | 3.49 dark | ✅ |

The `AI Feedback` label no longer uses `text-primary` at all: **tenants override that token**, so small text in it cannot be guaranteed to clear AA for any school. The icon keeps the accent — non-text UI only needs 3:1.

**The artifact panel printed the score over the pass mark, twice.** `62 / 70` reads as 89%, but 62 against a pass mark of 70 is a failure. That whole block was a near-copy of `ExerciseResultSummary`, so it now renders the shared card and the duplicate is gone.

![artifact](https://raw.githubusercontent.com/guillermoscript/lms-front/master/docs/screenshots/581-artifact-desktop.png?v=1)

**A failed checkpoint showed a green tick**, because its tone came from `completed` and a failed attempt is still completed. And the restored feedback sat behind a closed disclosure, so a returning student saw a score chip and nothing else. It now opens itself for the one state that asks something of them — a graded attempt they did not pass — and an explicit toggle still wins.

The retry field also sat *between* the answer and the grade for that answer, looking identical to the read-only answer above it. Order is now answer → result → retry, and the restored answer is borderless so it stops reading as an editable field.

![checkpoint](https://raw.githubusercontent.com/guillermoscript/lms-front/master/docs/screenshots/581-checkpoint-mobile-es.png?v=1)

**A sticky-column regression I introduced.** Putting the result card inside `lg:sticky lg:top-6` took that container to **1078px against a 900px viewport**. `position: sticky` does not pin an element taller than its scrollport, so the chat input scrolled away unreachable. The card is now a sibling above it (650px, sticks again) — which also puts the result **first** on mobile instead of **1157px down** the page, behind instructions the student has already followed.

**Measure and touch.** Prose capped at 68ch (was 85–90). Header stacks below `sm:`, where the metadata line was being squeezed to 161px and two lines. Long unbroken input wraps. On phones the retry button is 36px tall (was 24) and inputs are 16px, so iOS Safari stops zooming the page on focus.

## Verification

- `npm run build` exit 0 · `npm run typecheck` clean · **669 unit tests pass** (53 files, 23 new covering the parsers and the auto-expand rule)
- `npx impeccable detect` clean on all touched files
- Contrast audited programmatically in-page, both themes, 0 failures
- All QA fixtures removed afterwards; lesson content restored byte-for-byte

## Not in scope

The artifact page restores a grade while its own answer fields sit empty — checkpoints show "Your answer", the artifact engine has no equivalent. Noted in #581 as deserving its own issue.