### PR TITLE
refactor(billing): make platform-billing tables provider-agnostic (#601)

### DIFF
--- a/app/[locale]/platform/tenants/page.tsx
+++ b/app/[locale]/platform/tenants/page.tsx
@@ -24,7 +24,7 @@ export default async function TenantsPage({
 
   let query = adminClient
     .from('tenants')
-    .select('id, name, slug, plan, status, created_at, stripe_customer_id')
+    .select('id, name, slug, plan, status, created_at')
     .order('created_at', { ascending: false })
     .limit(100)
 

--- a/app/actions/admin/billing.ts
+++ b/app/actions/admin/billing.ts
@@ -70,10 +70,10 @@ export async function getSubscriptionStatus() {
   // here is the same number the downgrade pre-flight and course-creation
   // enforcement compare against — it used to count archived courses that
   // neither of those did.
-  const [tenantResult, subscriptionResult, usage] = await Promise.all([
+  const [tenantResult, subscriptionResult, billingCustomerResult, usage] = await Promise.all([
     adminClient
       .from('tenants')
-      .select('plan, billing_status, billing_period_end, billing_email, stripe_customer_id, access_cutoff_at')
+      .select('plan, billing_status, billing_period_end, billing_email, access_cutoff_at')
       .eq('id', tenantId)
       .single(),
     adminClient
@@ -81,6 +81,13 @@ export async function getSubscriptionStatus() {
       .select('*, platform_plans(*)')
       .eq('tenant_id', tenantId)
       .single(),
+    // The customer id now lives per-provider in tenant_billing_customers (#601).
+    adminClient
+      .from('tenant_billing_customers')
+      .select('provider_customer_id')
+      .eq('tenant_id', tenantId)
+      .eq('payment_provider', 'stripe')
+      .maybeSingle(),
     countTenantUsage(adminClient, tenantId),
   ])
 
@@ -107,11 +114,11 @@ export async function getSubscriptionStatus() {
     billingStatus: tenant?.billing_status || 'free',
     billingPeriodEnd: tenant?.billing_period_end,
     billingEmail: tenant?.billing_email,
-    hasStripeCustomer: !!tenant?.stripe_customer_id,
+    hasStripeCustomer: !!billingCustomerResult.data?.provider_customer_id,
     accessCutoffAt: tenant?.access_cutoff_at ?? null,
     subscription: subscription ? {
       status: subscription.status,
-      paymentMethod: subscription.payment_method,
+      paymentMethod: subscription.payment_provider,
       interval: subscription.interval,
       cancelAtPeriodEnd: subscription.cancel_at_period_end,
       currentPeriodStart: subscription.current_period_start,
@@ -122,7 +129,7 @@ export async function getSubscriptionStatus() {
       amount: nextPaymentAmount,
       currency: 'USD',
       dueDate: nextPaymentDate,
-      paymentMethod: subscription?.payment_method || null,
+      paymentMethod: subscription?.payment_provider || null,
     } : null,
     usage: {
       courses: {
@@ -349,7 +356,7 @@ export async function confirmManualPayment(requestId: string) {
       tenant_id: request.tenant_id,
       plan_id: request.plan_id,
       status: 'active',
-      payment_method: 'manual_transfer',
+      payment_provider: 'manual',
       interval: request.interval,
       current_period_start: periodStart.toISOString(),
       current_period_end: periodEnd.toISOString(),
@@ -413,20 +420,20 @@ async function resolvePlatformPlanChange(
 ) {
   const { data: sub } = await adminClient
     .from('platform_subscriptions')
-    .select('stripe_subscription_id, stripe_customer_id, payment_method, status')
+    .select('provider_subscription_id, provider_customer_id, payment_provider, status')
     .eq('tenant_id', tenantId)
     .single()
 
   if (!sub || sub.status !== 'active') {
     throw new Error('No active subscription to change')
   }
-  if (sub.payment_method !== 'stripe' || !sub.stripe_subscription_id) {
+  if (sub.payment_provider !== 'stripe' || !sub.provider_subscription_id) {
     throw new Error('In-app plan change is only available for Stripe subscriptions.')
   }
 
   const { data: plan } = await adminClient
     .from('platform_plans')
-    .select('plan_id, slug, name, transaction_fee_percent, stripe_price_id_monthly, stripe_price_id_yearly')
+    .select('plan_id, slug, name, transaction_fee_percent')
     .eq('plan_id', planId)
     .eq('is_active', true)
     .single()
@@ -436,14 +443,24 @@ async function resolvePlatformPlanChange(
     throw new Error('To move to the Free plan, cancel your subscription instead.')
   }
 
-  const targetPriceId = interval === 'yearly' ? plan.stripe_price_id_yearly : plan.stripe_price_id_monthly
+  // Price ids live per (plan, provider, interval) since #601.
+  const { data: price } = await adminClient
+    .from('platform_plan_prices')
+    .select('provider_price_id')
+    .eq('plan_id', planId)
+    .eq('payment_provider', 'stripe')
+    .eq('interval', interval)
+    .eq('is_active', true)
+    .maybeSingle()
+
+  const targetPriceId = price?.provider_price_id
   if (!targetPriceId) {
     throw new Error('Stripe price is not configured for this plan. Please contact support.')
   }
 
   const { getStripe } = await import('@/lib/stripe')
   const stripe = getStripe()
-  const stripeSub = await stripe.subscriptions.retrieve(sub.stripe_subscription_id)
+  const stripeSub = await stripe.subscriptions.retrieve(sub.provider_subscription_id)
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const item = (stripeSub as any).items?.data?.[0]
   if (!item?.id) {
@@ -452,10 +469,10 @@ async function resolvePlatformPlanChange(
 
   return {
     stripe,
-    subId: sub.stripe_subscription_id as string,
+    subId: sub.provider_subscription_id as string,
     itemId: item.id as string,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    customerId: (sub.stripe_customer_id as string) || ((stripeSub as any).customer as string),
+    customerId: (sub.provider_customer_id as string) || ((stripeSub as any).customer as string),
     targetPriceId: targetPriceId as string,
     plan,
   }
@@ -602,7 +619,7 @@ export async function cancelSubscription() {
 
   const { data: subscription } = await adminClient
     .from('platform_subscriptions')
-    .select('stripe_subscription_id, payment_method, status')
+    .select('provider_subscription_id, payment_provider, status')
     .eq('tenant_id', tenantId)
     .single()
 
@@ -610,10 +627,10 @@ export async function cancelSubscription() {
     throw new Error('No active subscription to cancel')
   }
 
-  if (subscription.payment_method === 'stripe' && subscription.stripe_subscription_id) {
+  if (subscription.payment_provider === 'stripe' && subscription.provider_subscription_id) {
     // Cancel via Stripe (at period end).
     const { getStripe } = await import('@/lib/stripe')
-    await getStripe().subscriptions.update(subscription.stripe_subscription_id, {
+    await getStripe().subscriptions.update(subscription.provider_subscription_id, {
       cancel_at_period_end: true,
     })
     // Mirror locally so the overview reflects the pending cancellation
@@ -659,7 +676,7 @@ export async function reactivateSubscription() {
 
   const { data: subscription } = await adminClient
     .from('platform_subscriptions')
-    .select('stripe_subscription_id, payment_method, status, cancel_at_period_end, current_period_end')
+    .select('provider_subscription_id, payment_provider, status, cancel_at_period_end, current_period_end')
     .eq('tenant_id', tenantId)
     .single()
 
@@ -680,11 +697,11 @@ export async function reactivateSubscription() {
     throw new Error('Your billing period has already ended. Please start a new plan instead.')
   }
 
-  if (subscription.payment_method === 'stripe' && subscription.stripe_subscription_id) {
+  if (subscription.payment_provider === 'stripe' && subscription.provider_subscription_id) {
     // Stripe is authoritative for Stripe subs — clear it there first so a
     // failure leaves both sides still cancelling rather than disagreeing.
     const { getStripe } = await import('@/lib/stripe')
-    await getStripe().subscriptions.update(subscription.stripe_subscription_id, {
+    await getStripe().subscriptions.update(subscription.provider_subscription_id, {
       cancel_at_period_end: false,
     })
   }
@@ -781,7 +798,7 @@ export async function requestManualRenewal() {
     .single()
 
   if (!subscription) throw new Error('No active subscription found')
-  if (subscription.payment_method !== 'manual_transfer') {
+  if (subscription.payment_provider !== 'manual') {
     throw new Error('Renewal is only for manual transfer subscriptions')
   }
 

--- a/app/actions/platform/billing-health.ts
+++ b/app/actions/platform/billing-health.ts
@@ -22,7 +22,7 @@ async function verifySuperAdmin() {
 
 const TENANT_SELECT = 'id, name, plan, access_cutoff_at'
 const SUBSCRIPTION_SELECT =
-  'tenant_id, status, payment_method, current_period_end, grace_period_end, updated_at'
+  'tenant_id, status, payment_provider, current_period_end, grace_period_end, updated_at'
 
 /**
  * Mapped through helpers rather than an `as` cast so a drifting select list
@@ -45,7 +45,7 @@ function toTenantRow(row: {
 function toSubscriptionInput(row: {
   tenant_id: string
   status: string | null
-  payment_method: string | null
+  payment_provider: string | null
   current_period_end: string | null
   grace_period_end: string | null
   updated_at: string | null
@@ -53,7 +53,7 @@ function toSubscriptionInput(row: {
   return {
     tenantId: row.tenant_id,
     status: row.status,
-    paymentMethod: row.payment_method,
+    paymentMethod: row.payment_provider,
     currentPeriodEnd: row.current_period_end,
     gracePeriodEnd: row.grace_period_end,
     updatedAt: row.updated_at,

--- a/app/actions/platform/plans.ts
+++ b/app/actions/platform/plans.ts
@@ -307,7 +307,7 @@ export async function forceTenantPlanChange(tenantId: string, planSlug: string) 
         tenant_id: tenantId,
         plan_id: plan.plan_id,
         status: 'active',
-        payment_method: 'manual_transfer',
+        payment_provider: 'manual',
         interval: 'monthly',
         current_period_start: nowIso,
         current_period_end: null,

--- a/app/api/cron/expire-platform-subscriptions/route.ts
+++ b/app/api/cron/expire-platform-subscriptions/route.ts
@@ -22,7 +22,7 @@ export const runtime = 'nodejs'
  * migration 20260719120000) so the flow lives in the app layer, where it can send
  * admin emails and honor pending renewal requests — neither of which SQL could do.
  *
- * Scope: only payment_method='manual_transfer'. Stripe platform subs stay
+ * Scope: only payment_provider='manual'. Stripe platform subs stay
  * webhook-driven; their expiry is handled by /api/stripe/platform-webhook.
  *
  * Phases (all status-gated, so re-running is idempotent):
@@ -147,7 +147,7 @@ export async function GET(req: NextRequest) {
   const { data: reminderSubs } = await supabase
     .from('platform_subscriptions')
     .select(SUB_SELECT)
-    .eq('payment_method', 'manual_transfer')
+    .eq('payment_provider', 'manual')
     .eq('status', 'active')
     .eq('cancel_at_period_end', false)
     .is('renewal_reminder_sent_at', null)
@@ -175,7 +175,7 @@ export async function GET(req: NextRequest) {
   const { data: lapsedSubs } = await supabase
     .from('platform_subscriptions')
     .select(SUB_SELECT)
-    .eq('payment_method', 'manual_transfer')
+    .eq('payment_provider', 'manual')
     .eq('status', 'active')
     .eq('cancel_at_period_end', false)
     .not('current_period_end', 'is', null)
@@ -221,7 +221,7 @@ export async function GET(req: NextRequest) {
   const { data: expiredSubs } = await supabase
     .from('platform_subscriptions')
     .select(SUB_SELECT)
-    .eq('payment_method', 'manual_transfer')
+    .eq('payment_provider', 'manual')
     .eq('status', 'past_due')
     .not('grace_period_end', 'is', null)
     .lt('grace_period_end', nowIso)
@@ -263,7 +263,7 @@ export async function GET(req: NextRequest) {
   const { data: cancelSubs } = await supabase
     .from('platform_subscriptions')
     .select(SUB_SELECT)
-    .eq('payment_method', 'manual_transfer')
+    .eq('payment_provider', 'manual')
     .eq('status', 'active')
     .eq('cancel_at_period_end', true)
     .not('current_period_end', 'is', null)

--- a/app/api/stripe/billing-portal/route.ts
+++ b/app/api/stripe/billing-portal/route.ts
@@ -37,14 +37,15 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'Only school admins can manage billing' }, { status: 403 })
     }
 
-    // Get tenant's Stripe customer ID
-    const { data: tenant } = await adminClient
-      .from('tenants')
-      .select('stripe_customer_id')
-      .eq('id', tenantId)
-      .single()
+    // Get tenant's Stripe customer ID (per-provider since #601)
+    const { data: billingCustomer } = await adminClient
+      .from('tenant_billing_customers')
+      .select('provider_customer_id')
+      .eq('tenant_id', tenantId)
+      .eq('payment_provider', 'stripe')
+      .maybeSingle()
 
-    if (!tenant?.stripe_customer_id) {
+    if (!billingCustomer?.provider_customer_id) {
       return NextResponse.json({ error: 'No billing account found' }, { status: 400 })
     }
 
@@ -53,7 +54,7 @@ export async function POST(req: NextRequest) {
     const returnUrl = `${origin}/${locale}/dashboard/admin/billing`
 
     const session = await getStripe().billingPortal.sessions.create({
-      customer: tenant.stripe_customer_id,
+      customer: billingCustomer.provider_customer_id,
       return_url: returnUrl,
     })
 

--- a/app/api/stripe/checkout-session/route.ts
+++ b/app/api/stripe/checkout-session/route.ts
@@ -43,16 +43,16 @@ export async function POST(req: NextRequest) {
     // Check for existing active subscription
     const { data: existingSub } = await adminClient
       .from('platform_subscriptions')
-      .select('subscription_id, stripe_subscription_id, status, payment_method')
+      .select('subscription_id, provider_subscription_id, status, payment_provider')
       .eq('tenant_id', tenantId)
       .single()
 
     // Block only if there's an active Stripe subscription (not manual)
-    // Allow checkout when switching from manual_transfer to Stripe
+    // Allow checkout when switching from a manual subscription to Stripe
     if (
-      existingSub?.stripe_subscription_id &&
+      existingSub?.provider_subscription_id &&
       existingSub.status === 'active' &&
-      existingSub.payment_method !== 'manual_transfer'
+      existingSub.payment_provider !== 'manual'
     ) {
       return NextResponse.json(
         { error: 'Active subscription exists. Use billing portal to change plans.' },
@@ -76,9 +76,17 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'Cannot subscribe to free plan via checkout' }, { status: 400 })
     }
 
-    const stripePriceId = interval === 'yearly'
-      ? plan.stripe_price_id_yearly
-      : plan.stripe_price_id_monthly
+    // Price ids live per (plan, provider, interval) in platform_plan_prices (#601).
+    const { data: price } = await adminClient
+      .from('platform_plan_prices')
+      .select('provider_price_id')
+      .eq('plan_id', planId)
+      .eq('payment_provider', 'stripe')
+      .eq('interval', interval === 'yearly' ? 'yearly' : 'monthly')
+      .eq('is_active', true)
+      .maybeSingle()
+
+    const stripePriceId = price?.provider_price_id
 
     if (!stripePriceId) {
       return NextResponse.json(
@@ -87,14 +95,22 @@ export async function POST(req: NextRequest) {
       )
     }
 
-    // Get or create Stripe customer for the tenant (platform billing)
+    // Get or create the tenant's Stripe customer (platform billing). The id now
+    // lives per-provider in tenant_billing_customers rather than on `tenants`.
     const { data: tenant } = await adminClient
       .from('tenants')
-      .select('stripe_customer_id, billing_email, name')
+      .select('billing_email, name')
       .eq('id', tenantId)
       .single()
 
-    let stripeCustomerId = tenant?.stripe_customer_id
+    const { data: billingCustomer } = await adminClient
+      .from('tenant_billing_customers')
+      .select('provider_customer_id')
+      .eq('tenant_id', tenantId)
+      .eq('payment_provider', 'stripe')
+      .maybeSingle()
+
+    let stripeCustomerId = billingCustomer?.provider_customer_id
     const stripe = getStripe()
 
     if (!stripeCustomerId) {
@@ -109,11 +125,19 @@ export async function POST(req: NextRequest) {
       stripeCustomerId = customer.id
 
       await adminClient
+        .from('tenant_billing_customers')
+        .upsert(
+          {
+            tenant_id: tenantId,
+            payment_provider: 'stripe',
+            provider_customer_id: stripeCustomerId,
+          },
+          { onConflict: 'tenant_id,payment_provider' }
+        )
+
+      await adminClient
         .from('tenants')
-        .update({
-          stripe_customer_id: stripeCustomerId,
-          billing_email: tenant?.billing_email || user.email,
-        })
+        .update({ billing_email: tenant?.billing_email || user.email })
         .eq('id', tenantId)
     }
 

--- a/app/api/stripe/platform-webhook/route.ts
+++ b/app/api/stripe/platform-webhook/route.ts
@@ -195,15 +195,31 @@ export async function POST(req: NextRequest) {
             .upsert({
               tenant_id: tenantId,
               plan_id: planId,
-              stripe_subscription_id: subscription.id,
-              stripe_customer_id: session.customer as string,
+              provider_subscription_id: subscription.id,
+              provider_customer_id: session.customer as string,
               status: 'active',
-              payment_method: 'stripe',
+              payment_provider: 'stripe',
               interval: interval,
               ...(periodStart ? { current_period_start: periodStart } : {}),
               ...(periodEnd ? { current_period_end: periodEnd } : {}),
               updated_at: now,
             }, { onConflict: 'tenant_id' })
+        )
+
+        // Record the tenant's Stripe customer. Since #601 this lives per-provider
+        // in tenant_billing_customers rather than on `tenants`.
+        await unwrap(
+          'tenant_billing_customers upsert',
+          adminClient
+            .from('tenant_billing_customers')
+            .upsert(
+              {
+                tenant_id: tenantId,
+                payment_provider: 'stripe',
+                provider_customer_id: session.customer as string,
+              },
+              { onConflict: 'tenant_id,payment_provider' }
+            )
         )
 
         // Update tenant plan
@@ -215,7 +231,6 @@ export async function POST(req: NextRequest) {
               plan: planSlug,
               billing_status: 'active',
               ...(periodEnd ? { billing_period_end: periodEnd } : {}),
-              stripe_customer_id: session.customer as string,
               updated_at: now,
             })
             .eq('id', tenantId)
@@ -360,11 +375,11 @@ export async function POST(req: NextRequest) {
         if (!subscriptionId) break
 
         const sub = await unwrap(
-          'platform_subscriptions lookup by stripe id',
+          'platform_subscriptions lookup by provider subscription id',
           adminClient
             .from('platform_subscriptions')
             .select('tenant_id')
-            .eq('stripe_subscription_id', subscriptionId)
+            .eq('provider_subscription_id', subscriptionId)
             .maybeSingle()
         )
 
@@ -438,11 +453,11 @@ export async function POST(req: NextRequest) {
         if (!subscriptionId) break
 
         const sub = await unwrap(
-          'platform_subscriptions lookup by stripe id',
+          'platform_subscriptions lookup by provider subscription id',
           adminClient
             .from('platform_subscriptions')
             .select('tenant_id, status')
-            .eq('stripe_subscription_id', subscriptionId)
+            .eq('provider_subscription_id', subscriptionId)
             .maybeSingle()
         )
 

--- a/lib/billing/billing-health.ts
+++ b/lib/billing/billing-health.ts
@@ -153,7 +153,7 @@ export interface AtRiskTenant {
  * path upserts on it, so a tenant cannot actually hold two rows — but the old
  * plain `.set()` over an unordered list meant that if the constraint were ever
  * relaxed (per-plan history, say), a stale `canceled` row could donate its
- * `payment_method` and `grace_period_end`, and therefore its countdown, to the
+ * `payment_provider` and `grace_period_end`, and therefore its countdown, to the
  * dashboard. Ranking explicitly costs nothing and removes the trap.
  */
 function subscriptionRank(sub: PastDueSubscriptionInput): number {

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -4659,6 +4659,53 @@ export type Database = {
           },
         ]
       }
+      platform_plan_prices: {
+        Row: {
+          amount: number | null
+          created_at: string
+          currency: Database["public"]["Enums"]["currency_type"]
+          interval: string
+          is_active: boolean
+          payment_provider: string
+          plan_id: string
+          price_id: string
+          provider_price_id: string
+          updated_at: string
+        }
+        Insert: {
+          amount?: number | null
+          created_at?: string
+          currency?: Database["public"]["Enums"]["currency_type"]
+          interval: string
+          is_active?: boolean
+          payment_provider: string
+          plan_id: string
+          price_id?: string
+          provider_price_id: string
+          updated_at?: string
+        }
+        Update: {
+          amount?: number | null
+          created_at?: string
+          currency?: Database["public"]["Enums"]["currency_type"]
+          interval?: string
+          is_active?: boolean
+          payment_provider?: string
+          plan_id?: string
+          price_id?: string
+          provider_price_id?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "platform_plan_prices_plan_id_fkey"
+            columns: ["plan_id"]
+            isOneToOne: false
+            referencedRelation: "platform_plans"
+            referencedColumns: ["plan_id"]
+          },
+        ]
+      }
       platform_plans: {
         Row: {
           created_at: string | null
@@ -4672,8 +4719,6 @@ export type Database = {
           price_yearly: number
           slug: string
           sort_order: number
-          stripe_price_id_monthly: string | null
-          stripe_price_id_yearly: string | null
           transaction_fee_percent: number
           updated_at: string | null
         }
@@ -4689,8 +4734,6 @@ export type Database = {
           price_yearly?: number
           slug: string
           sort_order?: number
-          stripe_price_id_monthly?: string | null
-          stripe_price_id_yearly?: string | null
           transaction_fee_percent?: number
           updated_at?: string | null
         }
@@ -4706,8 +4749,6 @@ export type Database = {
           price_yearly?: number
           slug?: string
           sort_order?: number
-          stripe_price_id_monthly?: string | null
-          stripe_price_id_yearly?: string | null
           transaction_fee_percent?: number
           updated_at?: string | null
         }
@@ -4722,12 +4763,12 @@ export type Database = {
           current_period_start: string | null
           grace_period_end: string | null
           interval: string
-          payment_method: string
+          payment_provider: string
           plan_id: string
           renewal_reminder_sent_at: string | null
           status: string
-          stripe_customer_id: string | null
-          stripe_subscription_id: string | null
+          provider_customer_id: string | null
+          provider_subscription_id: string | null
           subscription_id: string
           tenant_id: string
           updated_at: string | null
@@ -4740,12 +4781,12 @@ export type Database = {
           current_period_start?: string | null
           grace_period_end?: string | null
           interval?: string
-          payment_method?: string
+          payment_provider?: string
           plan_id: string
           renewal_reminder_sent_at?: string | null
           status?: string
-          stripe_customer_id?: string | null
-          stripe_subscription_id?: string | null
+          provider_customer_id?: string | null
+          provider_subscription_id?: string | null
           subscription_id?: string
           tenant_id: string
           updated_at?: string | null
@@ -4758,12 +4799,12 @@ export type Database = {
           current_period_start?: string | null
           grace_period_end?: string | null
           interval?: string
-          payment_method?: string
+          payment_provider?: string
           plan_id?: string
           renewal_reminder_sent_at?: string | null
           status?: string
-          stripe_customer_id?: string | null
-          stripe_subscription_id?: string | null
+          provider_customer_id?: string | null
+          provider_subscription_id?: string | null
           subscription_id?: string
           tenant_id?: string
           updated_at?: string | null
@@ -5742,6 +5783,35 @@ export type Database = {
           },
         ]
       }
+      tenant_billing_customers: {
+        Row: {
+          created_at: string
+          payment_provider: string
+          provider_customer_id: string
+          tenant_id: string
+        }
+        Insert: {
+          created_at?: string
+          payment_provider: string
+          provider_customer_id: string
+          tenant_id: string
+        }
+        Update: {
+          created_at?: string
+          payment_provider?: string
+          provider_customer_id?: string
+          tenant_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "tenant_billing_customers_tenant_id_fkey"
+            columns: ["tenant_id"]
+            isOneToOne: false
+            referencedRelation: "tenants"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       tenant_settings: {
         Row: {
           created_at: string | null
@@ -5830,7 +5900,6 @@ export type Database = {
           status: string | null
           stripe_account_id: string | null
           stripe_charges_enabled: boolean
-          stripe_customer_id: string | null
           stripe_details_submitted: boolean
           stripe_payouts_enabled: boolean
           updated_at: string | null
@@ -5852,7 +5921,6 @@ export type Database = {
           status?: string | null
           stripe_account_id?: string | null
           stripe_charges_enabled?: boolean
-          stripe_customer_id?: string | null
           stripe_details_submitted?: boolean
           stripe_payouts_enabled?: boolean
           updated_at?: string | null
@@ -5874,7 +5942,6 @@ export type Database = {
           status?: string | null
           stripe_account_id?: string | null
           stripe_charges_enabled?: boolean
-          stripe_customer_id?: string | null
           stripe_details_submitted?: boolean
           stripe_payouts_enabled?: boolean
           updated_at?: string | null

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -4413,9 +4413,9 @@ export type Database = {
           amount: number
           created_at: string | null
           currency: string | null
-          idempotency_key: string | null
           failed_at: string | null
           failure_reason: string | null
+          idempotency_key: string | null
           note: string | null
           paid_at: string | null
           payout_id: number
@@ -4432,9 +4432,9 @@ export type Database = {
           amount: number
           created_at?: string | null
           currency?: string | null
-          idempotency_key?: string | null
           failed_at?: string | null
           failure_reason?: string | null
+          idempotency_key?: string | null
           note?: string | null
           paid_at?: string | null
           payout_id?: number
@@ -4451,9 +4451,9 @@ export type Database = {
           amount?: number
           created_at?: string | null
           currency?: string | null
-          idempotency_key?: string | null
           failed_at?: string | null
           failure_reason?: string | null
+          idempotency_key?: string | null
           note?: string | null
           paid_at?: string | null
           payout_id?: number
@@ -4595,6 +4595,7 @@ export type Database = {
           confirmed_by: string | null
           created_at: string | null
           currency: string
+          expires_at: string
           interval: string
           notes: string | null
           plan_id: string
@@ -4613,6 +4614,7 @@ export type Database = {
           confirmed_by?: string | null
           created_at?: string | null
           currency?: string
+          expires_at?: string
           interval?: string
           notes?: string | null
           plan_id: string
@@ -4631,6 +4633,7 @@ export type Database = {
           confirmed_by?: string | null
           created_at?: string | null
           currency?: string
+          expires_at?: string
           interval?: string
           notes?: string | null
           plan_id?: string
@@ -4765,10 +4768,12 @@ export type Database = {
           interval: string
           payment_provider: string
           plan_id: string
-          renewal_reminder_sent_at: string | null
-          status: string
+          plan_override_at: string | null
+          plan_override_by: string | null
           provider_customer_id: string | null
           provider_subscription_id: string | null
+          renewal_reminder_sent_at: string | null
+          status: string
           subscription_id: string
           tenant_id: string
           updated_at: string | null
@@ -4783,10 +4788,12 @@ export type Database = {
           interval?: string
           payment_provider?: string
           plan_id: string
-          renewal_reminder_sent_at?: string | null
-          status?: string
+          plan_override_at?: string | null
+          plan_override_by?: string | null
           provider_customer_id?: string | null
           provider_subscription_id?: string | null
+          renewal_reminder_sent_at?: string | null
+          status?: string
           subscription_id?: string
           tenant_id: string
           updated_at?: string | null
@@ -4801,10 +4808,12 @@ export type Database = {
           interval?: string
           payment_provider?: string
           plan_id?: string
-          renewal_reminder_sent_at?: string | null
-          status?: string
+          plan_override_at?: string | null
+          plan_override_by?: string | null
           provider_customer_id?: string | null
           provider_subscription_id?: string | null
+          renewal_reminder_sent_at?: string | null
+          status?: string
           subscription_id?: string
           tenant_id?: string
           updated_at?: string | null
@@ -5704,6 +5713,35 @@ export type Database = {
         }
         Relationships: []
       }
+      tenant_billing_customers: {
+        Row: {
+          created_at: string
+          payment_provider: string
+          provider_customer_id: string
+          tenant_id: string
+        }
+        Insert: {
+          created_at?: string
+          payment_provider: string
+          provider_customer_id: string
+          tenant_id: string
+        }
+        Update: {
+          created_at?: string
+          payment_provider?: string
+          provider_customer_id?: string
+          tenant_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "tenant_billing_customers_tenant_id_fkey"
+            columns: ["tenant_id"]
+            isOneToOne: false
+            referencedRelation: "tenants"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       tenant_invitations: {
         Row: {
           accepted_at: string | null
@@ -5776,35 +5814,6 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "tenant_payment_wallets_tenant_id_fkey"
-            columns: ["tenant_id"]
-            isOneToOne: false
-            referencedRelation: "tenants"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      tenant_billing_customers: {
-        Row: {
-          created_at: string
-          payment_provider: string
-          provider_customer_id: string
-          tenant_id: string
-        }
-        Insert: {
-          created_at?: string
-          payment_provider: string
-          provider_customer_id: string
-          tenant_id: string
-        }
-        Update: {
-          created_at?: string
-          payment_provider?: string
-          provider_customer_id?: string
-          tenant_id?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "tenant_billing_customers_tenant_id_fkey"
             columns: ["tenant_id"]
             isOneToOne: false
             referencedRelation: "tenants"
@@ -6392,6 +6401,7 @@ export type Database = {
         Args: { p_tenant_id: string }
         Returns: number
       }
+      can_read_exam: { Args: { _exam_id: number }; Returns: boolean }
       cancel_subscription: {
         Args: { _plan_id: number; _user_id: string }
         Returns: undefined
@@ -6497,9 +6507,9 @@ export type Database = {
       }
       get_daily_digest_candidates: {
         Args: {
-          _after_tenant_id?: string | null
-          _after_user_id?: string | null
-          _limit?: number | null
+          _after_tenant_id?: string
+          _after_user_id?: string
+          _limit?: number
         }
         Returns: {
           current_streak: number

--- a/lib/payments/platform-plan-change.ts
+++ b/lib/payments/platform-plan-change.ts
@@ -51,12 +51,31 @@ interface PlanRow {
   name: string | null
   transaction_fee_percent: number
   limits: { max_courses?: number; max_students?: number } | null
-  stripe_price_id_monthly: string | null
-  stripe_price_id_yearly: string | null
 }
 
 const PLAN_COLUMNS =
-  'plan_id, slug, name, transaction_fee_percent, limits, stripe_price_id_monthly, stripe_price_id_yearly'
+  'plan_id, slug, name, transaction_fee_percent, limits'
+
+/**
+ * Resolve a plan's Stripe price id for an interval from `platform_plan_prices`
+ * (#601). Returns null when the plan has no active Stripe price for it.
+ */
+async function stripePriceIdFor(
+  admin: SupabaseClient,
+  planId: string,
+  interval: 'monthly' | 'yearly',
+): Promise<string | null> {
+  const { data } = (await admin
+    .from('platform_plan_prices')
+    .select('provider_price_id')
+    .eq('plan_id', planId)
+    .eq('payment_provider', 'stripe')
+    .eq('interval', interval)
+    .eq('is_active', true)
+    .maybeSingle()) as { data: { provider_price_id: string } | null }
+
+  return data?.provider_price_id ?? null
+}
 
 export async function applyPortalPlanChange(
   // Stripe.Subscription with 2026-02-25.clover typing quirks — treated as any
@@ -73,11 +92,22 @@ export async function applyPortalPlanChange(
     return { action: 'ignored', reason: 'missing tenant_id or price on event' }
   }
 
-  const { data: newPlan } = (await admin
-    .from('platform_plans')
-    .select(PLAN_COLUMNS)
-    .or(`stripe_price_id_monthly.eq.${newPriceId},stripe_price_id_yearly.eq.${newPriceId}`)
-    .maybeSingle()) as { data: PlanRow | null }
+  // The price -> plan mapping now lives in platform_plan_prices (#601), so the
+  // lookup is a join through it rather than an OR across two plan columns.
+  const { data: matchedPrice } = (await admin
+    .from('platform_plan_prices')
+    .select('plan_id')
+    .eq('payment_provider', 'stripe')
+    .eq('provider_price_id', newPriceId)
+    .maybeSingle()) as { data: { plan_id: string } | null }
+
+  const { data: newPlan } = matchedPrice
+    ? ((await admin
+        .from('platform_plans')
+        .select(PLAN_COLUMNS)
+        .eq('plan_id', matchedPrice.plan_id)
+        .maybeSingle()) as { data: PlanRow | null })
+    : { data: null }
 
   if (!newPlan) {
     return { action: 'ignored', reason: `no platform plan matches price ${newPriceId}` }
@@ -144,9 +174,10 @@ export async function applyPortalPlanChange(
   // falling back to whichever price the old plan actually has.
   const preferYearly =
     currentSub?.interval === 'yearly' || item?.price?.recurring?.interval === 'year'
-  const oldPriceId = preferYearly
-    ? oldPlan?.stripe_price_id_yearly || oldPlan?.stripe_price_id_monthly
-    : oldPlan?.stripe_price_id_monthly || oldPlan?.stripe_price_id_yearly
+  const oldPriceId = oldPlan
+    ? (await stripePriceIdFor(admin, oldPlan.plan_id, preferYearly ? 'yearly' : 'monthly')) ||
+      (await stripePriceIdFor(admin, oldPlan.plan_id, preferYearly ? 'monthly' : 'yearly'))
+    : null
 
   if (oldPriceId && item?.id) {
     try {

--- a/supabase/migrations/20260805120000_platform_billing_provider_agnostic.sql
+++ b/supabase/migrations/20260805120000_platform_billing_provider_agnostic.sql
@@ -1,0 +1,141 @@
+-- Platform billing: make the school -> platform loop provider-agnostic (issue #601).
+--
+-- 20260217040000_platform_billing.sql modelled school billing around one provider's
+-- primitives: the provider lives in column NAMES (stripe_price_id_*, stripe_subscription_id,
+-- stripe_customer_id) and `payment_method` is a two-value enum standing where the student
+-- half already uses the 8-value PaymentProvider slug (lib/payments/types.ts:6).
+--
+-- The student-side tables were fixed this way by #280 -- `subscriptions` uses
+-- (payment_provider, provider_subscription_id) and `plans` uses
+-- (payment_provider, provider_price_id). Platform billing now reads identically.
+--
+-- Pre-launch project (#540 standing note): drop and recreate, no backfill dances,
+-- no compatibility shims, no phased rollout. The only rows that exist are seed rows.
+--
+-- `tenants.stripe_account_id` is deliberately untouched -- that is Stripe *Connect*
+-- (student -> school), a different loop with a different meaning.
+
+-- ============================================================================
+-- 1. platform_plan_prices -- one row per (plan, provider, interval)
+-- ============================================================================
+-- `payment_provider` is a CHECKed text column rather than a Postgres enum, matching
+-- how subscriptions.payment_provider / plans.payment_provider are already typed on
+-- the student side: adding a 9th provider stays a one-line CHECK edit.
+CREATE TABLE IF NOT EXISTS platform_plan_prices (
+  price_id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  plan_id           UUID NOT NULL REFERENCES platform_plans(plan_id) ON DELETE CASCADE,
+  payment_provider  TEXT NOT NULL
+                      CHECK (payment_provider IN (
+                        'stripe', 'paypal', 'binance', 'binance_personal',
+                        'manual', 'lemonsqueezy', 'solana', 'solana_subs'
+                      )),
+  interval          TEXT NOT NULL
+                      CHECK (interval IN ('monthly', 'yearly')),
+  provider_price_id TEXT NOT NULL,
+  currency          currency_type NOT NULL DEFAULT 'usd',
+  -- What the provider actually charges. May differ from platform_plans.price_monthly
+  -- on non-USD rails, so the checkout amount is read from here, not derived.
+  amount            NUMERIC(10,2),
+  is_active         BOOLEAN NOT NULL DEFAULT true,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT platform_plan_prices_unique UNIQUE (plan_id, payment_provider, interval)
+);
+
+CREATE INDEX IF NOT EXISTS idx_platform_plan_prices_plan
+  ON platform_plan_prices(plan_id, is_active);
+CREATE INDEX IF NOT EXISTS idx_platform_plan_prices_provider_price
+  ON platform_plan_prices(payment_provider, provider_price_id);
+
+ALTER TABLE platform_plan_prices ENABLE ROW LEVEL SECURITY;
+
+-- Mirrors the platform_plans policies: the upgrade page needs to read active prices,
+-- only super admins may write them.
+CREATE POLICY "Anyone can read active platform plan prices"
+  ON platform_plan_prices FOR SELECT
+  USING (is_active = true);
+
+CREATE POLICY "Super admins can manage platform plan prices"
+  ON platform_plan_prices FOR ALL
+  USING (
+    EXISTS (SELECT 1 FROM super_admins WHERE user_id = auth.uid())
+  );
+
+-- Read by three call sites, written by none (#602) -- nothing to preserve.
+ALTER TABLE platform_plans
+  DROP COLUMN IF EXISTS stripe_price_id_monthly,
+  DROP COLUMN IF EXISTS stripe_price_id_yearly;
+
+-- ============================================================================
+-- 2. platform_subscriptions -- provider-shaped identifiers
+-- ============================================================================
+ALTER TABLE platform_subscriptions
+  RENAME COLUMN stripe_subscription_id TO provider_subscription_id;
+
+ALTER TABLE platform_subscriptions
+  RENAME COLUMN stripe_customer_id TO provider_customer_id;
+
+ALTER TABLE platform_subscriptions
+  ADD COLUMN IF NOT EXISTS payment_provider TEXT NOT NULL DEFAULT 'stripe';
+
+-- Fold the old two-value enum into the provider slug: 'manual_transfer' -> 'manual'
+-- so `manual` stops being a dimension parallel to the provider and becomes one of
+-- its values. Every downstream branch then compares a single column.
+UPDATE platform_subscriptions
+SET payment_provider = CASE
+  WHEN payment_method = 'manual_transfer' THEN 'manual'
+  ELSE 'stripe'
+END;
+
+ALTER TABLE platform_subscriptions
+  DROP COLUMN IF EXISTS payment_method;
+
+ALTER TABLE platform_subscriptions
+  ADD CONSTRAINT platform_subscriptions_payment_provider_check
+    CHECK (payment_provider IN (
+      'stripe', 'paypal', 'binance', 'binance_personal',
+      'manual', 'lemonsqueezy', 'solana', 'solana_subs'
+    ));
+
+DROP INDEX IF EXISTS idx_platform_subscriptions_stripe;
+CREATE INDEX IF NOT EXISTS idx_platform_subscriptions_provider
+  ON platform_subscriptions(payment_provider, provider_subscription_id);
+
+-- ============================================================================
+-- 3. tenant_billing_customers -- one customer id per (tenant, provider)
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS tenant_billing_customers (
+  tenant_id            UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  payment_provider     TEXT NOT NULL
+                         CHECK (payment_provider IN (
+                           'stripe', 'paypal', 'binance', 'binance_personal',
+                           'manual', 'lemonsqueezy', 'solana', 'solana_subs'
+                         )),
+  provider_customer_id TEXT NOT NULL,
+  created_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT tenant_billing_customers_pkey PRIMARY KEY (tenant_id, payment_provider)
+);
+
+CREATE INDEX IF NOT EXISTS idx_tenant_billing_customers_provider_customer
+  ON tenant_billing_customers(payment_provider, provider_customer_id);
+
+ALTER TABLE tenant_billing_customers ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Tenant admins can view own billing customers"
+  ON tenant_billing_customers FOR SELECT
+  USING (
+    tenant_id IN (
+      SELECT tenant_id FROM tenant_users
+      WHERE user_id = auth.uid() AND role = 'admin' AND status = 'active'
+    )
+  );
+
+CREATE POLICY "Super admins can manage tenant billing customers"
+  ON tenant_billing_customers FOR ALL
+  USING (
+    EXISTS (SELECT 1 FROM super_admins WHERE user_id = auth.uid())
+  );
+
+-- The provider is now a value in tenant_billing_customers, not a column name here.
+ALTER TABLE tenants
+  DROP COLUMN IF EXISTS stripe_customer_id;

--- a/supabase/seed-prod.sql
+++ b/supabase/seed-prod.sql
@@ -38,7 +38,7 @@ BEGIN
     -- commerce
     'products','plans','subscriptions','transactions','payment_requests',
     'revenue_splits','payouts','invoices',
-    'platform_subscriptions','platform_payment_requests',
+    'platform_subscriptions','platform_payment_requests','tenant_billing_customers',
     -- community
     'community_posts','community_comments','community_reactions',
     'community_polls','community_poll_votes','community_spaces',

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -690,18 +690,41 @@ ON CONFLICT (tenant_id, setting_key) DO NOTHING;
 -- ---------------------------------------------------------------------------
 -- 18. PLATFORM SUBSCRIPTIONS  (Code Academy is on Pro plan)
 -- ---------------------------------------------------------------------------
-INSERT INTO platform_subscriptions (tenant_id, plan_id, status, payment_method, interval, current_period_start, current_period_end, cancel_at_period_end)
+INSERT INTO platform_subscriptions (tenant_id, plan_id, status, payment_provider, interval, current_period_start, current_period_end, cancel_at_period_end)
 VALUES (
   '00000000-0000-0000-0000-000000000002',
   (SELECT plan_id FROM platform_plans WHERE slug = 'pro'),
   'active',
-  'manual_transfer',
+  'manual',
   'monthly',
   NOW(),
   NOW() + interval '30 days',
   false
 )
 ON CONFLICT (tenant_id) DO NOTHING;
+
+
+-- ---------------------------------------------------------------------------
+-- 18b. PLATFORM PLAN PRICES  (issue #601 / #602)
+--
+-- Without at least one row here every card upgrade 400s with "Stripe price not
+-- configured for this plan" — the funnel dead-ends before it reaches Stripe,
+-- which is the bug #602 documents. Seeding it means a local dev can walk the
+-- upgrade path without hand-written SQL.
+--
+-- These are PLACEHOLDER ids, not real Stripe prices: they get you past the
+-- configuration gate, and Stripe itself will then reject them. To exercise a
+-- real checkout, replace them with your own test-mode price ids.
+-- ---------------------------------------------------------------------------
+INSERT INTO platform_plan_prices (plan_id, payment_provider, interval, provider_price_id, currency, amount)
+SELECT pp.plan_id, 'stripe', i.interval,
+       'price_local_' || pp.slug || '_' || i.interval,
+       'usd',
+       CASE WHEN i.interval = 'yearly' THEN pp.price_yearly ELSE pp.price_monthly END
+FROM platform_plans pp
+CROSS JOIN (VALUES ('monthly'), ('yearly')) AS i(interval)
+WHERE pp.slug <> 'free'
+ON CONFLICT (plan_id, payment_provider, interval) DO NOTHING;
 
 
 -- ===========================================================================

--- a/tests/unit/expire-platform-subscriptions.test.ts
+++ b/tests/unit/expire-platform-subscriptions.test.ts
@@ -164,7 +164,7 @@ function seedSub(over: Row = {}) {
   db.platform_subscriptions.push({
     tenant_id: TENANT,
     plan_id: PLAN,
-    payment_method: 'manual_transfer',
+    payment_provider: 'manual',
     status: 'active',
     cancel_at_period_end: false,
     current_period_end: daysFromNow(-1),

--- a/tests/unit/plan-limit-count-parity.test.ts
+++ b/tests/unit/plan-limit-count-parity.test.ts
@@ -104,7 +104,7 @@ beforeEach(() => {
         plan_id: PLAN_PRO,
         status: 'active',
         interval: 'monthly',
-        payment_method: 'manual_transfer',
+        payment_provider: 'manual',
         cancel_at_period_end: false,
         current_period_end: new Date(Date.now() + 5 * 86_400_000).toISOString(),
       },

--- a/tests/unit/platform-billing-lifecycle.test.ts
+++ b/tests/unit/platform-billing-lifecycle.test.ts
@@ -76,7 +76,7 @@ function seedSub(over: Row = {}) {
       subscription_id: 'sub-row-1',
       tenant_id: TENANT,
       plan_id: PLAN_PRO,
-      payment_method: 'manual_transfer',
+      payment_provider: 'manual',
       status: 'active',
       interval: 'yearly',
       cancel_at_period_end: false,
@@ -85,7 +85,7 @@ function seedSub(over: Row = {}) {
       current_period_end: daysFromNow(5),
       grace_period_end: null,
       renewal_reminder_sent_at: null,
-      stripe_subscription_id: null,
+      provider_subscription_id: null,
       plan_override_by: null,
       plan_override_at: null,
       ...over,
@@ -130,8 +130,6 @@ beforeEach(() => {
         sort_order: 3,
         is_active: true,
         limits: { max_courses: 100, max_students: 1000 },
-        stripe_price_id_monthly: 'price_pro_m',
-        stripe_price_id_yearly: 'price_pro_y',
       },
       {
         plan_id: PLAN_BUSINESS,
@@ -143,10 +141,16 @@ beforeEach(() => {
         sort_order: 4,
         is_active: true,
         limits: { max_courses: -1, max_students: 5000 },
-        stripe_price_id_monthly: 'price_biz_m',
-        stripe_price_id_yearly: 'price_biz_y',
       },
     ],
+    // Price ids moved out of platform_plans into platform_plan_prices (#601).
+    platform_plan_prices: [
+      { plan_id: PLAN_PRO, payment_provider: 'stripe', interval: 'monthly', provider_price_id: 'price_pro_m', is_active: true },
+      { plan_id: PLAN_PRO, payment_provider: 'stripe', interval: 'yearly', provider_price_id: 'price_pro_y', is_active: true },
+      { plan_id: PLAN_BUSINESS, payment_provider: 'stripe', interval: 'monthly', provider_price_id: 'price_biz_m', is_active: true },
+      { plan_id: PLAN_BUSINESS, payment_provider: 'stripe', interval: 'yearly', provider_price_id: 'price_biz_y', is_active: true },
+    ],
+    tenant_billing_customers: [],
     platform_subscriptions: [],
     platform_payment_requests: [],
     revenue_splits: [],
@@ -195,8 +199,8 @@ describe('#546 §1 — reactivateSubscription', () => {
 
   it('clears the cancellation on Stripe first for a Stripe subscription', async () => {
     const sub = seedSub({
-      payment_method: 'stripe',
-      stripe_subscription_id: 'sub_live',
+      payment_provider: 'stripe',
+      provider_subscription_id: 'sub_live',
       cancel_at_period_end: true,
     })
 
@@ -220,8 +224,8 @@ describe('#546 §1 — reactivateSubscription', () => {
 describe('#546 §1 — changePlan does not leave a cancellation behind', () => {
   it('sends cancel_at_period_end: false to Stripe and mirrors it locally', async () => {
     const sub = seedSub({
-      payment_method: 'stripe',
-      stripe_subscription_id: 'sub_live',
+      payment_provider: 'stripe',
+      provider_subscription_id: 'sub_live',
       cancel_at_period_end: true,
       canceled_at: daysFromNow(-2),
       plan_override_at: daysFromNow(-20),

--- a/tests/unit/platform-plan-change.test.ts
+++ b/tests/unit/platform-plan-change.test.ts
@@ -15,8 +15,6 @@ interface PlanRow {
   name: string | null
   transaction_fee_percent: number
   limits: { max_courses?: number; max_students?: number } | null
-  stripe_price_id_monthly: string | null
-  stripe_price_id_yearly: string | null
 }
 
 interface FakeConfig {
@@ -26,6 +24,13 @@ interface FakeConfig {
   courseCount?: number
   studentCount?: number
   adminUsers?: string[]
+  /**
+   * Stripe price ids per plan, keyed by plan_id then interval. Since #601 these
+   * live in `platform_plan_prices` rather than on `platform_plans`, so a plan
+   * with no purchasable price is expressed by omitting it here — that is the
+   * "revert impossible" case, not a null column on the plan row.
+   */
+  prices?: Record<string, Partial<Record<'monthly' | 'yearly', string>>>
 }
 
 interface Recorder {
@@ -47,9 +52,11 @@ function makeFakeAdmin(cfg: FakeConfig) {
     stripeUpdates: [],
   }
 
+  const prices = cfg.prices ?? DEFAULT_PLAN_PRICES
+
   function makeBuilder(table: string) {
-    let usedOr = false
     let lastInsert: unknown = null
+    const filters: Record<string, unknown> = {}
     const builder: Record<string, unknown> = {
       select(cols: string) {
         if (table === 'platform_plans') calls.planSelects.push(cols)
@@ -68,19 +75,34 @@ function makeFakeAdmin(cfg: FakeConfig) {
         calls.inserts.push({ table, values })
         return builder
       },
-      or() {
-        usedOr = true
-        return builder
-      },
-      eq() {
+      eq(col: string, value: unknown) {
+        filters[col] = value
         return builder
       },
       neq() {
         return builder
       },
       maybeSingle() {
+        if (table === 'platform_plan_prices') {
+          // price id -> plan (the portal event carries only the price)
+          if (filters.provider_price_id) {
+            const planId = Object.keys(prices).find((id) =>
+              Object.values(prices[id]).includes(filters.provider_price_id as string)
+            )
+            return Promise.resolve({ data: planId ? { plan_id: planId } : null, error: null })
+          }
+          // plan + interval -> price id (resolving the revert target)
+          const interval = filters.interval as 'monthly' | 'yearly'
+          const priceId = prices[filters.plan_id as string]?.[interval] ?? null
+          return Promise.resolve({
+            data: priceId ? { provider_price_id: priceId } : null,
+            error: null,
+          })
+        }
         if (table === 'platform_plans') {
-          return Promise.resolve({ data: usedOr ? (cfg.newPlan ?? null) : (cfg.oldPlan ?? null), error: null })
+          const planId = filters.plan_id
+          const match = [cfg.newPlan, cfg.oldPlan].find((p) => p && p.plan_id === planId)
+          return Promise.resolve({ data: match ?? null, error: null })
         }
         if (table === 'platform_subscriptions') {
           return Promise.resolve({ data: cfg.currentSub ?? null, error: null })
@@ -157,8 +179,6 @@ const PRO: PlanRow = {
   name: 'Pro',
   transaction_fee_percent: 2,
   limits: { max_courses: 100, max_students: 1000 },
-  stripe_price_id_monthly: 'price_pro_m',
-  stripe_price_id_yearly: 'price_pro_y',
 }
 
 const STARTER: PlanRow = {
@@ -167,8 +187,12 @@ const STARTER: PlanRow = {
   name: 'Starter',
   transaction_fee_percent: 5,
   limits: { max_courses: 15, max_students: 200 },
-  stripe_price_id_monthly: 'price_starter_m',
-  stripe_price_id_yearly: 'price_starter_y',
+}
+
+/** Stands in for the `platform_plan_prices` rows both fixture plans have (#601). */
+const DEFAULT_PLAN_PRICES: Record<string, Partial<Record<'monthly' | 'yearly', string>>> = {
+  [PRO_ID]: { monthly: 'price_pro_m', yearly: 'price_pro_y' },
+  [STARTER_ID]: { monthly: 'price_starter_m', yearly: 'price_starter_y' },
 }
 
 function subscriptionEvent(priceId = 'price_starter_m') {
@@ -269,7 +293,10 @@ describe('applyPortalPlanChange', () => {
   it('revert impossible (old plan has no Stripe prices) → downgrade applied to DB + admins warned', async () => {
     const { admin, calls, sendEmailFn, makeStripe } = makeFakeAdmin({
       newPlan: STARTER,
-      oldPlan: { ...PRO, stripe_price_id_monthly: null, stripe_price_id_yearly: null },
+      oldPlan: PRO,
+      // PRO absent from `prices` — it has no purchasable Stripe price, so the
+      // revert has nothing to revert to.
+      prices: { [STARTER_ID]: { monthly: 'price_starter_m', yearly: 'price_starter_y' } },
       currentSub: { plan_id: PRO.plan_id, interval: 'monthly' },
       courseCount: 50,
       adminUsers: ['admin-a'],

--- a/tests/unit/platform-webhook.test.ts
+++ b/tests/unit/platform-webhook.test.ts
@@ -267,10 +267,10 @@ describe('platform webhook — checkout.session.completed', () => {
     expect(sub.values).toMatchObject({
       tenant_id: TENANT,
       plan_id: PLAN_ID,
-      stripe_subscription_id: 'sub_123',
-      stripe_customer_id: 'cus_1',
+      provider_subscription_id: 'sub_123',
+      provider_customer_id: 'cus_1',
       status: 'active',
-      payment_method: 'stripe',
+      payment_provider: 'stripe',
       interval: 'monthly',
       current_period_start: START_ISO,
       current_period_end: END_ISO,
@@ -281,7 +281,14 @@ describe('platform webhook — checkout.session.completed', () => {
       plan: 'pro',
       billing_status: 'active',
       billing_period_end: END_ISO,
-      stripe_customer_id: 'cus_1',
+    })
+
+    // The customer id moved off `tenants` into tenant_billing_customers (#601).
+    const billingCustomer = writesTo('tenant_billing_customers', 'upsert')[0]
+    expect(billingCustomer.values).toMatchObject({
+      tenant_id: TENANT,
+      payment_provider: 'stripe',
+      provider_customer_id: 'cus_1',
     })
 
     const split = writesTo('revenue_splits', 'upsert')[0]


### PR DESCRIPTION
## What

Makes the platform-billing tables provider-agnostic: adds `platform_plan_prices` and `tenant_billing_customers`, renames the Stripe-shaped columns on `platform_subscriptions`, drops `platform_plans.stripe_price_id_*` and `tenants.stripe_customer_id`, and moves every reader in the same PR.

Closes #601

## Why

`supabase/migrations/20260217040000_platform_billing.sql` encoded the provider in column *names* rather than in a value, so there was nowhere to put a second provider's identifiers — which is what blocks every other sub-issue in #600:

- `platform_plans.stripe_price_id_monthly` / `_yearly` — one provider, one column per interval.
- `platform_subscriptions.stripe_subscription_id` / `stripe_customer_id`, plus `payment_method CHECK (IN ('stripe','manual_transfer'))` — a two-value enum standing where the student half already uses the 8-value `PaymentProvider` slug (`lib/payments/types.ts:6`). `idx_platform_subscriptions_stripe` indexed the Stripe column only.
- `tenants.stripe_customer_id` — one customer id, provider implied by the name.

#280 fixed the student-side tables this way (`subscriptions.payment_provider` + `provider_subscription_id`, `plans.payment_provider` + `provider_price_id`). Platform billing now reads identically to anyone who knows the other half of the codebase.

Per the standing pre-launch note (#540): drop and recreate, no backfill dances, no compatibility shims, no phased rollout.

## Changes

**Migration** — `supabase/migrations/20260805120000_platform_billing_provider_agnostic.sql`

- **`platform_plan_prices`** (new): `(plan_id, payment_provider, interval)` unique → `provider_price_id`, `currency`, `amount` (what the provider actually charges, which may differ from `price_monthly` on non-USD rails), `is_active`. RLS mirrors `platform_plans` — anyone reads active rows, super admins write. Then drops `platform_plans.stripe_price_id_monthly` / `_yearly`.
- **`platform_subscriptions`**: `stripe_subscription_id` → `provider_subscription_id`, `stripe_customer_id` → `provider_customer_id`, new `payment_provider` (defaulted from the old `payment_method`, `'manual_transfer'` → `'manual'`), `payment_method` dropped. `idx_platform_subscriptions_stripe` → `(payment_provider, provider_subscription_id)`.
- **`tenant_billing_customers`** (new): PK `(tenant_id, payment_provider)` → `provider_customer_id`. RLS: tenant admins read their own, super admins manage all. Drops `tenants.stripe_customer_id`.

`payment_provider` is a CHECKed `text` column rather than a new Postgres enum, matching how `subscriptions.payment_provider` / `plans.payment_provider` are already typed — adding a 9th provider stays a one-line CHECK edit instead of a migration.

`tenants.stripe_account_id` and the three Connect flags are deliberately untouched — that is Stripe *Connect* (student → school), a different loop.

**Readers moved**: `app/actions/admin/billing.ts` (the largest — overview, manual upgrade, plan-change resolver, cancel, reactivate, renewal), `app/api/stripe/checkout-session/route.ts`, `app/api/stripe/platform-webhook/route.ts`, `app/api/stripe/billing-portal/route.ts`, `app/api/cron/expire-platform-subscriptions/route.ts`, `app/actions/platform/plans.ts`, `app/actions/platform/billing-health.ts`, `lib/payments/platform-plan-change.ts`, `lib/billing/billing-health.ts`, `app/[locale]/platform/tenants/page.tsx`, and 5 unit suites.

Two branchy spots got individual attention, since inverting either would fail silently: the `checkout-session` guard that allows checkout only when the existing subscription is manual, and the four expire-cron filters that must never touch Stripe-managed subscriptions.

**Seeds**: `supabase/seed.sql` gains 8 `platform_plan_prices` rows (4 paid plans × 2 intervals) so a local dev can walk the upgrade path without hand-written SQL — the absence of exactly this is #602. They are **placeholder** ids (`price_local_pro_monthly`), so they clear the configuration gate and Stripe itself then rejects them; swap in real test-mode ids to exercise a live checkout.

## How to QA

On a fresh `npm run db:reset` (this branch):

1. **Schema** — confirm the end state:
   ```sql
   \d platform_plan_prices
   \d tenant_billing_customers
   SELECT column_name FROM information_schema.columns
    WHERE table_name='platform_subscriptions' AND column_name LIKE '%provider%';
   SELECT column_name FROM information_schema.columns
    WHERE table_name='tenants' AND column_name LIKE 'stripe%';
   ```
   Expect `payment_provider` / `provider_subscription_id` / `provider_customer_id` on the subscription, no `payment_method`; on `tenants`, `stripe_account_id` + the three Connect flags remain and `stripe_customer_id` is gone.

2. **Seeded prices** — `SELECT pp.slug, ppp.interval, ppp.provider_price_id FROM platform_plan_prices ppp JOIN platform_plans pp USING (plan_id) ORDER BY pp.sort_order;` returns 8 rows across starter/pro/business/enterprise.

3. **Billing screen** — sign in as `creator@codeacademy.com` / `password123` at `code-academy.lvh.me:3000`, open `/dashboard/admin/billing`. The seeded Code Academy subscription is `payment_provider = 'manual'`; the page renders the Pro plan, its period, and usage without error (this is the `getSubscriptionStatus` path that now reads `tenant_billing_customers`).

4. **Upgrade page** — `/dashboard/admin/billing/upgrade` loads and the plans render. Picking a paid plan now gets *past* the "Stripe price not configured" 400 and fails at Stripe instead, because the placeholder price ids are not real — that is the expected result until #602 lands the admin UI for setting real ones.

5. **Super-admin tenants list** — as `owner@e2etest.com` / `password123`, open `/platform/tenants`; the table still renders (its select no longer requests the dropped column).

6. **RLS** — confirm both new tables have `relrowsecurity` and two policies each:
   ```sql
   SELECT relname, relrowsecurity FROM pg_class
    WHERE relname IN ('platform_plan_prices','tenant_billing_customers');
   SELECT tablename, policyname, cmd FROM pg_policies
    WHERE tablename IN ('platform_plan_prices','tenant_billing_customers');
   ```

## Screenshots / GIF

None — schema and server-side refactor. No user-visible surface changes: every touched screen renders the same information, read from the renamed columns.

## Two notes for the reviewer

**The issue's grep acceptance criterion cannot fully pass, by design.** `grep -rn "stripe_price_id_\|stripe_subscription_id\|payment_method" app/ lib/ components/` now returns **zero** `stripe_price_id_*` and **zero** `stripe_subscription_id` hits. The surviving `payment_method` hits are two unrelated families, both out of scope for this issue:

- **`payment_requests.payment_method` and `transactions.payment_method`** — student-side columns holding a free-text method label ("Bank Transfer", "Zelle"), sharing a name with the platform column but nothing else. In `app/[locale]/dashboard/student/payments/*`, `app/[locale]/dashboard/admin/payment-requests/*`, `app/[locale]/dashboard/admin/transactions/page.tsx`, `app/[locale]/(public)/checkout/actions.ts`, `app/actions/payment-requests.ts`, `app/api/invoices/[invoiceNumber]/route.ts`, and four `components/admin/payment-request-*` files.
- **Stripe SDK parameters** — `automatic_payment_methods`, `save_default_payment_method` in `lib/payments/stripe-provider.ts` and `create-payment-intent`.

`profiles.stripe_customer_id` (the *student's* Connect customer) likewise stays. Renaming either family would be a separate change with no bearing on provider-agnostic platform billing.

**Applied to cloud, and `lib/database.types.ts` is a genuine `--linked` regeneration.** Before applying, the cloud project was confirmed to hold **zero** rows in every dropped column — 0 plans with price ids, 0 `platform_subscriptions` rows at all, 0 tenants with a customer id. So the drops destroyed nothing, which also independently confirms #602's claim that nothing in the repo ever writes those price ids. Post-apply verification on cloud: `platform_subscriptions` has the three provider columns and no `payment_method`, `platform_plans` has no `stripe%` columns, `tenants` retains exactly the four Connect columns, both new tables report `relrowsecurity = true` with two policies each, and the index is `idx_platform_subscriptions_provider`. `get_advisors(security)` reports no findings against either new table.

Two mechanical notes for whoever works on cloud next:

- The Supabase CLI cannot reach this project over port 5432 from a normal network (`tls error … i/o timeout` to the pooler), so `db push` / `migration list` hang. The migration went through the Supabase MCP instead. `supabase gen types --linked` *does* work, because it uses the Management API over HTTPS.
- MCP `apply_migration` stamps its own fresh ledger timestamp (`20260805192951`) rather than the filename's — the #541 drift mechanism. The ledger row was corrected to `20260805120000` so it matches this PR's migration file and a future `db push` will not try to re-apply it.

The regenerated types therefore also pick up three things the committed file was stale on, because cloud already had them and nobody regenerated: `platform_payment_requests.expires_at`, `platform_subscriptions.plan_override_at` / `plan_override_by`, and `can_read_exam`. They are pre-existing drift, not part of this issue — a genuine regeneration simply cannot omit them. They arrive in their own commit (`chore(types)`) so they are easy to separate from the #601 change.

**Still open, and deliberately not done here**: the cloud ledger is missing `20260729120000_fix_version_restore_course_join.sql` (its top entry before this PR was `20260727130000`). That is unrelated pre-existing drift and belongs to whoever owns that migration, not to #601. Cloud also has no `platform_plan_prices` rows — `seed.sql` is not run against cloud — so plans there remain unpurchasable until #602 lands the super-admin price UI. That is the same state as before this PR, not a regression.

## Checklist

- [x] `npm run typecheck` and `npm run test:unit` pass — **675/675 unit tests across 54 files**
- [x] `npm run build` passes
- [x] Every new tenant-scoped query filters by `tenant_id` (`tenant_billing_customers` reads are keyed on it; `platform_plan_prices` is a global catalog table like `platform_plans`)
- [ ] Tested with every relevant role (student / teacher / admin) — admin + super-admin paths covered by the QA script above; no student-facing surface is touched
- [x] Loading and error states handled — the "price not configured" 400 and the "In-app plan change is only available for Stripe subscriptions" guard both survive the move
- [x] New UI strings added to both `messages/en.json` and `messages/es.json` — n/a, no new strings
- [x] Migration applies cleanly on `npm run db:reset`, has RLS policies, and `lib/database.types.ts` was regenerated — applied to cloud and regenerated with `--linked`; verified on both

`npm run lint` on the changed files reports 0 errors and 4 warnings, all pre-existing on `master` at identical lines (unused `supabase` / `userId` bindings in `billing.ts` and `plans.ts`).
