### PR TITLE
feat(mcp): certificate tools and widgets for the MCP server

### DIFF
--- a/mcp-server/.env.example
+++ b/mcp-server/.env.example
@@ -35,6 +35,12 @@ SUPABASE_SERVICE_ROLE_KEY=
 # server's INTERNAL address, e.g. http://127.0.0.1:3001.)
 MCP_SERVER_URL=http://localhost:3000
 # PORT=3000
+# Root domain tenants are served under (e.g. lmsplatform.com, lvh.me:3000
+# locally). Optional — only used to build shareable absolute links to the
+# public certificate verify page, https://<slug>.<domain>/verify/<code>. A
+# tenant with its own `tenants.domain` ignores this; with neither set the
+# certificate widgets show the verification code without a link.
+# LMS_PLATFORM_DOMAIN=lmsplatform.com
 # Bind address — mcp-use defaults to "localhost", which is loopback-only.
 # In Docker/production set 0.0.0.0 (the Dockerfile already does).
 # HOST=0.0.0.0

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -16,14 +16,14 @@ implementation.
   isolation and ownership**. The server holds no elevated data privileges.
 - **Tenant/role:** read from JWT claims (`tenant_id`, `tenant_role`) injected by
   the LMS `custom_access_token_hook`. `teacher`/`admin` get the management
-  tools; `student` gets only the 18 self-scoped learning/practice tools (list
+  tools; `student` gets only the 30 self-scoped learning/practice tools (list
   hiding in `src/tool-policy.ts`, call-time gating in `src/register.ts`).
 - **Audit:** an `mcp:tools/call` middleware logs every call to `mcp_audit_log`
   via a service-role client (no-op if `SUPABASE_SERVICE_ROLE_KEY` is unset).
 
 ## What it exposes
 
-- **75 tools** (`lms_*`) across courses, lessons, exercises, exams, analytics,
+- **91 tools** (`lms_*`) across courses, lessons, exercises, exams, analytics,
   student learning (`lms_my_learning`, `lms_view_lesson`,
   `lms_complete_lesson`, `lms_my_exam_results`, `lms_my_gamification`,
   `lms_browse_catalog`), AI-tutor practice (`lms_get_exercise_for_student`
@@ -47,8 +47,16 @@ implementation.
   replace-per-week, `lms_get_study_plan` with next-lesson + due-card context,
   `lms_complete_study_goal`), and consented teacher escalation
   (`lms_ask_teacher` — notifies the course's teacher via a SECURITY DEFINER
-  RPC, enrollment-validated and rate-limited to 3/day/course).
-- **17 widgets** (MCP Apps), teacher/admin: `course-dashboard`
+  RPC, enrollment-validated and rate-limited to 3/day/course), and
+  certificates (`lms_my_certificates`, `lms_get_certificate_eligibility`,
+  `lms_issue_certificate` — always through the `issue_certificate_if_eligible`
+  SECURITY DEFINER function, never a direct insert;
+  `lms_list_course_certificates`, `lms_get_certificate_template`,
+  `lms_set_certificate_template`, and admin-only `lms_revoke_certificate`.
+  Issuance is **template-gated**: a course with no active
+  `certificate_templates` row issues nothing at all, whatever a student has
+  completed — which is what the eligibility and template tools surface).
+- **21 widgets** (MCP Apps), teacher/admin: `course-dashboard`
   (← `lms_list_courses`), `course-detail` (← `lms_get_course`, with a live
   "Load stats" action), `exam-submissions` (← `lms_list_exam_submissions`,
   drill into a submission), `lesson-preview` (← `lms_get_lesson`),
@@ -67,7 +75,12 @@ implementation.
   Again/Hard/Good/Easy self-rating → `lms_grade_review`, end-of-session
   summary with a drill-my-misses action), `study-plan`
   (← `lms_get_study_plan`: weekly progress ring, kind-grouped goal checklist
-  with check-off → `lms_complete_study_goal`, plan-next-week action).
+  with check-off → `lms_complete_study_goal`, plan-next-week action),
+  `my-certificates` (← `lms_my_certificates`: validity, verification code and
+  public verify link per credential); teacher/admin `course-certificates`
+  (← `lms_list_course_certificates`: template criteria, issued roster, and an
+  Issue button per awaiting student calling `lms_issue_certificate` — disabled
+  while the course has no active template, since nothing could be issued).
 - **3 resource templates:** `course://{id}`, `lesson://{id}`, `exam://{id}`.
 - **12 prompts:** create-course-outline, generate-lesson-content,
   create-exam-questions, review-course, generate-remediation-exercises,

--- a/mcp-server/docs/WIDGET_DEMO_DATA.md
+++ b/mcp-server/docs/WIDGET_DEMO_DATA.md
@@ -38,7 +38,7 @@ Three deliberate consequences of the flag, all dev-only:
 2. **Demo tools register before `installToolGuards()`**, so the role gate does
    not reject them (an inspector session with no login has no tenant role) and
    they never write to `mcp_audit_log`.
-3. **`tools/list` shows only the 18 demo tools.** With no auth there is no role,
+3. **`tools/list` shows only the 21 demo tools.** With no auth there is no role,
    so the existing policy filter hides everything else. Real tools still refuse
    to run — `LmsSession.fromContext` throws "Authentication required."
 

--- a/mcp-server/index.ts
+++ b/mcp-server/index.ts
@@ -18,6 +18,7 @@ import { registerFlashcardTools } from "./src/tools/flashcards.js";
 import { registerStudyPlanTools } from "./src/tools/study-plan.js";
 import { registerAskTeacherTools } from "./src/tools/ask-teacher.js";
 import { registerLandingPageTools } from "./src/tools/landing-pages.js";
+import { registerCertificateTools } from "./src/tools/certificates.js";
 import { registerDemoTools } from "./src/tools/demo.js";
 import { registerResources } from "./src/resources.js";
 import { registerPrompts } from "./src/prompts.js";
