### PR TITLE
test(e2e): fix stale sign-up spec, add name coverage, park hidden-referrals tests

### DIFF
--- a/tests/playwright/auth-security.spec.ts
+++ b/tests/playwright/auth-security.spec.ts
@@ -23,10 +23,37 @@ test.describe('Authentication Security', () => {
   test('sign-up page accessible with form fields', async ({ page }) => {
     await page.goto(`${BASE}/en/auth/sign-up`)
     await expect(page.getByTestId('signup-title')).toBeVisible()
+    await expect(page.getByTestId('signup-name')).toBeVisible()
     await expect(page.getByTestId('signup-email')).toBeVisible()
     await expect(page.getByTestId('signup-password')).toBeVisible()
-    await expect(page.getByTestId('signup-repeat-password')).toBeVisible()
     await expect(page.getByTestId('signup-submit')).toBeVisible()
+  })
+
+  test('sign-up requires a full name', async ({ page }) => {
+    await page.goto(`${BASE}/en/auth/sign-up`)
+    await page.getByTestId('signup-email').fill(`e2e-noname-${Date.now()}@e2etest.com`)
+    await page.getByTestId('signup-password').fill('password123')
+    await page.getByTestId('signup-submit').click()
+    // HTML5 `required` blocks submission — still on sign-up, name flagged invalid
+    await expect(page).toHaveURL(/\/auth\/sign-up/)
+    const nameMissing = await page
+      .getByTestId('signup-name')
+      .evaluate((el) => (el as HTMLInputElement).validity.valueMissing)
+    expect(nameMissing).toBe(true)
+  })
+
+  test('sign-up with full name reaches success page', async ({ page }) => {
+    // Guards #590: signing up without a name made students read as "Unknown Student".
+    // Local GoTrue autoconfirms (enable_confirmations = false), so a successful
+    // sign-up lands on /auth/sign-up-success.
+    await page.goto(`${BASE}/en/auth/sign-up`)
+    await page.getByTestId('signup-name').fill('E2E Signup Tester')
+    await page.getByTestId('signup-email').fill(`e2e-signup-${Date.now()}@e2etest.com`)
+    await page.getByTestId('signup-password').fill('password123')
+    await page.getByTestId('signup-submit').click()
+    // A confirmed sign-up either shows the success page or — since the new user
+    // has a session but no tenant membership — gets proxied to /join-school.
+    await page.waitForURL(/\/auth\/sign-up-success|\/join-school/, { timeout: 20_000 })
   })
 
   // ─── Route Guards — Unauthenticated ──────────────────────────────────────

--- a/tests/playwright/platform-panel.spec.ts
+++ b/tests/playwright/platform-panel.spec.ts
@@ -345,7 +345,20 @@ test.describe('Platform Plans', () => {
 // Platform Referrals
 // ─────────────────────────────────────────────────────────────
 
-test.describe('Platform Referrals', () => {
+// While the referral program is hidden, the route must redirect — not 404 or
+// render the dead page (see app/[locale]/platform/referrals/page.tsx).
+test.describe('Platform Referrals (hidden)', () => {
+  test('referrals page redirects to platform overview while hidden', async ({ page }) => {
+    await loginAsSuperAdmin(page)
+    await page.goto(`${PLATFORM_BASE}/referrals`)
+    await page.waitForURL(/\/platform(?!\/referrals)/, { timeout: 10_000 })
+    expect(page.url()).not.toContain('/referrals')
+  })
+})
+
+// Skipped: /platform/referrals redirects to /platform until the referral schema
+// lands (see app/[locale]/platform/referrals/page.tsx) — unskip when restored.
+test.describe.skip('Platform Referrals', () => {
   test.beforeEach(async ({ page }) => {
     await loginAsSuperAdmin(page)
     await page.goto(`${PLATFORM_BASE}/referrals`)

--- a/tests/playwright/specs/auth-security.spec.md
+++ b/tests/playwright/specs/auth-security.spec.md
@@ -42,10 +42,12 @@ Password for all: `password123`
 | # | Test | Selector | Expected |
 |---|------|----------|----------|
 | 2.1 | Sign-up title visible | `[data-testid="signup-title"]` | visible |
-| 2.2 | Email input visible | `[data-testid="signup-email"]` | visible |
-| 2.3 | Password input visible | `[data-testid="signup-password"]` | visible |
-| 2.4 | Repeat password input visible | `[data-testid="signup-repeat-password"]` | visible |
+| 2.2 | Full name input visible | `[data-testid="signup-name"]` | visible |
+| 2.3 | Email input visible | `[data-testid="signup-email"]` | visible |
+| 2.4 | Password input visible | `[data-testid="signup-password"]` | visible |
 | 2.5 | Submit button visible | `[data-testid="signup-submit"]` | visible |
+| 2.6 | Full name is required | submit without name | stays on sign-up; `signup-name` fails `validity.valueMissing` |
+| 2.7 | Sign-up with name succeeds | fill name/email/password; submit | lands on `/auth/sign-up-success` or `/join-school` (guards #590 "Unknown Student") |
 
 ---
 

--- a/tests/playwright/specs/platform-panel.spec.md
+++ b/tests/playwright/specs/platform-panel.spec.md
@@ -85,6 +85,8 @@ Precondition: logged in as super admin; navigated to PLATFORM_BASE/plans.
 
 ### Platform Referrals (P1)
 
+**Currently skipped:** `/platform/referrals` redirects to `/platform` until the referral schema lands (see `app/[locale]/platform/referrals/page.tsx`). One active guard test asserts the redirect. Unskip the block when the page is restored.
+
 Precondition: logged in as super admin; navigated to PLATFORM_BASE/referrals.
 
 | # | Test | Assertions | Selectors |


### PR DESCRIPTION
## Summary
E2E maintenance surfaced while runtime-verifying the dependency upgrades (#593):

- **auth-security.spec.ts** — `signup-repeat-password` has not existed since #590 reworked the sign-up form (repeat-password field removed, full-name field added), so the test failed on every run. Now asserts `signup-name` instead, plus two new tests guarding #590's actual intent (students showing as "Unknown Student"):
  - *sign-up requires a full name* — submit without a name stays on the form with `validity.valueMissing` on the name input
  - *sign-up with full name reaches success page* — full flow with a unique email; accepts `/auth/sign-up-success` **or** `/join-school` (a fresh session with no tenant membership gets proxied to join-school — correct behavior)
- **platform-panel.spec.ts** — the *Platform Referrals* block waits for `platform-referrals-page`, but that page deliberately redirects until the referral schema lands. Block is now `describe.skip` with a pointer, and a new active guard asserts the hidden route redirects instead of 404ing/rendering.
- Companion `specs/*.spec.md` docs updated.

A full testid audit across all 38 spec files found no other stale selectors (several suspects turned out to be dynamic: `billing-tab-${value}`, `metric-${slug}`, conditional `post-registration-add-step`).

## QA
```bash
npm run dev  # PORT=3005, supabase up
npx playwright test auth-security --project=desktop-chromium --project=mobile --workers=1   # 30/30
npx playwright test platform-panel -g referrals --project=desktop-chromium --workers=1      # 1 passed, 4 skipped
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013FQG5ibgaQvsDbKh97B4xB