### PR TITLE
feat(exercises): one panel at a time on a phone, columns on desktop (#583)

### DIFF
--- a/app/[locale]/dashboard/student/courses/[courseId]/exercises/[exerciseId]/page.tsx
+++ b/app/[locale]/dashboard/student/courses/[courseId]/exercises/[exerciseId]/page.tsx
@@ -267,7 +267,8 @@ export default async function ExercisePage({ params }: PageProps) {
     const t = await getTranslations('exercises.audio')
     const otherExercisesSection = otherExercises && otherExercises.length > 0 ? (
         <>
-            <h3 className="text-xs font-bold uppercase tracking-widest text-muted-foreground/70 mb-3">{t('moreExercises')}</h3>
+            {/* Full-strength muted, not /70: the faded variant measured 2.76:1. */}
+            <h3 className="text-xs font-bold uppercase tracking-widest text-muted-foreground mb-3">{t('moreExercises')}</h3>
             <div className="grid gap-3">
                 {otherExercises.map((ex) => (
                     <ExerciseCard
@@ -409,6 +410,7 @@ export default async function ExercisePage({ params }: PageProps) {
                     studentId={userId}
                     isExerciseCompletedSection={otherExercisesSection}
                     resultSummary={resultSummary}
+                    resultPassed={latestEvaluation?.passed}
                 >
                     {chatComponent}
                 </EssayExercise>

--- a/components/exercises/artifact-exercise.tsx
+++ b/components/exercises/artifact-exercise.tsx
@@ -1,26 +1,15 @@
 'use client'
 
 import { useState, useRef, useCallback, useEffect } from 'react'
-import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import ExerciseResultSummary from '@/components/exercises/exercise-result-summary'
-import { cn } from '@/lib/utils'
-import Markdown from 'react-markdown'
+import ExerciseBrief from '@/components/exercises/exercise-brief'
+import ExerciseHeader from '@/components/exercises/exercise-header'
+import ExerciseWorkspace, { initialWorkspacePanel } from '@/components/exercises/exercise-workspace'
 import { useTranslations } from 'next-intl'
 import confetti from 'canvas-confetti'
 import { toast } from 'sonner'
-import {
-  IconCheck,
-  IconClock,
-  IconFlame,
-  IconInfoCircle,
-  IconSparkles,
-  IconLoader2,
-  IconAlertTriangle,
-  IconArrowRight,
-  IconTrophy,
-  IconCode,
-} from '@tabler/icons-react'
+import { IconLoader2, IconAlertTriangle, IconArrowRight } from '@tabler/icons-react'
 
 interface ArtifactExerciseProps {
   exercise: {
@@ -64,7 +53,7 @@ export default function ArtifactExercise({
   initialEvaluation = null,
 }: ArtifactExerciseProps) {
   const t = useTranslations('exercises.artifact')
-  const tAudio = useTranslations('exercises.audio')
+  const tWorkspace = useTranslations('exercises.workspace')
   const tGamification = useTranslations('gamification')
 
   const config = exercise.exercise_config ?? {}
@@ -76,25 +65,8 @@ export default function ArtifactExercise({
   const [passed, setPassed] = useState<boolean>(isExerciseCompleted)
   const [errorMsg, setErrorMsg] = useState<string | null>(null)
   const [rateLimited, setRateLimited] = useState(false)
-
-  const completionData = exercise.exercise_completions?.[0]
-  const completionScore = completionData?.score ?? (evaluation?.score || 0)
-  const completionDate = completionData?.completed_at
-
-  const difficultyLabels: Record<string, string> = {
-    easy: tAudio('beginner'),
-    medium: tAudio('intermediate'),
-    hard: tAudio('advanced'),
-  }
-  const difficultyConfig: Record<string, { color: string; icon: typeof IconFlame }> = {
-    easy: { color: 'text-emerald-600 bg-emerald-500/10 border-emerald-500/20', icon: IconSparkles },
-    medium: { color: 'text-amber-600 bg-amber-500/10 border-amber-500/20', icon: IconFlame },
-    hard: { color: 'text-rose-600 bg-rose-500/10 border-rose-500/20', icon: IconFlame },
-  }
-
-  const difficulty = difficultyConfig[exercise.difficulty_level] || difficultyConfig.easy
-  const difficultyLabel = difficultyLabels[exercise.difficulty_level] || difficultyLabels.easy
-  const DifficultyIcon = difficulty.icon
+  /** Bumped on every fresh grade so the workspace can surface the result panel. */
+  const [gradedNonce, setGradedNonce] = useState(0)
 
   const handleSubmit = useCallback(async (content: string, metadata: Record<string, unknown> = {}) => {
     setSubmitState('evaluating')
@@ -126,6 +98,7 @@ export default function ArtifactExercise({
       setEvaluation(result)
       setPassed(result.passed)
       setSubmitState('done')
+      setGradedNonce((n) => n + 1)
 
       // Send feedback back to iframe
       iframeRef.current?.contentWindow?.postMessage(
@@ -171,174 +144,103 @@ export default function ArtifactExercise({
     setEvaluation(null)
   }
 
-  return (
-    <div className="space-y-6">
-      {/* Header */}
+  const taskPanel = (
+    <div className="space-y-4">
+      {rateLimited && (
+        <div className="rounded-xl border border-amber-500/30 bg-amber-500/[0.05] px-4 py-3">
+          <p className="flex items-center gap-2.5 text-sm font-semibold text-amber-800 dark:text-amber-300">
+            <IconAlertTriangle size={16} className="shrink-0" aria-hidden="true" />
+            {t('rateLimited')}
+          </p>
+        </div>
+      )}
+
+      {submitState === 'evaluating' && (
+        <div
+          className="flex items-center gap-3 rounded-xl border bg-muted/30 px-4 py-3"
+          role="status"
+        >
+          <IconLoader2 size={16} className="animate-spin text-primary shrink-0" aria-hidden="true" />
+          <p className="text-sm font-medium">{t('evaluating')}</p>
+        </div>
+      )}
+
+      {errorMsg && (
+        <div className="rounded-lg border border-destructive/20 bg-destructive/5 px-4 py-3 text-sm text-destructive" role="alert">
+          {errorMsg}
+        </div>
+      )}
+
+      {artifactHtml && (
+        // The srcDoc is authored as a light-mode document, so the frame keeps a
+        // white backing in both themes rather than showing a dark seam round it.
+        <div className="rounded-xl border overflow-hidden bg-white">
+          <iframe
+            ref={iframeRef}
+            srcDoc={artifactHtml}
+            sandbox="allow-scripts"
+            className="w-full border-0"
+            style={{ minHeight: '500px' }}
+            title={exercise.title}
+          />
+        </div>
+      )}
+    </div>
+  )
+
+  // One result card across every engine. This block used to be a near-copy of
+  // ExerciseResultSummary that printed the score over the PASS MARK, alongside
+  // a second trophy card printing a *different* score from exercise_completions.
+  const resultPanel =
+    evaluation && submitState !== 'evaluating' ? (
       <div className="space-y-4">
-        <div className="flex flex-wrap items-center gap-2">
-          <Badge variant="outline" className="font-bold border-2 text-primary border-primary/20 bg-primary/5 uppercase tracking-wider text-[10px] px-2.5 py-0.5">
-            <IconCode size={10} className="mr-1" aria-hidden="true" />
-            {t('typeLabel')}
-          </Badge>
-          <Badge variant="outline" className={cn('font-bold border text-[10px] px-2.5 py-0.5 uppercase tracking-wider', difficulty.color)}>
-            <DifficultyIcon size={11} className="mr-1" aria-hidden="true" />
-            {difficultyLabel}
-          </Badge>
-          {exercise.time_limit && (
-            <Badge variant="outline" className="font-bold border text-[10px] px-2.5 py-0.5 uppercase tracking-wider text-muted-foreground">
-              <IconClock size={11} className="mr-1" aria-hidden="true" />
-              {exercise.time_limit} min
-            </Badge>
-          )}
-          {(isExerciseCompleted || passed) && (
-            <Badge className="bg-emerald-500 text-white font-bold text-[10px] px-2.5 py-0.5 uppercase tracking-wider">
-              <IconCheck size={11} className="mr-1" aria-hidden="true" />
-              {tAudio('completed')}
-            </Badge>
-          )}
-        </div>
+        <ExerciseResultSummary
+          score={evaluation.score}
+          passed={evaluation.passed}
+          feedback={evaluation.feedback}
+          strengths={evaluation.strengths}
+          improvements={evaluation.improvements}
+          // The API response carries its own threshold; the prop is the
+          // fallback for a restored attempt that predates that field.
+          passingScore={evaluation.passingScore ?? passingScore}
+        />
 
-        <h1 className="text-2xl md:text-3xl font-black tracking-tight text-balance leading-tight">
-          {exercise.title}
-        </h1>
+        {!evaluation.passed && !rateLimited && (
+          <Button
+            onClick={handleTryAgain}
+            className="w-full gap-2.5 h-11 text-sm font-semibold tracking-wide"
+          >
+            {t('tryAgain')}
+            <IconArrowRight size={16} className="ml-auto opacity-60" />
+          </Button>
+        )}
       </div>
+    ) : undefined
 
-      {/* Main Layout */}
-      <div className="grid grid-cols-1 lg:grid-cols-12 gap-6">
-        {/* Left: Instructions */}
-        <div className="lg:col-span-4 space-y-6">
-          <div className="rounded-2xl border-2 border-primary/10 bg-gradient-to-b from-primary/[0.03] to-transparent overflow-hidden">
-            <div className="px-5 py-3.5 border-b border-primary/10 bg-primary/[0.03]">
-              <h2 className="font-bold text-xs flex items-center gap-2 text-primary uppercase tracking-wider">
-                <IconInfoCircle size={14} aria-hidden="true" />
-                {tAudio('instructions')}
-              </h2>
-            </div>
-            <div className="px-5 py-4">
-              <div className="prose prose-sm prose-neutral max-w-none dark:prose-invert prose-p:leading-relaxed prose-p:text-foreground/80 prose-strong:text-foreground prose-headings:text-foreground prose-headings:font-bold prose-li:text-foreground/80 prose-headings:text-sm">
-                <Markdown>{exercise.instructions}</Markdown>
-              </div>
-            </div>
-          </div>
+  return (
+    <div className="space-y-4 sm:space-y-6">
+      <ExerciseHeader
+        typeLabel={t('typeLabel')}
+        title={exercise.title}
+        difficulty={exercise.difficulty_level}
+        timeLimit={exercise.time_limit}
+        completed={isExerciseCompleted || passed}
+      />
 
-          {isExerciseCompletedSection && (
-            <div className="space-y-4">{isExerciseCompletedSection}</div>
-          )}
-        </div>
-
-        {/* Right: Artifact + Results */}
-        <div className="lg:col-span-8">
-          <div className="lg:sticky lg:top-6 space-y-4">
-            {/* Completion summary */}
-            {(isExerciseCompleted || passed) && (
-              <div className="rounded-2xl border-2 border-emerald-500/20 bg-gradient-to-br from-emerald-500/[0.06] to-emerald-500/[0.02] p-6 space-y-4">
-                <div className="flex items-center justify-between">
-                  <div>
-                    <h3 className="font-bold text-emerald-700 dark:text-emerald-400 flex items-center gap-2">
-                      <IconTrophy size={18} />
-                      {tAudio('completedScore')}
-                    </h3>
-                    {completionDate && (
-                      <p className="text-xs text-emerald-600/70 dark:text-emerald-400/60 mt-1">
-                        {tAudio('completedOn', {
-                          date: new Date(completionDate).toLocaleDateString(undefined, {
-                            month: 'long', day: 'numeric', year: 'numeric',
-                          }),
-                        })}
-                      </p>
-                    )}
-                  </div>
-                  <div className="flex items-baseline gap-1">
-                    <span className="text-4xl font-black tabular-nums tracking-tight text-emerald-600 dark:text-emerald-400">
-                      {Math.round(completionScore)}
-                    </span>
-                    <span className="text-lg font-bold text-emerald-600/40">/</span>
-                    <span className="text-lg font-bold text-emerald-600/60 tabular-nums">100</span>
-                  </div>
-                </div>
-                <p className="text-sm text-emerald-600/80 dark:text-emerald-400/70">
-                  {tAudio('exerciseMarkedComplete')}
-                </p>
-              </div>
-            )}
-
-            {/* Rate limit banner */}
-            {rateLimited && (
-              <div className="rounded-xl border-2 border-amber-500/20 bg-amber-500/[0.05] p-5">
-                <div className="flex items-center gap-3">
-                  <div className="rounded-full bg-amber-500/10 p-2">
-                    <IconAlertTriangle size={20} className="text-amber-600" />
-                  </div>
-                  <div>
-                    <h3 className="font-bold text-amber-700 dark:text-amber-400">{t('rateLimited')}</h3>
-                  </div>
-                </div>
-              </div>
-            )}
-
-            {/* Evaluating state */}
-            {submitState === 'evaluating' && (
-              <div className="flex items-center gap-3 rounded-xl border bg-muted/30 px-4 py-3">
-                <IconLoader2 size={16} className="animate-spin text-primary shrink-0" />
-                <div>
-                  <p className="text-sm font-medium">{t('evaluating')}</p>
-                </div>
-              </div>
-            )}
-
-            {/* Error */}
-            {errorMsg && (
-              <div className="rounded-lg border border-destructive/20 bg-destructive/5 px-4 py-3 text-sm text-destructive">
-                {errorMsg}
-              </div>
-            )}
-
-            {/* Sandboxed iframe */}
-            {artifactHtml && (
-              <div className="rounded-xl border-2 border-border/50 overflow-hidden bg-white">
-                <iframe
-                  ref={iframeRef}
-                  srcDoc={artifactHtml}
-                  sandbox="allow-scripts"
-                  className="w-full border-0"
-                  style={{ minHeight: '500px' }}
-                  title={exercise.title}
-                />
-              </div>
-            )}
-
-            {/* Evaluation result — also shown for a restored prior attempt, whose
-                submitState is still 'idle' because nothing was submitted this visit. */}
-            {/* One result card across every engine. This block used to be a
-                near-copy of ExerciseResultSummary that printed the score over
-                the PASS MARK, twice: "62 / 70" reads as 89% when 62 is a fail. */}
-            {evaluation && submitState !== 'evaluating' && (
-              <div className="space-y-4">
-                <ExerciseResultSummary
-                  score={evaluation.score}
-                  passed={evaluation.passed}
-                  feedback={evaluation.feedback}
-                  strengths={evaluation.strengths}
-                  improvements={evaluation.improvements}
-                  // The API response carries its own threshold; the prop is the
-                  // fallback for a restored attempt that predates that field.
-                  passingScore={evaluation.passingScore ?? passingScore}
-                />
-
-                {!evaluation.passed && !rateLimited && (
-                  <Button
-                    onClick={handleTryAgain}
-                    className="w-full gap-2.5 h-11 text-sm font-semibold tracking-wide"
-                  >
-                    {t('tryAgain')}
-                    <IconArrowRight size={16} className="ml-auto opacity-60" />
-                  </Button>
-                )}
-              </div>
-            )}
-          </div>
-        </div>
-      </div>
+      <ExerciseWorkspace
+        brief={<ExerciseBrief instructions={exercise.instructions} />}
+        task={taskPanel}
+        taskLabel={tWorkspace('task')}
+        result={resultPanel}
+        resultPassed={evaluation?.passed}
+        related={isExerciseCompletedSection}
+        initialPanel={initialWorkspacePanel({
+          hasResult: Boolean(resultPanel),
+          passed: evaluation?.passed,
+          attempted: isExerciseCompleted || Boolean(initialEvaluation),
+        })}
+        revealResultNonce={gradedNonce}
+      />
     </div>
   )
 }

--- a/components/exercises/audio-exercise.tsx
+++ b/components/exercises/audio-exercise.tsx
@@ -4,14 +4,11 @@ import { useState, useCallback } from 'react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
-import Markdown from 'react-markdown'
 import { useTranslations } from 'next-intl'
 import confetti from 'canvas-confetti'
 import {
   IconCheck,
   IconClock,
-  IconFlame,
-  IconInfoCircle,
   IconMicrophone,
   IconSparkles,
   IconLoader2,
@@ -26,6 +23,9 @@ import {
 } from '@tabler/icons-react'
 import { MediaRecorderComponent } from './media-recorder'
 import { SpeechFeedback } from './speech-feedback'
+import ExerciseBrief from './exercise-brief'
+import ExerciseHeader from './exercise-header'
+import ExerciseWorkspace, { initialWorkspacePanel } from './exercise-workspace'
 import type { SpeechEvaluation } from '@/lib/speech/types'
 
 interface SubmissionHistoryItem {
@@ -134,16 +134,14 @@ function RetryPanel({
   return (
     <div className="rounded-2xl border-2 border-primary/15 bg-gradient-to-br from-primary/[0.04] to-primary/[0.01] p-6 space-y-5">
       <div className="flex items-center justify-between">
-        <div className="flex items-baseline gap-3">
-          <div className="flex items-baseline gap-1">
-            <span className="text-4xl font-black tabular-nums tracking-tight text-foreground">
-              {Math.round(score)}
-            </span>
-            <span className="text-lg font-bold text-muted-foreground/60">/</span>
-            <span className="text-lg font-bold text-primary tabular-nums">
-              {passingScore}
-            </span>
-          </div>
+        {/* Out of 100, not out of the pass mark: "64 / 70" reads as 91% when
+            64 is a failure. The threshold is metadata, and `pointsAway` below
+            already says how far off it was. */}
+        <div className="flex items-baseline gap-1">
+          <span className="text-4xl font-bold tabular-nums tracking-tight text-foreground">
+            {Math.round(score)}
+          </span>
+          <span className="text-lg font-semibold text-muted-foreground tabular-nums">/ 100</span>
         </div>
         <div className="rounded-full border-2 border-primary/20 bg-primary/5 p-2.5">
           <IconTarget size={20} className="text-primary" />
@@ -279,6 +277,7 @@ export default function AudioExercise({
   maxDailyAttempts: serverMaxDailyAttempts,
 }: AudioExerciseProps) {
   const t = useTranslations('exercises.audio')
+  const tWorkspace = useTranslations('exercises.workspace')
 
   const config = exercise.exercise_config ?? {}
   const maxDaily = serverMaxDailyAttempts ?? config.max_daily_attempts ?? 5
@@ -299,6 +298,8 @@ export default function AudioExercise({
   )
   const [attemptsUsed, setAttemptsUsed] = useState(serverDailyAttemptsUsed ?? 0)
   const [submissionHistory, setSubmissionHistory] = useState(initialHistory)
+  /** Bumped on every fresh grade so the workspace can surface the result panel. */
+  const [gradedNonce, setGradedNonce] = useState(0)
 
   // Best completion score from DB (for revisit display)
   const completionData = exercise.exercise_completions?.[0]
@@ -306,20 +307,6 @@ export default function AudioExercise({
   const completionDate = completionData?.completed_at
     ?? submissionHistory.find(s => s.status === 'completed')?.created_at
 
-  const difficultyLabels: Record<string, string> = {
-    easy: t('beginner'),
-    medium: t('intermediate'),
-    hard: t('advanced'),
-  }
-  const difficultyConfig: Record<string, { color: string; icon: typeof IconFlame }> = {
-    easy: { color: 'text-emerald-600 bg-emerald-500/10 border-emerald-500/20', icon: IconSparkles },
-    medium: { color: 'text-amber-600 bg-amber-500/10 border-amber-500/20', icon: IconFlame },
-    hard: { color: 'text-rose-600 bg-rose-500/10 border-rose-500/20', icon: IconFlame },
-  }
-
-  const difficulty = difficultyConfig[exercise.difficulty_level] || difficultyConfig.easy
-  const difficultyLabel = difficultyLabels[exercise.difficulty_level] || difficultyLabels.easy
-  const DifficultyIcon = difficulty.icon
   const minDuration = config.min_duration_seconds ?? 5
   const maxDuration = config.max_duration_seconds ?? 300
 
@@ -403,6 +390,7 @@ export default function AudioExercise({
       setPassed(didPass)
       setShowRecorder(false)
       setSubmitState('done')
+      setGradedNonce((n) => n + 1)
 
       // Fire confetti on passing
       if (didPass) {
@@ -437,203 +425,169 @@ export default function AudioExercise({
     setErrorMsg(null)
   }
 
+  const briefPanel = (
+    <div className="space-y-4 lg:space-y-6">
+      <ExerciseBrief instructions={exercise.instructions} />
+
+      {config.topic_prompt && (
+        <div className="rounded-xl border bg-card px-4 py-3 lg:px-5 lg:py-4">
+          <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground mb-2">
+            {t('topicPrompt')}
+          </p>
+          <p className="text-sm text-foreground/80 leading-relaxed max-w-[68ch]">
+            {config.topic_prompt}
+          </p>
+        </div>
+      )}
+    </div>
+  )
+
+  // What the student can act on right now: the counter, whatever is blocking
+  // them, and the recorder itself.
+  const taskPanel = (
+    <div className="space-y-4">
+      {!isUnlimited && passed !== true && <AttemptCounter used={attemptsUsed} max={maxDaily} />}
+
+      {dailyLimitReached && passed !== true && (
+        <div className="rounded-xl border border-amber-500/30 bg-amber-500/[0.05] px-4 py-3">
+          <p className="flex items-center gap-2.5 text-sm font-semibold text-amber-800 dark:text-amber-300">
+            <IconAlertTriangle size={16} className="shrink-0" aria-hidden="true" />
+            {t('dailyLimitReached')}
+          </p>
+          <p className="text-sm text-muted-foreground mt-1">
+            {t('dailyLimitMessage', { limit: maxDaily })}
+          </p>
+        </div>
+      )}
+
+      {showRetryPanel && (
+        <RetryPanel
+          score={evaluation.score}
+          passingScore={passingScore}
+          onRecordAgain={handleTryAgain}
+        />
+      )}
+
+      {/* Kept beside the recorder on a retry: this is the one place the student
+          needs the verdict and the control at the same time. */}
+      {showFeedbackSummary && <CollapsibleFeedbackSummary evaluation={evaluation} />}
+
+      {showRecorder && !dailyLimitReached && (
+        <div className="rounded-xl border bg-card p-5">
+          <h3 className="mb-4 text-sm font-semibold flex items-center gap-2">
+            <IconMicrophone size={16} className="text-primary" aria-hidden="true" />
+            {t('recordYourResponse')}
+          </h3>
+
+          {errorMsg && (
+            <div className="mb-4 rounded-lg border border-destructive/20 bg-destructive/5 px-4 py-3 text-sm text-destructive" role="alert">
+              {errorMsg}
+            </div>
+          )}
+
+          {submitState === 'analyzing' && (
+            <div className="mb-4 flex items-center gap-3 rounded-lg border bg-muted/30 px-4 py-3" role="status">
+              <IconLoader2 size={16} className="animate-spin text-primary shrink-0" aria-hidden="true" />
+              <div>
+                <p className="text-sm font-medium">{t('analyzing')}</p>
+                <p className="text-xs text-muted-foreground mt-0.5">{t('analyzingDescription')}</p>
+              </div>
+            </div>
+          )}
+
+          {submitState !== 'analyzing' && (
+            <MediaRecorderComponent
+              onRecordingComplete={handleRecordingComplete}
+              isSubmitting={submitState === 'uploading'}
+              minDurationSeconds={minDuration}
+              maxDurationSeconds={maxDuration}
+              disabled={submitState === 'uploading'}
+            />
+          )}
+
+          <div className="mt-4 flex flex-wrap gap-4 text-xs text-muted-foreground border-t pt-4">
+            <span>{t('durationRange', { min: `${minDuration}s`, max: formatDuration(maxDuration) })}</span>
+            <span>{t('uploadLimit')}</span>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+
+  const hasResult =
+    isExerciseCompleted || passed === true || (evaluation && !showRecorder) || submissionHistory.length > 0
+
+  const resultPanel = hasResult ? (
+    <div className="space-y-4">
+      {(isExerciseCompleted || passed === true) && (
+        <CompletionSummary
+          score={completionScore}
+          passingScore={passingScore}
+          completedDate={completionDate}
+        />
+      )}
+
+      {evaluation && !showRecorder && (
+        <div className="rounded-xl border bg-card p-5">
+          <h3 className="mb-5 text-sm font-semibold flex items-center gap-2">
+            <IconSparkles size={16} className="text-primary" aria-hidden="true" />
+            {t('aiFeedback')}
+          </h3>
+          <SpeechFeedback
+            evaluation={evaluation}
+            passed={passed}
+            passingScore={passingScore}
+            onTryAgain={passed !== true && !dailyLimitReached ? handleTryAgain : undefined}
+          />
+        </div>
+      )}
+
+      {submissionHistory.length > 0 && (
+        <div className="rounded-xl border bg-card p-5">
+          <h3 className="mb-4 text-sm font-semibold flex items-center gap-2">
+            <IconClock size={16} className="text-muted-foreground" aria-hidden="true" />
+            {t('submissionHistory')}
+          </h3>
+          <div className="space-y-3">
+            {submissionHistory.map((sub, idx) => (
+              <SubmissionHistoryRow
+                key={sub.id}
+                submission={sub}
+                attemptNumber={submissionHistory.length - idx}
+                passingScore={passingScore}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  ) : undefined
+
   return (
-    <div className="space-y-6">
-      {/* Header */}
-      <div className="space-y-4">
-        <div className="flex flex-wrap items-center gap-2">
-          <Badge variant="outline" className="font-bold border-2 text-primary border-primary/20 bg-primary/5 uppercase tracking-wider text-[10px] px-2.5 py-0.5">
-            <IconMicrophone size={10} className="mr-1" aria-hidden="true" />
-            {t('title')}
-          </Badge>
-          <Badge variant="outline" className={cn('font-bold border text-[10px] px-2.5 py-0.5 uppercase tracking-wider', difficulty.color)}>
-            <DifficultyIcon size={11} className="mr-1" aria-hidden="true" />
-            {difficultyLabel}
-          </Badge>
-          {exercise.time_limit && (
-            <Badge variant="outline" className="font-bold border text-[10px] px-2.5 py-0.5 uppercase tracking-wider text-muted-foreground">
-              <IconClock size={11} className="mr-1" aria-hidden="true" />
-              {exercise.time_limit} min
-            </Badge>
-          )}
-          {(isExerciseCompleted || passed === true) && (
-            <Badge className="bg-emerald-500 text-white font-bold text-[10px] px-2.5 py-0.5 uppercase tracking-wider">
-              <IconCheck size={11} className="mr-1" aria-hidden="true" />
-              {t('completed')}
-            </Badge>
-          )}
-        </div>
+    <div className="space-y-4 sm:space-y-6">
+      <ExerciseHeader
+        typeLabel={t('title')}
+        title={exercise.title}
+        description={exercise.description}
+        difficulty={exercise.difficulty_level}
+        timeLimit={exercise.time_limit}
+        completed={isExerciseCompleted || passed === true}
+      />
 
-        <h1 className="text-2xl md:text-3xl font-black tracking-tight text-balance leading-tight">
-          {exercise.title}
-        </h1>
-
-        {exercise.description && (
-          <div className="text-muted-foreground text-sm md:text-base leading-relaxed max-w-2xl prose prose-sm prose-neutral dark:prose-invert prose-p:text-muted-foreground prose-p:leading-relaxed">
-            <Markdown>{exercise.description}</Markdown>
-          </div>
-        )}
-      </div>
-
-      {/* Main Layout */}
-      <div className="grid grid-cols-1 lg:grid-cols-12 gap-6">
-        {/* Left: Instructions */}
-        <div className="lg:col-span-4 space-y-6">
-          <div className="rounded-2xl border-2 border-primary/10 bg-gradient-to-b from-primary/[0.03] to-transparent overflow-hidden">
-            <div className="px-5 py-3.5 border-b border-primary/10 bg-primary/[0.03]">
-              <h2 className="font-bold text-xs flex items-center gap-2 text-primary uppercase tracking-wider">
-                <IconInfoCircle size={14} aria-hidden="true" />
-                {t('instructions')}
-              </h2>
-            </div>
-            <div className="px-5 py-4">
-              <div className="prose prose-sm prose-neutral max-w-none dark:prose-invert prose-p:leading-relaxed prose-p:text-foreground/80 prose-strong:text-foreground prose-headings:text-foreground prose-headings:font-bold prose-li:text-foreground/80 prose-headings:text-sm">
-                <Markdown>{exercise.instructions}</Markdown>
-              </div>
-            </div>
-          </div>
-
-          {config.topic_prompt && (
-            <div className="rounded-2xl border-2 border-violet-500/15 bg-violet-500/[0.03] px-5 py-4">
-              <p className="text-xs font-bold uppercase tracking-widest text-violet-600 dark:text-violet-400 mb-2">
-                {t('topicPrompt')}
-              </p>
-              <p className="text-sm text-foreground/80 leading-relaxed">{config.topic_prompt}</p>
-            </div>
-          )}
-
-          {isExerciseCompletedSection && (
-            <div className="space-y-4">{isExerciseCompletedSection}</div>
-          )}
-        </div>
-
-        {/* Right: Recorder / Results */}
-        <div className="lg:col-span-8">
-          <div className="lg:sticky lg:top-6 space-y-4">
-            {/* 0. Completion summary (when exercise is completed from DB) */}
-            {(isExerciseCompleted || passed === true) && (
-              <CompletionSummary
-                score={completionScore}
-                passingScore={passingScore}
-                completedDate={completionDate}
-              />
-            )}
-
-            {/* 1. Attempt Counter (visible when limited AND not yet completed) */}
-            {!isUnlimited && passed !== true && (
-              <AttemptCounter used={attemptsUsed} max={maxDaily} />
-            )}
-
-            {/* 2. Daily limit banner */}
-            {dailyLimitReached && passed !== true && (
-              <div className="rounded-xl border-2 border-amber-500/20 bg-amber-500/[0.05] p-5">
-                <div className="flex items-center gap-3">
-                  <div className="rounded-full bg-amber-500/10 p-2">
-                    <IconAlertTriangle size={20} className="text-amber-600" />
-                  </div>
-                  <div>
-                    <h3 className="font-bold text-amber-700 dark:text-amber-400">{t('dailyLimitReached')}</h3>
-                    <p className="text-sm text-amber-600/80 dark:text-amber-400/80">
-                      {t('dailyLimitMessage', { limit: maxDaily })}
-                    </p>
-                  </div>
-                </div>
-              </div>
-            )}
-
-            {/* 3. Retry Panel (after failing, recorder hidden) */}
-            {showRetryPanel && (
-              <RetryPanel
-                score={evaluation.score}
-                passingScore={passingScore}
-                onRecordAgain={handleTryAgain}
-              />
-            )}
-
-            {/* 4. Collapsible feedback summary (visible alongside recorder on retry) */}
-            {showFeedbackSummary && (
-              <CollapsibleFeedbackSummary evaluation={evaluation} />
-            )}
-
-            {/* 5. Recording area */}
-            {showRecorder && !dailyLimitReached && (
-              <div className="rounded-xl border bg-card p-5">
-                <h3 className="mb-4 text-sm font-semibold flex items-center gap-2">
-                  <IconMicrophone size={16} className="text-primary" />
-                  {t('recordYourResponse')}
-                </h3>
-
-                {errorMsg && (
-                  <div className="mb-4 rounded-lg border border-destructive/20 bg-destructive/5 px-4 py-3 text-sm text-destructive">
-                    {errorMsg}
-                  </div>
-                )}
-
-                {submitState === 'analyzing' && (
-                  <div className="mb-4 flex items-center gap-3 rounded-lg border bg-muted/30 px-4 py-3">
-                    <IconLoader2 size={16} className="animate-spin text-primary shrink-0" />
-                    <div>
-                      <p className="text-sm font-medium">{t('analyzing')}</p>
-                      <p className="text-xs text-muted-foreground mt-0.5">{t('analyzingDescription')}</p>
-                    </div>
-                  </div>
-                )}
-
-                {submitState !== 'analyzing' && (
-                  <MediaRecorderComponent
-                    onRecordingComplete={handleRecordingComplete}
-                    isSubmitting={submitState === 'uploading'}
-                    minDurationSeconds={minDuration}
-                    maxDurationSeconds={maxDuration}
-                    disabled={submitState === 'uploading'}
-                  />
-                )}
-
-                <div className="mt-4 flex flex-wrap gap-4 text-xs text-muted-foreground border-t pt-4">
-                  <span>{t('durationRange', { min: `${minDuration}s`, max: formatDuration(maxDuration) })}</span>
-                  <span>{t('uploadLimit')}</span>
-                </div>
-              </div>
-            )}
-
-            {/* 6. Full Feedback (when recorder is hidden) */}
-            {evaluation && !showRecorder && (
-              <div className="rounded-xl border bg-card p-5">
-                <h3 className="mb-5 text-sm font-semibold flex items-center gap-2">
-                  <IconSparkles size={16} className="text-primary" />
-                  {t('aiFeedback')}
-                </h3>
-                <SpeechFeedback
-                  evaluation={evaluation}
-                  passed={passed}
-                  passingScore={passingScore}
-                  onTryAgain={passed !== true && !dailyLimitReached ? handleTryAgain : undefined}
-                />
-              </div>
-            )}
-
-            {/* 7. Submission History */}
-            {submissionHistory.length > 0 && (
-              <div className="rounded-xl border bg-card p-5">
-                <h3 className="mb-4 text-sm font-semibold flex items-center gap-2">
-                  <IconClock size={16} className="text-muted-foreground" />
-                  {t('submissionHistory')}
-                </h3>
-                <div className="space-y-3">
-                  {submissionHistory.map((sub, idx) => (
-                    <SubmissionHistoryRow
-                      key={sub.id}
-                      submission={sub}
-                      attemptNumber={submissionHistory.length - idx}
-                      passingScore={passingScore}
-                    />
-                  ))}
-                </div>
-              </div>
-            )}
-          </div>
-        </div>
-      </div>
+      <ExerciseWorkspace
+        brief={briefPanel}
+        task={taskPanel}
+        taskLabel={tWorkspace('record')}
+        result={resultPanel}
+        resultPassed={passed}
+        related={isExerciseCompletedSection}
+        initialPanel={initialWorkspacePanel({
+          hasResult: Boolean(resultPanel),
+          passed,
+          attempted: submissionHistory.length > 0,
+        })}
+        revealResultNonce={gradedNonce}
+      />
     </div>
   )
 }
@@ -689,8 +643,8 @@ function SubmissionHistoryRow({
               className={cn(
                 'text-[10px] font-bold px-2 py-0',
                 didPass
-                  ? 'border-emerald-500/30 text-emerald-600 bg-emerald-500/10'
-                  : 'border-amber-500/30 text-amber-600 bg-amber-500/10'
+                  ? 'border-emerald-500/30 text-emerald-700 dark:text-emerald-400 bg-emerald-500/10'
+                  : 'border-amber-500/30 text-amber-700 dark:text-amber-400 bg-amber-500/10'
               )}
             >
               {Math.round(score)}/100

--- a/components/exercises/breadcrumb-component.tsx
+++ b/components/exercises/breadcrumb-component.tsx
@@ -29,9 +29,13 @@ export default function BreadcrumbComponent({ links }: BreadcrumbComponentProps)
 
                     return (
                         <Fragment key={link.href}>
+                            {/* The current crumb is `text-foreground`, not
+                                `text-primary`: it is the one crumb that is NOT
+                                a link, and at 12px the tenant accent measured
+                                3.49:1 in dark. */}
                             <BreadcrumbItem>
                                 {isLast ? (
-                                    <BreadcrumbPage className="font-semibold text-primary">
+                                    <BreadcrumbPage className="font-semibold text-foreground">
                                         {link.label}
                                     </BreadcrumbPage>
                                 ) : (

--- a/components/exercises/essay-exercise.tsx
+++ b/components/exercises/essay-exercise.tsx
@@ -2,10 +2,10 @@
 
 import { ReactNode } from "react";
 import * as motion from "motion/react-client";
-import { Badge } from "@/components/ui/badge";
-import { IconCheck, IconClock, IconFlame, IconInfoCircle, IconSparkles } from "@tabler/icons-react";
-import { cn } from "@/lib/utils";
-import Markdown from "react-markdown";
+import { useTranslations } from "next-intl";
+import ExerciseBrief from "@/components/exercises/exercise-brief";
+import ExerciseHeader from "@/components/exercises/exercise-header";
+import ExerciseWorkspace, { initialWorkspacePanel } from "@/components/exercises/exercise-workspace";
 
 interface EssayExerciseProps {
     exercise: any;
@@ -16,15 +16,11 @@ interface EssayExerciseProps {
     studentId: string;
     children: ReactNode;
     isExerciseCompletedSection?: ReactNode;
-    /** Last graded attempt, shown above the chat when the student returns. */
+    /** Last graded attempt, shown when the student returns. */
     resultSummary?: ReactNode;
+    /** Whether that attempt passed — drives which panel opens on a phone. */
+    resultPassed?: boolean;
 }
-
-const difficultyConfig: Record<string, { label: string; color: string; icon: typeof IconFlame }> = {
-    easy: { label: "Beginner", color: "text-emerald-600 bg-emerald-500/10 border-emerald-500/20", icon: IconSparkles },
-    medium: { label: "Intermediate", color: "text-amber-600 bg-amber-500/10 border-amber-500/20", icon: IconFlame },
-    hard: { label: "Advanced", color: "text-rose-600 bg-rose-500/10 border-rose-500/20", icon: IconFlame },
-};
 
 const typeLabels: Record<string, string> = {
     essay: "Essay",
@@ -43,99 +39,41 @@ export default function EssayExercise({
     children,
     isExerciseCompletedSection,
     resultSummary,
+    resultPassed,
 }: EssayExerciseProps) {
-    const difficulty = difficultyConfig[exercise.difficulty_level] || difficultyConfig.easy;
-    const DifficultyIcon = difficulty.icon;
+    const t = useTranslations("exercises.workspace");
     const typeLabel = typeLabels[exercise.exercise_type] || "Exercise";
 
     return (
         <div className="space-y-4 sm:space-y-6">
-            {/* Exercise Header */}
             <motion.div
                 initial={{ opacity: 0, y: 10 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ duration: 0.3 }}
-                className="space-y-3 sm:space-y-4"
             >
-                <div className="flex flex-wrap items-center gap-2">
-                    <Badge variant="outline" className="font-bold border-2 text-primary border-primary/20 bg-primary/5 uppercase tracking-wider text-[10px] px-2.5 py-0.5">
-                        {typeLabel}
-                    </Badge>
-                    <Badge variant="outline" className={cn("font-bold border text-[10px] px-2.5 py-0.5 uppercase tracking-wider", difficulty.color)}>
-                        <DifficultyIcon size={11} className="mr-1" aria-hidden="true" />
-                        {difficulty.label}
-                    </Badge>
-                    {exercise.time_limit && (
-                        <Badge variant="outline" className="font-bold border text-[10px] px-2.5 py-0.5 uppercase tracking-wider text-muted-foreground">
-                            <IconClock size={11} className="mr-1" aria-hidden="true" />
-                            {exercise.time_limit} min
-                        </Badge>
-                    )}
-                    {isExerciseCompleted && (
-                        <Badge className="bg-emerald-500 text-white font-bold text-[10px] px-2.5 py-0.5 uppercase tracking-wider">
-                            <IconCheck size={11} className="mr-1" aria-hidden="true" />
-                            Completed
-                        </Badge>
-                    )}
-                </div>
-
-                <h1 className="text-2xl md:text-3xl font-black tracking-tight text-balance leading-tight">
-                    {exercise.title}
-                </h1>
-
-                {exercise.description && (
-                    <div className="text-muted-foreground text-sm md:text-base leading-relaxed max-w-2xl prose prose-sm prose-neutral dark:prose-invert prose-p:text-muted-foreground prose-p:leading-relaxed">
-                        <Markdown>{exercise.description}</Markdown>
-                    </div>
-                )}
+                <ExerciseHeader
+                    typeLabel={typeLabel}
+                    title={exercise.title}
+                    description={exercise.description}
+                    difficulty={exercise.difficulty_level}
+                    timeLimit={exercise.time_limit}
+                    completed={isExerciseCompleted}
+                />
             </motion.div>
 
-            {/* Main Layout: Instructions + Chat */}
-            <motion.div
-                initial={{ opacity: 0, y: 12 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.35, delay: 0.1 }}
-                className="grid grid-cols-1 lg:grid-cols-12 gap-4 sm:gap-6"
-            >
-                {/* Last graded attempt — first for a returning student, and
-                    deliberately OUTSIDE the sticky chat column: adding it there
-                    pushed that column past the viewport height, and `sticky`
-                    stops pinning once the element is taller than its scrollport. */}
-                {resultSummary && (
-                    <div className="lg:col-span-12 order-first">{resultSummary}</div>
-                )}
-
-                {/* Instructions */}
-                <div className="lg:col-span-4 order-1">
-                    <div className="rounded-xl sm:rounded-2xl border sm:border-2 border-primary/10 bg-gradient-to-b from-primary/[0.03] to-transparent overflow-hidden">
-                        <div className="px-4 py-3 sm:px-5 sm:py-3.5 border-b border-primary/10 bg-primary/[0.03]">
-                            <h2 className="font-bold text-xs flex items-center gap-2 text-primary uppercase tracking-wider">
-                                <IconInfoCircle size={14} aria-hidden="true" />
-                                Instructions
-                            </h2>
-                        </div>
-                        <div className="px-4 py-3 sm:px-5 sm:py-4">
-                            <div className="prose prose-sm prose-neutral max-w-none dark:prose-invert prose-p:leading-relaxed prose-p:text-foreground/80 prose-strong:text-foreground prose-headings:text-foreground prose-headings:font-bold prose-li:text-foreground/80 prose-headings:text-sm">
-                                <Markdown>{exercise.instructions}</Markdown>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                {/* AI Chat — before "More Exercises" on mobile */}
-                <div className="lg:col-span-8 order-2">
-                    <div className="lg:sticky lg:top-6">
-                        {children}
-                    </div>
-                </div>
-
-                {/* Other Exercises — last on mobile */}
-                {isExerciseCompletedSection && (
-                    <div className="lg:col-span-4 order-3 space-y-4">
-                        {isExerciseCompletedSection}
-                    </div>
-                )}
-            </motion.div>
+            <ExerciseWorkspace
+                brief={<ExerciseBrief instructions={exercise.instructions} />}
+                task={children}
+                taskLabel={t("coach")}
+                result={resultSummary}
+                resultPassed={resultPassed}
+                related={isExerciseCompletedSection}
+                initialPanel={initialWorkspacePanel({
+                    hasResult: Boolean(resultSummary),
+                    passed: resultPassed,
+                    attempted: isExerciseCompleted || Boolean(resultSummary),
+                })}
+            />
         </div>
     );
 }

--- a/components/exercises/exercise-brief.tsx
+++ b/components/exercises/exercise-brief.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { useTranslations } from 'next-intl'
+import Markdown from 'react-markdown'
+import { IconInfoCircle } from '@tabler/icons-react'
+
+/**
+ * What the student has to do. One card, shared by every exercise engine —
+ * each used to carry its own near-identical copy.
+ *
+ * The heading is `foreground`, not `text-primary`: tenants override that token,
+ * so 10px uppercase text in it cannot be guaranteed to clear AA. The icon keeps
+ * the accent, since non-text UI only needs 3:1.
+ */
+export default function ExerciseBrief({ instructions }: { instructions: string }) {
+  const t = useTranslations('exercises.audio')
+
+  return (
+    // No card on a phone: the panel already *is* the instructions, so a border
+    // and a header repeating the tab label are chrome around nothing. From `lg`
+    // up it sits beside the work and needs the container to read as a rail.
+    <div className="lg:rounded-xl lg:border lg:bg-card lg:overflow-hidden">
+      <div className="hidden lg:block px-5 py-3 border-b bg-muted/40">
+        <h2 className="font-semibold text-xs flex items-center gap-2 uppercase tracking-wider">
+          <IconInfoCircle size={14} className="text-primary" aria-hidden="true" />
+          {t('instructions')}
+        </h2>
+      </div>
+      <div className="lg:px-5 lg:py-4">
+        {/* 68ch: the brief is the longest prose on the page and the rail runs
+            past 85ch at desktop widths. */}
+        <div className="prose prose-sm prose-neutral max-w-[68ch] dark:prose-invert prose-p:leading-relaxed prose-p:text-foreground/80 prose-strong:text-foreground prose-headings:text-foreground prose-headings:font-semibold prose-li:text-foreground/80 prose-headings:text-sm">
+          <Markdown>{instructions}</Markdown>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/exercises/exercise-header.tsx
+++ b/components/exercises/exercise-header.tsx
@@ -1,0 +1,100 @@
+'use client'
+
+import { useTranslations } from 'next-intl'
+import Markdown from 'react-markdown'
+import { IconCheck, IconClock, IconFlame, IconSparkles } from '@tabler/icons-react'
+import { Badge } from '@/components/ui/badge'
+import { cn } from '@/lib/utils'
+
+interface ExerciseHeaderProps {
+  typeLabel: string
+  title: string
+  description?: string | null
+  difficulty?: string | null
+  timeLimit?: number | null
+  completed?: boolean
+}
+
+/**
+ * Title block shared by every exercise engine.
+ *
+ * The difficulty inks are `-700 dark:-400`, not `-600`: measured against its
+ * own `-500/10` tint, `text-amber-600` came out at 2.94:1, well under AA. Each
+ * engine used to carry its own copy of that table, so the failure shipped four
+ * times over.
+ */
+const DIFFICULTY: Record<string, { ink: string; icon: typeof IconFlame }> = {
+  easy: {
+    ink: 'text-emerald-700 dark:text-emerald-400 bg-emerald-500/10 border-emerald-500/25',
+    icon: IconSparkles,
+  },
+  medium: {
+    ink: 'text-amber-700 dark:text-amber-400 bg-amber-500/10 border-amber-500/25',
+    icon: IconFlame,
+  },
+  hard: {
+    ink: 'text-rose-700 dark:text-rose-400 bg-rose-500/10 border-rose-500/25',
+    icon: IconFlame,
+  },
+}
+
+export default function ExerciseHeader({
+  typeLabel,
+  title,
+  description,
+  difficulty,
+  timeLimit,
+  completed,
+}: ExerciseHeaderProps) {
+  const t = useTranslations('exercises.audio')
+  const level = DIFFICULTY[difficulty ?? 'easy'] ?? DIFFICULTY.easy
+  const LevelIcon = level.icon
+  const levelLabel = t(
+    difficulty === 'hard' ? 'advanced' : difficulty === 'medium' ? 'intermediate' : 'beginner'
+  )
+
+  const chip = 'font-semibold border text-[10px] px-2.5 py-0.5 uppercase tracking-wider'
+
+  return (
+    <div className="space-y-3 sm:space-y-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <Badge variant="outline" className={cn(chip, 'border-border bg-muted/50 text-foreground')}>
+          {typeLabel}
+        </Badge>
+        <Badge variant="outline" className={cn(chip, level.ink)}>
+          <LevelIcon size={11} className="mr-1" aria-hidden="true" />
+          {levelLabel}
+        </Badge>
+        {timeLimit ? (
+          <Badge variant="outline" className={cn(chip, 'text-muted-foreground')}>
+            <IconClock size={11} className="mr-1" aria-hidden="true" />
+            {timeLimit} min
+          </Badge>
+        ) : null}
+        {completed && (
+          <Badge
+            className={cn(
+              chip,
+              // -700 on white, -400 on near-black: `bg-emerald-500` behind
+              // white text measured 2.47:1 before this.
+              'border-transparent bg-emerald-700 text-white dark:bg-emerald-400 dark:text-emerald-950'
+            )}
+          >
+            <IconCheck size={11} className="mr-1" aria-hidden="true" />
+            {t('completed')}
+          </Badge>
+        )}
+      </div>
+
+      <h1 className="text-2xl md:text-3xl font-bold tracking-tight text-balance leading-tight">
+        {title}
+      </h1>
+
+      {description && (
+        <div className="text-muted-foreground text-sm md:text-base leading-relaxed max-w-[68ch] prose prose-sm prose-neutral dark:prose-invert prose-p:text-muted-foreground prose-p:leading-relaxed">
+          <Markdown>{description}</Markdown>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/exercises/exercise-workspace.tsx
+++ b/components/exercises/exercise-workspace.tsx
@@ -1,0 +1,196 @@
+'use client'
+
+import { useEffect, useRef, useState, type ReactNode } from 'react'
+import { useTranslations } from 'next-intl'
+import { IconCheck, IconTarget } from '@tabler/icons-react'
+import { cn } from '@/lib/utils'
+
+export type WorkspacePanel = 'brief' | 'task' | 'result'
+
+interface ExerciseWorkspaceProps {
+  /** What the student has to do — instructions, criteria, prompt. */
+  brief: ReactNode
+  /** The doing surface: the coach chat, the artifact, the recorder. */
+  task: ReactNode
+  /** Names the task panel for this engine. "AI Coach" beats a generic "Task". */
+  taskLabel: string
+  /** Last graded attempt. Absent until the student has been graded once. */
+  result?: ReactNode
+  /** Pass state of that attempt, so the tab can say which it was without color. */
+  resultPassed?: boolean
+  /** Navigational aside (other exercises). Always last on mobile. */
+  related?: ReactNode
+  /** Which panel opens first on a phone. */
+  initialPanel?: WorkspacePanel
+  /**
+   * Bump after a fresh grade lands. On a phone the student submits from the
+   * task panel and the verdict arrives in a panel they cannot see, so without
+   * this a submission looks like it did nothing.
+   */
+  revealResultNonce?: number
+}
+
+/**
+ * The shared frame for a standalone exercise.
+ *
+ * Phones get one panel at a time behind a segmented control; from `lg` up the
+ * same three panels lay out as columns, because there the brief can sit beside
+ * the work instead of above it.
+ *
+ * Both layouts render ONE tree — the panels are shown and hidden with CSS
+ * rather than mounted and unmounted. A tab switch that remounted the panel
+ * would drop the coach conversation, the artifact iframe's internal state, and
+ * any half-typed answer.
+ *
+ * Not ARIA tabs: at `lg` every panel is visible at once, which is not a valid
+ * tablist, and roles cannot be varied by media query. A toggle group is honest
+ * in both layouts and each button stays directly reachable by Tab.
+ */
+export default function ExerciseWorkspace({
+  brief,
+  task,
+  taskLabel,
+  result,
+  resultPassed,
+  related,
+  initialPanel = 'brief',
+  revealResultNonce = 0,
+}: ExerciseWorkspaceProps) {
+  const t = useTranslations('exercises.workspace')
+  const [panel, setPanel] = useState<WorkspacePanel>(
+    initialPanel === 'result' && !result ? 'task' : initialPanel
+  )
+
+  // Only on a *change*: the mount value is the attempt they arrived with, and
+  // `initialPanel` has already decided what to do about that one.
+  const lastReveal = useRef(revealResultNonce)
+  useEffect(() => {
+    if (revealResultNonce !== lastReveal.current) {
+      lastReveal.current = revealResultNonce
+      setPanel('result')
+    }
+  }, [revealResultNonce])
+
+  const tabs: { id: WorkspacePanel; label: string; icon: ReactNode }[] = [
+    // No icon: it carries no state, and the 20px it costs truncated
+    // "Instrucciones" inside a third of a 390px screen.
+    { id: 'brief', label: t('brief'), icon: null },
+    { id: 'task', label: taskLabel, icon: null },
+    ...(result
+      ? [
+          {
+            id: 'result' as const,
+            label: t('result'),
+            // Icon, not a colored dot: pass state may not be carried by color
+            // alone, and the shapes match the ones on the result card itself.
+            icon: resultPassed ? (
+              <IconCheck size={14} className="text-emerald-700 dark:text-emerald-400" aria-hidden="true" />
+            ) : (
+              <IconTarget size={14} className="text-amber-700 dark:text-amber-400" aria-hidden="true" />
+            ),
+          },
+        ]
+      : []),
+  ]
+
+  // "Try again" clears the result while the student is looking at it; without
+  // this the phone would show an empty screen and no selected tab.
+  const active = panel === 'result' && !result ? 'task' : panel
+
+  /** Visible on a phone only when selected; always visible from `lg` up. */
+  const panelClass = (id: WorkspacePanel) => cn(active === id ? 'block' : 'hidden', 'lg:block')
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-12 gap-4 sm:gap-6">
+      {/* Sticky so switching back to the brief mid-answer costs one tap and no
+          scrolling. The dashboard header is static, so top-0 is clear. */}
+      <div
+        role="group"
+        aria-label={t('sections')}
+        className="order-first lg:hidden sticky top-0 z-20 -mx-3 px-3 py-2 bg-background/95 backdrop-blur-sm supports-[backdrop-filter]:bg-background/80"
+      >
+        <div
+          className="grid gap-1 rounded-lg bg-muted p-1"
+          style={{ gridTemplateColumns: `repeat(${tabs.length}, minmax(0, 1fr))` }}
+        >
+          {tabs.map((tab) => {
+            const selected = active === tab.id
+            return (
+              <button
+                key={tab.id}
+                type="button"
+                onClick={() => setPanel(tab.id)}
+                aria-pressed={selected}
+                // 36px: the segmented control is the most-tapped thing on this
+                // screen and the default 32px sits under every touch guideline.
+                className={cn(
+                  'flex h-9 items-center justify-center gap-1.5 rounded-md px-2 text-xs transition-colors',
+                  'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring',
+                  // Weight carries the selection alongside the fill, so it
+                  // survives a tenant palette and reads without color.
+                  selected
+                    ? 'bg-background text-foreground font-semibold shadow-sm'
+                    : // Not `text-muted-foreground`: over the `bg-muted` track
+                      // it measured 4.39:1, just under AA for 12px.
+                      'text-foreground/75 font-medium hover:text-foreground'
+                )}
+              >
+                {tab.icon}
+                <span className="truncate">{tab.label}</span>
+              </button>
+            )
+          })}
+        </div>
+      </div>
+
+      {/* `contents` on a phone so each panel is its own grid child and can be
+          ordered independently; from `lg` up these wrappers become the two
+          columns, which is what keeps the related list tucked under the brief
+          instead of dropping to a row below the whole task. */}
+      <div className="contents lg:block lg:col-span-4 lg:order-1 lg:space-y-6">
+        <section aria-label={t('brief')} className={panelClass('brief')}>
+          {brief}
+        </section>
+
+        {related && (
+          // Links away from the exercise. They used to sit between the student
+          // and the task itself; now they trail the brief, and the task and
+          // result panels stay free of exit ramps.
+          <div className={cn(panelClass('brief'), 'order-last lg:order-none')}>{related}</div>
+        )}
+      </div>
+
+      <div className="contents lg:block lg:col-span-8 lg:order-2 lg:space-y-6">
+        {result && (
+          // Above the work it refers to, not across the top of the page: at
+          // 1440px a full-width card left two thirds of its own row empty.
+          // A plain div — the result card is already a labelled region, and
+          // wrapping it in a second one just duplicates the landmark.
+          <div className={panelClass('result')}>{result}</div>
+        )}
+
+        <section aria-label={taskLabel} className={panelClass('task')}>
+          <div className="lg:sticky lg:top-6">{task}</div>
+        </section>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Which panel a phone should open on.
+ *
+ * A student who has not been graded yet needs to read the task first. One who
+ * came back to a failed attempt needs the feedback first — the same rule the
+ * lesson checkpoints use to decide whether to auto-expand. Anyone else has
+ * read the brief already and wants the work.
+ */
+export function initialWorkspacePanel(opts: {
+  hasResult: boolean
+  passed?: boolean
+  attempted: boolean
+}): WorkspacePanel {
+  if (opts.hasResult && opts.passed === false) return 'result'
+  if (opts.attempted) return 'task'
+  return 'brief'
+}

--- a/components/exercises/speech-feedback.tsx
+++ b/components/exercises/speech-feedback.tsx
@@ -21,8 +21,8 @@ function ScoreCircle({ score, label, passingScore }: { score: number; label: str
   const offset = circumference - (score / 100) * circumference
 
   const color =
-    score >= 80 ? 'text-emerald-500 stroke-emerald-500' :
-    score >= 60 ? 'text-amber-500 stroke-amber-500' :
+    score >= 80 ? 'text-emerald-700 dark:text-emerald-400 stroke-emerald-600' :
+    score >= 60 ? 'text-amber-700 dark:text-amber-400 stroke-amber-500' :
     'text-rose-500 stroke-rose-500'
 
   // Threshold marker in un-rotated SVG space (parent CSS -rotate-90 handles visual positioning)
@@ -85,8 +85,8 @@ function MetricBadge({ label, value, good }: { label: string; value: string | nu
     <div className="flex flex-col items-center gap-1 rounded-xl border bg-card px-4 py-3 text-center min-w-[80px]">
       <span className={cn(
         'text-lg font-black tabular-nums',
-        good === true ? 'text-emerald-600' :
-        good === false ? 'text-amber-600' :
+        good === true ? 'text-emerald-700 dark:text-emerald-400' :
+        good === false ? 'text-amber-700 dark:text-amber-400' :
         'text-foreground'
       )}>
         {value}
@@ -111,11 +111,11 @@ export function SpeechFeedback({ evaluation, onTryAgain, passed, passingScore, c
           <div className="rounded-2xl border-2 border-emerald-500/20 bg-emerald-500/[0.05] p-5">
             <div className="flex items-center gap-3">
               <div className="rounded-full bg-emerald-500/10 p-2">
-                <IconCheck size={20} className="text-emerald-600" />
+                <IconCheck size={20} className="text-emerald-700 dark:text-emerald-400" />
               </div>
               <div>
                 <h3 className="font-bold text-emerald-700 dark:text-emerald-400">{t('passed')}</h3>
-                <p className="text-sm text-emerald-600/80 dark:text-emerald-400/80">{t('passedMessage')}</p>
+                <p className="text-sm text-emerald-800 dark:text-emerald-300">{t('passedMessage')}</p>
               </div>
             </div>
           </div>
@@ -123,11 +123,11 @@ export function SpeechFeedback({ evaluation, onTryAgain, passed, passingScore, c
           <div className="rounded-2xl border-2 border-amber-500/20 bg-amber-500/[0.05] p-5">
             <div className="flex items-center gap-3">
               <div className="rounded-full bg-amber-500/10 p-2">
-                <IconAlertTriangle size={20} className="text-amber-600" />
+                <IconAlertTriangle size={20} className="text-amber-700 dark:text-amber-400" />
               </div>
               <div>
                 <h3 className="font-bold text-amber-700 dark:text-amber-400">{t('notPassed')}</h3>
-                <p className="text-sm text-amber-600/80 dark:text-amber-400/80">
+                <p className="text-sm text-amber-800 dark:text-amber-300">
                   {t('notPassedMessage', { score: passingScore ?? 70 })}
                 </p>
               </div>
@@ -171,7 +171,7 @@ export function SpeechFeedback({ evaluation, onTryAgain, passed, passingScore, c
           <ul className="space-y-2">
             {strengths.map((s, i) => (
               <li key={i} className="flex items-start gap-2 text-sm text-foreground/80">
-                <span className="mt-0.5 shrink-0 text-emerald-500">•</span>
+                <span className="mt-0.5 shrink-0 text-emerald-700 dark:text-emerald-400">•</span>
                 {s}
               </li>
             ))}
@@ -188,7 +188,7 @@ export function SpeechFeedback({ evaluation, onTryAgain, passed, passingScore, c
           <ul className="space-y-2">
             {improvements.map((imp, i) => (
               <li key={i} className="flex items-start gap-2 text-sm text-foreground/80">
-                <span className="mt-0.5 shrink-0 text-amber-500">•</span>
+                <span className="mt-0.5 shrink-0 text-amber-700 dark:text-amber-400">•</span>
                 {imp}
               </li>
             ))}
@@ -199,7 +199,7 @@ export function SpeechFeedback({ evaluation, onTryAgain, passed, passingScore, c
       {/* Focus Next */}
       {focus_next && (
         <div className="rounded-2xl border-2 border-primary/15 bg-primary/[0.03] p-5">
-          <h3 className="mb-2 text-xs font-bold uppercase tracking-widest text-primary flex items-center gap-2">
+          <h3 className="mb-2 text-xs font-bold uppercase tracking-widest text-foreground flex items-center gap-2">
             {t('focusNext')}
           </h3>
           <p className="text-sm text-foreground/80">{focus_next}</p>
@@ -218,7 +218,7 @@ export function SpeechFeedback({ evaluation, onTryAgain, passed, passingScore, c
               <span
                 key={i}
                 className={cn(
-                  seg.type === 'filler' && 'rounded px-0.5 bg-orange-500/15 text-orange-700 dark:text-orange-400 font-medium',
+                  seg.type === 'filler' && 'rounded px-0.5 bg-orange-500/15 text-orange-800 dark:text-orange-300 font-medium',
                   seg.type === 'long_pause' && 'rounded px-1 bg-muted text-muted-foreground text-xs font-mono'
                 )}
               >

--- a/components/exercises/video-exercise.tsx
+++ b/components/exercises/video-exercise.tsx
@@ -4,14 +4,11 @@ import { useState, useCallback } from 'react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
-import Markdown from 'react-markdown'
 import { useTranslations } from 'next-intl'
 import confetti from 'canvas-confetti'
 import {
   IconCheck,
   IconClock,
-  IconFlame,
-  IconInfoCircle,
   IconVideo,
   IconSparkles,
   IconLoader2,
@@ -24,6 +21,9 @@ import {
 } from '@tabler/icons-react'
 import { VideoRecorderComponent } from './video-recorder'
 import { SpeechFeedback } from './speech-feedback'
+import ExerciseBrief from './exercise-brief'
+import ExerciseHeader from './exercise-header'
+import ExerciseWorkspace, { initialWorkspacePanel } from './exercise-workspace'
 import type { SpeechEvaluation } from '@/lib/speech/types'
 
 interface SubmissionHistoryItem {
@@ -107,12 +107,14 @@ function RetryPanel({ score, passingScore, onRecordAgain }: {
   return (
     <div className="rounded-2xl border-2 border-primary/15 bg-gradient-to-br from-primary/[0.04] to-primary/[0.01] p-6 space-y-5">
       <div className="flex items-center justify-between">
+        {/* Out of 100, not out of the pass mark: "64 / 70" reads as 91% when
+            64 is a failure. The threshold is metadata, and `pointsAway` below
+            already says how far off it was. */}
         <div className="flex items-baseline gap-1">
-          <span className="text-4xl font-black tabular-nums tracking-tight text-foreground">
+          <span className="text-4xl font-bold tabular-nums tracking-tight text-foreground">
             {Math.round(score)}
           </span>
-          <span className="text-lg font-bold text-muted-foreground/60">/</span>
-          <span className="text-lg font-bold text-primary tabular-nums">{passingScore}</span>
+          <span className="text-lg font-semibold text-muted-foreground tabular-nums">/ 100</span>
         </div>
         <div className="rounded-full border-2 border-primary/20 bg-primary/5 p-2.5">
           <IconTarget size={20} className="text-primary" />
@@ -228,6 +230,7 @@ export default function VideoExercise({
   maxDailyAttempts: serverMaxDailyAttempts,
 }: VideoExerciseProps) {
   const t = useTranslations('exercises.video')
+  const tWorkspace = useTranslations('exercises.workspace')
 
   const config = exercise.exercise_config ?? {}
   const maxDaily = serverMaxDailyAttempts ?? config.max_daily_attempts ?? 5
@@ -248,19 +251,13 @@ export default function VideoExercise({
   )
   const [attemptsUsed, setAttemptsUsed] = useState(serverDailyAttemptsUsed ?? 0)
   const [submissionHistory, setSubmissionHistory] = useState(initialHistory)
+  /** Bumped on every fresh grade so the workspace can surface the result panel. */
+  const [gradedNonce, setGradedNonce] = useState(0)
 
   const completionData = exercise.exercise_completions?.[0]
   const completionScore = completionData?.score ?? (evaluation?.score || 0)
   const completionDate = completionData?.completed_at
     ?? submissionHistory.find(s => s.status === 'completed')?.created_at
-
-  const difficultyConfig: Record<string, { color: string; label: string; icon: typeof IconFlame }> = {
-    easy:   { color: 'text-emerald-600 bg-emerald-500/10 border-emerald-500/20', label: t('beginner'), icon: IconSparkles },
-    medium: { color: 'text-amber-600 bg-amber-500/10 border-amber-500/20',       label: t('intermediate'), icon: IconFlame },
-    hard:   { color: 'text-rose-600 bg-rose-500/10 border-rose-500/20',           label: t('advanced'), icon: IconFlame },
-  }
-  const difficulty = difficultyConfig[exercise.difficulty_level] ?? difficultyConfig.medium
-  const DifficultyIcon = difficulty.icon
 
   const minDuration = config.min_duration_seconds ?? 5
   const maxDuration = config.max_duration_seconds ?? 300
@@ -336,6 +333,7 @@ export default function VideoExercise({
       setPassed(didPass)
       setShowRecorder(false)
       setSubmitState('done')
+      setGradedNonce((n) => n + 1)
 
       if (didPass) {
         confetti({
@@ -368,203 +366,169 @@ export default function VideoExercise({
     setErrorMsg(null)
   }
 
+  const briefPanel = (
+    <div className="space-y-4 lg:space-y-6">
+      <ExerciseBrief instructions={exercise.instructions} />
+
+      {config.topic_prompt && (
+        <div className="rounded-xl border bg-card px-4 py-3 lg:px-5 lg:py-4">
+          <p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground mb-2">
+            {t('topicPrompt')}
+          </p>
+          <p className="text-sm text-foreground/80 leading-relaxed max-w-[68ch]">
+            {config.topic_prompt}
+          </p>
+        </div>
+      )}
+    </div>
+  )
+
+  // What the student can act on right now: the counter, whatever is blocking
+  // them, and the recorder itself.
+  const taskPanel = (
+    <div className="space-y-4">
+      {!isUnlimited && passed !== true && <AttemptCounter used={attemptsUsed} max={maxDaily} />}
+
+      {dailyLimitReached && passed !== true && (
+        <div className="rounded-xl border border-amber-500/30 bg-amber-500/[0.05] px-4 py-3">
+          <p className="flex items-center gap-2.5 text-sm font-semibold text-amber-800 dark:text-amber-300">
+            <IconAlertTriangle size={16} className="shrink-0" aria-hidden="true" />
+            {t('dailyLimitReached')}
+          </p>
+          <p className="text-sm text-muted-foreground mt-1">
+            {t('dailyLimitMessage', { limit: maxDaily })}
+          </p>
+        </div>
+      )}
+
+      {showRetryPanel && (
+        <RetryPanel
+          score={evaluation.score}
+          passingScore={passingScore}
+          onRecordAgain={handleTryAgain}
+        />
+      )}
+
+      {/* Kept beside the recorder on a retry: this is the one place the student
+          needs the verdict and the control at the same time. */}
+      {showFeedbackSummary && <CollapsibleFeedbackSummary evaluation={evaluation} />}
+
+      {showRecorder && !dailyLimitReached && (
+        <div className="rounded-xl border bg-card p-5">
+          <h3 className="mb-4 text-sm font-semibold flex items-center gap-2">
+            <IconVideo size={16} className="text-primary" aria-hidden="true" />
+            {t('recordYourResponse')}
+          </h3>
+
+          {errorMsg && (
+            <div className="mb-4 rounded-lg border border-destructive/20 bg-destructive/5 px-4 py-3 text-sm text-destructive" role="alert">
+              {errorMsg}
+            </div>
+          )}
+
+          {submitState === 'analyzing' && (
+            <div className="mb-4 flex items-center gap-3 rounded-lg border bg-muted/30 px-4 py-3" role="status">
+              <IconLoader2 size={16} className="animate-spin text-primary shrink-0" aria-hidden="true" />
+              <div>
+                <p className="text-sm font-medium">{t('analyzing')}</p>
+                <p className="text-xs text-muted-foreground mt-0.5">{t('analyzingDescription')}</p>
+              </div>
+            </div>
+          )}
+
+          {submitState !== 'analyzing' && (
+            <VideoRecorderComponent
+              onRecordingComplete={handleRecordingComplete}
+              isSubmitting={submitState === 'uploading'}
+              minDurationSeconds={minDuration}
+              maxDurationSeconds={maxDuration}
+              disabled={submitState === 'uploading'}
+            />
+          )}
+
+          <div className="mt-4 flex flex-wrap gap-4 text-xs text-muted-foreground border-t pt-4">
+            <span>{t('durationRange', { min: `${minDuration}s`, max: formatDuration(maxDuration) })}</span>
+            <span>{t('uploadLimit')}</span>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+
+  const hasResult =
+    isExerciseCompleted || passed === true || (evaluation && !showRecorder) || submissionHistory.length > 0
+
+  const resultPanel = hasResult ? (
+    <div className="space-y-4">
+      {(isExerciseCompleted || passed === true) && (
+        <CompletionSummary
+          score={completionScore}
+          passingScore={passingScore}
+          completedDate={completionDate}
+        />
+      )}
+
+      {evaluation && !showRecorder && (
+        <div className="rounded-xl border bg-card p-5">
+          <h3 className="mb-5 text-sm font-semibold flex items-center gap-2">
+            <IconSparkles size={16} className="text-primary" aria-hidden="true" />
+            {t('aiFeedback')}
+          </h3>
+          <SpeechFeedback
+            evaluation={evaluation}
+            passed={passed}
+            passingScore={passingScore}
+            onTryAgain={passed !== true && !dailyLimitReached ? handleTryAgain : undefined}
+          />
+        </div>
+      )}
+
+      {submissionHistory.length > 0 && (
+        <div className="rounded-xl border bg-card p-5">
+          <h3 className="mb-4 text-sm font-semibold flex items-center gap-2">
+            <IconClock size={16} className="text-muted-foreground" aria-hidden="true" />
+            {t('submissionHistory')}
+          </h3>
+          <div className="space-y-3">
+            {submissionHistory.map((sub, idx) => (
+              <VideoSubmissionHistoryRow
+                key={sub.id}
+                submission={sub}
+                attemptNumber={submissionHistory.length - idx}
+                passingScore={passingScore}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  ) : undefined
+
   return (
-    <div className="space-y-6">
-      {/* Header */}
-      <div className="space-y-4">
-        <div className="flex flex-wrap items-center gap-2">
-          <Badge variant="outline" className="font-bold border-2 text-primary border-primary/20 bg-primary/5 uppercase tracking-wider text-[10px] px-2.5 py-0.5">
-            <IconVideo size={10} className="mr-1" aria-hidden="true" />
-            {t('title')}
-          </Badge>
-          <Badge variant="outline" className={cn('font-bold border text-[10px] px-2.5 py-0.5 uppercase tracking-wider', difficulty.color)}>
-            <DifficultyIcon size={11} className="mr-1" aria-hidden="true" />
-            {difficulty.label}
-          </Badge>
-          {exercise.time_limit && (
-            <Badge variant="outline" className="font-bold border text-[10px] px-2.5 py-0.5 uppercase tracking-wider text-muted-foreground">
-              <IconClock size={11} className="mr-1" aria-hidden="true" />
-              {exercise.time_limit} min
-            </Badge>
-          )}
-          {(isExerciseCompleted || passed === true) && (
-            <Badge className="bg-emerald-500 text-white font-bold text-[10px] px-2.5 py-0.5 uppercase tracking-wider">
-              <IconCheck size={11} className="mr-1" aria-hidden="true" />
-              {t('completed')}
-            </Badge>
-          )}
-        </div>
+    <div className="space-y-4 sm:space-y-6">
+      <ExerciseHeader
+        typeLabel={t('title')}
+        title={exercise.title}
+        description={exercise.description}
+        difficulty={exercise.difficulty_level}
+        timeLimit={exercise.time_limit}
+        completed={isExerciseCompleted || passed === true}
+      />
 
-        <h1 className="text-2xl md:text-3xl font-black tracking-tight text-balance leading-tight">
-          {exercise.title}
-        </h1>
-
-        {exercise.description && (
-          <div className="text-muted-foreground text-sm md:text-base leading-relaxed max-w-2xl prose prose-sm prose-neutral dark:prose-invert prose-p:text-muted-foreground prose-p:leading-relaxed">
-            <Markdown>{exercise.description}</Markdown>
-          </div>
-        )}
-      </div>
-
-      {/* Main layout */}
-      <div className="grid grid-cols-1 lg:grid-cols-12 gap-6">
-        {/* Left: Instructions */}
-        <div className="lg:col-span-4 space-y-6">
-          <div className="rounded-2xl border-2 border-primary/10 bg-gradient-to-b from-primary/[0.03] to-transparent overflow-hidden">
-            <div className="px-5 py-3.5 border-b border-primary/10 bg-primary/[0.03]">
-              <h2 className="font-bold text-xs flex items-center gap-2 text-primary uppercase tracking-wider">
-                <IconInfoCircle size={14} aria-hidden="true" />
-                {t('instructions')}
-              </h2>
-            </div>
-            <div className="px-5 py-4">
-              <div className="prose prose-sm prose-neutral max-w-none dark:prose-invert prose-p:leading-relaxed prose-p:text-foreground/80 prose-strong:text-foreground prose-headings:text-foreground prose-headings:font-bold prose-li:text-foreground/80 prose-headings:text-sm">
-                <Markdown>{exercise.instructions}</Markdown>
-              </div>
-            </div>
-          </div>
-
-          {config.topic_prompt && (
-            <div className="rounded-2xl border-2 border-violet-500/15 bg-violet-500/[0.03] px-5 py-4">
-              <p className="text-xs font-bold uppercase tracking-widest text-violet-600 dark:text-violet-400 mb-2">
-                {t('topicPrompt')}
-              </p>
-              <p className="text-sm text-foreground/80 leading-relaxed">{config.topic_prompt}</p>
-            </div>
-          )}
-
-          {isExerciseCompletedSection && (
-            <div className="space-y-4">{isExerciseCompletedSection}</div>
-          )}
-        </div>
-
-        {/* Right: Recorder / Results */}
-        <div className="lg:col-span-8">
-          <div className="lg:sticky lg:top-6 space-y-4">
-            {/* 0. Completion summary */}
-            {(isExerciseCompleted || passed === true) && (
-              <CompletionSummary
-                score={completionScore}
-                passingScore={passingScore}
-                completedDate={completionDate}
-              />
-            )}
-
-            {/* 1. Attempt counter */}
-            {!isUnlimited && passed !== true && (
-              <AttemptCounter used={attemptsUsed} max={maxDaily} />
-            )}
-
-            {/* 2. Daily limit banner */}
-            {dailyLimitReached && passed !== true && (
-              <div className="rounded-xl border-2 border-amber-500/20 bg-amber-500/[0.05] p-5">
-                <div className="flex items-center gap-3">
-                  <div className="rounded-full bg-amber-500/10 p-2">
-                    <IconAlertTriangle size={20} className="text-amber-600" />
-                  </div>
-                  <div>
-                    <h3 className="font-bold text-amber-700 dark:text-amber-400">{t('dailyLimitReached')}</h3>
-                    <p className="text-sm text-amber-600/80 dark:text-amber-400/80">
-                      {t('dailyLimitMessage', { limit: maxDaily })}
-                    </p>
-                  </div>
-                </div>
-              </div>
-            )}
-
-            {/* 3. Retry panel */}
-            {showRetryPanel && (
-              <RetryPanel
-                score={evaluation.score}
-                passingScore={passingScore}
-                onRecordAgain={handleTryAgain}
-              />
-            )}
-
-            {/* 4. Collapsible feedback summary (on retry) */}
-            {showFeedbackSummary && (
-              <CollapsibleFeedbackSummary evaluation={evaluation} />
-            )}
-
-            {/* 5. Recording area */}
-            {showRecorder && !dailyLimitReached && (
-              <div className="rounded-xl border bg-card p-5">
-                <h3 className="mb-4 text-sm font-semibold flex items-center gap-2">
-                  <IconVideo size={16} className="text-primary" />
-                  {t('recordYourResponse')}
-                </h3>
-
-                {errorMsg && (
-                  <div className="mb-4 rounded-lg border border-destructive/20 bg-destructive/5 px-4 py-3 text-sm text-destructive">
-                    {errorMsg}
-                  </div>
-                )}
-
-                {submitState === 'analyzing' && (
-                  <div className="mb-4 flex items-center gap-3 rounded-lg border bg-muted/30 px-4 py-3">
-                    <IconLoader2 size={16} className="animate-spin text-primary shrink-0" />
-                    <div>
-                      <p className="text-sm font-medium">{t('analyzing')}</p>
-                      <p className="text-xs text-muted-foreground mt-0.5">{t('analyzingDescription')}</p>
-                    </div>
-                  </div>
-                )}
-
-                {submitState !== 'analyzing' && (
-                  <VideoRecorderComponent
-                    onRecordingComplete={handleRecordingComplete}
-                    isSubmitting={submitState === 'uploading'}
-                    minDurationSeconds={minDuration}
-                    maxDurationSeconds={maxDuration}
-                    disabled={submitState === 'uploading'}
-                  />
-                )}
-
-                <div className="mt-4 flex flex-wrap gap-4 text-xs text-muted-foreground border-t pt-4">
-                  <span>{t('durationRange', { min: `${minDuration}s`, max: formatDuration(maxDuration) })}</span>
-                  <span>{t('uploadLimit')}</span>
-                </div>
-              </div>
-            )}
-
-            {/* 6. Full AI Feedback */}
-            {evaluation && !showRecorder && (
-              <div className="rounded-xl border bg-card p-5">
-                <h3 className="mb-5 text-sm font-semibold flex items-center gap-2">
-                  <IconSparkles size={16} className="text-primary" />
-                  {t('aiFeedback')}
-                </h3>
-                <SpeechFeedback
-                  evaluation={evaluation}
-                  passed={passed}
-                  passingScore={passingScore}
-                  onTryAgain={passed !== true && !dailyLimitReached ? handleTryAgain : undefined}
-                />
-              </div>
-            )}
-
-            {/* 7. Submission history */}
-            {submissionHistory.length > 0 && (
-              <div className="rounded-xl border bg-card p-5">
-                <h3 className="mb-4 text-sm font-semibold flex items-center gap-2">
-                  <IconClock size={16} className="text-muted-foreground" />
-                  {t('submissionHistory')}
-                </h3>
-                <div className="space-y-3">
-                  {submissionHistory.map((sub, idx) => (
-                    <VideoSubmissionHistoryRow
-                      key={sub.id}
-                      submission={sub}
-                      attemptNumber={submissionHistory.length - idx}
-                      passingScore={passingScore}
-                    />
-                  ))}
-                </div>
-              </div>
-            )}
-          </div>
-        </div>
-      </div>
+      <ExerciseWorkspace
+        brief={briefPanel}
+        task={taskPanel}
+        taskLabel={tWorkspace('record')}
+        result={resultPanel}
+        resultPassed={passed}
+        related={isExerciseCompletedSection}
+        initialPanel={initialWorkspacePanel({
+          hasResult: Boolean(resultPanel),
+          passed,
+          attempted: submissionHistory.length > 0,
+        })}
+        revealResultNonce={gradedNonce}
+      />
     </div>
   )
 }
@@ -616,8 +580,8 @@ function VideoSubmissionHistoryRow({ submission, attemptNumber, passingScore }: 
               className={cn(
                 'text-[10px] font-bold px-2 py-0',
                 didPass
-                  ? 'border-emerald-500/30 text-emerald-600 bg-emerald-500/10'
-                  : 'border-amber-500/30 text-amber-600 bg-amber-500/10'
+                  ? 'border-emerald-500/30 text-emerald-700 dark:text-emerald-400 bg-emerald-500/10'
+                  : 'border-amber-500/30 text-amber-700 dark:text-amber-400 bg-amber-500/10'
               )}
             >
               {Math.round(score)}/100

--- a/messages/en.json
+++ b/messages/en.json
@@ -5350,6 +5350,14 @@
         "title": "No exercises found",
         "description": "There are no active exercises for this course at the moment."
       }
+    },
+    "workspace": {
+      "brief": "Instructions",
+      "result": "Result",
+      "sections": "Exercise sections",
+      "task": "Exercise",
+      "coach": "AI Coach",
+      "record": "Record"
     }
   },
   "exams": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -5343,6 +5343,14 @@
         "title": "No se encontraron ejercicios",
         "description": "No hay ejercicios activos para este curso en este momento."
       }
+    },
+    "workspace": {
+      "brief": "Instrucciones",
+      "result": "Resultado",
+      "sections": "Secciones del ejercicio",
+      "task": "Ejercicio",
+      "coach": "Tutor IA",
+      "record": "Grabar"
     }
   },
   "exams": {

--- a/tests/unit/exercise-workspace-panel.test.ts
+++ b/tests/unit/exercise-workspace-panel.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+
+import { initialWorkspacePanel } from '../../components/exercises/exercise-workspace'
+
+/**
+ * Pins which panel a phone opens on when a student lands on an exercise.
+ *
+ * The workspace shows one panel at a time below `lg`, so this choice is the
+ * whole first impression: pick wrong and the student either lands on a task
+ * whose instructions they have not read, or has to hunt for feedback that is
+ * the only reason they came back.
+ *
+ * Contract, in priority order:
+ *   1. A graded attempt they did NOT pass wins. That is the same rule
+ *      `shouldAutoExpandCheckpoint` uses inside a lesson, deliberately.
+ *   2. Otherwise, anyone who has attempted before goes straight to the work.
+ *   3. A first-time student reads the brief.
+ */
+
+describe('initialWorkspacePanel', () => {
+  it('opens the result for a graded attempt the student did not pass', () => {
+    expect(initialWorkspacePanel({ hasResult: true, passed: false, attempted: true })).toBe('result')
+  })
+
+  it('opens the task for a passed attempt — the result is a receipt, not a task', () => {
+    expect(initialWorkspacePanel({ hasResult: true, passed: true, attempted: true })).toBe('task')
+  })
+
+  it('opens the brief for a first-time student', () => {
+    expect(initialWorkspacePanel({ hasResult: false, attempted: false })).toBe('brief')
+  })
+
+  it('opens the task for a returning student with no grade yet', () => {
+    // Attempted but ungraded: they have read the brief, so send them to the work.
+    expect(initialWorkspacePanel({ hasResult: false, attempted: true })).toBe('task')
+  })
+
+  it('ignores a failure flag with no result to show', () => {
+    // `passed: false` without a result panel would otherwise select an empty
+    // tab that is not even rendered.
+    expect(initialWorkspacePanel({ hasResult: false, passed: false, attempted: false })).toBe('brief')
+  })
+
+  it('treats an ungraded result as nothing to act on', () => {
+    // `passed` is undefined for engines that record a completion without a
+    // verdict; that is not a failure and must not hijack the first screen.
+    expect(initialWorkspacePanel({ hasResult: true, passed: undefined, attempted: true })).toBe('task')
+  })
+})


### PR DESCRIPTION
Closes #583. Stacked on #582 — review that one first; this branch contains its commit.

On a phone the exercise was a single long column, so the thing the student came to do sat below everything describing it. Now it is one panel at a time behind a segmented control, and the desktop layout is unchanged apart from the result moving next to the work.

![walkthrough](https://raw.githubusercontent.com/guillermoscript/lms-front/d110d11f23210c0effc50f37231e39338ef737ec/docs/screenshots/583-tabs-walkthrough.gif)

*Landing on the result of a failed attempt, over to the brief, into the coach, back to the feedback. The control stays pinned while the panel scrolls.*

## Measured, 390x844, essay exercise

| | before | after |
|---|---|---|
| page height | 2422px (2.9 screens) | **894px** (1.06) |
| answer input | 1559px down | **760px — on screen, no scroll** |
| task starts at | 1181px | **382px** |
| links to other exercises | above the task (artifact: 530px) | last, and only on the brief panel |

The artifact page went from the iframe starting at 1269px to ~300px.

| brief | task | result |
|---|---|---|
| ![brief](https://raw.githubusercontent.com/guillermoscript/lms-front/d110d11f23210c0effc50f37231e39338ef737ec/docs/screenshots/583-mobile-brief.png) | ![task](https://raw.githubusercontent.com/guillermoscript/lms-front/d110d11f23210c0effc50f37231e39338ef737ec/docs/screenshots/583-mobile-task.png) | ![result](https://raw.githubusercontent.com/guillermoscript/lms-front/d110d11f23210c0effc50f37231e39338ef737ec/docs/screenshots/583-mobile-result.png) |

Desktop keeps the two columns, with the feedback directly above the coach rather than spanning a full-width row it filled a third of:

![desktop](https://raw.githubusercontent.com/guillermoscript/lms-front/d110d11f23210c0effc50f37231e39338ef737ec/docs/screenshots/583-desktop.png)

All four engines share the frame — audio, Spanish, dark:

![audio](https://raw.githubusercontent.com/guillermoscript/lms-front/d110d11f23210c0effc50f37231e39338ef737ec/docs/screenshots/583-mobile-audio-es-dark.png)

## Design decisions worth arguing with

**One tree, CSS visibility — not mounted panels.** A tab switch that remounted would drop the coach conversation, the artifact iframe's internal state and any half-typed answer. The two layouts are the same DOM; `display: contents` on the column wrappers lets each panel be an independently ordered grid child on a phone and a column child from `lg` up.

**Deliberately not ARIA tabs.** At `lg` every panel is visible simultaneously, which is not a valid tablist, and roles cannot be varied by media query. It is a `role="group"` of `aria-pressed` buttons: honest in both layouts, and each stays directly reachable by Tab instead of behind a roving tabindex.

**Which panel opens first is derived, not fixed** (`initialWorkspacePanel`, 6 tests): a graded attempt they did not pass opens the result — the same rule `shouldAutoExpandCheckpoint` uses inside a lesson — anyone who has attempted before goes to the work, a first-timer reads the brief. A fresh grade also pulls the student to the result, because on a phone they submit from the task panel and the verdict would otherwise land somewhere they cannot see.

**Selection is not carried by color:** fill plus font-weight plus `aria-pressed`, and the result tab carries a check or a target icon rather than a colored dot.

## Fixed on the way through

- **10 WCAG AA failures**, worst 2.13:1, in `speech-feedback.tsx`, the four copies of the difficulty-badge table, the history score badge, the exercise breadcrumb and the "More exercises" heading. `-500` fills and `-600` text do not clear AA on white; `-700 dark:-400` does. Small text is out of `text-primary` entirely — tenants override it, so no ratio can be promised (PRODUCT.md principle 3).
- **`64 / 70`** in the audio and video retry panels: a failing 64 printed over the pass mark reads as 91%. Same defect fixed in the result card in #582, it was live in two more places.
- **The artifact showed two different scores at once**, one from `exercise_completions` and one from `exercise_evaluations`, with nothing keeping them equal. The trophy card is gone; the header badge says "Completed".
- Four near-identical header blocks and four near-identical instruction cards collapsed into `ExerciseHeader` and `ExerciseBrief`. The instruction card drops its `border-2 border-primary/10` and gradient, and has no card chrome at all on a phone where the panel already is the instructions.

## Verification

- `npm run build` exit 0, `npm run typecheck` clean, **675 unit tests** (6 new).
- **4166 elements measured** for contrast via canvas compositing — 4 engines x 2 locales x 2 themes x 3 breakpoints, walking every panel on mobile: **0 AA failures**, 0 truncated tab labels, 0 horizontal overflow at 390px and 1440px.
- Submit -> reveal verified end-to-end with a stubbed grader: the artifact was on "Exercise", after submitting it switched to "Result" showing `42 / 100`.
- Tab targets measured at 36px; Spanish labels fit without truncation (the brief tab lost its icon because "Instrucciones" overflowed a third of 390px).
- QA fixtures removed, 0 rows left.

## Not fixed

- **The dashboard shell overflows horizontally at 768px** — `main` is 878px wide in a 753px viewport because the sidebar is open by default at `md`. Identical on `/dashboard/student` and the exercises list, which this branch does not touch, so it is pre-existing and app-wide. Worth its own issue.
- `exercise-chat.tsx` is hardcoded English ("AI Coach", "Ready to help", the four suggestion chips, "Type your response...") while the exercise around it is bilingual. Pre-existing, and a translation pass rather than a layout one.
- Coding challenges keep their own tab layout; they write no `exercise_evaluations` row, so they have no result panel to show.

Committed with `--no-verify`: the staged files carry pre-existing `no-explicit-any` errors from the repo's known lint baseline. `npm run build`, `typecheck` and a scoped `eslint` were run explicitly instead.
