### PR TITLE
chore(deps): stripe SDK 20 → 22, API pin → 2026-07-29.dahlia

### DIFF
--- a/app/api/stripe/platform-webhook/route.ts
+++ b/app/api/stripe/platform-webhook/route.ts
@@ -53,7 +53,8 @@ const toIso = (unix: unknown): string | undefined =>
     ? new Date(unix * 1000).toISOString()
     : undefined
 
-// API 2026-02-25.clover (pinned in lib/stripe.ts): current_period_start/end moved
+// Since API 2026-02-25.clover (lib/stripe.ts pins a later version, shapes
+// unchanged): current_period_start/end moved
 // off the Subscription onto its SubscriptionItems, and Invoice.subscription moved
 // under parent.subscription_details. Same accessors as the student webhook —
 // lib/payments/stripe-provider.ts:454-460. The `??` fallbacks read the pre-clover

--- a/lib/payments/stripe-provider.ts
+++ b/lib/payments/stripe-provider.ts
@@ -43,7 +43,7 @@ export class StripePaymentProvider implements IPaymentProvider {
 
   constructor(apiKey: string) {
     this.stripe = new Stripe(apiKey, {
-      apiVersion: '2026-02-25.clover',
+      apiVersion: '2026-07-29.dahlia',
     })
   }
 

--- a/lib/stripe.ts
+++ b/lib/stripe.ts
@@ -10,7 +10,7 @@ export function getStripe(): Stripe {
       throw new Error('STRIPE_SECRET_KEY is not set in environment variables')
     }
     _stripe = new Stripe(secretKey, {
-      apiVersion: '2026-02-25.clover',
+      apiVersion: '2026-07-29.dahlia',
     })
   }
   return _stripe

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,7 +92,7 @@
         "shiki": "^3.23.0",
         "sonner": "^2.0.7",
         "streamdown": "^2.5.0",
-        "stripe": "^20.4.1",
+        "stripe": "^22.4.0",
         "tailwind-merge": "^3.6.0",
         "tokenlens": "^1.3.1",
         "tw-animate-css": "^1.4.0",
@@ -21884,15 +21884,15 @@
       }
     },
     "node_modules/stripe": {
-      "version": "20.4.1",
-      "resolved": "https://registry.npmjs.org/stripe/-/stripe-20.4.1.tgz",
-      "integrity": "sha512-axCguHItc8Sxt0HC6aSkdVRPffjYPV7EQqZRb2GkIa8FzWDycE7nHJM19C6xAIynH1Qp1/BHiopSi96jGBxT0w==",
+      "version": "22.4.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.4.0.tgz",
+      "integrity": "sha512-LVJ+tcSYeqOSnXr3i+Kz2tZ7y0crLLdP2uwD/4wccrmEVyn0g/Heo0pF7as7rxS/sOjJzrb1lxgZY0Y0Dx1pSA==",
       "license": "MIT",
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "@types/node": ">=16"
+        "@types/node": ">=18"
       },
       "peerDependenciesMeta": {
         "@types/node": {

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "shiki": "^3.23.0",
     "sonner": "^2.0.7",
     "streamdown": "^2.5.0",
-    "stripe": "^20.4.1",
+    "stripe": "^22.4.0",
     "tailwind-merge": "^3.6.0",
     "tokenlens": "^1.3.1",
     "tw-animate-css": "^1.4.0",


### PR DESCRIPTION
## Summary
Upgrades the server-side Stripe SDK `^20.4.1` → `^22.4.0` and moves the pinned API version from `2026-02-25.clover` → `2026-07-29.dahlia` in both clients (`lib/stripe.ts` — platform billing, `lib/payments/stripe-provider.ts` — Connect student payments).

### Dahlia risk audit
Breaking changes ship only in a release cycle's first version (`2026-03-25.dahlia`); `2026-07-29.dahlia` is additive on top. Checked every dahlia breaking change against the codebase:

| Dahlia change | Us |
|---|---|
| Checkout Session `ui_mode` enum values | not used |
| Subscription `cancellation_reason` new enum value | never read |
| Capabilities API risk requirements | not used |
| Event Destinations `events_from` | not used (classic webhooks) |
| Stripe.js legacy method removals/renames | none used (and @stripe/stripe-js 9 already landed in #595) |

The clover-era shapes the webhooks/provider rely on — `invoice.parent.subscription_details`, item-level `current_period_start/end`, `latest_invoice.confirmation_secret` — are **unchanged** in dahlia. The `??` fallbacks for replayed pre-clover payloads are kept.

## Verification
- `tsc --noEmit` clean against v22's dahlia typings (no more type drift on the pinned literal)
- 675/675 unit tests, including the route-level suites for both `/api/stripe/webhook` and `/api/stripe/platform-webhook`
- Production build passes

## QA
```bash
npm install && npm run typecheck && npm run test:unit && npm run build
# live webhook smoke: stripe listen --forward-to localhost:3005/api/stripe/webhook
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013FQG5ibgaQvsDbKh97B4xB