### PR TITLE
feat(landing): open the page builder to the free plan, capped at one page

### DIFF
--- a/app/[locale]/(public)/layout.tsx
+++ b/app/[locale]/(public)/layout.tsx
@@ -5,14 +5,13 @@ import { getCurrentTenantId, getCurrentTenant } from "@/lib/supabase/tenant";
 import { createAdminClient } from "@/lib/supabase/admin";
 
 const DEFAULT_TENANT_ID = '00000000-0000-0000-0000-000000000001'
-const PAID_PLANS = ['starter', 'pro', 'business', 'enterprise']
 
 async function hasPuckPage(): Promise<boolean> {
     try {
         const tenantId = await getCurrentTenantId()
         if (tenantId === DEFAULT_TENANT_ID) return false
         const tenant = await getCurrentTenant()
-        if (!tenant || !PAID_PLANS.includes(tenant.plan)) return false
+        if (!tenant) return false
         const adminClient = createAdminClient()
         const { data } = await adminClient
             .from('landing_pages')

--- a/app/[locale]/(public)/p/[slug]/page.tsx
+++ b/app/[locale]/(public)/p/[slug]/page.tsx
@@ -5,9 +5,9 @@ import { PuckPageRenderer } from '@/components/public/landing-page/puck-page-ren
 import { getLandingData } from '@/lib/puck/utils/landing-data'
 import { ogImageUrl } from '@/lib/seo'
 import type { Metadata } from 'next'
+import type { Data } from '@measured/puck'
 
 const DEFAULT_TENANT_ID = '00000000-0000-0000-0000-000000000001'
-const PAID_PLANS = ['starter', 'pro', 'business', 'enterprise']
 
 interface PageProps {
   params: Promise<{ slug: string }>
@@ -18,7 +18,7 @@ async function getPageData(slug: string) {
   if (tenantId === DEFAULT_TENANT_ID) return null
 
   const tenant = await getCurrentTenant()
-  if (!tenant || !PAID_PLANS.includes(tenant.plan)) return null
+  if (!tenant) return null
 
   const adminClient = createAdminClient()
   const { data: page } = await adminClient
@@ -38,7 +38,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const result = await getPageData(slug)
   if (!result) return {}
 
-  const rootProps = (result.page.puck_data as any)?.root?.props
+  const rootProps = (result.page.puck_data as { root?: { props?: Record<string, string | undefined> } })?.root?.props
   const title =
     rootProps?.metaTitle ||
     result.page.title ||
@@ -71,5 +71,5 @@ export default async function CustomPage({ params }: PageProps) {
   if (!result) notFound()
 
   const landingData = await getLandingData(result.tenantId)
-  return <PuckPageRenderer data={result.page.puck_data as any} landingData={landingData} />
+  return <PuckPageRenderer data={result.page.puck_data as unknown as Data} landingData={landingData} />
 }

--- a/app/[locale]/(public)/page.tsx
+++ b/app/[locale]/(public)/page.tsx
@@ -21,7 +21,6 @@ import {
   Bell,
   FileText,
   Layers,
-  Lock,
   Sparkles,
   TrendingUp,
   Award,
@@ -38,10 +37,10 @@ import type { Metadata } from "next";
 import { buildPageMetadata, getRequestBaseUrl } from "@/lib/seo";
 import { JsonLd, organizationJsonLd } from "@/lib/structured-data";
 import { PuckPageRenderer } from "@/components/public/landing-page/puck-page-renderer";
+import type { Data } from "@measured/puck";
 import { getLandingData } from "@/lib/puck/utils/landing-data";
 
 const DEFAULT_TENANT_ID = '00000000-0000-0000-0000-000000000001'
-const PAID_PLANS = ['starter', 'pro', 'business', 'enterprise']
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }): Promise<Metadata> {
   const { locale } = await params
@@ -60,25 +59,24 @@ export default async function LandingPage() {
         url: baseUrl,
         logo: tenant.logo_url,
       })
-      // Check if tenant has a paid plan with a custom active landing page
-      if (PAID_PLANS.includes(tenant.plan)) {
-        const adminClient = createAdminClient()
-        const { data: customPage } = await adminClient
-          .from('landing_pages')
-          .select('puck_data')
-          .eq('tenant_id', tenantId)
-          .eq('slug', 'home')
-          .eq('is_published', true)
-          .maybeSingle()
-        if (customPage?.puck_data && typeof customPage.puck_data === 'object') {
-          const landingData = await getLandingData(tenantId)
-          return (
-            <>
-              <JsonLd data={orgStructuredData} />
-              <PuckPageRenderer data={customPage.puck_data as any} landingData={landingData} />
-            </>
-          )
-        }
+      // Custom landing pages are available on every plan (free is capped at one
+      // page at creation time — see app/actions/admin/landing-pages.ts)
+      const adminClient = createAdminClient()
+      const { data: customPage } = await adminClient
+        .from('landing_pages')
+        .select('puck_data')
+        .eq('tenant_id', tenantId)
+        .eq('slug', 'home')
+        .eq('is_published', true)
+        .maybeSingle()
+      if (customPage?.puck_data && typeof customPage.puck_data === 'object') {
+        const landingData = await getLandingData(tenantId)
+        return (
+          <>
+            <JsonLd data={orgStructuredData} />
+            <PuckPageRenderer data={customPage.puck_data as unknown as Data} landingData={landingData} />
+          </>
+        )
       }
 
       // Fallback: default school landing page
@@ -97,8 +95,6 @@ export default async function LandingPage() {
       )
     }
   }
-
-  const t = await getTranslations("landing");
 
   return (
     <div className="flex flex-col min-h-screen bg-[#0A0A0A] overflow-hidden selection:bg-blue-500/30">
@@ -421,7 +417,7 @@ export default async function LandingPage() {
                 </div>
                 {/* Leaderboard mini */}
                 <div className="border-t border-zinc-800 pt-4">
-                  <p className="text-xs text-zinc-500 mb-2 font-medium">This Week's Leaders</p>
+                  <p className="text-xs text-zinc-500 mb-2 font-medium">This Week&apos;s Leaders</p>
                   {[
                     { rank: 1, name: "Maria S.", xp: "4,820 XP" },
                     { rank: 2, name: "Carlos R.", xp: "4,210 XP" },
@@ -452,7 +448,7 @@ export default async function LandingPage() {
               Everything Included
             </Badge>
             <h2 className="text-4xl md:text-5xl font-bold text-white tracking-tight" style={{ textWrap: "balance" }}>
-              Every Feature You Need, Nothing You Don't
+              Every Feature You Need, Nothing You Don&apos;t
             </h2>
             <p className="text-zinc-400 text-lg leading-relaxed">
               No plugins. No paid add-ons. No nickel-and-diming. Everything ships in the box.
@@ -555,7 +551,7 @@ export default async function LandingPage() {
                 Every School Is a Completely Separate World
               </h2>
               <p className="text-zinc-400 leading-relaxed">
-                Database-level isolation means School A can never see School B's students,
+                Database-level isolation means School A can never see School B&apos;s students,
                 courses, or transactions — even if they share the same platform.
                 RLS policies enforce this at the query level, not the application layer.
               </p>
@@ -649,7 +645,7 @@ export default async function LandingPage() {
               Start Free. Grow Without Limits.
             </h2>
             <p className="text-zinc-400 text-lg">
-              No platform fee on the free plan. Upgrade when you're ready to scale.
+              No platform fee on the free plan. Upgrade when you&apos;re ready to scale.
             </p>
           </div>
 

--- a/app/actions/admin/landing-pages.ts
+++ b/app/actions/admin/landing-pages.ts
@@ -74,6 +74,29 @@ function validateSlug(slug: string): string | null {
   return null
 }
 
+// Free plan gets the builder but is capped at one page. The client hides the
+// create/duplicate buttons at the cap (landing-pages-client.tsx) — this is the
+// server-side enforcement so the actions can't be called directly around it.
+const FREE_PLAN_PAGE_LIMIT = 1
+
+async function checkFreePlanPageLimit(
+  adminClient: ReturnType<typeof createAdminClient>,
+  tenantId: string
+): Promise<string | null> {
+  const { data: planResult } = await adminClient.rpc('get_plan_features', { _tenant_id: tenantId })
+  const plan = (planResult as { plan?: string } | null)?.plan ?? 'free'
+  if (plan !== 'free') return null
+
+  const { count } = await adminClient
+    .from('landing_pages')
+    .select('page_id', { count: 'exact', head: true })
+    .eq('tenant_id', tenantId)
+  if ((count ?? 0) >= FREE_PLAN_PAGE_LIMIT) {
+    return 'The free plan includes 1 landing page. Upgrade your plan to create more pages.'
+  }
+  return null
+}
+
 function friendlyDbError(err: unknown): string {
   const msg = err instanceof Error
     ? err.message
@@ -163,6 +186,9 @@ export async function createLandingPage(
     const pageSlug = sanitizeSlug(slug)
     const slugError = validateSlug(pageSlug)
     if (slugError) return { success: false, error: slugError } as ActionResult<LandingPage>
+
+    const limitError = await checkFreePlanPageLimit(adminClient, tenantId)
+    if (limitError) return { success: false, error: limitError } as ActionResult<LandingPage>
 
     const { data, error } = await adminClient
       .from('landing_pages')
@@ -352,6 +378,9 @@ export async function duplicateLandingPage(id: string, newName: string): Promise
 
     const nameError = validateName(newName)
     if (nameError) return { success: false, error: nameError } as ActionResult<LandingPage>
+
+    const limitError = await checkFreePlanPageLimit(adminClient, tenantId)
+    if (limitError) return { success: false, error: limitError } as ActionResult<LandingPage>
 
     const { data: original } = await adminClient
       .from('landing_pages')

--- a/app/api/landing/generate/route.ts
+++ b/app/api/landing/generate/route.ts
@@ -44,9 +44,9 @@ export const maxDuration = 120
 const MAX_MESSAGES = 20
 const MAX_CONTENT_LEN = 4000
 
-// Plans allowed to use the landing-page builder + its AI assistant. Mirrors the UI gate in
-// components/admin/landing-page/landing-pages-client.tsx (PAID_PLANS / canUseBuilder) so the
-// endpoint can't be called directly on the free plan to burn OpenAI tokens.
+// Plans allowed to use the landing-page AI assistant. The builder itself is available on every
+// plan (free is capped at one page), but the AI assistant stays paid-only — the UI hides the
+// panel (PuckEditor aiEnabled) and this server gate stops direct calls from burning OpenAI tokens.
 const PAID_PLANS = ['starter', 'pro', 'business', 'enterprise']
 
 // AI generation is expensive (OpenAI tokens + ~10s of compute), so cap how often a single user

--- a/components/admin/landing-page/landing-pages-client.tsx
+++ b/components/admin/landing-page/landing-pages-client.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useRef, useCallback, useEffect } from 'react'
+import { useState, useRef, useCallback } from 'react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -77,11 +77,13 @@ interface Props {
   plan: string
   tenantId: string
   templates: PuckTemplate[]
-  brandingSettings: Record<string, any>
+  brandingSettings: Record<string, unknown>
   landingData: LandingData
 }
 
-const PAID_PLANS = ['starter', 'pro', 'business', 'enterprise']
+// The builder is available on every plan; free tenants are capped at one page.
+// Keep in sync with the server-side cap in app/actions/admin/landing-pages.ts.
+const FREE_PLAN_PAGE_LIMIT = 1
 
 function timeAgo(dateStr: string): string {
   const diff = Date.now() - new Date(dateStr).getTime()
@@ -104,9 +106,13 @@ export function LandingPagesClient({ pages: initialPages, plan, tenantId, templa
   const t = useTranslations('landingPageBuilder')
   const [pages, setPages] = useState<LandingPage[]>(initialPages)
 
-  useEffect(() => {
+  // Sync server-provided pages after router.refresh() — render-time adjustment
+  // instead of an effect (react-hooks/set-state-in-effect)
+  const [prevInitialPages, setPrevInitialPages] = useState(initialPages)
+  if (prevInitialPages !== initialPages) {
+    setPrevInitialPages(initialPages)
     setPages(initialPages)
-  }, [initialPages])
+  }
 
   const [editingPage, setEditingPage] = useState<LandingPage | null>(null)
   const [showTemplatePicker, setShowTemplatePicker] = useState(false)
@@ -114,7 +120,7 @@ export function LandingPagesClient({ pages: initialPages, plan, tenantId, templa
   const [loadingAction, setLoadingAction] = useState<string | null>(null)
   const pendingRef = useRef(false)
 
-  const canUseBuilder = PAID_PLANS.includes(plan)
+  const atFreePageLimit = plan === 'free' && pages.length >= FREE_PLAN_PAGE_LIMIT
   const isLoading = loadingAction !== null
 
   const withGuard = useCallback(async <T,>(actionKey: string, fn: () => Promise<T>): Promise<T | null> => {
@@ -214,6 +220,7 @@ export function LandingPagesClient({ pages: initialPages, plan, tenantId, templa
         initialData={editingPage.puck_data || { root: { props: {} }, content: [], zones: {} }}
         brandingSettings={brandingSettings}
         landingData={landingData}
+        aiEnabled={plan !== 'free'}
         onBack={() => {
           router.refresh()
           setEditingPage(null)
@@ -224,21 +231,23 @@ export function LandingPagesClient({ pages: initialPages, plan, tenantId, templa
 
   return (
     <div className="space-y-6">
-      {/* Feature gate for free plan */}
-      {!canUseBuilder && (
+      {/* Free plan is capped at one page — nudge toward upgrade once the cap is hit */}
+      {atFreePageLimit && (
         <Card>
-          <CardContent className="py-12">
-            <div className="flex flex-col items-center justify-center gap-4 text-center">
-              <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-muted">
-                <IconLock className="h-5 w-5 text-muted-foreground" />
+          <CardContent className="py-4">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex items-center gap-3">
+                <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-muted">
+                  <IconLock className="h-4 w-4 text-muted-foreground" />
+                </div>
+                <div>
+                  <h3 className="font-semibold text-sm">{t('freeLimit.title')}</h3>
+                  <p className="text-muted-foreground text-sm leading-relaxed">
+                    {t('freeLimit.description')}
+                  </p>
+                </div>
               </div>
-              <div>
-                <h3 className="font-semibold text-base">{t('featureGate.title')}</h3>
-                <p className="text-muted-foreground text-sm mt-1.5 max-w-md leading-relaxed">
-                  {t('featureGate.description')}
-                </p>
-              </div>
-              <Button onClick={() => router.push('/dashboard/admin/billing/upgrade')} className="gap-2">
+              <Button onClick={() => router.push('/dashboard/admin/billing/upgrade')} size="sm" className="gap-2 shrink-0">
                 {t('featureGate.upgrade')}
                 <IconArrowRight className="w-4 h-4" />
               </Button>
@@ -248,8 +257,7 @@ export function LandingPagesClient({ pages: initialPages, plan, tenantId, templa
       )}
 
       {/* Pages list */}
-      {canUseBuilder && (
-        <>
+      <>
           {pages.length === 0 ? (
             <Card>
               <CardContent className="py-16">
@@ -275,7 +283,7 @@ export function LandingPagesClient({ pages: initialPages, plan, tenantId, templa
               <CardHeader>
                 <CardTitle>{t('title')}</CardTitle>
                 <div className="col-start-2 row-span-2 row-start-1 self-start justify-self-end">
-                  <Button onClick={() => setShowTemplatePicker(true)} disabled={isLoading} size="sm" className="gap-2">
+                  <Button onClick={() => setShowTemplatePicker(true)} disabled={isLoading || atFreePageLimit} size="sm" className="gap-2">
                     <IconPlus className="w-4 h-4" />
                     {t('newPage')}
                   </Button>
@@ -394,7 +402,7 @@ export function LandingPagesClient({ pages: initialPages, plan, tenantId, templa
                                       <><IconWorldUpload className="w-4 h-4 mr-2" /> {t('pageCard.activate')}</>
                                     )}
                                   </DropdownMenuItem>
-                                  <DropdownMenuItem onClick={() => handleDuplicate(page)} disabled={isLoading}>
+                                  <DropdownMenuItem onClick={() => handleDuplicate(page)} disabled={isLoading || atFreePageLimit}>
                                     <IconCopy className="w-4 h-4 mr-2" /> {t('pageCard.duplicate')}
                                   </DropdownMenuItem>
                                   <DropdownMenuSeparator />
@@ -418,7 +426,6 @@ export function LandingPagesClient({ pages: initialPages, plan, tenantId, templa
             </Card>
           )}
         </>
-      )}
 
       <TemplatePicker
         open={showTemplatePicker}

--- a/components/admin/landing-page/puck-editor.tsx
+++ b/components/admin/landing-page/puck-editor.tsx
@@ -28,8 +28,10 @@ interface Props {
   pageName: string
   pageStatus: 'draft' | 'published'
   initialData: Data
-  brandingSettings: Record<string, any>
+  brandingSettings: Record<string, unknown>
   landingData: LandingData
+  /** The AI assistant is a paid feature — /api/landing/generate rejects free-plan tenants */
+  aiEnabled?: boolean
   onBack: () => void
 }
 
@@ -87,7 +89,7 @@ function SaveButton({ pageId, saving, onSaveStateChange }: { pageId: string; sav
   )
 }
 
-export function PuckEditor({ pageId, pageName, pageStatus, initialData, brandingSettings, landingData, onBack }: Props) {
+export function PuckEditor({ pageId, pageName, pageStatus, initialData, brandingSettings, landingData, aiEnabled = true, onBack }: Props) {
   const [saving, setSaving] = useState(false)
   const [status, setStatus] = useState(pageStatus)
   const [brandingOpen, setBrandingOpen] = useState(false)
@@ -154,7 +156,7 @@ export function PuckEditor({ pageId, pageName, pageStatus, initialData, branding
                 <IconPalette className="w-4 h-4" />
                 {t('editor.branding')}
               </Button>
-              <AiChatPanel />
+              {aiEnabled && <AiChatPanel />}
               <SaveButton pageId={pageId} saving={saving} onSaveStateChange={setSaving} />
               {children}
             </>

--- a/lib/hooks/use-plan-features.ts
+++ b/lib/hooks/use-plan-features.ts
@@ -19,7 +19,7 @@ const DEFAULT_FEATURES: PlanFeatures = {
   xp: true,
   levels: true,
   streaks: true,
-  landing_pages: false,
+  landing_pages: true,
   remove_branding: false,
   voice_exercises: false,
   community: false,

--- a/lib/plans/features.ts
+++ b/lib/plans/features.ts
@@ -40,7 +40,6 @@ export const FEATURE_REQUIRED_PLAN: Record<string, string> = {
   leaderboard: 'starter',
   achievements: 'starter',
   analytics: 'starter',
-  landing_pages: 'starter',
   community: 'starter',
   store: 'pro',
   ai_grading: 'pro',

--- a/messages/en.json
+++ b/messages/en.json
@@ -5168,6 +5168,10 @@
       "description": "Create beautiful, customizable pages for your school with our drag-and-drop builder. Available on Starter plan ($9/mo) and above.",
       "upgrade": "Upgrade Plan"
     },
+    "freeLimit": {
+      "title": "You've used your free landing page",
+      "description": "The free plan includes 1 landing page. Upgrade to create unlimited pages and unlock the AI page assistant."
+    },
     "pageCard": {
       "section": "section",
       "sections": "sections",

--- a/messages/es.json
+++ b/messages/es.json
@@ -5161,6 +5161,10 @@
       "description": "Crea páginas hermosas y personalizables para tu escuela con nuestro constructor visual. Disponible en el plan Starter ($9/mes) y superiores.",
       "upgrade": "Mejorar Plan"
     },
+    "freeLimit": {
+      "title": "Ya usaste tu página de inicio gratuita",
+      "description": "El plan gratuito incluye 1 página de inicio. Mejora tu plan para crear páginas ilimitadas y desbloquear el asistente de IA."
+    },
     "pageCard": {
       "section": "sección",
       "sections": "secciones",


### PR DESCRIPTION
## Summary

Free-plan tenants can now use the landing-page builder — capped at **one page** — and their published page renders publicly on their subdomain. Previously the whole feature (builder + public rendering) was gated to `starter` and above.

**What changed**
- **Builder** (`landing-pages-client.tsx`): the free-plan lock card is gone. Free tenants get the full template picker + Puck editor. At the 1-page cap, an upgrade banner appears and New Page / Duplicate are disabled.
- **Server enforcement** (`app/actions/admin/landing-pages.ts`): `createLandingPage` and `duplicateLandingPage` reject past the cap via `get_plan_features` + page count, so the client gate can't be bypassed.
- **Public rendering** (`(public)/page.tsx`, `layout.tsx`, `p/[slug]/page.tsx`): the `PAID_PLANS` checks were removed — a published page renders for every plan.
- **AI assistant stays paid-only**: `PuckEditor` gets an `aiEnabled` prop that hides the panel on free; the server gate in `/api/landing/generate` is unchanged.
- `landing_pages` removed from `FEATURE_REQUIRED_PLAN`; `use-plan-features` default flipped to `true`; new `landingPageBuilder.freeLimit` strings (en/es).
- Pre-existing lint errors in touched files were fixed so lint-staged passes (`no-explicit-any`, unescaped entities, `set-state-in-effect` → render-time adjustment).

## QA script

1. `npm run dev`, log in as `owner@e2etest.com` (Default School is `free`) at `default.lvh.me:3000`.
2. Dashboard → Website: builder shows (no lock card). Create a page from a template → editor opens; no AI assistant button in the header.
3. Save + Publish. Back on the list: upgrade banner appears, **New Page** and **Duplicate** are disabled.
4. Simulate the public view on a non-default free tenant (the default tenant always shows the platform marketing home): set `code-academy` to `plan='free'`, give it a published `home` page → `code-academy.lvh.me:3000/en` renders the Puck page anonymously.
5. `npm run typecheck` passes; eslint on touched files: 0 errors.

Verified live locally (steps 1–5) with Playwright + psql.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LfDPWeghPSC5Xh1AhRMzvu