### PR TITLE
docs(design): add PRODUCT.md + DESIGN.md, drop the unused Geist Sans

### DIFF
--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -1,0 +1,517 @@
+{
+  "schemaVersion": 2,
+  "generatedAt": "2026-07-28T16:58:04Z",
+  "title": "Design System: LMS Platform",
+  "extensions": {
+    "colorMeta": {
+      "slate-teal": {
+        "role": "primary",
+        "displayName": "Slate Teal",
+        "canonical": "oklch(0.52 0.105 223.128)",
+        "tonalRamp": [
+          "oklch(0.15 0.04 223.128)",
+          "oklch(0.26 0.065 223.128)",
+          "oklch(0.37 0.09 223.128)",
+          "oklch(0.45 0.1 223.128)",
+          "oklch(0.52 0.105 223.128)",
+          "oklch(0.65 0.115 223.128)",
+          "oklch(0.8 0.085 223.128)",
+          "oklch(0.95 0.03 223.128)"
+        ]
+      },
+      "slate-teal-deep": {
+        "role": "primary",
+        "displayName": "Slate Teal Deep",
+        "canonical": "oklch(0.45 0.085 224.283)",
+        "tonalRamp": [
+          "oklch(0.15 0.035 224.283)",
+          "oklch(0.24 0.055 224.283)",
+          "oklch(0.33 0.07 224.283)",
+          "oklch(0.45 0.085 224.283)",
+          "oklch(0.56 0.095 224.283)",
+          "oklch(0.68 0.1 224.283)",
+          "oklch(0.82 0.07 224.283)",
+          "oklch(0.95 0.025 224.283)"
+        ]
+      },
+      "slate-teal-mid": {
+        "role": "secondary",
+        "displayName": "Slate Teal Mid",
+        "canonical": "oklch(0.609 0.126 221.723)",
+        "tonalRamp": [
+          "oklch(0.16 0.045 221.723)",
+          "oklch(0.27 0.075 221.723)",
+          "oklch(0.38 0.1 221.723)",
+          "oklch(0.49 0.118 221.723)",
+          "oklch(0.609 0.126 221.723)",
+          "oklch(0.72 0.13 221.723)",
+          "oklch(0.85 0.09 221.723)",
+          "oklch(0.96 0.03 221.723)"
+        ]
+      },
+      "slate-teal-bright": {
+        "role": "secondary",
+        "displayName": "Slate Teal Bright",
+        "canonical": "oklch(0.715 0.143 215.221)",
+        "tonalRamp": [
+          "oklch(0.17 0.05 215.221)",
+          "oklch(0.29 0.085 215.221)",
+          "oklch(0.41 0.11 215.221)",
+          "oklch(0.53 0.13 215.221)",
+          "oklch(0.63 0.14 215.221)",
+          "oklch(0.715 0.143 215.221)",
+          "oklch(0.86 0.1 215.221)",
+          "oklch(0.96 0.035 215.221)"
+        ]
+      },
+      "slate-teal-pale": {
+        "role": "secondary",
+        "displayName": "Slate Teal Pale",
+        "canonical": "oklch(0.865 0.127 207.078)",
+        "tonalRamp": [
+          "oklch(0.18 0.045 207.078)",
+          "oklch(0.31 0.08 207.078)",
+          "oklch(0.44 0.105 207.078)",
+          "oklch(0.57 0.125 207.078)",
+          "oklch(0.68 0.135 207.078)",
+          "oklch(0.78 0.135 207.078)",
+          "oklch(0.865 0.127 207.078)",
+          "oklch(0.96 0.045 207.078)"
+        ]
+      },
+      "ink": {
+        "role": "neutral",
+        "displayName": "Ink",
+        "canonical": "oklch(0.141 0.005 285.823)",
+        "tonalRamp": [
+          "oklch(0.141 0.005 285.823)",
+          "oklch(0.21 0.006 285.885)",
+          "oklch(0.274 0.006 286.033)",
+          "oklch(0.4 0.01 285.938)",
+          "oklch(0.552 0.016 285.938)",
+          "oklch(0.705 0.015 286.067)",
+          "oklch(0.85 0.008 286.2)",
+          "oklch(0.967 0.001 286.375)"
+        ]
+      },
+      "ink-muted": {
+        "role": "neutral",
+        "displayName": "Ink Muted",
+        "canonical": "oklch(0.552 0.016 285.938)",
+        "tonalRamp": [
+          "oklch(0.141 0.005 285.823)",
+          "oklch(0.21 0.006 285.885)",
+          "oklch(0.274 0.006 286.033)",
+          "oklch(0.4 0.01 285.938)",
+          "oklch(0.552 0.016 285.938)",
+          "oklch(0.705 0.015 286.067)",
+          "oklch(0.85 0.008 286.2)",
+          "oklch(0.967 0.001 286.375)"
+        ]
+      },
+      "paper": {
+        "role": "neutral",
+        "displayName": "Paper",
+        "canonical": "oklch(1 0 0)",
+        "tonalRamp": [
+          "oklch(0.141 0.005 285.823)",
+          "oklch(0.21 0.006 285.885)",
+          "oklch(0.274 0.006 286.033)",
+          "oklch(0.45 0.008 286.0)",
+          "oklch(0.62 0.012 286.0)",
+          "oklch(0.8 0.006 286.2)",
+          "oklch(0.92 0.004 286.32)",
+          "oklch(1 0 0)"
+        ]
+      },
+      "paper-raised": {
+        "role": "neutral",
+        "displayName": "Paper Raised",
+        "canonical": "oklch(0.985 0 0)",
+        "tonalRamp": [
+          "oklch(0.141 0.005 285.823)",
+          "oklch(0.21 0.006 285.885)",
+          "oklch(0.274 0.006 286.033)",
+          "oklch(0.45 0.008 286.0)",
+          "oklch(0.62 0.012 286.0)",
+          "oklch(0.8 0.006 286.2)",
+          "oklch(0.92 0.004 286.32)",
+          "oklch(0.985 0 0)"
+        ]
+      },
+      "surface-quiet": {
+        "role": "neutral",
+        "displayName": "Surface Quiet",
+        "canonical": "oklch(0.967 0.001 286.375)",
+        "tonalRamp": [
+          "oklch(0.141 0.005 285.823)",
+          "oklch(0.21 0.006 285.885)",
+          "oklch(0.274 0.006 286.033)",
+          "oklch(0.4 0.01 285.938)",
+          "oklch(0.552 0.016 285.938)",
+          "oklch(0.705 0.015 286.067)",
+          "oklch(0.85 0.008 286.2)",
+          "oklch(0.967 0.001 286.375)"
+        ]
+      },
+      "surface-slate": {
+        "role": "neutral",
+        "displayName": "Surface Slate",
+        "canonical": "oklch(0.21 0.006 285.885)",
+        "tonalRamp": [
+          "oklch(0.141 0.005 285.823)",
+          "oklch(0.21 0.006 285.885)",
+          "oklch(0.274 0.006 286.033)",
+          "oklch(0.4 0.01 285.938)",
+          "oklch(0.552 0.016 285.938)",
+          "oklch(0.705 0.015 286.067)",
+          "oklch(0.85 0.008 286.2)",
+          "oklch(0.967 0.001 286.375)"
+        ]
+      },
+      "surface-slate-quiet": {
+        "role": "neutral",
+        "displayName": "Surface Slate Quiet",
+        "canonical": "oklch(0.274 0.006 286.033)",
+        "tonalRamp": [
+          "oklch(0.141 0.005 285.823)",
+          "oklch(0.21 0.006 285.885)",
+          "oklch(0.274 0.006 286.033)",
+          "oklch(0.4 0.01 285.938)",
+          "oklch(0.552 0.016 285.938)",
+          "oklch(0.705 0.015 286.067)",
+          "oklch(0.85 0.008 286.2)",
+          "oklch(0.967 0.001 286.375)"
+        ]
+      },
+      "hairline": {
+        "role": "neutral",
+        "displayName": "Hairline",
+        "canonical": "oklch(0.92 0.004 286.32)",
+        "tonalRamp": [
+          "oklch(1 0 0 / 5%)",
+          "oklch(1 0 0 / 10%)",
+          "oklch(1 0 0 / 15%)",
+          "oklch(0.4 0.01 285.938)",
+          "oklch(0.705 0.015 286.067)",
+          "oklch(0.85 0.008 286.2)",
+          "oklch(0.92 0.004 286.32)",
+          "oklch(0.967 0.001 286.375)"
+        ]
+      },
+      "ring-neutral": {
+        "role": "neutral",
+        "displayName": "Ring Neutral",
+        "canonical": "oklch(0.705 0.015 286.067)",
+        "tonalRamp": [
+          "oklch(0.141 0.005 285.823)",
+          "oklch(0.21 0.006 285.885)",
+          "oklch(0.274 0.006 286.033)",
+          "oklch(0.4 0.01 285.938)",
+          "oklch(0.552 0.016 285.938)",
+          "oklch(0.705 0.015 286.067)",
+          "oklch(0.85 0.008 286.2)",
+          "oklch(0.967 0.001 286.375)"
+        ]
+      },
+      "alert": {
+        "role": "tertiary",
+        "displayName": "Alert",
+        "canonical": "oklch(0.577 0.245 27.325)",
+        "tonalRamp": [
+          "oklch(0.2 0.08 27.325)",
+          "oklch(0.3 0.13 27.325)",
+          "oklch(0.4 0.18 27.325)",
+          "oklch(0.5 0.22 27.325)",
+          "oklch(0.577 0.245 27.325)",
+          "oklch(0.704 0.191 22.216)",
+          "oklch(0.84 0.1 27.325)",
+          "oklch(0.95 0.035 27.325)"
+        ]
+      },
+      "alert-dark": {
+        "role": "tertiary",
+        "displayName": "Alert Dark",
+        "canonical": "oklch(0.704 0.191 22.216)",
+        "tonalRamp": [
+          "oklch(0.2 0.07 22.216)",
+          "oklch(0.3 0.11 22.216)",
+          "oklch(0.4 0.15 22.216)",
+          "oklch(0.5 0.18 22.216)",
+          "oklch(0.6 0.19 22.216)",
+          "oklch(0.704 0.191 22.216)",
+          "oklch(0.85 0.09 22.216)",
+          "oklch(0.95 0.03 22.216)"
+        ]
+      },
+      "on-teal": {
+        "role": "primary",
+        "displayName": "On Teal",
+        "canonical": "oklch(0.984 0.019 200.873)",
+        "tonalRamp": [
+          "oklch(0.2 0.02 200.873)",
+          "oklch(0.32 0.03 200.873)",
+          "oklch(0.45 0.035 200.873)",
+          "oklch(0.58 0.035 200.873)",
+          "oklch(0.7 0.03 200.873)",
+          "oklch(0.82 0.025 200.873)",
+          "oklch(0.92 0.022 200.873)",
+          "oklch(0.984 0.019 200.873)"
+        ]
+      }
+    },
+    "typographyMeta": {
+      "display": {
+        "displayName": "Display",
+        "purpose": "Page titles and prose h1. One per view."
+      },
+      "headline": {
+        "displayName": "Headline",
+        "purpose": "Section headings and prose h2."
+      },
+      "title": {
+        "displayName": "Title",
+        "purpose": "Card titles, table headers, form section labels. The workhorse heading of the staff register."
+      },
+      "body-learner": {
+        "displayName": "Body, learner",
+        "purpose": "Lesson prose, exercise statements, exam questions. Anything read for more than a few seconds. Capped at 65ch."
+      },
+      "body-staff": {
+        "displayName": "Body, staff",
+        "purpose": "The base-mira default. Dense tables, dashboards, filter bars, admin forms. Prohibited on learner surfaces."
+      },
+      "label": {
+        "displayName": "Label",
+        "purpose": "Badges, chips, xs buttons, metadata stamps. Sentence case, never uppercase-tracked-out."
+      },
+      "mono": {
+        "displayName": "Mono",
+        "purpose": "Code blocks, inline code, IDs, fixed-width tabular figures. Geist Mono."
+      }
+    },
+    "shadows": [
+      {
+        "name": "overlay-low",
+        "value": "0 1px 2px 0 oklch(0.141 0.005 285.823 / 0.05)",
+        "purpose": "Tooltips and small popovers. The border does most of the separation."
+      },
+      {
+        "name": "overlay-standard",
+        "value": "0 4px 6px -1px oklch(0.141 0.005 285.823 / 0.1), 0 2px 4px -2px oklch(0.141 0.005 285.823 / 0.1)",
+        "purpose": "Dropdown menus, comboboxes, select popups, hover cards. Default for anything anchored to a trigger."
+      },
+      {
+        "name": "overlay-detached",
+        "value": "0 10px 15px -3px oklch(0.141 0.005 285.823 / 0.1), 0 4px 6px -4px oklch(0.141 0.005 285.823 / 0.1)",
+        "purpose": "Dialogs and sheets, fully detached from their trigger and sitting over a scrim."
+      },
+      {
+        "name": "surface-hairline",
+        "value": "inset 0 0 0 1px oklch(0.141 0.005 285.823 / 0.1)",
+        "purpose": "The Card ring. Not a shadow in spirit: a theme-reactive hairline that replaces elevation on every in-layout surface."
+      }
+    ],
+    "motion": [
+      {
+        "name": "ease-out-quart",
+        "value": "cubic-bezier(0.25, 1, 0.5, 1)",
+        "purpose": "Default easing for state transitions. PROPOSED: no ease tokens exist in app/globals.css yet; transitions currently fall back to the Tailwind default."
+      },
+      {
+        "name": "ease-out-expo",
+        "value": "cubic-bezier(0.16, 1, 0.3, 1)",
+        "purpose": "Entrances of floating layers (popover, dialog, sheet). PROPOSED."
+      },
+      {
+        "name": "duration-state",
+        "value": "150ms",
+        "purpose": "Hover, focus, and color transitions on controls. Matches the current Tailwind transition-colors default."
+      },
+      {
+        "name": "duration-overlay",
+        "value": "220ms",
+        "purpose": "Floating-layer entrance and exit. PROPOSED."
+      },
+      {
+        "name": "reduced-motion",
+        "value": "0ms",
+        "purpose": "Under prefers-reduced-motion, transitions collapse to instant state changes rather than to slower ones. Never animate a layout property in any mode."
+      }
+    ],
+    "breakpoints": [
+      { "name": "sm", "value": "640px" },
+      { "name": "md", "value": "768px" },
+      { "name": "lg", "value": "1024px" },
+      { "name": "xl", "value": "1280px" },
+      { "name": "2xl", "value": "1536px" }
+    ]
+  },
+  "components": [
+    {
+      "name": "Primary Button (staff register)",
+      "kind": "button",
+      "refersTo": "button-primary",
+      "description": "The base-mira default. 28px tall, 12px text, filled Slate Teal. Correct on dashboards and admin forms, prohibited as a learner primary action.",
+      "html": "<button class=\"ds-btn-primary\">Save changes</button>",
+      "css": ".ds-btn-primary { display: inline-flex; align-items: center; justify-content: center; gap: 4px; height: 28px; padding: 0 8px; border: 1px solid transparent; border-radius: calc(var(--radius, 0.625rem) - 2px); background: var(--primary, oklch(0.52 0.105 223.128)); color: var(--primary-foreground, oklch(0.984 0.019 200.873)); font-family: var(--font-sans, 'Noto Sans', sans-serif); font-size: 0.75rem; line-height: 1.625; font-weight: 500; white-space: nowrap; cursor: pointer; outline: none; transition: background 150ms cubic-bezier(0.25, 1, 0.5, 1), opacity 150ms cubic-bezier(0.25, 1, 0.5, 1); } .ds-btn-primary:hover { background: color-mix(in oklch, var(--primary, oklch(0.52 0.105 223.128)) 80%, transparent); } .ds-btn-primary:focus-visible { border-color: var(--ring, oklch(0.705 0.015 286.067)); box-shadow: 0 0 0 2px color-mix(in oklch, var(--ring, oklch(0.705 0.015 286.067)) 30%, transparent); } .ds-btn-primary:disabled { opacity: 0.5; pointer-events: none; }"
+    },
+    {
+      "name": "Primary Button (learner register)",
+      "kind": "button",
+      "refersTo": "button-primary-learner",
+      "description": "The single filled element on a learner view: the next action. 40px tall, 14px text, generous padding. Minimum touch target on any learner surface.",
+      "html": "<button class=\"ds-btn-primary-learner\">Continue<svg class=\"ds-icon\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M5 12h14M12 5l7 7-7 7\"/></svg></button>",
+      "css": ".ds-btn-primary-learner { display: inline-flex; align-items: center; justify-content: center; gap: 8px; height: 40px; padding: 0 16px; border: 1px solid transparent; border-radius: calc(var(--radius, 0.625rem) - 2px); background: var(--primary, oklch(0.52 0.105 223.128)); color: var(--primary-foreground, oklch(0.984 0.019 200.873)); font-family: var(--font-sans, 'Noto Sans', sans-serif); font-size: 0.875rem; line-height: 1.4; font-weight: 500; cursor: pointer; outline: none; transition: background 150ms cubic-bezier(0.25, 1, 0.5, 1); } .ds-btn-primary-learner .ds-icon { width: 16px; height: 16px; flex-shrink: 0; } .ds-btn-primary-learner:hover { background: color-mix(in oklch, var(--primary, oklch(0.52 0.105 223.128)) 80%, transparent); } .ds-btn-primary-learner:focus-visible { box-shadow: 0 0 0 2px color-mix(in oklch, var(--ring, oklch(0.705 0.015 286.067)) 30%, transparent); }"
+    },
+    {
+      "name": "Outline Button",
+      "kind": "button",
+      "refersTo": "button-outline",
+      "description": "The default for anything that is not the single next action. Hairline border, muted hover fill, no background at rest.",
+      "html": "<button class=\"ds-btn-outline\">Cancel</button>",
+      "css": ".ds-btn-outline { display: inline-flex; align-items: center; justify-content: center; gap: 4px; height: 28px; padding: 0 8px; border: 1px solid var(--border, oklch(0.92 0.004 286.32)); border-radius: calc(var(--radius, 0.625rem) - 2px); background: transparent; color: var(--foreground, oklch(0.141 0.005 285.823)); font-family: var(--font-sans, 'Noto Sans', sans-serif); font-size: 0.75rem; line-height: 1.625; font-weight: 500; cursor: pointer; outline: none; transition: background 150ms cubic-bezier(0.25, 1, 0.5, 1); } .ds-btn-outline:hover { background: color-mix(in oklch, var(--input, oklch(0.92 0.004 286.32)) 50%, transparent); } .ds-btn-outline:focus-visible { border-color: var(--ring, oklch(0.705 0.015 286.067)); box-shadow: 0 0 0 2px color-mix(in oklch, var(--ring, oklch(0.705 0.015 286.067)) 30%, transparent); }"
+    },
+    {
+      "name": "Destructive Button",
+      "kind": "button",
+      "refersTo": "button-destructive",
+      "description": "A 10 percent Alert tint with Alert-colored text, escalating to 20 percent on hover. A solid red fill is prohibited system-wide.",
+      "html": "<button class=\"ds-btn-destructive\">Delete course</button>",
+      "css": ".ds-btn-destructive { display: inline-flex; align-items: center; justify-content: center; gap: 4px; height: 28px; padding: 0 8px; border: 1px solid transparent; border-radius: calc(var(--radius, 0.625rem) - 2px); background: color-mix(in oklch, var(--destructive, oklch(0.577 0.245 27.325)) 10%, transparent); color: var(--destructive, oklch(0.577 0.245 27.325)); font-family: var(--font-sans, 'Noto Sans', sans-serif); font-size: 0.75rem; line-height: 1.625; font-weight: 500; cursor: pointer; outline: none; transition: background 150ms cubic-bezier(0.25, 1, 0.5, 1); } .ds-btn-destructive:hover { background: color-mix(in oklch, var(--destructive, oklch(0.577 0.245 27.325)) 20%, transparent); } .ds-btn-destructive:focus-visible { border-color: color-mix(in oklch, var(--destructive, oklch(0.577 0.245 27.325)) 40%, transparent); box-shadow: 0 0 0 2px color-mix(in oklch, var(--destructive, oklch(0.577 0.245 27.325)) 20%, transparent); }"
+    },
+    {
+      "name": "Text Input",
+      "kind": "input",
+      "refersTo": "input-default",
+      "description": "28px tall, hairline border, 20 percent tonal fill. Focus shifts the border to ring color plus a 2px ring at 30 percent. No glow, no scale.",
+      "html": "<input class=\"ds-input\" type=\"text\" placeholder=\"Nombre del curso\" />",
+      "css": ".ds-input { display: block; width: 100%; min-width: 0; height: 28px; padding: 2px 8px; border: 1px solid var(--input, oklch(0.92 0.004 286.32)); border-radius: calc(var(--radius, 0.625rem) - 2px); background: color-mix(in oklch, var(--input, oklch(0.92 0.004 286.32)) 20%, transparent); color: var(--foreground, oklch(0.141 0.005 285.823)); font-family: var(--font-sans, 'Noto Sans', sans-serif); font-size: 0.75rem; line-height: 1.625; outline: none; transition: border-color 150ms cubic-bezier(0.25, 1, 0.5, 1), box-shadow 150ms cubic-bezier(0.25, 1, 0.5, 1); } .ds-input::placeholder { color: var(--muted-foreground, oklch(0.552 0.016 285.938)); } .ds-input:focus-visible { border-color: var(--ring, oklch(0.705 0.015 286.067)); box-shadow: 0 0 0 2px color-mix(in oklch, var(--ring, oklch(0.705 0.015 286.067)) 30%, transparent); } .ds-input[aria-invalid=\"true\"] { border-color: var(--destructive, oklch(0.577 0.245 27.325)); box-shadow: 0 0 0 2px color-mix(in oklch, var(--destructive, oklch(0.577 0.245 27.325)) 20%, transparent); } .ds-input:disabled { opacity: 0.5; cursor: not-allowed; }"
+    },
+    {
+      "name": "Card",
+      "kind": "card",
+      "refersTo": "card-default",
+      "description": "Flat surface with a theme-reactive hairline ring at 10 percent of the text color. No shadow, ever. Nesting a card inside a card is prohibited.",
+      "html": "<div class=\"ds-card\"><div class=\"ds-card-header\"><div class=\"ds-card-title\">Progreso del curso</div><div class=\"ds-card-description\">4 de 12 lecciones completadas</div></div><div class=\"ds-card-content\">Continúa donde lo dejaste.</div></div>",
+      "css": ".ds-card { display: flex; flex-direction: column; gap: 16px; overflow: hidden; padding: 16px 0; border-radius: var(--radius, 0.625rem); background: var(--card, oklch(1 0 0)); color: var(--card-foreground, oklch(0.141 0.005 285.823)); box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--card-foreground, oklch(0.141 0.005 285.823)) 10%, transparent); font-family: var(--font-sans, 'Noto Sans', sans-serif); font-size: 0.75rem; line-height: 1.625; } .ds-card-header { display: grid; gap: 4px; padding: 0 16px; } .ds-card-title { font-size: 0.875rem; font-weight: 500; } .ds-card-description { font-size: 0.75rem; line-height: 1.625; color: var(--muted-foreground, oklch(0.552 0.016 285.938)); } .ds-card-content { padding: 0 16px; }"
+    },
+    {
+      "name": "Sidebar Nav Item",
+      "kind": "nav",
+      "description": "Active state carried by fill and weight together, never by color alone. Uses the dedicated sidebar token set so it sits a half-step off the page without a shadow.",
+      "html": "<nav class=\"ds-nav\"><a class=\"ds-nav-item ds-nav-item-active\" href=\"#\"><svg class=\"ds-icon\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M4 19.5A2.5 2.5 0 0 1 6.5 17H20\"/><path d=\"M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z\"/></svg>Mis cursos</a><a class=\"ds-nav-item\" href=\"#\"><svg class=\"ds-icon\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><path d=\"M12 20V10M18 20V4M6 20v-4\"/></svg>Progreso</a></nav>",
+      "css": ".ds-nav { display: flex; flex-direction: column; gap: 2px; padding: 8px; background: var(--sidebar, oklch(0.985 0 0)); border-radius: var(--radius, 0.625rem); } .ds-nav-item { display: flex; align-items: center; gap: 8px; height: 28px; padding: 0 8px; border-radius: calc(var(--radius, 0.625rem) - 2px); color: var(--sidebar-foreground, oklch(0.141 0.005 285.823)); font-family: var(--font-sans, 'Noto Sans', sans-serif); font-size: 0.75rem; line-height: 1.625; font-weight: 400; text-decoration: none; transition: background 150ms cubic-bezier(0.25, 1, 0.5, 1); } .ds-nav-item .ds-icon { width: 14px; height: 14px; flex-shrink: 0; } .ds-nav-item:hover { background: var(--sidebar-accent, oklch(0.967 0.001 286.375)); } .ds-nav-item-active { background: var(--sidebar-primary, oklch(0.609 0.126 221.723)); color: var(--sidebar-primary-foreground, oklch(0.984 0.019 200.873)); font-weight: 500; } .ds-nav-item:focus-visible { outline: none; box-shadow: 0 0 0 2px color-mix(in oklch, var(--sidebar-ring, oklch(0.705 0.015 286.067)) 30%, transparent); }"
+    },
+    {
+      "name": "Gamification Ledger Chip",
+      "kind": "chip",
+      "description": "Signature component. XP, streaks, levels, and achievements render as ledger entries, not reward graphics. Label-sized type on a tonal fill. No saturated medal, no confetti, no exclamation mark.",
+      "html": "<div class=\"ds-ledger\"><span class=\"ds-ledger-chip\">+40 XP</span><span class=\"ds-ledger-label\">Checkpoint completado</span><span class=\"ds-ledger-meta\">hoy 14:02</span></div>",
+      "css": ".ds-ledger { display: flex; align-items: center; gap: 8px; padding: 8px 0; font-family: var(--font-sans, 'Noto Sans', sans-serif); border-bottom: 1px solid color-mix(in oklch, var(--foreground, oklch(0.141 0.005 285.823)) 10%, transparent); } .ds-ledger-chip { display: inline-flex; align-items: center; height: 20px; padding: 0 6px; border-radius: calc(var(--radius, 0.625rem) - 4px); background: var(--muted, oklch(0.967 0.001 286.375)); color: var(--foreground, oklch(0.141 0.005 285.823)); font-size: 0.625rem; font-weight: 500; letter-spacing: 0.01em; font-variant-numeric: tabular-nums; } .ds-ledger-label { font-size: 0.75rem; line-height: 1.625; color: var(--foreground, oklch(0.141 0.005 285.823)); } .ds-ledger-meta { margin-left: auto; font-size: 0.625rem; color: var(--muted-foreground, oklch(0.552 0.016 285.938)); font-variant-numeric: tabular-nums; }"
+    }
+  ],
+  "narrative": {
+    "northStar": "The Quiet Classroom",
+    "overview": "A good classroom is not decorated. It is arranged. The walls recede, the light is even, the seats face one direction, and everything you notice is either the material or your own place in the sequence. That is the whole system: a quiet room built so the content can be the loudest thing in it. Nothing on screen is present for atmosphere. If an element is not carrying information, state, or a next action, it is removed rather than styled down.\n\nThe room has two arrangements. On learner surfaces (lesson, exercise, checkpoint, exam, browse) it is a reading room: generous, single-focus, one primary action visible, body type sized for a session that lasts an hour on a phone. On staff surfaces (analytics, grading, payouts, enrollment, platform panel) it is a desk: dense, comparative, scan-first, small type in exchange for seeing more at once. Same tokens, same components, two spacing registers. The component library defaults to the desk, so the reading room is always an explicit choice.\n\nThe room is also rented. Every school overrides the primary color, the corner radius, and the body typeface through CSS custom properties, so nothing structural may depend on any of the three. What stays constant is the arrangement: the hierarchy, the density rules, the hairlines, the placement of the next action. Two schools must be recognizably the same product and recognizably different brands. This system explicitly rejects the generic shadcn template look, gamified candy, the cluttered enterprise LMS, and SaaS marketing cliché.",
+    "keyCharacteristics": [
+      "Flat surfaces, hairline separation, shadows reserved for floating layers only",
+      "Muted teal accent at low chroma, deployed sparingly, never as decoration",
+      "Neutrals held at a constant violet-grey hue that is deliberately independent of the tenant brand",
+      "Two named density registers, learner and staff, never averaged",
+      "Progress communicated by position and sequence, not by reward graphics",
+      "Bilingual layouts (en/es) with Spanish as the sizing case, not the afterthought"
+    ],
+    "rules": [
+      {
+        "name": "The Constant Neutral Rule",
+        "body": "The neutrals sit at hue 285 to 286, a cool violet-grey, while the brand sits at hue 223. They are not tinted toward the brand, and this is deliberate rather than an oversight. The brand hue is tenant-variable; a neutral tinted toward it would shift under every school, and the whole product would change temperature per tenant. The neutral axis is the constant that makes two tenants read as one product. Never re-tint neutrals to match a tenant primary.",
+        "section": "colors"
+      },
+      {
+        "name": "The Single Filled Element Rule",
+        "body": "On any learner view, exactly one element carries a filled Slate Teal background: the next action. Everything else is text, hairline, or tonal fill. If a screen has two filled teal elements, one of them is not the next action and should be an outline or ghost variant.",
+        "section": "colors"
+      },
+      {
+        "name": "The Tenant-Proof Rule",
+        "body": "Every contrast, emphasis, and state decision must hold when the primary is replaced by an arbitrary tenant color. Color is never the sole carrier of meaning: status, validation, correctness, and severity always pair color with text, icon, or position. Derived inks are computed from the resolved color, never hardcoded. This has already shipped as a bug (issue #569); it is not hypothetical.",
+        "section": "colors"
+      },
+      {
+        "name": "The No Pure Ink Rule",
+        "body": "#000 and #fff are prohibited as text colors. Text on light is Ink at lightness 0.141; text on dark is oklch(0.985 0 0). Pure white survives only as a page background.",
+        "section": "colors"
+      },
+      {
+        "name": "The Two Registers Rule",
+        "body": "base-mira ships tuned for dense tooling: h-7 buttons, text-xs bodies, text-xs/relaxed cards. Those defaults are the staff register and they are correct there. Learner surfaces must explicitly opt into the learner register: size=\"lg\" or larger controls, text-sm minimum and text-base for read prose, gap and padding one step up from the component default. Never ship a lesson, exercise, checkpoint, or exam surface on the raw component defaults. A learner reading 12px prose for an hour on a mid-range Android is the failure this rule exists to prevent.",
+        "section": "typography"
+      },
+      {
+        "name": "The One Sans Rule",
+        "body": "There is exactly one sans in the system, bound to --font-sans, and every text role resolves through it. Display is that face at weight 700, not a second family. Adding a display or heading font is prohibited: it doubles the font payload for the mid-range-Android baseline, and because tenants override --font-sans, a hardcoded second face would pair a school's chosen font against one they never picked. Geist Mono is the only other family, and it earns its place by doing work no sans can do. Geist Sans was previously loaded with no consumer and has been removed.",
+        "section": "typography"
+      },
+      {
+        "name": "The Spanish Sizing Rule",
+        "body": "Spanish strings run 20 to 30 percent longer than English. Every label, button, table header, and nav item is sized against its Spanish string, not its English one. If it only fits in English, it does not fit. Truncation is a bug, not a layout strategy.",
+        "section": "typography"
+      },
+      {
+        "name": "The Measure Rule",
+        "body": "Read prose is capped at 65ch and never exceeds 75ch. This is already enforced by .prose { max-width: 65ch } in app/globals.css; do not override it to fill a wide container. Empty space beside a column of text is correct.",
+        "section": "typography"
+      },
+      {
+        "name": "The Tenant Typeface Rule",
+        "body": "Tenants may override --font-sans entirely (components/tenant/tenant-css-vars.tsx). No layout may depend on Noto Sans metrics. Fixed heights sized to a specific font's cap height, single-line assumptions, and ch-based widths outside the prose container are all prohibited.",
+        "section": "typography"
+      },
+      {
+        "name": "The Nothing Floats Rule",
+        "body": "Cards, panels, table rows, list items, sidebars, headers, and stat blocks are flat. If it participates in the page layout, it gets a hairline or a tonal fill, never a shadow. If you reach for shadow-md on a card to make it pop, the hierarchy is wrong somewhere else.",
+        "section": "elevation"
+      },
+      {
+        "name": "The Hairline Composites Rule",
+        "body": "Borders use ring-foreground/10 or oklch(1 0 0 / 10%) style alpha values rather than solid greys, so a divider stays correct over paper, over a muted fill, and over any tonal dark layer. A solid oklch(0.92 ...) border hardcoded onto a dark surface is a bug.",
+        "section": "elevation"
+      },
+      {
+        "name": "The Two-Layer Limit Rule",
+        "body": "No more than two nested elevation contexts. A card inside a card is prohibited outright. A popover inside a dialog is the maximum stack.",
+        "section": "elevation"
+      }
+    ],
+    "dos": [
+      "Do use OKLCH for every color. The entire token layer is OKLCH and mixing in hex or HSL breaks the tenant-theming pipeline.",
+      "Do pick a register before you start: staff (base-mira defaults, text-xs, h-7) or learner (text-sm minimum, text-base prose, 40px controls, 24px padding). Write it down in the component before styling.",
+      "Do keep exactly one filled Slate Teal element per learner view: the next action.",
+      "Do pair every color signal with a text, icon, or positional signal. Status, validation, correctness, severity, all of them.",
+      "Do separate surfaces with ring-1 ring-foreground/10 or a tonal fill step.",
+      "Do size every label against its Spanish string and check the layout at /es before calling it done.",
+      "Do design the empty, missing, loading, and error states in the same pass as the happy path. Missing data renders as missing; ungraded renders as ungraded, never as zero (issues #567, #568).",
+      "Do respect prefers-reduced-motion by collapsing transitions to instant state changes, not to slower ones.",
+      "Do ease out with exponential curves (ease-out-quart / quint / expo) on the transitions that remain.",
+      "Do verify focus rings and contrast against a non-default tenant primary, not just the shipped Slate Teal."
+    ],
+    "donts": [
+      "Don't ship the generic shadcn template: default zinc neutrals, identical icon-heading-text card grids repeated down a page, everything wrapped in a bordered box, or a hero-metric row of big numbers with small labels. This is the single most likely failure mode in this codebase.",
+      "Don't ship gamified candy: cartoon mascots, ambient confetti, bouncy or elastic easing, saturated primary-colored reward badges, or exclamation marks in system copy. Adults use this, and the creator's professional reputation is attached to it.",
+      "Don't build a cluttered enterprise LMS: dense nav trees, competing toolbars, tables without hierarchy, five routes to the same page. No Moodle, no Blackboard, no Canvas.",
+      "Don't use SaaS marketing cliché: gradient text (background-clip: text is banned outright), glassmorphic hero cards, purple-and-blue mesh gradients. This applies to (public)/* and to everything the AI landing-page builder is permitted to emit.",
+      "Don't put a shadow on anything that participates in the page layout. Cards, rows, panels, headers, sidebars: flat.",
+      "Don't nest a card inside a card. Ever.",
+      "Don't use a border-left or border-right greater than 1px as a colored accent stripe on a card, list item, callout, or alert. The neutral .prose blockquote border is the only exception in the system.",
+      "Don't hardcode a derived ink, tint, or contrast value against Slate Teal. Compute it from the resolved primary; tenants override it.",
+      "Don't re-tint the neutrals toward a tenant's brand hue. The violet-grey neutral axis is what keeps two tenants recognizable as one product.",
+      "Don't use a solid red fill for destructive actions. Tint at 10 percent with Alert-colored text.",
+      "Don't render text-xs body copy on a learner surface. That is the staff register leaking into a reading session.",
+      "Don't let color be the only difference between two states, two series, or two severities.",
+      "Don't reach for a modal first. Exhaust inline and progressive-disclosure alternatives; the product already has sheets and popovers for detail.",
+      "Don't animate layout properties. Transform and opacity only.",
+      "Don't add a second hue to a chart. The ramp is monochromatic by design because a second hue collides with tenant theming; encode the second dimension with label, shape, or order."
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,10 +207,12 @@ Pre-commit checklist: `npm run build` · tenant filter on every query · tested 
 
 ## Design Context
 
+**Canonical source: [`PRODUCT.md`](PRODUCT.md) (strategy) + [`DESIGN.md`](DESIGN.md) (visual system).** Read PRODUCT.md before any UI work — it carries the register (`product`, with `(public)/*` and Puck blocks in `brand`), the four user groups, the anti-references, and the five design principles. The summary below is a pointer, not the authority.
+
 Users span independent creators/solo educators and multi-staff schools, across LATAM and English-speaking markets (en/es). Brand personality: **minimal, elegant, focused** — content over chrome, no visual noise.
 
 - **Aesthetic:** clean, spacious, content-first; hierarchy via typography weight/size over color/ornament. References: Duolingo/Khan Academy, Teachable/Thinkific. Anti-references: cluttered enterprise dashboards, generic Bootstrap.
-- **Theme:** light + dark, tenant theming overrides primary/accent via CSS custom properties (default primary ~293 hue OKLCH).
+- **Theme:** light + dark, tenant theming overrides primary/accent via CSS custom properties. Default primary is **teal-cyan** `oklch(0.52 0.105 223.128)` light / `oklch(0.45 0.085 224.283)` dark — hue ~223, not 293. Nothing may depend on that hue holding; tenants override it.
 - **Typography/icons:** Noto Sans (body), Geist Sans/Mono (UI/code); Tabler Icons + Lucide (outline style).
 - **Motion:** subtle, via `motion` lib; respect `prefers-reduced-motion`; convey state changes, not decoration.
 - **Principles:** content over chrome · obvious over clever · consistent structure across tenants (brand via color/logo, not layout) · WCAG AA by default · progressive disclosure (sheets/dialogs for detail).

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,319 @@
+---
+name: LMS Platform
+description: Multi-tenant LMS where the room stays quiet so the material can be loud.
+colors:
+  slate-teal: "oklch(0.52 0.105 223.128)"
+  slate-teal-deep: "oklch(0.45 0.085 224.283)"
+  slate-teal-mid: "oklch(0.609 0.126 221.723)"
+  slate-teal-bright: "oklch(0.715 0.143 215.221)"
+  slate-teal-pale: "oklch(0.865 0.127 207.078)"
+  ink: "oklch(0.141 0.005 285.823)"
+  ink-muted: "oklch(0.552 0.016 285.938)"
+  paper: "oklch(1 0 0)"
+  paper-raised: "oklch(0.985 0 0)"
+  surface-quiet: "oklch(0.967 0.001 286.375)"
+  surface-slate: "oklch(0.21 0.006 285.885)"
+  surface-slate-quiet: "oklch(0.274 0.006 286.033)"
+  hairline: "oklch(0.92 0.004 286.32)"
+  ring-neutral: "oklch(0.705 0.015 286.067)"
+  alert: "oklch(0.577 0.245 27.325)"
+  alert-dark: "oklch(0.704 0.191 22.216)"
+  on-teal: "oklch(0.984 0.019 200.873)"
+typography:
+  display:
+    fontFamily: "Noto Sans, ui-sans-serif, system-ui, sans-serif"
+    fontSize: "2rem"
+    fontWeight: 700
+    lineHeight: 1.2
+    letterSpacing: "-0.01em"
+  headline:
+    fontFamily: "Noto Sans, ui-sans-serif, system-ui, sans-serif"
+    fontSize: "1.5rem"
+    fontWeight: 600
+    lineHeight: 1.3
+    letterSpacing: "normal"
+  title:
+    fontFamily: "Noto Sans, ui-sans-serif, system-ui, sans-serif"
+    fontSize: "0.875rem"
+    fontWeight: 500
+    lineHeight: 1.4
+    letterSpacing: "normal"
+  body-learner:
+    fontFamily: "Noto Sans, ui-sans-serif, system-ui, sans-serif"
+    fontSize: "1rem"
+    fontWeight: 400
+    lineHeight: 1.75
+    letterSpacing: "normal"
+  body-staff:
+    fontFamily: "Noto Sans, ui-sans-serif, system-ui, sans-serif"
+    fontSize: "0.75rem"
+    fontWeight: 400
+    lineHeight: 1.625
+    letterSpacing: "normal"
+  label:
+    fontFamily: "Noto Sans, ui-sans-serif, system-ui, sans-serif"
+    fontSize: "0.625rem"
+    fontWeight: 500
+    lineHeight: 1.4
+    letterSpacing: "0.01em"
+  mono:
+    fontFamily: "Geist Mono, ui-monospace, monospace"
+    fontSize: "0.875rem"
+    fontWeight: 400
+    lineHeight: 1.6
+    letterSpacing: "normal"
+rounded:
+  sm: "6px"
+  md: "8px"
+  lg: "10px"
+  xl: "14px"
+  2xl: "18px"
+spacing:
+  hairline-gap: "4px"
+  tight: "8px"
+  snug: "12px"
+  base: "16px"
+  loose: "24px"
+  section: "40px"
+  chapter: "64px"
+components:
+  button-primary:
+    backgroundColor: "{colors.slate-teal}"
+    textColor: "{colors.on-teal}"
+    typography: "{typography.label}"
+    rounded: "{rounded.md}"
+    padding: "0 8px"
+    height: "28px"
+  button-primary-hover:
+    backgroundColor: "oklch(0.52 0.105 223.128 / 0.8)"
+    textColor: "{colors.on-teal}"
+  button-primary-learner:
+    backgroundColor: "{colors.slate-teal}"
+    textColor: "{colors.on-teal}"
+    typography: "{typography.title}"
+    rounded: "{rounded.md}"
+    padding: "0 16px"
+    height: "40px"
+  button-outline:
+    backgroundColor: "transparent"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.md}"
+    padding: "0 8px"
+    height: "28px"
+  button-ghost:
+    backgroundColor: "transparent"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.md}"
+    padding: "0 8px"
+    height: "28px"
+  button-destructive:
+    backgroundColor: "oklch(0.577 0.245 27.325 / 0.1)"
+    textColor: "{colors.alert}"
+    rounded: "{rounded.md}"
+    padding: "0 8px"
+    height: "28px"
+  input-default:
+    backgroundColor: "oklch(0.92 0.004 286.32 / 0.2)"
+    textColor: "{colors.ink}"
+    typography: "{typography.body-staff}"
+    rounded: "{rounded.md}"
+    padding: "2px 8px"
+    height: "28px"
+  card-default:
+    backgroundColor: "{colors.paper}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body-staff}"
+    rounded: "{rounded.lg}"
+    padding: "16px 0"
+  card-sm:
+    backgroundColor: "{colors.paper}"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.lg}"
+    padding: "12px 0"
+---
+
+# Design System: LMS Platform
+
+## 1. Overview
+
+**Creative North Star: "The Quiet Classroom"**
+
+A good classroom is not decorated. It is arranged. The walls recede, the light is even, the seats face one direction, and everything you notice is either the material or your own place in the sequence. That is the whole system: a quiet room built so the content can be the loudest thing in it. Nothing on screen is present for atmosphere. If an element is not carrying information, state, or a next action, it is removed rather than styled down.
+
+The room has two arrangements. On **learner surfaces** (lesson, exercise, checkpoint, exam, browse) it is a reading room: generous, single-focus, one primary action visible, body type sized for a session that lasts an hour on a phone. On **staff surfaces** (analytics, grading, payouts, enrollment, platform panel) it is a desk: dense, comparative, scan-first, small type in exchange for seeing more at once. Same tokens, same components, two spacing registers. The component library defaults to the desk, so the reading room is always an explicit choice.
+
+The room is also rented. Every school overrides the primary color, the corner radius, and the body typeface through CSS custom properties, so nothing structural may depend on any of the three. What stays constant is the arrangement: the hierarchy, the density rules, the hairlines, the placement of the next action. Two schools must be recognizably the same product and recognizably different brands. This system explicitly rejects the generic shadcn template look (default zinc, identical icon-heading-text card grids, hero-metric rows), gamified candy (mascots, confetti, elastic motion, saturated reward badges), the cluttered enterprise LMS (Moodle, Blackboard, Canvas), and SaaS marketing cliché (gradient text, glassmorphic heroes, purple mesh).
+
+**Key Characteristics:**
+- Flat surfaces, hairline separation, shadows reserved for floating layers only
+- Muted teal accent at low chroma, deployed sparingly, never as decoration
+- Neutrals held at a constant violet-grey hue that is deliberately independent of the tenant brand
+- Two named density registers, learner and staff, never averaged
+- Progress communicated by position and sequence, not by reward graphics
+- Bilingual layouts (en/es) with Spanish as the sizing case, not the afterthought
+
+## 2. Colors: The Slate Teal Palette
+
+A cool, deliberately desaturated palette. The brand teal sits at chroma 0.105, roughly half what a default framework accent would use, because it has to survive being the only saturated thing on a page full of text.
+
+### Primary
+- **Slate Teal** (`oklch(0.52 0.105 223.128)`): the brand accent. Primary buttons, active navigation, links inside prose, focus emphasis, the single filled element in an otherwise flat view. Tenant-overridable. Light theme value.
+- **Slate Teal Deep** (`oklch(0.45 0.085 224.283)`): the dark-theme primary and the darkest step of the data ramp. Lower chroma than its light counterpart so it does not glare against a near-black surface.
+- **On Teal** (`oklch(0.984 0.019 200.873)`): the only ink permitted on a filled Slate Teal surface. Very slightly teal-tinted white, never pure white.
+
+### Secondary
+- **Slate Teal Mid** (`oklch(0.609 0.126 221.723)`) and **Slate Teal Bright** (`oklch(0.715 0.143 215.221)`): the sidebar active state and the mid steps of the chart ramp. Chroma rises as lightness rises, which is what keeps the ramp readable at both ends.
+- **Slate Teal Pale** (`oklch(0.865 0.127 207.078)`): the lightest chart step and the tint used behind selected or highlighted rows.
+
+Together these five form the data-visualization ramp (`--chart-1` through `--chart-5`). It is monochromatic by construction: a single hue family stepped by lightness. That is a deliberate constraint. A categorical series needs a second encoding (label, shape, order) rather than a second hue, because a second hue would collide with tenant theming.
+
+### Neutral
+- **Ink** (`oklch(0.141 0.005 285.823)`): primary text on light, and the page surface on dark.
+- **Ink Muted** (`oklch(0.552 0.016 285.938)`): secondary text, captions, placeholder text, metadata. Never used for anything a user must act on.
+- **Paper** (`oklch(1 0 0)`) and **Paper Raised** (`oklch(0.985 0 0)`): the light page surface and the sidebar. The only place a pure value is permitted, and only as a background.
+- **Surface Quiet** (`oklch(0.967 0.001 286.375)`): muted and secondary fills on light. Inline code, table headers, secondary buttons, disabled fills.
+- **Surface Slate** (`oklch(0.21 0.006 285.885)`) and **Surface Slate Quiet** (`oklch(0.274 0.006 286.033)`): the dark-theme card and muted fills. Dark mode layers tonally rather than with shadow.
+- **Hairline** (`oklch(0.92 0.004 286.32)`): every border, divider, and input stroke on light. On dark this becomes `oklch(1 0 0 / 10%)`, an alpha value rather than a solid, so it composites correctly over any tonal layer.
+- **Ring Neutral** (`oklch(0.705 0.015 286.067)`): the default focus ring where the brand color would be too loud or is not yet resolved.
+
+### Tertiary
+- **Alert** (`oklch(0.577 0.245 27.325)`) light, **Alert Dark** (`oklch(0.704 0.191 22.216)`) dark: destructive and error only. This is the one high-chroma color in the system and its chroma is the signal. It appears as a 10 to 20 percent tint behind red text, not as a solid red fill. A solid red button is prohibited.
+
+### Named Rules
+
+**The Constant Neutral Rule.** The neutrals sit at hue 285 to 286, a cool violet-grey, while the brand sits at hue 223. They are not tinted toward the brand, and this is deliberate rather than an oversight. The brand hue is tenant-variable; a neutral tinted toward it would shift under every school, and the whole product would change temperature per tenant. The neutral axis is the constant that makes two tenants read as one product. Never re-tint neutrals to match a tenant primary.
+
+**The Single Filled Element Rule.** On any learner view, exactly one element carries a filled Slate Teal background: the next action. Everything else is text, hairline, or tonal fill. If a screen has two filled teal elements, one of them is not the next action and should be an outline or ghost variant.
+
+**The Tenant-Proof Rule.** Every contrast, emphasis, and state decision must hold when the primary is replaced by an arbitrary tenant color. Color is never the sole carrier of meaning: status, validation, correctness, and severity always pair color with text, icon, or position. Derived inks are computed from the resolved color, never hardcoded. This has already shipped as a bug (issue #569); it is not hypothetical.
+
+**The No Pure Ink Rule.** `#000` and `#fff` are prohibited as text colors. Text on light is Ink at lightness 0.141; text on dark is `oklch(0.985 0 0)`. Pure white survives only as a page background.
+
+## 3. Typography
+
+**Body and UI Font:** Noto Sans (with `ui-sans-serif, system-ui, sans-serif`), bound to `--font-sans` and applied to `html`. Chosen for its Latin coverage and its even color at small sizes in both English and Spanish.
+**Mono Font:** Geist Mono, bound to `--font-mono`. Code blocks, inline code, IDs, and any fixed-width tabular figure.
+**Display:** the same Noto Sans at heavier weight. There is no separate display face.
+
+**Character:** a single humanist sans doing all the work, differentiated by weight and size rather than by family. This is the typographic expression of "content over chrome": the interface has no typographic personality of its own, so the material supplies it. Geist Sans was previously loaded as `--font-geist-sans` with no consumer and has been removed; do not reintroduce a second sans. Display is Noto Sans at weight 700, and it must resolve through `--font-sans` so that a tenant overriding the body face gets a coherent pairing rather than their font against a hardcoded one.
+
+### Hierarchy
+
+- **Display** (700, 2rem / 32px, 1.2): page titles and prose `h1`. One per view.
+- **Headline** (600, 1.5rem / 24px, 1.3): section headings and prose `h2`.
+- **Title** (500, 0.875rem / 14px, 1.4): card titles, table headers, form section labels. The workhorse heading of the staff register.
+- **Body, learner** (400, 1rem / 16px, 1.75): lesson prose, exercise statements, exam questions, anything read for more than a few seconds. Capped at 65ch, matching the existing `.prose` container.
+- **Body, staff** (400, 0.75rem / 12px, 1.625): the base-mira default. Dense tables, dashboards, filter bars, admin forms.
+- **Label** (500, 0.625rem / 10px, `0.01em`): badges, chips, `xs` buttons, metadata stamps. Sentence case, never uppercase-tracked-out.
+
+### Named Rules
+
+**The Two Registers Rule.** base-mira ships tuned for dense tooling: `h-7` buttons, `text-xs` bodies, `text-xs/relaxed` cards. Those defaults are the **staff register** and they are correct there. Learner surfaces must explicitly opt into the **learner register**: `size="lg"` or larger controls, `text-sm` minimum and `text-base` for read prose, `gap`/`padding` one step up from the component default. Never ship a lesson, exercise, checkpoint, or exam surface on the raw component defaults. A learner reading 12px prose for an hour on a mid-range Android is the failure this rule exists to prevent.
+
+**The Spanish Sizing Rule.** Spanish strings run 20 to 30 percent longer than English. Every label, button, table header, and nav item is sized against its Spanish string, not its English one. If it only fits in English, it does not fit. Truncation is a bug, not a layout strategy.
+
+**The Measure Rule.** Read prose is capped at 65ch and never exceeds 75ch. This is already enforced by `.prose { max-width: 65ch }` in `app/globals.css`; do not override it to fill a wide container. Empty space beside a column of text is correct.
+
+**The One Sans Rule.** There is exactly one sans in the system, bound to `--font-sans`, and every text role resolves through it. Display is that face at weight 700, not a second family. Adding a display or heading font is prohibited: it doubles the font payload for the mid-range-Android baseline, and because tenants override `--font-sans`, a hardcoded second face would pair a school's chosen font against one they never picked. Geist Mono is the only other family, and it earns its place by doing work no sans can do.
+
+**The Tenant Typeface Rule.** Tenants may override `--font-sans` entirely (`components/tenant/tenant-css-vars.tsx`). No layout may depend on Noto Sans metrics. Fixed heights sized to a specific font's cap height, single-line assumptions, and `ch`-based widths outside the prose container are all prohibited.
+
+## 4. Elevation
+
+This system is flat. Surfaces do not float, and depth is communicated by hairlines and tonal layering rather than by shadow. `Card` is defined as `ring-1 ring-foreground/10`: a single hairline ring at 10 percent of the text color, which means it darkens or lightens correctly with the theme instead of being a fixed grey. On dark, layering is entirely tonal: page at `oklch(0.141 ...)`, card at `oklch(0.21 ...)`, muted fill at `oklch(0.274 ...)`. Three steps, no shadow between them.
+
+Shadows exist in exactly one situation: an element that is genuinely floating above the page and detached from the layout. Popovers, dropdown menus, dialogs, sheets, tooltips, and toasts. Their shadow says "this is temporary and will be dismissed", which is information. A shadow on a card says nothing.
+
+### Shadow Vocabulary
+
+- **Overlay, low** (`shadow-sm`): tooltips and small popovers. Barely present; the border does most of the separation.
+- **Overlay, standard** (`shadow-md`): dropdown menus, comboboxes, select popups, hover cards. The default for anything anchored to a trigger.
+- **Overlay, detached** (`shadow-lg`): dialogs and sheets, which are fully detached from their trigger and sit over a scrim.
+
+### Named Rules
+
+**The Nothing Floats Rule.** Cards, panels, table rows, list items, sidebars, headers, and stat blocks are flat. If it participates in the page layout, it gets a hairline or a tonal fill, never a shadow. If you reach for `shadow-md` on a card to make it "pop", the hierarchy is wrong somewhere else.
+
+**The Hairline Composites Rule.** Borders use `ring-foreground/10` or `oklch(1 0 0 / 10%)` style alpha values rather than solid greys, so a divider stays correct over paper, over a muted fill, and over any tonal dark layer. A solid `oklch(0.92 ...)` border hardcoded onto a dark surface is a bug.
+
+**The Two-Layer Limit Rule.** No more than two nested elevation contexts. A card inside a card is prohibited outright. A popover inside a dialog is the maximum stack.
+
+## 5. Components
+
+Built on Shadcn UI in the base-mira variant over `@base-ui/react` primitives. The character is **precise and unassuming**: tight geometry, hairline definition, low contrast at rest, decisive on interaction. Nothing announces itself until it is being used.
+
+Note for implementers: base-ui's `Button` has no `asChild` prop. Wrap `<Link>` around `<Button>`, and use the `render={...}` prop on `DropdownMenuTrigger` and `BreadcrumbLink`.
+
+### Buttons
+
+- **Shape:** softly rounded (8px, `rounded-md`); the `xs` and `icon-xs` sizes tighten to 6px (`rounded-sm`). All radii derive from `--radius: 0.625rem`, which tenants may override.
+- **Sizes:** the staff register runs `xs` (20px) through `lg` (32px), with `default` at 28px and 12px text. The learner register uses `lg` at minimum, and learner primary actions should be raised to 40px with 14px text. Touch targets on learner surfaces never go below 40px.
+- **Primary:** filled Slate Teal with On Teal ink, at the tightest padding in the system (`px-2` at default size). It is small and saturated rather than large and soft.
+- **Hover:** primary drops to 80 percent opacity (`hover:bg-primary/80`). Outline and ghost fill with a muted tint. All transitions run on color and opacity only.
+- **Focus:** `focus-visible:border-ring` plus a 2px ring at 30 percent (`ring-ring/30`). The ring must stay visible against tenant-overridden backgrounds; verify it, do not assume it.
+- **Outline / Secondary / Ghost:** the default for anything that is not the single next action. Outline carries a hairline border and a muted hover; ghost carries nothing at rest.
+- **Destructive:** a 10 percent Alert tint with Alert-colored text, not a solid red fill. Escalates to 20 percent on hover. A solid red button is prohibited.
+- **Link:** Slate Teal text with `underline-offset-4`, underlined on hover.
+
+### Cards / Containers
+
+- **Corner Style:** 10px (`rounded-lg`).
+- **Background:** Paper on light, Surface Slate on dark.
+- **Shadow Strategy:** none. `ring-1 ring-foreground/10` only. See Elevation.
+- **Internal Padding:** 16px (`px-4 py-4`) at default, 12px at `size="sm"`. Learner surfaces step up to 24px.
+- **Content:** first-child and last-child images bleed to the card edge and inherit the corner radius. Use this rather than an inner image wrapper.
+- Cards are not the default container. Most content does not need one. Nested cards are prohibited.
+
+### Inputs / Fields
+
+- **Style:** 28px tall, hairline border, a 20 percent tint of the input color as fill (`bg-input/20`, `dark:bg-input/30`), 8px horizontal padding, 8px radius. Learner-facing forms step to 40px.
+- **Focus:** border shifts to ring color plus a 2px ring at 30 percent. No glow, no scale, no color flood.
+- **Error:** `aria-invalid` drives the styling, not a class. Destructive border plus a 20 percent destructive ring, paired with a text message. Color alone never marks a field invalid.
+- **Disabled:** 50 percent opacity, `cursor-not-allowed`, pointer events off.
+
+### Navigation
+
+- **Sidebar** carries its own token set (`--sidebar`, `--sidebar-primary`, `--sidebar-accent`, `--sidebar-border`) so it can sit a half-step off the page surface without a shadow. Active items use Slate Teal Mid on light, Slate Teal Bright on dark.
+- **Active state** is carried by fill and weight together, never by color alone.
+- **Mobile:** the sidebar becomes a sheet. Learner surfaces keep the primary action reachable in the thumb zone rather than in a collapsed nav.
+
+### Prose (signature component)
+
+The `.prose` container in `app/globals.css` is the most-read surface in the product and the one place with a hand-authored type scale: 65ch measure, 1.75 body line-height, `h1` 2rem / `h2` 1.5rem / `h3` 1.25rem, code and `pre` on Surface Quiet with a hairline and the base radius, links in Slate Teal with a 4px underline offset, blockquotes with a 4px left border in Hairline. That blockquote border is the single sanctioned exception to the side-stripe prohibition, because it is a typographic convention with centuries of precedent and it is neutral-colored, not an accent stripe. It does not license colored left-borders anywhere else.
+
+### Gamification surfaces (signature component)
+
+XP, levels, streaks, achievements, leagues, and the coin store render as a **ledger**, not a reward screen. Numbers are typographic, set in Title or Body weight, not oversized. Badges are Label-sized chips on tonal fills, never saturated primary-colored medals. Level-up and streak events get a single state transition and then rest. No confetti, no mascots, no elastic motion, no exclamation marks. The test: it should read as a bank statement a professional would not mind having on screen in public.
+
+## 6. Do's and Don'ts
+
+### Do:
+
+- **Do** use OKLCH for every color. The entire token layer is OKLCH and mixing in hex or HSL breaks the tenant-theming pipeline.
+- **Do** pick a register before you start: staff (base-mira defaults, `text-xs`, `h-7`) or learner (`text-sm` minimum, `text-base` prose, 40px controls, 24px padding). Write it down in the component before styling.
+- **Do** keep exactly one filled Slate Teal element per learner view: the next action.
+- **Do** pair every color signal with a text, icon, or positional signal. Status, validation, correctness, severity, all of them.
+- **Do** separate surfaces with `ring-1 ring-foreground/10` or a tonal fill step.
+- **Do** size every label against its Spanish string and check the layout at `/es` before calling it done.
+- **Do** design the empty, missing, loading, and error states in the same pass as the happy path. Missing data renders as missing; ungraded renders as ungraded, never as zero (issues #567, #568).
+- **Do** respect `prefers-reduced-motion` by collapsing transitions to instant state changes, not to slower ones.
+- **Do** ease out with exponential curves (ease-out-quart / quint / expo) on the transitions that remain.
+- **Do** verify focus rings and contrast against a non-default tenant primary, not just the shipped Slate Teal.
+
+### Don't:
+
+- **Don't** ship the **generic shadcn template**: default zinc neutrals, identical icon-heading-text card grids repeated down a page, everything wrapped in a bordered box, or a hero-metric row of big numbers with small labels. This is the single most likely failure mode in this codebase.
+- **Don't** ship **gamified candy**: cartoon mascots, ambient confetti, bouncy or elastic easing, saturated primary-colored reward badges, or exclamation marks in system copy. Adults use this, and the creator's professional reputation is attached to it.
+- **Don't** build a **cluttered enterprise LMS**: dense nav trees, competing toolbars, tables without hierarchy, five routes to the same page. No Moodle, no Blackboard, no Canvas.
+- **Don't** use **SaaS marketing cliché**: gradient text (`background-clip: text` is banned outright), glassmorphic hero cards, purple-and-blue mesh gradients. This applies to `(public)/*` and to everything the AI landing-page builder is permitted to emit.
+- **Don't** put a shadow on anything that participates in the page layout. Cards, rows, panels, headers, sidebars: flat.
+- **Don't** nest a card inside a card. Ever.
+- **Don't** use a `border-left` or `border-right` greater than 1px as a colored accent stripe on a card, list item, callout, or alert. The neutral `.prose blockquote` border is the only exception in the system.
+- **Don't** hardcode a derived ink, tint, or contrast value against Slate Teal. Compute it from the resolved primary; tenants override it.
+- **Don't** re-tint the neutrals toward a tenant's brand hue. The violet-grey neutral axis is what keeps two tenants recognizable as one product.
+- **Don't** use a solid red fill for destructive actions. Tint at 10 percent with Alert-colored text.
+- **Don't** render `text-xs` body copy on a learner surface. That is the staff register leaking into a reading session.
+- **Don't** let color be the only difference between two states, two series, or two severities.
+- **Don't** reach for a modal first. Exhaust inline and progressive-disclosure alternatives; the product already has sheets and popovers for detail.
+- **Don't** animate layout properties. Transform and opacity only.
+- **Don't** add a second hue to a chart. The ramp is monochromatic by design because a second hue collides with tenant theming; encode the second dimension with label, shape, or order.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,80 @@
+# Product
+
+## Register
+
+product
+
+Default register for all design work. Two exceptions run in **brand** register and should be treated as such per task, without changing this default:
+
+- `app/[locale]/(public)/*` (landing, `/about`, `/pricing`, `/platform-pricing`, `/creators`, `/courses`, public product pages)
+- Puck landing-page blocks and anything the AI landing-page builder emits, since those are marketing surfaces authored by tenants
+
+## Users
+
+Four groups, all first-class. They differ in session length, device, and tolerance for chrome.
+
+**Students learning.** The core user. In a lesson, exercise, checkpoint, or exam, often for a long stretch, frequently on a phone, across LATAM and English-speaking markets. Their job: understand the material and prove they understood it. They are adults or older teens, not children. Bandwidth and device quality vary widely, so weight and latency are accessibility concerns here, not just performance ones.
+
+**Creators and solo educators.** Building and selling courses on their own subdomain. Their job: ship a course and get paid. Critically, they judge this platform by how it makes *them* look to *their* students. Every learner-facing surface is the creator's storefront, which means learner polish is a creator-retention feature.
+
+**School admins and teachers.** Multi-staff operations: analytics, grading, enrollment, payouts, tenant settings, plan limits. Their job: see the state of the school and act on it. They scan, compare, and drill down. Density and scan-speed serve them better than whitespace.
+
+**Prospective buyers.** Creators and schools evaluating the platform on the public site before signing up. Short sessions, high skepticism, comparing against Teachable and Thinkific in one tab each.
+
+Platform super-admins exist (`/platform/*`) but are a small internal audience and never drive design decisions.
+
+## Product Purpose
+
+Multi-tenant LMS where every school operates as an independent tenant on its own subdomain with its own branding, students, and payment rails. Creators build block-editor courses with exercises, checkpoints, and AI-graded exams; students enroll, learn, and earn verifiable certificates; schools get analytics, payouts, and provider-agnostic payments built for markets where cards fail.
+
+The product exists because the LATAM independent-educator market is served badly: the incumbent hosted platforms assume US card payments and English-first UX, and the open-source alternatives look like 2009. Success means a solo educator in Caracas or Bogotá can stand up a school in under five minutes, take payment in whatever their students can actually pay with, and have the result look better than what a funded competitor ships.
+
+Open source, MIT, self-hostable. The codebase is also a reference implementation for multi-tenant Supabase RLS patterns, so it gets read by engineers as well as used by educators.
+
+## Brand Personality
+
+**Minimal, elegant, focused.** Content over chrome. Hierarchy through typographic weight and scale rather than color and ornament. Nothing on screen that is not doing work.
+
+Voice: direct, plain, competent. Speaks to adults who are here to learn or here to run a business. Never chirpy, never congratulatory for its own sake, never apologetic. Encouragement is earned and specific ("3 of 5 checkpoints cleared") rather than generic ("Great job!").
+
+Emotional goal on learning surfaces: **calm momentum.** The learner should feel steady forward motion without being hyped at. Emotional goal on staff surfaces: **grounded confidence.** The admin should feel the numbers are real and the system is not hiding anything.
+
+Bilingual by construction (en/es). Spanish is not a translation layer bolted on, it is a first-class render target, and Spanish strings run roughly 20 to 30 percent longer than English. Any layout that only survives in English is broken.
+
+## Anti-references
+
+**Generic shadcn template.** Default zinc palette, identical icon-heading-text card grids repeated down the page, every element wrapped in a bordered box, hero-metric rows of big numbers with small labels. This is the single most likely failure mode here, because the project genuinely is built on shadcn and the path of least resistance leads straight into it. Using the component library is fine. Looking like its documentation site is not.
+
+**Gamified candy.** The product has XP, levels, streaks, achievements, leagues, and a coin store, and that entire subsystem is one bad decision away from looking like a children's app. No cartoon mascots, no ambient confetti, no bouncy or elastic motion, no saturated primary-color reward badges, no exclamation marks in system copy. These users are adults, and the creator's professional reputation is attached to what they see.
+
+**Cluttered enterprise LMS.** Moodle, Blackboard, Canvas. Dense nav trees, competing toolbars, tables with no hierarchy, five ways to reach the same page.
+
+**SaaS marketing cliché.** Gradient-text headlines, glassmorphic hero cards, purple-and-blue mesh gradients. Especially relevant to the public site and to anything the AI landing-page builder is allowed to emit.
+
+## Design Principles
+
+**1. Momentum without candy.**
+Take the pedagogical core of Duolingo and Khan Academy, visible progress, a clear next action, feedback that lands immediately, and reject their visual register entirely. Momentum is communicated through position, sequence, and state changes, not through rewards theater. Concretely: progress belongs in the layout (where you are in the sequence, what unlocks next), motion conveys the state change and then stops, and gamification surfaces read as a quiet ledger rather than a slot machine. If a learner surface would embarrass an adult professional in a coffee shop, it is wrong.
+
+**2. Density is a property of the surface, not the system.**
+One token set, two spacing and information-density registers. Learner surfaces (lesson, exercise, checkpoint, exam, browse) are calm, spacious, single-focus, one primary action visible. Staff surfaces (analytics, grading queues, payouts, enrollment, platform panel) are dense, comparative, and scan-first, and accept smaller type and tighter rows in exchange for seeing more at once. Never average the two into a compromise that serves neither.
+
+**3. The tenant supplies the brand, we supply the structure.**
+Tenants override the primary and accent colors through CSS custom properties, so no layout, hierarchy, or affordance may depend on a specific hue. Two schools must be recognizably the same product and recognizably different brands. Practically: contrast, emphasis, and state must survive an arbitrary tenant color, meaning color is never the only carrier of meaning, and every derived ink must be computed rather than hardcoded. This is not theoretical, it has already shipped as a bug (#569).
+
+**4. Every learner surface is the creator's storefront.**
+The creator is selling to their own students on our UI. A rough edge in a lesson player is not a learner annoyance, it is a churn risk for the paying customer. Weight learner-surface polish accordingly, above internal staff tooling, when effort has to be split.
+
+**5. Never render absent, stale, or unearned state as if it were real.**
+Missing data shows as missing. Ungraded shows as ungraded, not as zero. Estimates are labeled as estimates. Empty states say what is actually true and what to do next rather than filling space with a plausible-looking placeholder. Money, grades, and progress are the three places where a confident-looking lie costs the most trust, and all three have already produced real bugs here (#567, #568). Design for the empty and error case in the same pass as the happy path, never as a follow-up.
+
+## Accessibility & Inclusion
+
+**Target: WCAG 2.2 AA, verified under tenant theming.** AA is the floor, not the aspiration, and it must hold for every tenant primary color, not just the default teal. A contrast check that only passes against the shipped palette has not been done.
+
+- **Color is never the sole carrier of meaning.** Status, validation, correctness, and severity always pair color with text, icon, or position. Serves color-blind users and survives arbitrary tenant hues at the same time.
+- **`prefers-reduced-motion` is respected everywhere.** Under reduced motion, transitions become instant state changes, not slower animations. Nothing essential is communicated only through movement.
+- **Full keyboard operability** with visible focus. Focus rings must remain visible against tenant-overridden backgrounds.
+- **Bilingual layout resilience.** Every layout is checked in Spanish. Text does not truncate, wrap awkwardly, or overflow its container in either language.
+- **Long-session legibility.** Learning surfaces carry the longest reading sessions in the product. Body copy stays at 65 to 75ch, and both light and dark themes are genuinely usable rather than one being an afterthought.
+- **Real-world devices and networks.** Mid-range Android and constrained mobile bandwidth are the assumed baseline for the LATAM student audience, not an edge case.

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata, Viewport } from "next";
-import { Geist, Geist_Mono, Noto_Sans } from "next/font/google";
+import { Geist_Mono, Noto_Sans } from "next/font/google";
 import "../globals.css";
 import { Toaster } from "@/components/ui/sonner";
 import { RouteProgress } from "@/components/shared/route-progress";
@@ -19,11 +19,6 @@ import type { StoredPreset } from '@/lib/themes/presets';
 import { getSeoContext, ogImageUrl } from '@/lib/seo';
 
 const notoSans = Noto_Sans({ variable: '--font-sans', subsets: ["latin"] });
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
 
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
@@ -158,7 +153,7 @@ export default async function RootLayout({
         />
       </head>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${geistMono.variable} antialiased`}
       >
         <NextIntlClientProvider messages={messages}>
           <ThemeProvider


### PR DESCRIPTION
## What

Adds the two design-context files every `/impeccable` command reads before doing any work (`PRODUCT.md` for strategy, `DESIGN.md` for the visual system), plus the machine-readable sidecar. Fixes the one live defect the scan turned up: **Geist Sans was loaded on every page with zero consumers.**

Closes #587

## Why

There was no written design context, so every design pass re-derived the palette, the type scale, and the register from scratch, and drifted. Three things were true in the code and documented nowhere:

- **`base-mira` ships dense.** `h-7` buttons, `text-xs` bodies, `text-xs/relaxed` cards. That is correct for dashboards and grading queues. It is wrong for a student reading an exercise for an hour on a mid-range Android, which is the baseline device this product targets. Nothing said so, so the dense default was silently winning everywhere. `DESIGN.md` names the two registers and requires learner surfaces to opt into the larger one.
- **Tenants override `--radius` and `--font-sans`, not just colours** (`components/tenant/tenant-css-vars.tsx:34-39`). Shape and typeface are tenant-variable. Any layout depending on Noto Sans metrics is a latent bug.
- **The neutrals are deliberately not tinted toward the brand.** They sit at hue ~285 while the brand sits at 223. That inverts the usual "tint neutrals toward the brand hue" advice, and it is correct here: the brand hue is tenant-variable, so a brand-tinted neutral would change the product's temperature per school. Written up as The Constant Neutral Rule specifically so it does not get "fixed" later.

`CLAUDE.md`'s Design Context also claimed the default primary was **"~293 hue OKLCH"**. The app ships `oklch(0.52 0.105 223.128)`, a teal-cyan at hue **223**. Anything trusting that line was designing against a purple this codebase has never used. Corrected, and the section now points at `PRODUCT.md` as canonical.

On the font: `Geist Sans` was declared in `app/[locale]/layout.tsx` and attached to `<body>` as `--font-geist-sans`, but **nothing referenced it** — no class, no CSS, no `@theme` binding. It shipped weight and did no work. Dropped rather than bound to a display role, because:

1. `DESIGN.md` commits to one sans differentiated by weight, not family.
2. Tenants override `--font-sans`. A hardcoded display face would pair a school's chosen font against one they never picked.
3. It loaded on every page for the LATAM mid-range-Android baseline.

`Geist Mono` is untouched — it is genuinely used by `--font-mono`, the `font-mono` utility, and direct `[font-family:var(--font-geist-mono)]` refs in `not-found.tsx`.

## How to QA

Mostly documentation; the only behavioural change is the font removal, and its correctness claim is "nothing changes".

1. `npm run build` — passes.
2. Confirm the dropped font has no consumers left:
   ```bash
   grep -rn "geist-sans\|geistSans" --include="*.tsx" --include="*.ts" --include="*.css" . | grep -v node_modules
   ```
   Expected: no matches.
3. Load any page (`default.lvh.me:3000/en/dashboard/student`), open DevTools, inspect `<body>` and any heading. Computed `font-family` should resolve through `--font-sans` (Noto Sans) exactly as before. `Geist` should not appear in any computed style, and no Geist Sans file should appear in the Network tab.
4. Check a `font-mono` element still renders in Geist Mono, e.g. the code stamp on `/en/not-found` or a slug cell in `/en/platform/tenants`.
5. Read `PRODUCT.md` and `DESIGN.md` and push back on anything that misstates the product. They are the input to every future design pass, so a wrong line here propagates.

## Screenshots / GIF

**No visual diff, by construction.** The removed font had zero consumers: `next/font` with the `variable` option only declares a CSS custom property, it does not apply a `font-family`, and nothing consumed `--font-geist-sans`. Rendering is byte-identical. Step 3 above is the verification rather than a screenshot pair, since two identical screenshots would prove nothing either way.

## Checklist

- [x] `npm run typecheck` and `npm run test:unit` pass (54 files, 675 tests)
- [x] `npm run build` passes
- [x] Every new tenant-scoped query filters by `tenant_id` (or the table genuinely has no such column) — no queries in this PR
- [x] Tested with every relevant role (student / teacher / admin) — no role-dependent behaviour; the font change is global and inert
- [x] Loading and error states handled — no new UI
- [x] New UI strings added to both `messages/en.json` and `messages/es.json` — no new strings
- [x] Migration (if any) applies cleanly on `npm run db:reset`, has RLS policies, and `lib/database.types.ts` was regenerated — no migration

## Notes for the reviewer

- Branched from `master`, **not** stacked on #581/#583, though it was authored while those were in flight.
- `.impeccable/design.json` is the machine-readable sidecar the impeccable live panel renders from. `.impeccable/config.local.json`, `hook.cache.json`, and `critique/` are local artifacts and stay out of the repo.
- `PRODUCT.md` records **four** first-class user groups rather than picking one, with an explicit surface-level tiebreak, because that is what was actually decided. If you disagree with the tiebreak, that is the line to argue with.