@@ -37,7 +38,7 @@ const server = new MCPServer({
   description:
     "Manage courses, lessons, exercises, exams, and analytics for the LMS. Teachers and admins get management tools; students get self-scoped learning tools.",
   instructions:
-    "Teachers/admins: use lms_list_courses to browse courses (renders a dashboard widget), lms_get_course for a course detail widget, lms_get_lesson to preview lesson content, and lms_list_exam_submissions to review student submissions. Admins can also draft school landing pages: lms_get_landing_blocks for the block vocabulary, then lms_create_landing_page (draft) and lms_publish_landing_page. Students: use lms_my_learning for the learning dashboard, lms_view_lesson to read a lesson, lms_complete_lesson to mark it done, lms_my_exam_results for scores and feedback, lms_my_gamification for XP/achievements, and lms_browse_catalog to discover courses. All actions are scoped to the caller's tenant and enforced by row-level security.",
+    "Teachers/admins: use lms_list_courses to browse courses (renders a dashboard widget), lms_get_course for a course detail widget, lms_get_lesson to preview lesson content, and lms_list_exam_submissions to review student submissions. Admins can also draft school landing pages: lms_get_landing_blocks for the block vocabulary, then lms_create_landing_page (draft) and lms_publish_landing_page. Students: use lms_my_learning for the learning dashboard, lms_view_lesson to read a lesson, lms_complete_lesson to mark it done, lms_my_exam_results for scores and feedback, lms_my_gamification for XP/achievements, and lms_browse_catalog to discover courses. Certificates: students use lms_my_certificates and lms_get_certificate_eligibility; teachers/admins use lms_list_course_certificates for a course's roster (it can issue) plus lms_get_certificate_template / lms_set_certificate_template — a course with no active template issues no certificates at all, which is the usual reason none appear. All actions are scoped to the caller's tenant and enforced by row-level security.",
   baseUrl:
     process.env.MCP_SERVER_URL || process.env.MCP_URL || "http://localhost:3000",
   favicon: "favicon.ico",
@@ -102,6 +103,7 @@ registerFlashcardTools(server);
 registerStudyPlanTools(server);
 registerAskTeacherTools(server);
 registerLandingPageTools(server);
+registerCertificateTools(server);
 registerResources(server);
 registerPrompts(server);
 

--- a/mcp-server/resources/course-certificates/widget.tsx
+++ b/mcp-server/resources/course-certificates/widget.tsx
@@ -1,0 +1,425 @@
+import { useState } from "react";
+import {
+  McpUseProvider,
+  useWidget,
+  useWidgetTheme,
+  useCallTool,
+  type WidgetMetadata,
+} from "mcp-use/react";
+import { Brand } from "../shared/branding";
+import { useFormat, useStrings } from "../shared/i18n";
+import { studentDisplayName, studentInitials } from "../shared/student-display";
+import { z } from "zod";
+
+// ── Schema ──────────────────────────────────────────────────────────────────
+
+const certificateSchema = z.object({
+  certificate_id: z.string(),
+  student_id: z.string().nullable(),
+  student_name: z.string().nullable(),
+  verification_code: z.string(),
+  verify_url: z.string().nullable(),
+  issued_at: z.string().nullable(),
+  expires_at: z.string().nullable(),
+  revoked_at: z.string().nullable(),
+  revoke_reason: z.string().nullable(),
+  status: z.enum(["valid", "expired", "revoked"]),
+});
+
+const propsSchema = z.object({
+  course: z.object({ id: z.number(), title: z.string() }),
+  /** null when the course has no template at all — nothing can ever be issued. */
+  template: z
+    .object({
+      name: z.string(),
+      issuer_name: z.string().nullable(),
+      is_active: z.boolean(),
+      min_lesson_completion_pct: z.number().nullable(),
+      min_exam_pass_score: z.number().nullable(),
+      requires_all_exams: z.boolean(),
+      expiration_days: z.number().nullable(),
+    })
+    .nullable(),
+  summary: z.object({
+    issued: z.number(),
+    revoked: z.number(),
+    active_students: z.number(),
+    awaiting: z.number(),
+  }),
+  certificates: z.array(certificateSchema),
+  awaiting: z.array(
+    z.object({ student_id: z.string(), student_name: z.string().nullable() })
+  ),
+});
+
+export const widgetMetadata: WidgetMetadata = {
+  description:
+    "Course certificate roster for teachers: template criteria, issued certificates, and one-click issuance for students still awaiting one",
+  props: propsSchema,
+  exposeAsTool: false,
+  metadata: {
+    invoking: "Loading certificates...",
+    invoked: "Certificate roster ready",
+  },
+};
+
+type Props = z.infer<typeof propsSchema>;
+type Certificate = z.infer<typeof certificateSchema>;
+
+// ── Strings ──────────────────────────────────────────────────────────────────
+
+const STRINGS = {
+  en: {
+    loading: "Loading certificates…",
+    title: "Certificates",
+    statIssued: "Issued",
+    statStudents: "Active students",
+    statAwaiting: "Awaiting",
+    statRevoked: "Revoked",
+    noTemplateTitle: "No active certificate template",
+    noTemplateBody:
+      "This course issues no certificates until a template is configured — automatic issuance on lesson and exam completion is template-gated.",
+    inactiveTemplate: "inactive",
+    criteria: (pct: string, score: string, all: boolean) =>
+      `${pct} of lessons · ${all ? `every exam ≥ ${score}` : `average exam score ≥ ${score}`}`,
+    expiry: (days: string) => ` · expires after ${days} days`,
+    noExpiry: " · no expiry",
+    issuedTitle: "Issued",
+    colStudent: "Student",
+    colDate: "Date",
+    colCode: "Code",
+    noneIssued: "No certificates issued yet.",
+    awaitingTitle: "Awaiting a certificate",
+    issue: "Issue",
+    issuing: "Issuing…",
+    issued: "Issued ✓",
+    verify: "Verify ↗",
+    unnamed: "Unnamed student",
+    expired: "Expired",
+    revoked: "Revoked",
+    valid: "Valid",
+    issueFailed: "Could not issue — the student has not met the criteria yet.",
+  },
+  es: {
+    loading: "Cargando certificados…",
+    title: "Certificados",
+    statIssued: "Emitidos",
+    statStudents: "Estudiantes activos",
+    statAwaiting: "Pendientes",
+    statRevoked: "Revocados",
+    noTemplateTitle: "Sin plantilla de certificado activa",
+    noTemplateBody:
+      "Este curso no emite certificados hasta que se configure una plantilla: la emisión automática al completar lecciones y exámenes depende de ella.",
+    inactiveTemplate: "inactiva",
+    criteria: (pct: string, score: string, all: boolean) =>
+      `${pct} de las lecciones · ${all ? `cada examen ≥ ${score}` : `nota media ≥ ${score}`}`,
+    expiry: (days: string) => ` · caduca a los ${days} días`,
+    noExpiry: " · sin caducidad",
+    issuedTitle: "Emitidos",
+    colStudent: "Estudiante",
+    colDate: "Fecha",
+    colCode: "Código",
+    noneIssued: "Todavía no se ha emitido ningún certificado.",
+    awaitingTitle: "Pendientes de certificado",
+    issue: "Emitir",
+    issuing: "Emitiendo…",
+    issued: "Emitido ✓",
+    verify: "Verificar ↗",
+    unnamed: "Estudiante sin nombre",
+    expired: "Caducado",
+    revoked: "Revocado",
+    valid: "Vigente",
+    issueFailed: "No se pudo emitir: el estudiante aún no cumple los criterios.",
+  },
+};
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const PILL: Record<Certificate["status"], string> = {
+  valid:
+    "bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-400",
+  expired: "bg-amber-100 text-amber-700 dark:bg-amber-950 dark:text-amber-400",
+  revoked: "bg-red-100 text-red-700 dark:bg-red-950 dark:text-red-400",
+};
+
+/**
+ * The tool's own words for a refusal.
+ *
+ * `lms_issue_certificate` answers a not-yet-eligible student with a plain-text
+ * result rather than an error — the refusal *is* the answer, and it names the
+ * missing criterion. Surfacing that text beats a generic failure message, so
+ * the fallback only covers a result we cannot read.
+ */
+function resultText(raw: unknown): string | null {
+  const content = (raw as { content?: Array<{ type?: string; text?: string }> } | null)
+    ?.content;
+  const first = content?.find((c) => typeof c?.text === "string");
+  return first?.text?.trim() || null;
+}
+
+function didIssue(raw: unknown): boolean {
+  const structured = (raw as { structuredContent?: { success?: boolean } } | null)
+    ?.structuredContent;
+  return structured?.success === true;
+}
+
+// ── Component ────────────────────────────────────────────────────────────────
+
+export default function CourseCertificates() {
+  const { props, isPending } = useWidget<Props>();
+  const theme = useWidgetTheme();
+  // Explicit generics: `mcp-use dev` generates the tool-registry types, and a
+  // tool registered in a sibling file is not in them until it regenerates.
+  const { callToolAsync } = useCallTool<{ course_id: number; student_id: string }>(
+    "lms_issue_certificate"
+  );
+  // One shared hook instance serves every row, so per-row state is tracked here.
+  const [pendingId, setPendingId] = useState<string | null>(null);
+  const [issuedIds, setIssuedIds] = useState<Set<string>>(new Set());
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  const dark = theme === "dark";
+  const t = useStrings(STRINGS);
+  const fmt = useFormat();
+
+  if (isPending) {
+    return (
+      <McpUseProvider autoSize>
+        <Brand />
+        <div className={dark ? "dark" : ""}>
+          <div className="bg-zinc-50 p-10 text-center font-sans text-zinc-400 dark:bg-zinc-950 dark:text-zinc-500">
+            <div className="mx-auto mb-3 size-9 animate-spin rounded-full border-[3px] border-zinc-200 border-t-[var(--brand-600)] dark:border-zinc-800 dark:border-t-[var(--brand-400)]" />
+            <p className="m-0 text-sm">{t.loading}</p>
+          </div>
+        </div>
+      </McpUseProvider>
+    );
+  }
+
+  const { course, template, summary, certificates, awaiting } = props;
+  const templateActive = !!template && template.is_active;
+
+  const statusLabel = (status: Certificate["status"]) =>
+    status === "valid" ? t.valid : status === "expired" ? t.expired : t.revoked;
+
+  const handleIssue = async (studentId: string) => {
+    setPendingId(studentId);
+    setErrors((prev) => {
+      const next = { ...prev };
+      delete next[studentId];
+      return next;
+    });
+    try {
+      const result = await callToolAsync({
+        course_id: course.id,
+        student_id: studentId,
+      });
+      if (didIssue(result)) {
+        setIssuedIds((prev) => new Set(prev).add(studentId));
+      } else {
+        setErrors((prev) => ({
+          ...prev,
+          [studentId]: resultText(result) ?? t.issueFailed,
+        }));
+      }
+    } catch {
+      setErrors((prev) => ({ ...prev, [studentId]: t.issueFailed }));
+    } finally {
+      setPendingId(null);
+    }
+  };
+
+  const stats: Array<{ label: string; value: number; tone: string }> = [
+    { label: t.statIssued, value: summary.issued, tone: "text-zinc-900 dark:text-zinc-100" },
+    { label: t.statStudents, value: summary.active_students, tone: "text-zinc-900 dark:text-zinc-100" },
+    { label: t.statAwaiting, value: summary.awaiting, tone: "text-amber-700 dark:text-amber-400" },
+    { label: t.statRevoked, value: summary.revoked, tone: "text-red-700 dark:text-red-400" },
+  ];
+
+  return (
+    <McpUseProvider autoSize>
+      <Brand />
+      <div className={dark ? "dark" : ""}>
+        <div className="mx-auto max-w-[860px] bg-zinc-50 p-6 font-sans dark:bg-zinc-950">
+          {/* Header */}
+          <div className="mb-4">
+            <h1 className="m-0 text-[22px] font-bold tracking-tight text-zinc-900 dark:text-zinc-100">
+              {t.title}
+            </h1>
+            <p className="mt-0.5 mb-0 text-[13px] text-zinc-500 dark:text-zinc-400">
+              {course.title}
+            </p>
+          </div>
+
+          {/* Stats */}
+          <div className="mb-4 grid grid-cols-2 gap-3 sm:grid-cols-4">
+            {stats.map((s) => (
+              <div
+                key={s.label}
+                className="rounded-xl border border-zinc-200 bg-white px-4 py-3 dark:border-zinc-800 dark:bg-zinc-900"
+              >
+                <div className={`text-xl font-bold tabular-nums ${s.tone}`}>
+                  {fmt.number(s.value)}
+                </div>
+                <div className="mt-0.5 text-[11px] font-semibold tracking-wide text-zinc-500 uppercase dark:text-zinc-400">
+                  {s.label}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* Template */}
+          {templateActive ? (
+            <div className="mb-5 rounded-xl border border-zinc-200 bg-white px-4 py-3 dark:border-zinc-800 dark:bg-zinc-900">
+              <div className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+                {template!.name}
+                {template!.issuer_name ? ` · ${template!.issuer_name}` : ""}
+              </div>
+              <div className="mt-0.5 text-[13px] text-zinc-500 dark:text-zinc-400">
+                {t.criteria(
+                  fmt.percent(template!.min_lesson_completion_pct ?? 100),
+                  fmt.number(template!.min_exam_pass_score ?? 70),
+                  template!.requires_all_exams
+                )}
+                {template!.expiration_days
+                  ? t.expiry(fmt.number(template!.expiration_days))
+                  : t.noExpiry}
+              </div>
+            </div>
+          ) : (
+            <div className="mb-5 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 dark:border-amber-900 dark:bg-amber-950">
+              <div className="text-sm font-semibold text-amber-800 dark:text-amber-300">
+                {t.noTemplateTitle}
+                {template && !template.is_active ? ` (${t.inactiveTemplate})` : ""}
+              </div>
+              <p className="mt-1 mb-0 text-[13px] text-amber-800 dark:text-amber-300">
+                {t.noTemplateBody}
+              </p>
+            </div>
+          )}
+
+          {/* Issued */}
+          <h2 className="mt-0 mb-2 text-[11px] font-bold tracking-wider text-zinc-500 uppercase dark:text-zinc-400">
+            {t.issuedTitle}
+          </h2>
+          <div className="overflow-x-auto overflow-y-hidden rounded-xl border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
+            <div className="grid min-w-[520px] grid-cols-[minmax(150px,1fr)_104px_minmax(140px,1fr)_136px] border-b border-zinc-200 bg-zinc-100 px-4 py-[9px] dark:border-zinc-800 dark:bg-zinc-800">
+              {[t.colStudent, t.colDate, t.colCode, ""].map((col, i) => (
+                <span
+                  key={i}
+                  className="text-[11px] font-bold tracking-wider text-zinc-500 uppercase dark:text-zinc-400"
+                >
+                  {col}
+                </span>
+              ))}
+            </div>
+
+            {certificates.length === 0 ? (
+              <div className="p-10 text-center text-zinc-400 dark:text-zinc-500">
+                <div className="mb-2.5 text-3xl">🎓</div>
+                <p className="m-0 text-sm">{t.noneIssued}</p>
+              </div>
+            ) : (
+              certificates.map((c, idx) => (
+                <div
+                  key={c.certificate_id}
+                  className={`grid min-w-[520px] grid-cols-[minmax(150px,1fr)_104px_minmax(140px,1fr)_136px] items-center px-4 py-3 ${
+                    idx === certificates.length - 1
+                      ? ""
+                      : "border-b border-zinc-100 dark:border-zinc-800"
+                  }`}
+                >
+                  <div className="flex min-w-0 items-center gap-2.5">
+                    <span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-zinc-100 text-[11px] font-bold text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">
+                      {studentInitials(c.student_name)}
+                    </span>
+                    <span className="truncate text-sm text-zinc-900 dark:text-zinc-100">
+                      {studentDisplayName(c.student_name, t.unnamed)}
+                    </span>
+                  </div>
+                  <span className="text-xs text-zinc-500 tabular-nums dark:text-zinc-400">
+                    {fmt.date(c.issued_at)}
+                  </span>
+                  <code className="truncate text-[12px] text-zinc-700 dark:text-zinc-300">
+                    {c.verification_code}
+                  </code>
+                  <div className="flex items-center justify-end gap-2">
+                    <span
+                      className={`rounded-full px-2 py-0.5 text-[10px] font-bold ${PILL[c.status]}`}
+                    >
+                      {statusLabel(c.status)}
+                    </span>
+                    {c.verify_url && (
+                      <a
+                        href={c.verify_url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-[11px] font-semibold whitespace-nowrap text-[var(--brand-700)] no-underline hover:underline dark:text-[var(--brand-400)]"
+                      >
+                        {t.verify}
+                      </a>
+                    )}
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+
+          {/* Awaiting */}
+          {awaiting.length > 0 && (
+            <>
+              <h2 className="mt-6 mb-2 text-[11px] font-bold tracking-wider text-zinc-500 uppercase dark:text-zinc-400">
+                {t.awaitingTitle}
+              </h2>
+              <div className="overflow-hidden rounded-xl border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
+                {awaiting.map((s, idx) => {
+                  const done = issuedIds.has(s.student_id);
+                  const busy = pendingId === s.student_id;
+                  const error = errors[s.student_id];
+                  return (
+                    <div
+                      key={s.student_id}
+                      className={
+                        idx === awaiting.length - 1
+                          ? ""
+                          : "border-b border-zinc-100 dark:border-zinc-800"
+                      }
+                    >
+                      <div className="flex items-center gap-3 px-4 py-2.5">
+                        <span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-zinc-100 text-[11px] font-bold text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400">
+                          {studentInitials(s.student_name)}
+                        </span>
+                        <span className="min-w-0 flex-1 truncate text-sm text-zinc-900 dark:text-zinc-100">
+                          {studentDisplayName(s.student_name, t.unnamed)}
+                        </span>
+                        {done ? (
+                          <span className="text-[13px] font-semibold text-emerald-700 dark:text-emerald-400">
+                            {t.issued}
+                          </span>
+                        ) : (
+                          <button
+                            type="button"
+                            onClick={() => handleIssue(s.student_id)}
+                            disabled={busy || !templateActive}
+                            className="cursor-pointer rounded-lg bg-[var(--brand-600)] px-3 py-1.5 text-[13px] font-semibold text-white disabled:cursor-not-allowed disabled:opacity-50"
+                          >
+                            {busy ? t.issuing : t.issue}
+                          </button>
+                        )}
+                      </div>
+                      {error && (
+                        <p className="mt-0 mr-4 mb-2.5 ml-[54px] rounded-lg bg-amber-50 px-3 py-2 text-[12px] text-amber-800 dark:bg-amber-950 dark:text-amber-300">
+                          {error}
+                        </p>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </McpUseProvider>
+  );
+}

--- a/mcp-server/resources/my-certificates/widget.tsx
+++ b/mcp-server/resources/my-certificates/widget.tsx
@@ -1,0 +1,240 @@
+import {
+  McpUseProvider,
+  useWidget,
+  useWidgetTheme,
+  type WidgetMetadata,
+} from "mcp-use/react";
+import { Brand } from "../shared/branding";
+import { useFormat, useStrings } from "../shared/i18n";
+import { z } from "zod";
+
+// ── Schema ──────────────────────────────────────────────────────────────────
+
+const certificateSchema = z.object({
+  certificate_id: z.string(),
+  course_id: z.number().nullable(),
+  course_title: z.string().nullable(),
+  verification_code: z.string(),
+  /** Absolute link to the public verify page, or null when the host is unknown. */
+  verify_url: z.string().nullable(),
+  pdf_url: z.string().nullable(),
+  issued_at: z.string().nullable(),
+  expires_at: z.string().nullable(),
+  revoked_at: z.string().nullable(),
+  revoke_reason: z.string().nullable(),
+  status: z.enum(["valid", "expired", "revoked"]),
+  share_count: z.number(),
+  view_count: z.number(),
+});
+
+const propsSchema = z.object({
+  total: z.number(),
+  valid: z.number(),
+  certificates: z.array(certificateSchema),
+});
+
+export const widgetMetadata: WidgetMetadata = {
+  description:
+    "A student's own course certificates with validity, verification code and public verify link",
+  props: propsSchema,
+  exposeAsTool: false,
+  metadata: {
+    invoking: "Loading your certificates...",
+    invoked: "Certificates ready",
+  },
+};
+
+type Props = z.infer<typeof propsSchema>;
+type Certificate = z.infer<typeof certificateSchema>;
+
+// ── Strings ──────────────────────────────────────────────────────────────────
+
+const STRINGS = {
+  en: {
+    loading: "Loading your certificates…",
+    title: "My Certificates",
+    subtitle: (n: number, count: string) => `${count} certificate${n === 1 ? "" : "s"}`,
+    validSuffix: (valid: string) => ` · ${valid} valid`,
+    emptyTitle: "No certificates yet",
+    emptyHint:
+      "Finish a course's lessons and exams and your certificate appears here automatically.",
+    issued: "Issued",
+    expires: "Expires",
+    expired: "Expired",
+    revoked: "Revoked",
+    valid: "Valid",
+    code: "Verification code",
+    verify: "Verify page",
+    pdf: "PDF",
+    views: (n: string) => `${n} views`,
+    unknownCourse: "Course",
+  },
+  es: {
+    loading: "Cargando tus certificados…",
+    title: "Mis certificados",
+    subtitle: (n: number, count: string) => `${count} certificado${n === 1 ? "" : "s"}`,
+    validSuffix: (valid: string) => ` · ${valid} vigente(s)`,
+    emptyTitle: "Todavía no tienes certificados",
+    emptyHint:
+      "Termina las lecciones y exámenes de un curso y tu certificado aparecerá aquí automáticamente.",
+    issued: "Emitido",
+    expires: "Caduca",
+    expired: "Caducado",
+    revoked: "Revocado",
+    valid: "Vigente",
+    code: "Código de verificación",
+    verify: "Página de verificación",
+    pdf: "PDF",
+    views: (n: string) => `${n} visitas`,
+    unknownCourse: "Curso",
+  },
+};
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Status pill colours.
+ *
+ * The inks are `-700` in light and `-400` in dark: the `-600`/`-500` pairs used
+ * elsewhere in this repo fail WCAG AA against these tinted backgrounds.
+ */
+const PILL: Record<Certificate["status"], string> = {
+  valid:
+    "bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-400",
+  expired: "bg-amber-100 text-amber-700 dark:bg-amber-950 dark:text-amber-400",
+  revoked: "bg-red-100 text-red-700 dark:bg-red-950 dark:text-red-400",
+};
+
+// ── Component ────────────────────────────────────────────────────────────────
+
+export default function MyCertificates() {
+  const { props, isPending } = useWidget<Props>();
+  const theme = useWidgetTheme();
+
+  const dark = theme === "dark";
+  const t = useStrings(STRINGS);
+  const fmt = useFormat();
+
+  if (isPending) {
+    return (
+      <McpUseProvider autoSize>
+        <Brand />
+        <div className={dark ? "dark" : ""}>
+          <div className="bg-zinc-50 p-10 text-center font-sans text-zinc-400 dark:bg-zinc-950 dark:text-zinc-500">
+            <div className="mx-auto mb-3 size-9 animate-spin rounded-full border-[3px] border-zinc-200 border-t-[var(--brand-600)] dark:border-zinc-800 dark:border-t-[var(--brand-400)]" />
+            <p className="m-0 text-sm">{t.loading}</p>
+          </div>
+        </div>
+      </McpUseProvider>
+    );
+  }
+
+  const { total, valid, certificates } = props;
+
+  const statusLabel = (status: Certificate["status"]) =>
+    status === "valid" ? t.valid : status === "expired" ? t.expired : t.revoked;
+
+  return (
+    <McpUseProvider autoSize>
+      <Brand />
+      <div className={dark ? "dark" : ""}>
+        <div className="mx-auto max-w-[760px] bg-zinc-50 p-6 font-sans dark:bg-zinc-950">
+          <div className="mb-[18px] flex flex-wrap items-baseline justify-between gap-2">
+            <h1 className="m-0 text-[22px] font-bold tracking-tight text-zinc-900 dark:text-zinc-100">
+              {t.title}
+            </h1>
+            <span className="text-[13px] text-zinc-500 dark:text-zinc-400">
+              {t.subtitle(total, fmt.number(total))}
+              {total > 0 ? t.validSuffix(fmt.number(valid)) : ""}
+            </span>
+          </div>
+
+          {certificates.length === 0 ? (
+            <div className="rounded-xl border border-zinc-200 bg-white p-10 text-center dark:border-zinc-800 dark:bg-zinc-900">
+              <div className="mb-2 text-3xl">🎓</div>
+              <p className="m-0 text-[15px] font-semibold text-zinc-900 dark:text-zinc-100">
+                {t.emptyTitle}
+              </p>
+              <p className="mt-1.5 mb-0 text-[13px] text-zinc-400 dark:text-zinc-500">
+                {t.emptyHint}
+              </p>
+            </div>
+          ) : (
+            <div className="grid gap-3">
+              {certificates.map((c) => (
+                <div
+                  key={c.certificate_id}
+                  className="rounded-xl border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-900"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <h2 className="m-0 truncate text-[15px] font-semibold text-zinc-900 dark:text-zinc-100">
+                        {c.course_title ?? t.unknownCourse}
+                      </h2>
+                      <p className="mt-1 mb-0 text-xs text-zinc-500 dark:text-zinc-400">
+                        {t.issued} {fmt.date(c.issued_at)}
+                        {c.expires_at
+                          ? ` · ${c.status === "expired" ? t.expired : t.expires} ${fmt.date(c.expires_at)}`
+                          : ""}
+                      </p>
+                    </div>
+                    <span
+                      className={`shrink-0 rounded-full px-2.5 py-1 text-[11px] font-bold ${PILL[c.status]}`}
+                    >
+                      {statusLabel(c.status)}
+                    </span>
+                  </div>
+
+                  {c.status === "revoked" && c.revoke_reason && (
+                    <p className="mt-2.5 mb-0 rounded-lg bg-red-50 px-3 py-2 text-[13px] text-red-700 dark:bg-red-950 dark:text-red-400">
+                      {c.revoke_reason}
+                    </p>
+                  )}
+
+                  <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-2 border-t border-zinc-100 pt-3 dark:border-zinc-800">
+                    <div className="min-w-0">
+                      <span className="block text-[10px] font-bold tracking-wider text-zinc-400 uppercase dark:text-zinc-500">
+                        {t.code}
+                      </span>
+                      <code className="text-[12px] font-medium text-zinc-700 dark:text-zinc-300">
+                        {c.verification_code}
+                      </code>
+                    </div>
+
+                    <div className="ml-auto flex items-center gap-3 text-[13px] font-semibold">
+                      {c.verify_url && (
+                        <a
+                          href={c.verify_url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-[var(--brand-700)] no-underline hover:underline dark:text-[var(--brand-400)]"
+                        >
+                          {t.verify} ↗
+                        </a>
+                      )}
+                      {c.pdf_url && (
+                        <a
+                          href={c.pdf_url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-[var(--brand-700)] no-underline hover:underline dark:text-[var(--brand-400)]"
+                        >
+                          {t.pdf} ↗
+                        </a>
+                      )}
+                      {c.view_count > 0 && (
+                        <span className="text-xs font-normal text-zinc-400 dark:text-zinc-500">
+                          {t.views(fmt.number(c.view_count))}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </McpUseProvider>
+  );
+}

--- a/mcp-server/src/demo-data.ts
+++ b/mcp-server/src/demo-data.ts
@@ -2018,6 +2018,174 @@ export const WIDGET_DEMOS: WidgetDemo[] = [
       },
     ],
   },
+
+  // ────────────────────────────────────────────────────────── my-certificates
+  {
+    widget: "my-certificates",
+    tool: "lms_demo_my_certificates",
+    title: "A student's own certificates (lms_my_certificates)",
+    variants: [
+      {
+        id: "default",
+        label: "3 certificates: valid, expiring, revoked",
+        output: "3 certificate(s), 1 currently valid.",
+        props: {
+          total: 3,
+          valid: 1,
+          certificates: [
+            {
+              certificate_id: "c1f0a4de-1b21-4a55-9a6e-2b0d7e4c1101",
+              course_id: 101,
+              course_title: "React 19 en la práctica",
+              verification_code: "A7K2M9QX4R1TB6VZ0P3N",
+              verify_url: "https://code-academy.lmsplatform.com/verify/A7K2M9QX4R1TB6VZ0P3N",
+              pdf_url: "https://cdn.lmsplatform.com/certs/c1f0a4de.pdf",
+              issued_at: "2026-06-18T10:22:00Z",
+              expires_at: null,
+              revoked_at: null,
+              revoke_reason: null,
+              status: "valid",
+              share_count: 4,
+              view_count: 37,
+            },
+            {
+              // Expiry is the branch schools forget exists: expiration_days is
+              // optional, so most certificates never expire and this one must
+              // not read like an error.
+              certificate_id: "c1f0a4de-1b21-4a55-9a6e-2b0d7e4c1102",
+              course_id: 102,
+              course_title: "Fundamentos de bases de datos",
+              verification_code: "B3D8W1LC5H7YE2QM6F0S",
+              verify_url: "https://code-academy.lmsplatform.com/verify/B3D8W1LC5H7YE2QM6F0S",
+              pdf_url: null,
+              issued_at: "2025-02-02T09:00:00Z",
+              expires_at: "2026-02-02T09:00:00Z",
+              revoked_at: null,
+              revoke_reason: null,
+              status: "expired",
+              share_count: 0,
+              view_count: 2,
+            },
+            {
+              // No course title: certificates.course_id is ON DELETE SET NULL,
+              // so a deleted course leaves a real, still-verifiable credential
+              // with nothing to name it.
+              certificate_id: "c1f0a4de-1b21-4a55-9a6e-2b0d7e4c1103",
+              course_id: null,
+              course_title: null,
+              verification_code: "Z9V4T2GK8J6XN1RA5C7U",
+              verify_url: null,
+              pdf_url: null,
+              issued_at: "2026-01-14T16:40:00Z",
+              expires_at: null,
+              revoked_at: "2026-03-01T11:05:00Z",
+              revoke_reason: "Issued in error during a data import.",
+              status: "revoked",
+              share_count: 0,
+              view_count: 11,
+            },
+          ],
+        },
+      },
+      {
+        id: "empty",
+        label: "No certificates yet",
+        output: "You have no certificates yet.",
+        props: { total: 0, valid: 0, certificates: [] },
+      },
+    ],
+  },
+
+  // ────────────────────────────────────────────────────── course-certificates
+  {
+    widget: "course-certificates",
+    tool: "lms_demo_course_certificates",
+    title: "Course certificate roster (lms_list_course_certificates)",
+    variants: [
+      {
+        id: "default",
+        label: "Template active, 3 issued, 3 awaiting",
+        output:
+          "3 certificate(s) issued for «React 19 en la práctica»; 3 of 6 active student(s) still awaiting one.",
+        props: {
+          course: { id: 101, title: "React 19 en la práctica" },
+          template: {
+            name: "Certificado de finalización",
+            issuer_name: "Code Academy",
+            is_active: true,
+            min_lesson_completion_pct: 100,
+            min_exam_pass_score: 70,
+            requires_all_exams: true,
+            expiration_days: null,
+          },
+          summary: { issued: 3, revoked: 1, active_students: 6, awaiting: 3 },
+          certificates: [
+            {
+              certificate_id: "d2e1b5cf-2c32-4b66-8b7f-3c1e8f5d2201",
+              student_id: "u-001",
+              student_name: "Alicia Nguyen",
+              verification_code: "A7K2M9QX4R1TB6VZ0P3N",
+              verify_url: "https://code-academy.lmsplatform.com/verify/A7K2M9QX4R1TB6VZ0P3N",
+              issued_at: "2026-06-18T10:22:00Z",
+              expires_at: null,
+              revoked_at: null,
+              revoke_reason: null,
+              status: "valid",
+            },
+            {
+              certificate_id: "d2e1b5cf-2c32-4b66-8b7f-3c1e8f5d2202",
+              student_id: "u-005",
+              student_name: "Emma Whitfield",
+              verification_code: "M4P8R2XW9K1LQ7ZC3B6T",
+              verify_url: "https://code-academy.lmsplatform.com/verify/M4P8R2XW9K1LQ7ZC3B6T",
+              issued_at: "2026-07-02T08:15:00Z",
+              expires_at: "2027-07-02T08:15:00Z",
+              revoked_at: null,
+              revoke_reason: null,
+              status: "valid",
+            },
+            {
+              // The profile row has no full_name — the widget must say so
+              // rather than invent a name out of the user id.
+              certificate_id: "d2e1b5cf-2c32-4b66-8b7f-3c1e8f5d2203",
+              student_id: "u-008",
+              student_name: null,
+              verification_code: "Q1N6H3JD7S9WF2VK8Y5R",
+              verify_url: null,
+              issued_at: "2026-07-11T19:03:00Z",
+              expires_at: null,
+              revoked_at: null,
+              revoke_reason: null,
+              status: "valid",
+            },
+          ],
+          awaiting: [
+            { student_id: "u-002", student_name: "Bruno Salas" },
+            { student_id: "u-004", student_name: "Diego Fernández" },
+            { student_id: "u-006", student_name: null },
+          ],
+        },
+      },
+      {
+        id: "no-template",
+        label: "No template — the course issues nothing",
+        output:
+          "Course «Diseño de APIs REST» has no active certificate template, so nothing is issued automatically.",
+        props: {
+          course: { id: 104, title: "Diseño de APIs REST" },
+          template: null,
+          summary: { issued: 0, revoked: 0, active_students: 4, awaiting: 4 },
+          certificates: [],
+          awaiting: [
+            { student_id: "u-011", student_name: "Lucía Ferrer" },
+            { student_id: "u-012", student_name: "Marc Oliver" },
+            { student_id: "u-013", student_name: "Nadia Rahmani" },
+            { student_id: "u-014", student_name: "Oscar Peña" },
+          ],
+        },
+      },
+    ],
+  },
 ];
 
 /** Look a demo up by tool name. */

--- a/mcp-server/src/env.ts
+++ b/mcp-server/src/env.ts
@@ -41,6 +41,24 @@ export function getServiceRoleKey(): string | undefined {
   return process.env.SUPABASE_SERVICE_ROLE_KEY || undefined;
 }
 
+/**
+ * Root domain the LMS tenants are served under (e.g. `lmsplatform.com`, or
+ * `lvh.me:3000` locally). Optional.
+ *
+ * Only used to build shareable absolute URLs for things a widget links out to —
+ * today the public certificate verification page,
+ * `https://<tenant-slug>.<domain>/verify/<code>`. A tenant with its own
+ * `tenants.domain` wins over this. When neither is known the widget shows the
+ * verification code alone rather than an unclickable guess.
+ */
+export function getPlatformDomain(): string | undefined {
+  const raw =
+    process.env.LMS_PLATFORM_DOMAIN ||
+    process.env.NEXT_PUBLIC_PLATFORM_DOMAIN ||
+    undefined;
+  return raw?.trim().replace(/^https?:\/\//, "").replace(/\/$/, "") || undefined;
+}
+
 /** Whether JWTs should be cryptographically verified (disable only in local dev). */
 export function shouldVerifyJwt(): boolean {
   return process.env.NODE_ENV === "production";

--- a/mcp-server/src/tool-policy.ts
+++ b/mcp-server/src/tool-policy.ts
@@ -68,12 +68,23 @@ const STUDENT_TOOLS = new Set<string>([
   "lms_get_study_plan",
   "lms_complete_study_goal",
   "lms_ask_teacher",
+  // Certificates — self-scoped. `lms_issue_certificate` writes, but only ever
+  // through `issue_certificate_if_eligible`, which re-checks the course's
+  // template criteria in the database; a student naming someone else's
+  // student_id is refused in the handler.
+  "lms_my_certificates",
+  "lms_get_certificate_eligibility",
+  "lms_issue_certificate",
 ]);
 
 const TEACHER_DENY_TOOLS = new Set<string>([
   // Destructive — admin only. Analytics tools stay allowed for teachers because
   // they are ownership-scoped (a teacher only ever sees their own courses' data).
   "lms_archive_course",
+  // Revoking a credential a student already holds is destructive and public
+  // (the verify page flips to "revoked"), so it follows lms_archive_course.
+  // Teachers keep every other certificate tool for their own courses.
+  "lms_revoke_certificate",
   // School-wide cross-course aggregate — admin only. A teacher would see only a
   // partial "school" (their own courses via RLS), which is misleading; the
   // per-course tools (lms_get_course_stats, lms_get_student_progress) cover them.

--- a/mcp-server/src/tools/certificates.test.ts
+++ b/mcp-server/src/tools/certificates.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest";
+import {
+  certificateStatus,
+  describeEligibility,
+  originForHost,
+  verifyUrlFor,
+} from "./certificates.js";
+
+/**
+ * Unit tests for the pure helpers behind the certificate tools. The Supabase
+ * calls themselves are covered by RLS and the `issue_certificate_if_eligible`
+ * function; what is worth pinning here is the shaping the widgets depend on.
+ */
+
+const NOW = new Date("2026-07-29T12:00:00.000Z");
+
+describe("certificateStatus", () => {
+  it("is valid when there is no expiry and no revocation", () => {
+    expect(certificateStatus({ revoked_at: null, expires_at: null }, NOW)).toBe("valid");
+  });
+
+  it("is valid when the expiry is still in the future", () => {
+    expect(
+      certificateStatus({ revoked_at: null, expires_at: "2027-01-01T00:00:00Z" }, NOW)
+    ).toBe("valid");
+  });
+
+  it("is expired once a non-null expiry has passed", () => {
+    expect(
+      certificateStatus({ revoked_at: null, expires_at: "2026-02-02T09:00:00Z" }, NOW)
+    ).toBe("expired");
+  });
+
+  it("revoked wins over expired", () => {
+    expect(
+      certificateStatus(
+        { revoked_at: "2026-03-01T00:00:00Z", expires_at: "2026-02-02T00:00:00Z" },
+        NOW
+      )
+    ).toBe("revoked");
+  });
+});
+
+describe("originForHost", () => {
+  it("uses https for real domains", () => {
+    expect(originForHost("code-academy.lmsplatform.com")).toBe(
+      "https://code-academy.lmsplatform.com"
+    );
+  });
+
+  it("uses http for the lvh.me / localhost dev hosts, port included", () => {
+    expect(originForHost("default.lvh.me:3000")).toBe("http://default.lvh.me:3000");
+    expect(originForHost("localhost:3000")).toBe("http://localhost:3000");
+  });
+});
+
+describe("verifyUrlFor", () => {
+  it("builds the public verify path", () => {
+    expect(verifyUrlFor("https://school.example.com", "ABC123")).toBe(
+      "https://school.example.com/verify/ABC123"
+    );
+  });
+
+  it("returns null when the origin or the code is unknown", () => {
+    expect(verifyUrlFor(null, "ABC123")).toBeNull();
+    expect(verifyUrlFor("https://school.example.com", null)).toBeNull();
+  });
+});
+
+describe("describeEligibility", () => {
+  it("reports an already-issued certificate with its id", () => {
+    const out = describeEligibility({
+      success: false,
+      reason: "Certificate already issued",
+      certificateId: "cert-1",
+    });
+    expect(out).toContain("already issued");
+    expect(out).toContain("cert-1");
+  });
+
+  it("names the missing criteria when the student falls short", () => {
+    const out = describeEligibility({
+      success: false,
+      reason: "Not eligible for certificate",
+      completion: {
+        eligible: false,
+        completedLessons: 14,
+        totalLessons: 22,
+        submittedExams: 2,
+        totalExams: 3,
+        averageExamScore: 64,
+        criteria: { minLessonCompletionPct: 100, minExamPassScore: 70 },
+      },
+    });
+    expect(out).toContain("lessons 14/22");
+    expect(out).toContain("needs 100%");
+    expect(out).toContain("exams 2/3");
+    expect(out).toContain("avg score 64");
+  });
+
+  it("passes the no-template refusal through verbatim — it is the fixable one", () => {
+    // `calculate_course_completion` collapses a missing template into a plain
+    // not-eligible with this reason and no completion figures at all.
+    const out = describeEligibility({
+      eligible: false,
+      reason: "No active certificate template for this course",
+    });
+    expect(out).toBe("No active certificate template for this course.");
+  });
+
+  it("says eligible when the RPC reports success", () => {
+    expect(
+      describeEligibility({ success: true, eligible: true, completion: { eligible: true } })
+    ).toContain("Eligible");
+  });
+
+  it("degrades gracefully on a null result", () => {
+    expect(describeEligibility(null)).toContain("could not be determined");
+  });
+});

--- a/mcp-server/src/tools/certificates.ts
+++ b/mcp-server/src/tools/certificates.ts
@@ -1,0 +1,981 @@
+import { z } from "zod";
+import type { MCPServer } from "mcp-use/server";
+import { widget, text } from "mcp-use/server";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { LmsSession } from "../session.js";
+import { ok, okText, errorResult } from "../format.js";
+import { getPlatformDomain } from "../env.js";
+
+/**
+ * Certificate tools — the credential half of the LMS, which had no MCP surface
+ * at all until now (the web app has had one since `20260216000100`).
+ *
+ * ── WHY THESE GUARD MORE THAN RLS DOES ─────────────────────────────────────
+ * The `certificates` policies are unusually loose for this codebase, and the
+ * tools here must not lean on them:
+ *
+ *   - SELECT for staff is `user_roles.role IN ('teacher','admin') OR
+ *     courses.author_id = auth.uid()` — an OR, with **no tenant predicate**.
+ *     Any teacher can therefore read any tenant's certificates as far as
+ *     Postgres is concerned.
+ *   - UPDATE (the revoke path) has the same shape.
+ *   - INSERT is `user_id = auth.uid() OR <is staff> OR <is author>`, so a
+ *     student can technically mint their own row.
+ *
+ * So every read below carries an explicit `.eq("tenant_id", …)`, and every
+ * course-scoped tool runs `verifyCourseOwnership` (staff) or
+ * `verifyCourseAccess` (learner) first. Issuance never inserts directly: it
+ * calls `issue_certificate_if_eligible`, the SECURITY DEFINER function the
+ * lesson/exam triggers use, which re-checks the template criteria server-side.
+ * That keeps "who may hold this credential" a database decision rather than
+ * something an MCP client can assert.
+ *
+ * ── THE TEMPLATE GATE ──────────────────────────────────────────────────────
+ * `calculate_course_completion` returns `eligible: false, reason: "No active
+ * certificate template for this course"` when the course has no active
+ * `certificate_templates` row, and `issue_certificate_if_eligible` refuses on
+ * the same condition. A course with no template issues nothing, ever, however
+ * complete the student is — which is the single most common "why did nobody
+ * get a certificate?" answer. `lms_get_certificate_template` /
+ * `lms_set_certificate_template` exist so an agent can see and fix that.
+ */
+
+// ── Tenant verify-page origin ───────────────────────────────────────────────
+
+/**
+ * Public origin the school's certificates verify under.
+ *
+ * A certificate is only useful if the holder can hand someone a link, and the
+ * verify page (`/verify/<code>`) is public. The MCP server has no idea what
+ * host it is fronted by, so the origin is derived the same way the app routes
+ * tenants: a custom `tenants.domain` if the school has one, otherwise
+ * `<slug>.<platform domain>`. With neither configured we return `null` and the
+ * widgets show the bare verification code — an unclickable guessed URL is
+ * worse than no URL.
+ */
+const VERIFY_BASE_TTL_MS = 5 * 60 * 1000;
+const verifyBaseCache = new Map<string, { at: number; value: string | null }>();
+
+/** Local hosts are served over http; everything else is https. */
+export function originForHost(host: string): string {
+  const scheme = /^(localhost|127\.0\.0\.1|([\w-]+\.)*lvh\.me)(:\d+)?$/i.test(host)
+    ? "http"
+    : "https";
+  return `${scheme}://${host}`;
+}
+
+/** `<origin>/verify/<code>`, or null when we don't know the origin. */
+export function verifyUrlFor(base: string | null, code: string | null | undefined): string | null {
+  if (!base || !code) return null;
+  return `${base}/verify/${encodeURIComponent(code)}`;
+}
+
+async function getVerifyBase(session: LmsSession): Promise<string | null> {
+  const tenantId = session.getTenantId();
+  const hit = verifyBaseCache.get(tenantId);
+  if (hit && Date.now() - hit.at < VERIFY_BASE_TTL_MS) return hit.value;
+
+  let value: string | null = null;
+  try {
+    const { data } = await session
+      .getClient()
+      .from("tenants")
+      .select("slug, domain")
+      .eq("id", tenantId)
+      .maybeSingle();
+
+    const custom = (data?.domain as string | undefined)?.trim();
+    const slug = (data?.slug as string | undefined)?.trim();
+    const platform = getPlatformDomain();
+
+    if (custom) value = originForHost(custom);
+    else if (slug && platform) value = originForHost(`${slug}.${platform}`);
+  } catch {
+    // A share link is a nicety. Never fail a tool over it.
+  }
+
+  verifyBaseCache.set(tenantId, { at: Date.now(), value });
+  return value;
+}
+
+// ── Row shaping ─────────────────────────────────────────────────────────────
+
+export type CertificateStatus = "valid" | "expired" | "revoked";
+
+/**
+ * Revoked beats expired beats valid.
+ *
+ * `expires_at` is nullable and usually IS null — `certificate_templates
+ * .expiration_days` is optional, and a certificate with no expiry never
+ * expires. Only a non-null date in the past demotes a certificate.
+ */
+export function certificateStatus(
+  row: { revoked_at?: string | null; expires_at?: string | null },
+  now: Date = new Date()
+): CertificateStatus {
+  if (row.revoked_at) return "revoked";
+  if (row.expires_at && new Date(row.expires_at).getTime() < now.getTime()) return "expired";
+  return "valid";
+}
+
+/**
+ * Resolve student display names by user id.
+ *
+ * `certificates.user_id` does FK `profiles`, so a PostgREST embed would work
+ * here — but `enrollments.user_id` FKs `auth.users` and cannot be embedded, and
+ * `lms_list_course_certificates` needs names for both sets. One lookup keyed by
+ * id covers both and mirrors `fetchProfileNames` in analytics.ts.
+ */
+async function fetchProfileNames(
+  supabase: SupabaseClient,
+  userIds: (string | null | undefined)[]
+): Promise<Map<string, string>> {
+  const unique = [...new Set(userIds.filter((id): id is string => !!id))];
+  const names = new Map<string, string>();
+  if (unique.length === 0) return names;
+  const { data } = await supabase.from("profiles").select("id, full_name").in("id", unique);
+  for (const p of (data as { id: string; full_name: string | null }[] | null) ?? []) {
+    const name = p.full_name?.trim();
+    if (name) names.set(p.id, name);
+  }
+  return names;
+}
+
+/** Shape of the jsonb both certificate RPCs return. */
+interface CompletionSnapshot {
+  eligible?: boolean;
+  reason?: string;
+  completionPercentage?: number;
+  totalLessons?: number;
+  completedLessons?: number;
+  totalExams?: number;
+  submittedExams?: number;
+  averageExamScore?: number;
+  allExamsPassed?: boolean;
+  criteria?: {
+    minLessonCompletionPct?: number;
+    minExamPassScore?: number;
+    requiresAllExams?: boolean;
+  };
+}
+interface EligibilityResult {
+  success?: boolean;
+  eligible?: boolean;
+  reason?: string;
+  message?: string;
+  certificateId?: string;
+  verificationCode?: string;
+  completion?: CompletionSnapshot;
+}
+
+/**
+ * One-line human summary of an eligibility result.
+ *
+ * Exported for tests: the branch that matters is "eligible but no template",
+ * which reads as a hard `false` from the RPC and is the only one an agent can
+ * actually fix.
+ */
+export function describeEligibility(result: EligibilityResult | null): string {
+  if (!result) return "Eligibility could not be determined.";
+  if (result.certificateId && result.reason) {
+    return `${result.reason} (certificate ${result.certificateId}).`;
+  }
+  const c = result.completion ?? {};
+  const eligible = result.success === true || result.eligible === true || c.eligible === true;
+  if (eligible) return "Eligible — a certificate can be issued now.";
+
+  const reason = result.reason ?? c.reason ?? "Not eligible yet";
+  const parts: string[] = [];
+  if (typeof c.completedLessons === "number" && typeof c.totalLessons === "number") {
+    parts.push(
+      `lessons ${c.completedLessons}/${c.totalLessons}` +
+        (typeof c.criteria?.minLessonCompletionPct === "number"
+          ? ` (needs ${c.criteria.minLessonCompletionPct}%)`
+          : "")
+    );
+  }
+  if (typeof c.submittedExams === "number" && typeof c.totalExams === "number") {
+    parts.push(`exams ${c.submittedExams}/${c.totalExams}`);
+  }
+  if (typeof c.averageExamScore === "number" && c.totalExams) {
+    parts.push(
+      `avg score ${c.averageExamScore}` +
+        (typeof c.criteria?.minExamPassScore === "number"
+          ? ` (needs ${c.criteria.minExamPassScore})`
+          : "")
+    );
+  }
+  return parts.length > 0 ? `${reason}: ${parts.join(", ")}.` : `${reason}.`;
+}
+
+// ── Shared guards ───────────────────────────────────────────────────────────
+
+/**
+ * Resolve which student a tool is acting on.
+ *
+ * Omitting `student_id` always means "me". Naming someone else is a staff
+ * action: it requires teacher/admin plus ownership of the course, which is what
+ * stops a student passing a classmate's id. A learner acting on themselves must
+ * still hold course access (`entitlements`, via `has_course_access`) — an
+ * `enrollments` row is not an access grant (#543).
+ */
+async function resolveTargetStudent(
+  session: LmsSession,
+  courseId: number,
+  studentId: string | undefined
+): Promise<string> {
+  const callerId = session.getUserId();
+  const target = studentId?.trim() || callerId;
+
+  if (target === callerId) {
+    await session.verifyCourseAccess(courseId);
+    return target;
+  }
+
+  if (session.getRole() === "student") {
+    throw new Error(
+      "Students can only act on their own certificates. Omit student_id."
+    );
+  }
+  await session.verifyCourseOwnership(courseId);
+  return target;
+}
+
+export function registerCertificateTools(server: MCPServer) {
+  // ── lms_my_certificates ───────────────────────────────────────────────────
+  server.tool(
+    {
+      name: "lms_my_certificates",
+      description:
+        "List the caller's own course certificates: course, issue date, validity, verification code and public verify link. Includes revoked and expired ones on request.",
+      schema: z.object({
+        include_revoked: z
+          .boolean()
+          .default(false)
+          .describe("Include revoked certificates (default: only live ones)"),
+      }),
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+      widget: {
+        name: "my-certificates",
+        invoking: "Loading your certificates...",
+        invoked: "Certificates ready",
+      },
+    },
+    async (input, ctx) => {
+      let session: LmsSession;
+      try {
+        session = LmsSession.fromContext(ctx);
+      } catch (err) {
+        return errorResult(err instanceof Error ? err.message : String(err));
+      }
+
+      try {
+        const supabase = session.getClient();
+
+        let query = supabase
+          .from("certificates")
+          .select(
+            "certificate_id, course_id, verification_code, issued_at, expires_at, revoked_at, revoke_reason, pdf_url, share_count, view_count, courses(title)"
+          )
+          .eq("user_id", session.getUserId())
+          .eq("tenant_id", session.getTenantId())
+          .order("issued_at", { ascending: false })
+          .limit(100);
+
+        if (!input.include_revoked) query = query.is("revoked_at", null);
+
+        const { data, error } = await query;
+        if (error) return errorResult(`Loading certificates: ${error.message}`);
+
+        const base = await getVerifyBase(session);
+        const certificates = (data ?? []).map((row) => {
+          const course = row.courses as unknown as { title: string } | null;
+          return {
+            certificate_id: row.certificate_id as string,
+            course_id: (row.course_id as number | null) ?? null,
+            course_title: course?.title ?? null,
+            verification_code: row.verification_code as string,
+            verify_url: verifyUrlFor(base, row.verification_code as string),
+            pdf_url: (row.pdf_url as string | null) ?? null,
+            issued_at: (row.issued_at as string | null) ?? null,
+            expires_at: (row.expires_at as string | null) ?? null,
+            revoked_at: (row.revoked_at as string | null) ?? null,
+            revoke_reason: (row.revoke_reason as string | null) ?? null,
+            status: certificateStatus(row as { revoked_at?: string | null; expires_at?: string | null }),
+            share_count: (row.share_count as number | null) ?? 0,
+            view_count: (row.view_count as number | null) ?? 0,
+          };
+        });
+
+        const valid = certificates.filter((c) => c.status === "valid").length;
+
+        return widget({
+          props: { total: certificates.length, valid, certificates },
+          output: text(
+            certificates.length === 0
+              ? "You have no certificates yet. Finish a course's lessons and exams, then check lms_get_certificate_eligibility for what's still missing."
+              : `${certificates.length} certificate(s), ${valid} currently valid.`
+          ),
+        });
+      } catch (err) {
+        return errorResult(err instanceof Error ? err.message : String(err));
+      }
+    }
+  );
+
+  // ── lms_get_certificate_eligibility ───────────────────────────────────────
+  server.tool(
+    {
+      name: "lms_get_certificate_eligibility",
+      description:
+        "Check whether a student has met a course's certificate criteria (lesson completion %, exam pass score, all-exams rule) and what is still missing. Defaults to the caller; teachers and admins may pass student_id for a student on a course they own.",
+      schema: z.object({
+        course_id: z.number().int().describe("The course to check"),
+        student_id: z
+          .string()
+          .uuid()
+          .optional()
+          .describe(
+            "Teacher/admin only: the student to check. Omit to check yourself."
+          ),
+      }),
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async (input, ctx) => {
+      let session: LmsSession;
+      try {
+        session = LmsSession.fromContext(ctx);
+      } catch (err) {
+        return errorResult(err instanceof Error ? err.message : String(err));
+      }
+
+      try {
+        const targetId = await resolveTargetStudent(
+          session,
+          input.course_id,
+          input.student_id
+        );
+        const supabase = session.getClient();
+
+        // Report the template gate explicitly. The RPC collapses "no template"
+        // into a generic not-eligible, which sends agents off optimising a
+        // student's completion when the actual blocker is school configuration.
+        const { data: template } = await supabase
+          .from("certificate_templates")
+          .select("template_id, template_name, is_active")
+          .eq("course_id", input.course_id)
+          .eq("tenant_id", session.getTenantId())
+          .maybeSingle();
+
+        const templateActive = !!template && template.is_active !== false;
+
+        const { data, error } = await supabase.rpc("check_and_issue_certificate", {
+          p_user_id: targetId,
+          p_course_id: input.course_id,
+        });
+        if (error) return errorResult(`Checking eligibility: ${error.message}`);
+
+        const result = (data ?? null) as EligibilityResult | null;
+        const completion = result?.completion ?? {};
+        const alreadyIssued = !!result?.certificateId;
+        const eligible =
+          !alreadyIssued && templateActive && (result?.success === true || result?.eligible === true);
+
+        const summary = !templateActive
+          ? `Course ${input.course_id} has no active certificate template, so nothing can be issued. Create one with lms_set_certificate_template.`
+          : describeEligibility(result);
+
+        return ok(
+          {
+            course_id: input.course_id,
+            student_id: targetId,
+            eligible,
+            already_issued: alreadyIssued,
+            certificate_id: result?.certificateId ?? null,
+            template_configured: templateActive,
+            template_name: template?.template_name ?? null,
+            completion,
+          },
+          summary
+        );
+      } catch (err) {
+        return errorResult(err instanceof Error ? err.message : String(err));
+      }
+    }
+  );
+
+  // ── lms_issue_certificate ─────────────────────────────────────────────────
+  server.tool(
+    {
+      name: "lms_issue_certificate",
+      description:
+        "Issue a course certificate. Criteria are re-checked in the database, so this succeeds only for a student who has genuinely met the course's template criteria; it is a no-op if one was already issued. Defaults to the caller; teachers and admins may pass student_id for a course they own.",
+      schema: z.object({
+        course_id: z.number().int().describe("The course to issue for"),
+        student_id: z
+          .string()
+          .uuid()
+          .optional()
+          .describe(
+            "Teacher/admin only: the student to issue to. Omit to issue to yourself."
+          ),
+      }),
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async (input, ctx) => {
+      let session: LmsSession;
+      try {
+        session = LmsSession.fromContext(ctx);
+      } catch (err) {
+        return errorResult(err instanceof Error ? err.message : String(err));
+      }
+
+      try {
+        const targetId = await resolveTargetStudent(
+          session,
+          input.course_id,
+          input.student_id
+        );
+
+        // SECURITY DEFINER, and the same function the lesson-completion and
+        // exam-score triggers call. It re-runs the criteria check, resolves the
+        // active template (refusing when there is none), generates the
+        // verification code and writes the credential JSON. Doing our own
+        // INSERT instead would let an MCP client mint a certificate nobody
+        // earned — the table's INSERT policy would allow it.
+        const { data, error } = await session
+          .getClient()
+          .rpc("issue_certificate_if_eligible", {
+            p_user_id: targetId,
+            p_course_id: input.course_id,
+          });
+        if (error) return errorResult(`Issuing certificate: ${error.message}`);
+
+        const result = (data ?? null) as EligibilityResult | null;
+
+        if (result?.success !== true) {
+          const reason = result?.reason ?? "Not eligible for a certificate";
+          // A refusal is a legitimate answer here, not a failure: the model
+          // should relay *why* and, when it's the template, how to fix it.
+          return okText(
+            reason.includes("template")
+              ? `${reason}. Configure one with lms_set_certificate_template (course_id ${input.course_id}); until then this course issues no certificates at all.`
+              : `Certificate not issued — ${describeEligibility(result)}`
+          );
+        }
+
+        const base = await getVerifyBase(session);
+        const code = result.verificationCode ?? null;
+
+        return ok(
+          {
+            success: true,
+            course_id: input.course_id,
+            student_id: targetId,
+            certificate_id: result.certificateId ?? null,
+            verification_code: code,
+            verify_url: verifyUrlFor(base, code),
+          },
+          `Certificate issued${code ? ` — verification code ${code}` : ""}.`
+        );
+      } catch (err) {
+        return errorResult(err instanceof Error ? err.message : String(err));
+      }
+    }
+  );
+
+  // ── lms_list_course_certificates ──────────────────────────────────────────
+  server.tool(
+    {
+      name: "lms_list_course_certificates",
+      description:
+        "Teacher/admin view of a course's certificates: the active template and its criteria, every certificate issued (student, date, code), and the enrolled students still awaiting one. Renders an interactive roster that can issue certificates.",
+      schema: z.object({
+        course_id: z.number().int().describe("The course to inspect"),
+        include_revoked: z
+          .boolean()
+          .default(false)
+          .describe("Include revoked certificates in the list"),
+      }),
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+      widget: {
+        name: "course-certificates",
+        invoking: "Loading certificates...",
+        invoked: "Certificate roster ready",
+      },
+    },
+    async (input, ctx) => {
+      let session: LmsSession;
+      try {
+        session = LmsSession.fromContext(ctx);
+      } catch (err) {
+        return errorResult(err instanceof Error ? err.message : String(err));
+      }
+
+      try {
+        await session.verifyCourseOwnership(input.course_id);
+        const supabase = session.getClient();
+        const tenantId = session.getTenantId();
+
+        const [courseRes, templateRes, certsRes, enrollmentsRes] = await Promise.all([
+          supabase
+            .from("courses")
+            .select("course_id, title")
+            .eq("course_id", input.course_id)
+            .eq("tenant_id", tenantId)
+            .maybeSingle(),
+          supabase
+            .from("certificate_templates")
+            .select(
+              "template_id, template_name, issuer_name, is_active, min_lesson_completion_pct, min_exam_pass_score, requires_all_exams, expiration_days"
+            )
+            .eq("course_id", input.course_id)
+            .eq("tenant_id", tenantId)
+            .maybeSingle(),
+          supabase
+            .from("certificates")
+            .select(
+              "certificate_id, user_id, verification_code, issued_at, expires_at, revoked_at, revoke_reason"
+            )
+            .eq("course_id", input.course_id)
+            .eq("tenant_id", tenantId)
+            .order("issued_at", { ascending: false })
+            .limit(500),
+          supabase
+            .from("enrollments")
+            .select("user_id")
+            .eq("course_id", input.course_id)
+            .eq("tenant_id", tenantId)
+            .eq("status", "active")
+            .limit(500),
+        ]);
+
+        if (certsRes.error)
+          return errorResult(`Loading certificates: ${certsRes.error.message}`);
+        if (!courseRes.data) return errorResult(`Course ${input.course_id} not found`);
+
+        const allCerts = certsRes.data ?? [];
+        const enrollments = (enrollmentsRes.data ?? []) as { user_id: string }[];
+
+        const names = await fetchProfileNames(supabase, [
+          ...allCerts.map((c) => c.user_id as string | null),
+          ...enrollments.map((e) => e.user_id),
+        ]);
+        const base = await getVerifyBase(session);
+
+        const shaped = allCerts.map((row) => ({
+          certificate_id: row.certificate_id as string,
+          student_id: (row.user_id as string | null) ?? null,
+          student_name: row.user_id ? names.get(row.user_id as string) ?? null : null,
+          verification_code: row.verification_code as string,
+          verify_url: verifyUrlFor(base, row.verification_code as string),
+          issued_at: (row.issued_at as string | null) ?? null,
+          expires_at: (row.expires_at as string | null) ?? null,
+          revoked_at: (row.revoked_at as string | null) ?? null,
+          revoke_reason: (row.revoke_reason as string | null) ?? null,
+          status: certificateStatus(row as { revoked_at?: string | null; expires_at?: string | null }),
+        }));
+
+        const revoked = shaped.filter((c) => c.status === "revoked").length;
+        const certificates = input.include_revoked
+          ? shaped
+          : shaped.filter((c) => c.status !== "revoked");
+
+        // "Awaiting" is deliberately about live certificates only: a student
+        // whose certificate was revoked is back in the queue, which is the
+        // whole point of revoking one.
+        const holders = new Set(
+          shaped.filter((c) => c.status !== "revoked").map((c) => c.student_id)
+        );
+        const awaiting = enrollments
+          .filter((e) => !holders.has(e.user_id))
+          .map((e) => ({
+            student_id: e.user_id,
+            student_name: names.get(e.user_id) ?? null,
+          }));
+
+        const t = templateRes.data;
+        const template = t
+          ? {
+              name: t.template_name as string,
+              issuer_name: (t.issuer_name as string | null) ?? null,
+              is_active: t.is_active !== false,
+              min_lesson_completion_pct: (t.min_lesson_completion_pct as number | null) ?? null,
+              min_exam_pass_score: (t.min_exam_pass_score as number | null) ?? null,
+              requires_all_exams: t.requires_all_exams === true,
+              expiration_days: (t.expiration_days as number | null) ?? null,
+            }
+          : null;
+
+        return widget({
+          props: {
+            course: {
+              id: courseRes.data.course_id as number,
+              title: courseRes.data.title as string,
+            },
+            template,
+            summary: {
+              issued: shaped.length - revoked,
+              revoked,
+              active_students: enrollments.length,
+              awaiting: awaiting.length,
+            },
+            certificates,
+            awaiting,
+          },
+          output: text(
+            !template || !template.is_active
+              ? `Course "${courseRes.data.title}" has no active certificate template, so nothing is issued automatically. ${shaped.length - revoked} certificate(s) exist. Configure the template with lms_set_certificate_template.`
+              : `${shaped.length - revoked} certificate(s) issued for "${courseRes.data.title}"; ${awaiting.length} of ${enrollments.length} active student(s) still awaiting one.`
+          ),
+        });
+      } catch (err) {
+        return errorResult(err instanceof Error ? err.message : String(err));
+      }
+    }
+  );
+
+  // ── lms_get_certificate_template ──────────────────────────────────────────
+  server.tool(
+    {
+      name: "lms_get_certificate_template",
+      description:
+        "Read a course's certificate template: the criteria that decide who earns the credential, plus issuer and design settings. A course with no active template never issues certificates.",
+      schema: z.object({
+        course_id: z.number().int().describe("The course whose template to read"),
+      }),
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async (input, ctx) => {
+      let session: LmsSession;
+      try {
+        session = LmsSession.fromContext(ctx);
+      } catch (err) {
+        return errorResult(err instanceof Error ? err.message : String(err));
+      }
+
+      try {
+        await session.verifyCourseOwnership(input.course_id);
+
+        const { data, error } = await session
+          .getClient()
+          .from("certificate_templates")
+          .select("*")
+          .eq("course_id", input.course_id)
+          .eq("tenant_id", session.getTenantId())
+          .maybeSingle();
+
+        if (error) return errorResult(`Loading template: ${error.message}`);
+
+        if (!data) {
+          return okText(
+            `Course ${input.course_id} has no certificate template. No certificate can be issued for it — automatic issuance on lesson/exam completion is template-gated. Create one with lms_set_certificate_template.`
+          );
+        }
+
+        return ok(
+          { course_id: input.course_id, template: data as Record<string, unknown> },
+          `Template "${data.template_name}"${data.is_active === false ? " (INACTIVE — issues nothing)" : ""}: needs ${data.min_lesson_completion_pct}% of lessons, ${
+            data.requires_all_exams
+              ? `every exam passed at ${data.min_exam_pass_score}+`
+              : `an average exam score of ${data.min_exam_pass_score}+`
+          }${data.expiration_days ? `, expires after ${data.expiration_days} days` : ", no expiry"}.`
+        );
+      } catch (err) {
+        return errorResult(err instanceof Error ? err.message : String(err));
+      }
+    }
+  );
+
+  // ── lms_set_certificate_template ──────────────────────────────────────────
+  server.tool(
+    {
+      name: "lms_set_certificate_template",
+      description:
+        "Create or update a course's certificate template — the criteria (lesson completion %, exam pass score, all-exams rule, expiry) plus issuer and design details. Only the fields you pass are changed. Activating a template is what enables automatic issuance for the course.",
+      schema: z.object({
+        course_id: z.number().int().describe("The course this template belongs to"),
+        template_name: z
+          .string()
+          .min(1)
+          .max(120)
+          .optional()
+          .describe("Certificate title, e.g. 'Certificate of Completion'. Required when creating."),
+        issuer_name: z
+          .string()
+          .min(1)
+          .max(120)
+          .optional()
+          .describe("Who issues it — usually the school name. Required when creating."),
+        issuer_url: z.string().url().optional().describe("Issuer website shown on the credential"),
+        description: z.string().max(2000).optional().describe("What the certificate attests to"),
+        issuance_criteria: z
+          .string()
+          .max(2000)
+          .optional()
+          .describe("Human-readable criteria printed on the credential"),
+        signature_name: z.string().max(120).optional().describe("Name on the signature line"),
+        signature_title: z.string().max(120).optional().describe("Title under the signature"),
+        logo_url: z.string().url().optional().describe("Logo shown on the certificate"),
+        min_lesson_completion_pct: z
+          .number()
+          .min(0)
+          .max(100)
+          .optional()
+          .describe("Percent of published lessons required (default 100 on create)"),
+        min_exam_pass_score: z
+          .number()
+          .min(0)
+          .max(100)
+          .optional()
+          .describe("Score required per exam, or as an average when requires_all_exams is false (default 70)"),
+        requires_all_exams: z
+          .boolean()
+          .optional()
+          .describe(
+            "true: every published exam must be submitted and pass. false: the average score is compared instead."
+          ),
+        expiration_days: z
+          .number()
+          .int()
+          .min(1)
+          .nullable()
+          .optional()
+          .describe("Days until the certificate expires. null for no expiry."),
+        is_active: z
+          .boolean()
+          .optional()
+          .describe("Deactivate to stop the course issuing certificates without deleting the template"),
+        primary_color: z
+          .string()
+          .max(32)
+          .optional()
+          .describe("Certificate primary colour, e.g. '#3B82F6'"),
+        secondary_color: z.string().max(32).optional().describe("Certificate secondary colour"),
+        show_qr_code: z
+          .boolean()
+          .optional()
+          .describe("Print a QR code linking to the public verify page"),
+      }),
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async (input, ctx) => {
+      let session: LmsSession;
+      try {
+        session = LmsSession.fromContext(ctx);
+      } catch (err) {
+        return errorResult(err instanceof Error ? err.message : String(err));
+      }
+
+      try {
+        await session.verifyCourseOwnership(input.course_id);
+        const supabase = session.getClient();
+        const tenantId = session.getTenantId();
+
+        const { data: existing } = await supabase
+          .from("certificate_templates")
+          .select("*")
+          .eq("course_id", input.course_id)
+          .eq("tenant_id", tenantId)
+          .maybeSingle();
+
+        const templateName = input.template_name ?? existing?.template_name;
+        const issuerName = input.issuer_name ?? existing?.issuer_name;
+        if (!templateName || !issuerName) {
+          return errorResult(
+            "Creating a certificate template needs at least template_name and issuer_name."
+          );
+        }
+
+        // Read-merge-write rather than a bare upsert: PostgREST's ON CONFLICT
+        // updates exactly the columns in the payload, so a partial call would
+        // otherwise be indistinguishable from a full one on insert and would
+        // reset the design blob (a jsonb column, replaced wholesale) on update.
+        const design = {
+          ...((existing?.design_settings as Record<string, unknown> | null) ?? {}),
+          ...(input.primary_color !== undefined ? { primary_color: input.primary_color } : {}),
+          ...(input.secondary_color !== undefined ? { secondary_color: input.secondary_color } : {}),
+          ...(input.show_qr_code !== undefined ? { show_qr_code: input.show_qr_code } : {}),
+          ...(input.logo_url !== undefined ? { logo_url: input.logo_url } : {}),
+        };
+
+        const pick = <T>(next: T | undefined, prev: T | null | undefined, fallback: T): T =>
+          next !== undefined ? next : (prev ?? fallback);
+
+        const payload = {
+          course_id: input.course_id,
+          tenant_id: tenantId,
+          template_name: templateName,
+          issuer_name: issuerName,
+          issuer_url: pick(input.issuer_url, existing?.issuer_url, ""),
+          description: pick(input.description, existing?.description, ""),
+          issuance_criteria: pick(input.issuance_criteria, existing?.issuance_criteria, ""),
+          signature_name: pick(input.signature_name, existing?.signature_name, ""),
+          signature_title: pick(input.signature_title, existing?.signature_title, ""),
+          logo_url: pick(input.logo_url, existing?.logo_url, ""),
+          min_lesson_completion_pct: pick(
+            input.min_lesson_completion_pct,
+            existing?.min_lesson_completion_pct,
+            100
+          ),
+          min_exam_pass_score: pick(
+            input.min_exam_pass_score,
+            existing?.min_exam_pass_score,
+            70
+          ),
+          requires_all_exams: pick(
+            input.requires_all_exams,
+            existing?.requires_all_exams,
+            false
+          ),
+          // Distinct from the others: `null` is a meaningful value (no expiry),
+          // so only `undefined` falls back to what is already stored.
+          expiration_days:
+            input.expiration_days !== undefined
+              ? input.expiration_days
+              : (existing?.expiration_days ?? null),
+          is_active: pick(input.is_active, existing?.is_active, true),
+          design_settings: design,
+          updated_at: new Date().toISOString(),
+          ...(existing ? {} : { created_by: session.getUserId() }),
+        };
+
+        const { data, error } = await supabase
+          .from("certificate_templates")
+          .upsert(payload, { onConflict: "course_id,tenant_id" })
+          .select(
+            "template_id, template_name, is_active, min_lesson_completion_pct, min_exam_pass_score, requires_all_exams, expiration_days"
+          )
+          .single();
+
+        if (error) return errorResult(`Saving template: ${error.message}`);
+
+        return ok(
+          { course_id: input.course_id, created: !existing, template: data as Record<string, unknown> },
+          `${existing ? "Updated" : "Created"} certificate template "${data.template_name}" for course ${input.course_id}${
+            data.is_active === false
+              ? " (inactive — it issues nothing until is_active is true)"
+              : ""
+          }. Criteria: ${data.min_lesson_completion_pct}% of lessons, ${
+            data.requires_all_exams
+              ? `every exam passed at ${data.min_exam_pass_score}+`
+              : `average exam score ${data.min_exam_pass_score}+`
+          }.`
+        );
+      } catch (err) {
+        return errorResult(err instanceof Error ? err.message : String(err));
+      }
+    }
+  );
+
+  // ── lms_revoke_certificate ────────────────────────────────────────────────
+  server.tool(
+    {
+      name: "lms_revoke_certificate",
+      description:
+        "Revoke an issued certificate with a reason. The credential stays on record but verifies as revoked on the public page, and the student re-enters the awaiting list. Admin only.",
+      schema: z.object({
+        certificate_id: z.string().uuid().describe("The certificate to revoke"),
+        reason: z
+          .string()
+          .min(3)
+          .max(500)
+          .describe("Why it is being revoked — shown on the public verification page"),
+      }),
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async (input, ctx) => {
+      let session: LmsSession;
+      try {
+        session = LmsSession.fromContext(ctx);
+      } catch (err) {
+        return errorResult(err instanceof Error ? err.message : String(err));
+      }
+
+      try {
+        const supabase = session.getClient();
+
+        const { data: cert, error: loadError } = await supabase
+          .from("certificates")
+          .select("certificate_id, course_id, tenant_id, user_id, revoked_at")
+          .eq("certificate_id", input.certificate_id)
+          .maybeSingle();
+
+        if (loadError) return errorResult(`Loading certificate: ${loadError.message}`);
+        // The SELECT policy for staff carries no tenant predicate, so this
+        // check is the one that actually keeps revocation inside the school.
+        if (!cert || cert.tenant_id !== session.getTenantId()) {
+          return errorResult(`Certificate ${input.certificate_id} not found`);
+        }
+        if (cert.revoked_at) {
+          return okText(
+            `Certificate ${input.certificate_id} was already revoked on ${cert.revoked_at}.`
+          );
+        }
+        if (cert.course_id) await session.verifyCourseOwnership(cert.course_id as number);
+
+        const revokedAt = new Date().toISOString();
+        const { error } = await supabase
+          .from("certificates")
+          .update({
+            revoked_at: revokedAt,
+            revoke_reason: input.reason,
+            revoked_by: session.getUserId(),
+            updated_at: revokedAt,
+          })
+          .eq("certificate_id", input.certificate_id)
+          .eq("tenant_id", session.getTenantId());
+
+        if (error) return errorResult(`Revoking certificate: ${error.message}`);
+
+        return ok(
+          {
+            certificate_id: input.certificate_id,
+            course_id: cert.course_id ?? null,
+            student_id: cert.user_id ?? null,
+            revoked_at: revokedAt,
+            reason: input.reason,
+          },
+          `Certificate ${input.certificate_id} revoked: ${input.reason}`
+        );
+      } catch (err) {
+        return errorResult(err instanceof Error ? err.message : String(err));
+      }
+    }
+  );
+}


### PR DESCRIPTION
## What

Adds a certificate surface to the MCP server: seven `lms_*` tools and two MCP App widgets covering what the web app has had since migration `20260216000100`. Certificates were the one major LMS domain with no MCP coverage at all — an agent could read courses, lessons, exams, analytics, gamification and landing pages, but could not tell a student whether they had earned a credential, nor a teacher why nobody in their course had one.

No linked issue — this gap was found while auditing MCP coverage, not filed in advance.

| Tool | Who | What it does |
| --- | --- | --- |
| `lms_my_certificates` | student | The caller's own credentials (widget) |
| `lms_get_certificate_eligibility` | student; staff may pass `student_id` | Criteria met vs. still missing |
| `lms_issue_certificate` | student for self; staff for owned courses | Issue via the eligibility RPC |
| `lms_list_course_certificates` | teacher/admin | Course roster + template (widget) |
| `lms_get_certificate_template` | teacher/admin | Read the criteria |
| `lms_set_certificate_template` | teacher/admin | Create/update the criteria |
| `lms_revoke_certificate` | **admin only** | Revoke with a reason |

Server inventory goes from 84 tools / 19 widgets to **91 tools / 21 widgets**; the student tier grows from 27 to 30 self-scoped tools.

## Why

Two problems, both invisible from an MCP client until now.

**1. Nobody could answer "where is my certificate?".** Issuance is driven by triggers on lesson completion and exam scoring, so when it silently does not happen there is no surface that says why. `lms_get_certificate_eligibility` reports the criteria against the student's actual completion, and `lms_my_certificates` shows what they hold, with the public verify link.

**2. The template gate is the usual culprit and it was unreportable.** A course with no active `certificate_templates` row issues nothing, whatever a student has completed — `issue_certificate_if_eligible` refuses outright, and `calculate_course_completion` collapses the same condition into a generic "not eligible", which sends you off optimising the student instead of fixing the school's configuration. The eligibility tool, the issue refusal and the roster widget's banner all name it explicitly and point at `lms_set_certificate_template`.

**Security shape.** The `certificates` policies are looser than the rest of this codebase and the tools deliberately do not lean on them: staff SELECT and UPDATE are `user_roles teacher/admin OR courses.author_id = auth.uid()` with **no tenant predicate**, and INSERT permits `user_id = auth.uid()`. So every read here carries an explicit `.eq('tenant_id', …)`, every course-scoped tool runs `verifyCourseOwnership` (staff) or `verifyCourseAccess` (learner) first, and issuance never inserts a row — it calls `issue_certificate_if_eligible`, the SECURITY DEFINER function the triggers already use, so the criteria are re-checked in the database rather than asserted by an MCP client. Revocation is admin-only, following the `lms_archive_course` precedent for destructive operations.

## How to QA

Two halves: the widgets render offline from fixtures, the tools need a login. On a fresh `npm run db:reset`:

1. **Widgets, no database and no login.** `cd mcp-server && MCP_DEMO_WIDGETS=1 npm run dev`, open the inspector, and execute `lms_demo_my_certificates` (variants `default`, `empty`) and `lms_demo_course_certificates` (variants `default`, `no-template`). Add `lang=es` and `brand=ocean` to check the Spanish strings and tenant theming. In the `no-template` variant the amber banner appears and every **Issue** button is disabled — nothing could be issued, so offering the action would lie.
2. **The template gate, in SQL.** `docker exec -i supabase_db_lms-front psql -U postgres -d postgres -c "select public.check_and_issue_certificate('a1000000-0000-0000-0000-000000000001', 1001);"` — with no template seeded it returns not-eligible. That is the state `lms_get_certificate_eligibility` now explains instead of repeating.
3. **End to end as a teacher/admin.** Connect an MCP client as `owner@e2etest.com` (Default School), then: `lms_get_certificate_template` for course 1001 → "no template"; `lms_set_certificate_template` with `template_name`, `issuer_name` and `min_lesson_completion_pct: 100`; `lms_list_course_certificates` → template card, empty issued table, both enrolled students under "Awaiting"; press **Issue** on the student → the refusal names the missing lessons.
4. **End to end as the student.** As `student@e2etest.com`, complete both lessons of course 1001 (`lms_complete_lesson` for 1001 and 1002). The trigger issues the certificate on the last completion, so `lms_my_certificates` shows it with a verification code, and `lms_issue_certificate` correctly answers "Certificate already issued".
5. **Revocation and its blast radius.** As the admin, `lms_revoke_certificate` with a reason → the student's card flips to a red **Revoked** pill carrying that reason, and the student reappears in the teacher's "Awaiting" list. Confirm a student cannot undo it: the RLS UPDATE policy matches no row for them.
6. **Tenant isolation.** As `creator@codeacademy.com` (Code Academy), `lms_list_course_certificates` for course 1001 must fail with "not found" — a different tenant's course, even though the raw `certificates` policies would permit the read.

Set `LMS_PLATFORM_DOMAIN=lvh.me:3000` in `mcp-server/.env` to see verification codes become clickable `/verify/<code>` links; without it the widgets show the bare code, by design.

## Screenshots / GIF

**`my-certificates`** — valid, expired and revoked in one list; a certificate whose course was deleted (`course_id` is ON DELETE SET NULL) still verifies, so it renders without a course name rather than being hidden.

![my-certificates, light](https://raw.githubusercontent.com/guillermoscript/lms-front/185665267cf308f92e56f38e668e5e5e2d44524f/docs/images/mcp-certificates/my-certificates-light.png)

**`course-certificates`** — template criteria, issued roster and the per-student Issue action.

![course-certificates, light](https://raw.githubusercontent.com/guillermoscript/lms-front/185665267cf308f92e56f38e668e5e5e2d44524f/docs/images/mcp-certificates/course-certificates-light.png)

![course-certificates, dark](https://raw.githubusercontent.com/guillermoscript/lms-front/185665267cf308f92e56f38e668e5e5e2d44524f/docs/images/mcp-certificates/course-certificates-dark.png)

**The state this PR exists for** — no active template, in Spanish: the banner explains it and the Issue buttons are disabled.

![course-certificates, no template, Spanish](https://raw.githubusercontent.com/guillermoscript/lms-front/185665267cf308f92e56f38e668e5e5e2d44524f/docs/images/mcp-certificates/course-certificates-no-template-es.png)

**Empty state**, Spanish, dark:

![my-certificates, empty, Spanish](https://raw.githubusercontent.com/guillermoscript/lms-front/185665267cf308f92e56f38e668e5e5e2d44524f/docs/images/mcp-certificates/my-certificates-empty-es-dark.png)

## Checklist

- [x] `npm run typecheck` and `npm run test:unit` pass — root: clean, 54 files / 675 tests. `mcp-server`: `npm test` 6 files / 79 tests (13 new in `src/tools/certificates.test.ts`), `npm run build` clean with its own type-check step, reporting 91 tools and 21 widgets built.
- [x] `npm run build` passes — `mcp-server`'s build is the one this change affects; the Next.js app is untouched by this PR and its type-check passes above.
- [x] Every new tenant-scoped query filters by `tenant_id` (or the table genuinely has no such column) — deliberately belt-and-braces here, since the `certificates` policies carry no tenant predicate of their own.
- [x] Tested with every relevant role (student / teacher / admin) — verified against local Postgres under simulated JWT claims: template creation as admin, not-eligible before completion, auto-issue on the last lesson, student read, admin revoke, and a student's attempt to un-revoke matching zero rows.
- [x] Loading and error states handled — both widgets have pending, empty and error branches; the roster surfaces the tool's own refusal text per row rather than a generic failure.
- [ ] New UI strings added to both `messages/en.json` and `messages/es.json` — not applicable: widgets render in a host iframe that never sees next-intl, so their strings live in per-widget `STRINGS` tables (`resources/shared/i18n.tsx`). Both languages are provided and screenshotted.
- [ ] Migration (if any) applies cleanly — no migration; this reuses the existing certificate schema and RPCs untouched.

### Follow-up worth filing separately

The `certificates` RLS policies themselves are worth tightening: no tenant predicate on the staff SELECT/UPDATE policies, and an INSERT policy that lets a user write their own row. This PR guards around them in application code rather than changing policies mid-feature, but the database-level fix belongs in its own PR alongside the app's `/api/certificates/*` routes, which have the same exposure.
