### PR TITLE
fix(auth): ask for a name at sign-up so students stop reading as "Unknown Student"

### DIFF
--- a/app/[locale]/dashboard/teacher/courses/[courseId]/page.tsx
+++ b/app/[locale]/dashboard/teacher/courses/[courseId]/page.tsx
@@ -35,6 +35,7 @@ import {
 } from '@tabler/icons-react'
 import { CourseStudentsTable } from '@/components/teacher/course-students-table'
 import {getCurrentTenantId, getCurrentUserId } from '@/lib/supabase/tenant'
+import { createAdminClient } from '@/lib/supabase/admin'
 import { CourseEditorTour } from '@/components/tours/course-editor-tour'
 import { getUiState } from '@/lib/supabase/ui-state'
 import { isTourCompleted, areToursEnabled } from '@/lib/ui-state-keys'
@@ -181,9 +182,28 @@ export default async function CourseManagementPage({ params }: PageProps) {
     ? await supabase.from('profiles').select('id, full_name, avatar_url').in('id', enrolledUserIds)
     : { data: [] }
   const profilesMap = new Map((enrollmentProfiles || []).map((p) => [p.id, p]))
+
+  // The email/password sign-up form never collects a name (only Google gives one),
+  // so handle_new_user() leaves profiles.full_name NULL and every row rendered
+  // "Unknown Student". Fall back to the auth email — profiles has no email column,
+  // so it only comes from the admin API, one call per user (chunked to spare GoTrue).
+  const namelessIds = enrolledUserIds.filter((id) => !profilesMap.get(id)?.full_name)
+  const emailMap = new Map<string, string>()
+  if (namelessIds.length > 0) {
+    const adminClient = createAdminClient()
+    for (let i = 0; i < namelessIds.length; i += 20) {
+      const chunk = namelessIds.slice(i, i + 20)
+      const results = await Promise.all(chunk.map((id) => adminClient.auth.admin.getUserById(id)))
+      results.forEach((r, j) => {
+        if (r.data?.user?.email) emailMap.set(chunk[j], r.data.user.email)
+      })
+    }
+  }
+
   const enrollments = rawEnrollments.map((e) => ({
     ...e,
     profiles: profilesMap.get(e.user_id) || null,
+    email: emailMap.get(e.user_id) || null,
   }))
 
   return (

--- a/components/sign-up-form.tsx
+++ b/components/sign-up-form.tsx
@@ -31,6 +31,7 @@ interface SignUpFormProps extends React.ComponentPropsWithoutRef<'div'> {
 
 export function SignUpForm({ className, tenantId, ...props }: SignUpFormProps) {
   const t = useTranslations('auth.signup')
+  const [fullName, setFullName] = useState('')
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState<string | null>(null)
@@ -41,20 +42,39 @@ export function SignUpForm({ className, tenantId, ...props }: SignUpFormProps) {
   const searchParams = useSearchParams()
   const nextPath = getSafeNextPath(searchParams.get('next'), '')
 
+  // Supabase returns raw English strings; map the ones users actually hit to
+  // translated copy and keep the rest as a last resort.
+  const localizedError = (err: unknown) => {
+    const raw = err instanceof Error ? err.message : ''
+    const m = raw.toLowerCase()
+    if (m.includes('already registered') || m.includes('already exists')) return t('errors.emailTaken')
+    if (m.includes('rate limit') || m.includes('too many')) return t('errors.rateLimited')
+    if (m.includes('password')) return t('errors.weakPassword')
+    return raw || t('errors.generic')
+  }
+
   const handleSignUp = async (e: React.FormEvent) => {
     e.preventDefault()
     const supabase = createClient()
+    const name = fullName.trim()
+    if (!name) {
+      setError(t('errors.nameRequired'))
+      return
+    }
     setIsLoading(true)
     setError(null)
 
     try {
       await supabase.auth.signOut({ scope: 'local' })
       const { data, error } = await supabase.auth.signUp({
-        email,
+        email: email.trim(),
         password,
         options: {
           emailRedirectTo: `${window.location.origin}/auth/confirm${nextPath ? `?next=${encodeURIComponent(nextPath)}` : ''}`,
           data: {
+            // handle_new_user() copies full_name into profiles. Without it every
+            // teacher/admin list shows the student as "Unknown Student".
+            full_name: name,
             // handle_new_user() reads preferred_tenant_id to stamp the JWT's
             // tenant claim; without it a fresh signup can't see tenant content.
             ...(tenantId ? { tenant_id: tenantId, preferred_tenant_id: tenantId } : {}),
@@ -70,7 +90,7 @@ export function SignUpForm({ className, tenantId, ...props }: SignUpFormProps) {
       }
       router.push(data.session && nextPath ? nextPath : '/auth/sign-up-success')
     } catch (error: unknown) {
-      setError(error instanceof Error ? error.message : t('common.error'))
+      setError(localizedError(error))
     } finally {
       setIsLoading(false)
     }
@@ -91,7 +111,7 @@ export function SignUpForm({ className, tenantId, ...props }: SignUpFormProps) {
       })
       if (error) throw error
     } catch (error: unknown) {
-      setError(error instanceof Error ? error.message : t('common.error'))
+      setError(localizedError(error))
       setIsSocialLoading(false)
     }
   }
@@ -144,11 +164,25 @@ export function SignUpForm({ className, tenantId, ...props }: SignUpFormProps) {
               </div>
 
               <div className="grid gap-2">
+                <Label htmlFor="full-name">{t('fullName')}</Label>
+                <Input
+                  id="full-name"
+                  data-testid="signup-name"
+                  type="text"
+                  autoComplete="name"
+                  placeholder={t('fullNamePlaceholder')}
+                  required
+                  value={fullName}
+                  onChange={(e) => setFullName(e.target.value)}
+                />
+              </div>
+              <div className="grid gap-2">
                 <Label htmlFor="email">{t('email')}</Label>
                 <Input
                   id="email"
                   data-testid="signup-email"
                   type="email"
+                  autoComplete="email"
                   placeholder="m@example.com"
                   required
                   value={email}
@@ -164,6 +198,8 @@ export function SignUpForm({ className, tenantId, ...props }: SignUpFormProps) {
                     id="password"
                     data-testid="signup-password"
                     type={showPassword ? 'text' : 'password'}
+                    autoComplete="new-password"
+                    aria-describedby="password-hint"
                     required
                     minLength={6}
                     value={password}
@@ -173,14 +209,21 @@ export function SignUpForm({ className, tenantId, ...props }: SignUpFormProps) {
                     <InputGroupButton
                       size="icon-xs"
                       onClick={() => setShowPassword(!showPassword)}
-                      aria-label={showPassword ? 'Hide password' : 'Show password'}
+                      aria-label={showPassword ? t('hidePassword') : t('showPassword')}
                     >
                       {showPassword ? <EyeOff /> : <Eye />}
                     </InputGroupButton>
                   </InputGroupAddon>
                 </InputGroup>
+                <p id="password-hint" className="text-xs text-muted-foreground">
+                  {t('passwordHint')}
+                </p>
               </div>
-              {error && <p className="text-sm text-red-500">{error}</p>}
+              {error && (
+                <p role="alert" className="text-sm text-destructive">
+                  {error}
+                </p>
+              )}
               <Button type="submit" className="w-full" disabled={isLoading || isSocialLoading} data-testid="signup-submit">
                 {isLoading ? t('submitting') : t('submit')}
               </Button>

--- a/components/teacher/course-students-table.tsx
+++ b/components/teacher/course-students-table.tsx
@@ -25,6 +25,8 @@ interface StudentEnrollment {
   enrollment_date: string
   status: string
   profiles?: { full_name?: string | null; avatar_url?: string | null } | null
+  /** Auth email, resolved server-side when the profile has no full_name. */
+  email?: string | null
 }
 
 interface IssuedCertificate {
@@ -69,17 +71,22 @@ export function CourseStudentsTable({ enrollments, issuedCertificates, courseId 
           </TableHeader>
           <TableBody>
             {paginatedEnrollments.length > 0 ? (
-              paginatedEnrollments.map((enrollment) => (
+              paginatedEnrollments.map((enrollment) => {
+                // Most students sign up without a name, so the email is the only
+                // thing that identifies them — show it instead of "Unknown Student".
+                const displayName =
+                  enrollment.profiles?.full_name || enrollment.email || t('studentList.unknownStudent')
+                return (
                 <TableRow key={enrollment.enrollment_id}>
                   <TableCell className="px-4">
                     <div className="flex items-center gap-3">
                       <Avatar size="sm">
                         {enrollment.profiles?.avatar_url && (
-                          <AvatarImage src={enrollment.profiles.avatar_url} alt={enrollment.profiles?.full_name || ''} />
+                          <AvatarImage src={enrollment.profiles.avatar_url} alt={displayName} />
                         )}
-                        <AvatarFallback>{getInitials(enrollment.profiles?.full_name)}</AvatarFallback>
+                        <AvatarFallback>{getInitials(displayName)}</AvatarFallback>
                       </Avatar>
-                      <span className="font-medium">{enrollment.profiles?.full_name || t('studentList.unknownStudent')}</span>
+                      <span className="font-medium truncate">{displayName}</span>
                     </div>
                   </TableCell>
                   <TableCell className="px-4 whitespace-nowrap text-muted-foreground">
@@ -98,12 +105,13 @@ export function CourseStudentsTable({ enrollments, issuedCertificates, courseId 
                     <IssueCertificateButton
                       courseId={courseId}
                       userId={enrollment.user_id}
-                      studentName={enrollment.profiles?.full_name || t('studentList.unknownStudent')}
+                      studentName={displayName}
                       existingCertificateId={issuedCertificates.find((c) => c.user_id === enrollment.user_id)?.id}
                     />
                   </TableCell>
                 </TableRow>
-              ))
+                )
+              })
             ) : (
               <TableRow>
                 <TableCell colSpan={4} className="py-12 text-center">

--- a/components/tenant/create-school-flow.tsx
+++ b/components/tenant/create-school-flow.tsx
@@ -45,6 +45,7 @@ export function CreateSchoolFlow({ user, plan, interval }: CreateSchoolFlowProps
   const [signedInEmail, setSignedInEmail] = useState(user?.email || '')
 
   // Account state
+  const [ownerName, setOwnerName] = useState('')
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [showPassword, setShowPassword] = useState(false)
@@ -86,6 +87,12 @@ export function CreateSchoolFlow({ user, plan, interval }: CreateSchoolFlowProps
     e.preventDefault()
     setError(null)
 
+    const name = ownerName.trim()
+    if (!name) {
+      setError('Please enter your name')
+      return
+    }
+
     if (password.length < 6) {
       setError('Password must be at least 6 characters')
       return
@@ -102,6 +109,9 @@ export function CreateSchoolFlow({ user, plan, interval }: CreateSchoolFlowProps
       password,
       options: {
         emailRedirectTo: `${window.location.origin}/auth/confirm?next=/create-school`,
+        // handle_new_user() copies full_name into profiles; without it the owner
+        // shows up as "Unknown" in every people list.
+        data: { full_name: name },
       },
     })
 
@@ -264,17 +274,33 @@ export function CreateSchoolFlow({ user, plan, interval }: CreateSchoolFlowProps
               </div>
 
               <div className="space-y-2">
+                <Label htmlFor="owner-name" className="text-zinc-300">Your name</Label>
+                <Input
+                  id="owner-name"
+                  type="text"
+                  autoComplete="name"
+                  value={ownerName}
+                  onChange={(e) => setOwnerName(e.target.value)}
+                  placeholder="Ada Lovelace"
+                  className="bg-zinc-800 border-zinc-700 text-white"
+                  required
+                  disabled={loading}
+                  autoFocus
+                />
+              </div>
+
+              <div className="space-y-2">
                 <Label htmlFor="email" className="text-zinc-300">Email</Label>
                 <Input
                   id="email"
                   type="email"
+                  autoComplete="email"
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
                   placeholder="you@example.com"
                   className="bg-zinc-800 border-zinc-700 text-white"
                   required
                   disabled={loading}
-                  autoFocus
                 />
               </div>
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -183,8 +183,18 @@
       "login": "Login",
       "orContinueWith": "Or continue with email",
       "continueWithGoogle": "Sign up with Google",
+      "fullName": "Full name",
+      "fullNamePlaceholder": "Ada Lovelace",
+      "passwordHint": "At least 6 characters",
+      "showPassword": "Show password",
+      "hidePassword": "Hide password",
       "errors": {
-        "passwordsDontMatch": "Passwords do not match"
+        "passwordsDontMatch": "Passwords do not match",
+        "nameRequired": "Please enter your name",
+        "emailTaken": "That email already has an account. Log in instead.",
+        "weakPassword": "Your password must be at least 6 characters.",
+        "rateLimited": "Too many attempts. Wait a minute and try again.",
+        "generic": "Something went wrong. Please try again."
       }
     },
     "forgotPassword": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -183,8 +183,18 @@
       "login": "Inicia sesión",
       "orContinueWith": "O continuar con email",
       "continueWithGoogle": "Registrarse con Google",
+      "fullName": "Nombre completo",
+      "fullNamePlaceholder": "Ada Lovelace",
+      "passwordHint": "Al menos 6 caracteres",
+      "showPassword": "Mostrar contraseña",
+      "hidePassword": "Ocultar contraseña",
       "errors": {
-        "passwordsDontMatch": "Las contraseñas no coinciden"
+        "passwordsDontMatch": "Las contraseñas no coinciden",
+        "nameRequired": "Ingresa tu nombre",
+        "emailTaken": "Ese correo ya tiene una cuenta. Inicia sesión.",
+        "weakPassword": "La contraseña debe tener al menos 6 caracteres.",
+        "rateLimited": "Demasiados intentos. Espera un minuto e inténtalo de nuevo.",
+        "generic": "Algo salió mal. Inténtalo de nuevo."
       }
     },
     "forgotPassword": {


### PR DESCRIPTION
## What

Sign-up now asks for a full name and sends it as `signUp` metadata, so `handle_new_user()` has something to copy into `profiles.full_name`. For the users who already signed up without one, the course **Students** tab falls back to their auth email instead of "Unknown Student".

Closes #

## Why

`components/sign-up-form.tsx` never collected a name, and `handle_new_user()` only copies `raw_user_meta_data->>'full_name'` — so every email/password signup landed with `profiles.full_name = NULL` and the teacher's Students tab rendered *every* row as "Unknown Student" (only Google users got a name). Seed users have names, which is why this never showed up locally. The create-school owner step had the same gap.

Two things came along for the ride:

- The sign-up catch block called `t('common.error')` under the `auth.signup` namespace. That key doesn't exist, so any failed signup rendered a `MISSING_MESSAGE` string at the user. Errors users actually hit (email taken, rate limit, weak password) are now mapped to translated copy.
- The error line was `text-red-500`, which misses AA on both themes; it's `text-destructive` with `role="alert"` now. Also added `autoComplete` on name/email/password, translated the show/hide-password labels (they were hardcoded English), and wired the "At least 6 characters" hint via `aria-describedby`.

Existing accounts can't have their names recovered — the email fallback is what covers them.

## How to QA

On a fresh `npm run db:reset`, with `npm run dev` running:

1. **New signup keeps its name** — go to `http://default.lvh.me:3000/en/auth/sign-up`, fill Full name / Email / Password, submit. Then:
   `select full_name from profiles p join auth.users u on u.id = p.id where u.email = '<the email>';` → the name you typed.
2. **Name is required** — submit with the name blank: the form blocks with "Please enter your name" (and "Ingresa tu nombre" on `/es/auth/sign-up`).
3. **Email fallback for nameless students** — `update profiles set full_name = null where id = 'a1000000-0000-0000-0000-000000000004';`, log in as `creator@codeacademy.com` / `password123` on `code-academy.lvh.me:3000`, open `/dashboard/teacher/courses/2001` → **Students**. The row reads `alice@student.com`, not "Unknown Student". Restore the name and it reads "Alice Student" again.
4. **School owner** — `http://default.lvh.me:3000/en/create-school` now asks "Your name" before email; the created owner's profile carries it.

## Screenshots / GIF

Before (reporter's screenshot): every enrolled student rendered as "Unknown Student" with a blank avatar.

After — Students tab, nameless student falls back to their email:

![Students tab after](https://raw.githubusercontent.com/guillermoscript/lms-front/f1e0326ddd4fb49e5c35149364dcd52f33f2df89/docs/images/signup-full-name/students-tab-after.png?v=1)

After — sign-up form with the name field and password hint:

![Sign-up form after](https://raw.githubusercontent.com/guillermoscript/lms-front/f1e0326ddd4fb49e5c35149364dcd52f33f2df89/docs/images/signup-full-name/signup-form-after.png?v=1)

## Checklist

- [x] `npm run typecheck` and `npm run test:unit` pass (675 tests)
- [ ] `npm run build` — not run locally (a dev server is using `.next`); leaving it to CI
- [x] Every new tenant-scoped query filters by `tenant_id` (the only new lookups are `profiles` and the auth admin API, neither of which is tenant-scoped)
- [x] Tested with every relevant role (student signup, teacher/admin course view)
- [x] Loading and error states handled
- [x] New UI strings added to both `messages/en.json` and `messages/es.json`
- [x] Migration (if any) applies cleanly — no migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197Tp41ASnCMkHfd6c7HEcm
