### PR TITLE
feat(billing): super-admin provider prices for platform plans (#602)

### DIFF
--- a/app/[locale]/dashboard/admin/billing/billing-dashboard-client.tsx
+++ b/app/[locale]/dashboard/admin/billing/billing-dashboard-client.tsx
@@ -37,7 +37,7 @@ interface BillingDashboardClientProps {
     hasStripeCustomer: boolean
     subscription: {
       status: string
-      paymentMethod: string
+      paymentProvider: string
       interval: string
       cancelAtPeriodEnd: boolean
       currentPeriodStart: string | null
@@ -48,7 +48,7 @@ interface BillingDashboardClientProps {
       amount: number
       currency: string
       dueDate: string
-      paymentMethod: string | null
+      paymentProvider: string | null
     } | null
     usage: {
       courses: { current: number; limit: number }
@@ -192,7 +192,7 @@ export function BillingDashboardClient({ status, paymentRequests }: BillingDashb
     (r) => !['confirmed', 'rejected', 'expired'].includes(r.status)
   )
 
-  const isManualSub = status.subscription?.paymentMethod === 'manual_transfer'
+  const isManualSub = status.subscription?.paymentProvider === 'manual'
   const periodEnd = status.subscription?.currentPeriodEnd ? new Date(status.subscription.currentPeriodEnd) : null
   const now = new Date()
   const daysUntilEnd = periodEnd ? Math.ceil((periodEnd.getTime() - now.getTime()) / (1000 * 60 * 60 * 24)) : null

--- a/app/[locale]/dashboard/admin/billing/upgrade/page.tsx
+++ b/app/[locale]/dashboard/admin/billing/upgrade/page.tsx
@@ -26,7 +26,7 @@ export default async function UpgradePage({
     intervalParam === 'yearly' || intervalParam === 'monthly' ? intervalParam : undefined
 
   const sub = status.subscription
-  const activeStripeSub = !!sub && sub.paymentMethod === 'stripe' && sub.status === 'active'
+  const activeStripeSub = !!sub && sub.paymentProvider === 'stripe' && sub.status === 'active'
   const currentInterval: 'monthly' | 'yearly' = sub?.interval === 'yearly' ? 'yearly' : 'monthly'
 
   return (

--- a/app/[locale]/platform/billing-health/page.tsx
+++ b/app/[locale]/platform/billing-health/page.tsx
@@ -1,5 +1,10 @@
-import { getAtRiskTenants } from '@/app/actions/platform/billing-health'
+import Link from 'next/link'
+import {
+  getAtRiskTenants,
+  getPlanConfigurationHealth,
+} from '@/app/actions/platform/billing-health'
 import type { AtRiskReason } from '@/lib/billing/billing-health'
+import { providerLabel } from '@/lib/billing/plan-prices'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { format } from 'date-fns'
@@ -23,7 +28,10 @@ function reasonLabel(reason: AtRiskReason, cutoffActive: boolean): string {
 }
 
 export default async function PlatformBillingHealthPage() {
-  const atRisk = await getAtRiskTenants()
+  const [atRisk, planHealth] = await Promise.all([
+    getAtRiskTenants(),
+    getPlanConfigurationHealth(),
+  ])
 
   // The metric cards deliberately keep counting past-due tenants only, so the
   // numbers do not silently change meaning now that #514 also lists tenants
@@ -36,7 +44,7 @@ export default async function PlatformBillingHealthPage() {
       t.reasons.includes('tenant_past_due') || t.reasons.includes('subscription_past_due')
     if (isPastDue) {
       counts.pastDue++
-      if (t.paymentMethod === 'manual_transfer') {
+      if (t.paymentProvider === 'manual') {
         counts.manualTransfer++
         if (t.daysUntilDowngrade !== null && t.daysUntilDowngrade <= 3) counts.urgent++
       } else {
@@ -93,6 +101,100 @@ export default async function PlatformBillingHealthPage() {
           downgrade or access cutoff.
         </p>
       </div>
+
+      {/*
+        Plan configuration (#602). Its own section, not a row in the at-risk
+        table: a plan with no price belongs to no tenant and breaks checkout for
+        every school at once, so it outranks any individual school's countdown.
+      */}
+      <Card className="mb-8" data-testid="plan-configuration-health">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            Plan configuration
+            {planHealth.unpurchasable.length === 0 &&
+            planHealth.partiallyPriced.length === 0 ? (
+              <Badge variant="secondary" className="text-[10px]" data-testid="plan-config-status" data-status="ok">
+                All plans purchasable
+              </Badge>
+            ) : (
+              <Badge variant="destructive" className="text-[10px]" data-testid="plan-config-status" data-status="broken">
+                {planHealth.unpurchasable.length + planHealth.partiallyPriced.length} needing attention
+              </Badge>
+            )}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {planHealth.unpurchasable.length === 0 && planHealth.partiallyPriced.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              Every active paid plan has an active provider price. Card checkout can reach a
+              hosted page for all of them.
+            </p>
+          ) : (
+            <>
+              {planHealth.unpurchasable.length > 0 && (
+                <div
+                  className="rounded-lg border border-red-200 bg-red-50 p-4 dark:border-red-900/50 dark:bg-red-950/40"
+                  data-testid="unpurchasable-plans"
+                >
+                  <p className="text-sm font-medium text-red-800 dark:text-red-300">
+                    Not purchasable — no active provider price
+                  </p>
+                  <p className="mt-0.5 text-xs text-red-700/80 dark:text-red-400/80">
+                    These plans are advertised with a price but every card upgrade fails with
+                    &ldquo;price not configured&rdquo;. The only way to pay for them is an offline
+                    transfer.
+                  </p>
+                  <ul className="mt-3 space-y-1.5 text-sm">
+                    {planHealth.unpurchasable.map((plan) => (
+                      <li
+                        key={plan.planId}
+                        className="flex items-center gap-2"
+                        data-testid="unpurchasable-plan-row"
+                        data-plan-slug={plan.slug}
+                      >
+                        <span className="font-medium text-red-800 dark:text-red-300">{plan.name}</span>
+                        <Badge variant="outline" className="font-mono text-[10px]">{plan.slug}</Badge>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              {planHealth.partiallyPriced.length > 0 && (
+                <div
+                  className="rounded-lg border border-amber-200 bg-amber-50 p-4 dark:border-amber-900/50 dark:bg-amber-950/40"
+                  data-testid="partially-priced-plans"
+                >
+                  <p className="text-sm font-medium text-amber-800 dark:text-amber-300">
+                    Priced on some intervals only
+                  </p>
+                  <ul className="mt-3 space-y-1.5 text-sm">
+                    {planHealth.partiallyPriced.map((plan) => (
+                      <li
+                        key={plan.planId}
+                        data-testid="partially-priced-plan-row"
+                        data-plan-slug={plan.slug}
+                      >
+                        <span className="font-medium text-amber-800 dark:text-amber-300">{plan.name}</span>{' '}
+                        <span className="text-amber-700/80 dark:text-amber-400/80">
+                          — no price for {plan.missingIntervals.join(' or ')}; buyable via{' '}
+                          {plan.providers.map((p) => providerLabel(p.provider)).join(', ')}
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              <p className="text-sm">
+                <Link href="/platform/plans" className="text-primary underline underline-offset-4">
+                  Configure provider prices on /platform/plans
+                </Link>
+              </p>
+            </>
+          )}
+        </CardContent>
+      </Card>
 
       <div className="mb-8 grid gap-3 sm:grid-cols-2 lg:grid-cols-4" data-testid="billing-health-metrics">
         {metricCards.map((card) => (
@@ -155,7 +257,7 @@ export default async function PlatformBillingHealthPage() {
                         </div>
                       </td>
                       <td className="py-2.5 text-muted-foreground">
-                        {t.paymentMethod === 'manual_transfer' ? 'Manual transfer' : t.paymentMethod === 'stripe' ? 'Stripe' : '—'}
+                        {t.paymentProvider ? providerLabel(t.paymentProvider) : '—'}
                       </td>
                       <td className="py-2.5 text-muted-foreground">
                         {t.pastDueSince ? format(new Date(t.pastDueSince), 'MMM d, yyyy') : '—'}

--- a/app/[locale]/platform/plans/page.tsx
+++ b/app/[locale]/platform/plans/page.tsx
@@ -1,33 +1,104 @@
 import { createAdminClient } from '@/lib/supabase/admin'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
+import { IconAlertTriangle } from '@tabler/icons-react'
+import {
+  summarizePlanPurchasability,
+  type PlatformPlanPriceInput,
+} from '@/lib/billing/plan-prices'
 import { PlanEditor } from './plan-editor'
+import {
+  PlanPricesEditor,
+  PlanPurchasabilityBadge,
+  PlanPurchasabilityChip,
+} from './plan-prices-editor'
 
 export default async function PlatformPlansPage() {
   const adminClient = createAdminClient()
 
-  const { data: plans } = await adminClient
-    .from('platform_plans')
-    .select('*')
-    .order('sort_order', { ascending: true })
+  const [{ data: plans }, { data: priceRows }] = await Promise.all([
+    adminClient.from('platform_plans').select('*').order('sort_order', { ascending: true }),
+    adminClient
+      .from('platform_plan_prices')
+      .select('*')
+      .order('payment_provider', { ascending: true })
+      .order('interval', { ascending: true }),
+  ])
+
+  // Mapped rather than `as`-cast so a drifting select list fails the build here
+  // instead of rendering a plan as unpurchasable when it is merely unmapped.
+  const prices: PlatformPlanPriceInput[] = (priceRows || []).map((row) => ({
+    priceId: row.price_id,
+    planId: row.plan_id,
+    paymentProvider: row.payment_provider,
+    interval: row.interval,
+    providerPriceId: row.provider_price_id,
+    currency: row.currency,
+    amount: row.amount,
+    isActive: row.is_active,
+  }))
+
+  const purchasability = summarizePlanPurchasability(
+    (plans || []).map((plan) => ({
+      planId: plan.plan_id,
+      slug: plan.slug,
+      name: plan.name,
+      priceMonthly: Number(plan.price_monthly ?? 0),
+      priceYearly: Number(plan.price_yearly ?? 0),
+      isActive: plan.is_active,
+    })),
+    prices,
+  )
+  const purchasabilityByPlan = new Map(purchasability.map((p) => [p.planId, p]))
+  const unpurchasableCount = purchasability.filter(
+    (p) => p.isActive && p.isPaid && !p.isPurchasable,
+  ).length
 
   return (
     <main className="flex-1 px-4 py-6 sm:px-6 lg:px-8" data-testid="platform-plans-page">
       <div className="mb-6 flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold tracking-tight">Platform Plans</h1>
-          <p className="text-sm text-muted-foreground mt-1">Manage pricing and feature limits for all plans.</p>
+          <p className="text-sm text-muted-foreground mt-1">Manage pricing, provider prices and feature limits for all plans.</p>
         </div>
       </div>
 
+      {unpurchasableCount > 0 && (
+        <div
+          className="mb-6 flex items-start gap-3 rounded-lg border border-red-200 bg-red-50 p-4 dark:border-red-900/50 dark:bg-red-950/40"
+          data-testid="plans-unpurchasable-warning"
+          role="status"
+        >
+          <IconAlertTriangle
+            className="mt-0.5 h-[18px] w-[18px] shrink-0 text-red-700 dark:text-red-400"
+            strokeWidth={1.75}
+          />
+          <div className="text-sm">
+            <p className="font-medium text-red-800 dark:text-red-300">
+              {unpurchasableCount} active paid {unpurchasableCount === 1 ? 'plan is' : 'plans are'} not purchasable
+            </p>
+            <p className="mt-0.5 text-red-700/80 dark:text-red-400/80">
+              They are advertised on the pricing page but have no active provider price, so card
+              checkout fails with &ldquo;price not configured&rdquo;. Add one under <strong>Prices</strong>.
+            </p>
+          </div>
+        </div>
+      )}
+
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-        {(plans || []).map((plan: any) => (
+        {(plans || []).map((plan) => {
+          const summary = purchasabilityByPlan.get(plan.plan_id)
+          const planPrices = prices.filter((p) => p.planId === plan.plan_id)
+          return (
           <Card key={plan.plan_id} className={`transition-all ${!plan.is_active ? 'opacity-50' : 'hover:shadow-md'}`} data-testid="plan-card" data-plan-slug={plan.slug}>
             <CardHeader className="pb-3">
               <div className="flex items-center justify-between">
                 <CardTitle className="text-lg capitalize">{plan.name}</CardTitle>
                 <div className="flex gap-1.5">
                   {!plan.is_active && <Badge variant="secondary" className="text-[10px]">Inactive</Badge>}
+                  {plan.is_active && summary?.isPaid && (
+                    <PlanPurchasabilityChip isPurchasable={summary.isPurchasable} />
+                  )}
                   <Badge variant="outline" className="font-mono text-[10px]">{plan.slug}</Badge>
                 </div>
               </div>
@@ -71,10 +142,32 @@ export default async function PlatformPlansPage() {
                 </div>
               )}
 
+              {/* Purchasability — the #602 check, per plan. */}
+              <div className="border-t pt-4">
+                <p className="text-[11px] uppercase tracking-wider text-muted-foreground mb-2">Checkout</p>
+                {summary && (
+                  <PlanPurchasabilityBadge
+                    isPaid={summary.isPaid}
+                    isPurchasable={summary.isPurchasable}
+                    providers={summary.providers}
+                    missingIntervals={summary.missingIntervals}
+                  />
+                )}
+              </div>
+
+              <div className="flex gap-2 pt-2 border-t">
+                <PlanPricesEditor
+                  planId={plan.plan_id}
+                  planSlug={plan.slug}
+                  prices={planPrices}
+                />
+              </div>
+
               <PlanEditor plan={plan} />
             </CardContent>
           </Card>
-        ))}
+          )
+        })}
       </div>
     </main>
   )

--- a/app/[locale]/platform/plans/plan-prices-editor.tsx
+++ b/app/[locale]/platform/plans/plan-prices-editor.tsx
@@ -1,0 +1,421 @@
+"use client"
+
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+import { toast } from "sonner"
+import { IconTrash } from "@tabler/icons-react"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Badge } from "@/components/ui/badge"
+import { Switch } from "@/components/ui/switch"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  deletePlatformPlanPrice,
+  upsertPlatformPlanPrice,
+} from "@/app/actions/platform/plans"
+import {
+  PLAN_PRICE_CURRENCIES,
+  PLAN_PRICE_INTERVALS,
+  PLATFORM_BILLING_UI_PROVIDERS,
+  providerLabel,
+  type PlatformPlanPriceInput,
+} from "@/lib/billing/plan-prices"
+
+interface Props {
+  planId: string
+  planSlug: string
+  /** Every price row for this plan, active or not. */
+  prices: PlatformPlanPriceInput[]
+}
+
+const EMPTY_FORM = {
+  paymentProvider: PLATFORM_BILLING_UI_PROVIDERS[0] as string,
+  interval: "monthly" as string,
+  providerPriceId: "",
+  currency: "usd" as string,
+  amount: "",
+  isActive: true,
+}
+
+/**
+ * Super-admin price management for one platform plan (#602).
+ *
+ * Until this existed, `platform_plan_prices` (and before #601, the
+ * `stripe_price_id_*` columns) had no writer anywhere in the repo — the only
+ * documented way to make a plan buyable was a line in `docs/MONETIZATION.md`
+ * telling a human to run SQL, which is why every plan 400s on card checkout on
+ * any environment where nobody did.
+ */
+export function PlanPricesEditor({ planId, planSlug, prices }: Props) {
+  const router = useRouter()
+  const [open, setOpen] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [busyPriceId, setBusyPriceId] = useState<string | null>(null)
+  const [form, setForm] = useState(EMPTY_FORM)
+
+  const activeCount = prices.filter((p) => p.isActive).length
+
+  // Saving a (provider, interval) that already has a row updates it — the
+  // action upserts on the table's unique constraint. Say so, rather than
+  // letting a super admin discover it by finding a duplicate that never appears.
+  const editingExisting = prices.find(
+    (p) => p.paymentProvider === form.paymentProvider && p.interval === form.interval
+  )
+
+  async function handleSave() {
+    setSaving(true)
+    try {
+      const trimmedAmount = form.amount.trim()
+      await upsertPlatformPlanPrice({
+        planId,
+        paymentProvider: form.paymentProvider,
+        interval: form.interval,
+        providerPriceId: form.providerPriceId,
+        currency: form.currency,
+        amount: trimmedAmount === "" ? null : Number(trimmedAmount),
+        isActive: form.isActive,
+      })
+      toast.success(editingExisting ? "Price updated" : "Price added")
+      setForm(EMPTY_FORM)
+      router.refresh()
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to save price")
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function handleToggleActive(price: PlatformPlanPriceInput) {
+    setBusyPriceId(price.priceId)
+    try {
+      await upsertPlatformPlanPrice({
+        planId,
+        paymentProvider: price.paymentProvider,
+        interval: price.interval,
+        providerPriceId: price.providerPriceId,
+        currency: price.currency,
+        amount: price.amount,
+        isActive: !price.isActive,
+      })
+      toast.success(price.isActive ? "Price deactivated" : "Price activated")
+      router.refresh()
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to update price")
+    } finally {
+      setBusyPriceId(null)
+    }
+  }
+
+  async function handleDelete(price: PlatformPlanPriceInput) {
+    setBusyPriceId(price.priceId)
+    try {
+      await deletePlatformPlanPrice(price.priceId)
+      toast.success("Price removed")
+      router.refresh()
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to remove price")
+    } finally {
+      setBusyPriceId(null)
+    }
+  }
+
+  return (
+    <>
+      <Button
+        size="sm"
+        variant="outline"
+        onClick={() => setOpen(true)}
+        className="flex-1"
+        data-testid="plan-prices-btn"
+      >
+        Prices{activeCount > 0 ? ` (${activeCount})` : ""}
+      </Button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-w-2xl" data-testid="plan-prices-dialog">
+          <DialogHeader>
+            <DialogTitle>Provider prices — {planSlug}</DialogTitle>
+          </DialogHeader>
+
+          <div className="space-y-5 py-2">
+            <p className="text-xs text-muted-foreground">
+              A plan is only purchasable through a provider that has an active price here.
+              Paste the id the provider generated (Stripe <code className="font-mono">price_…</code>,
+              Lemon Squeezy variant id); this app never creates it for you.
+            </p>
+
+            <div>
+              <p className="mb-2 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+                Configured prices
+              </p>
+              {prices.length === 0 ? (
+                <p
+                  className="rounded-md border border-dashed p-4 text-sm text-muted-foreground"
+                  data-testid="plan-prices-empty"
+                >
+                  No prices configured — this plan cannot be bought through any provider.
+                </p>
+              ) : (
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="border-b text-left text-[11px] uppercase tracking-wider text-muted-foreground">
+                        <th className="pb-2 font-medium">Provider</th>
+                        <th className="pb-2 font-medium">Interval</th>
+                        <th className="pb-2 font-medium">Price ID</th>
+                        <th className="pb-2 font-medium">Amount</th>
+                        <th className="pb-2 font-medium">Active</th>
+                        <th className="pb-2" aria-label="Actions" />
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {prices.map((price) => (
+                        <tr
+                          key={price.priceId}
+                          className="border-b last:border-0"
+                          data-testid="plan-price-row"
+                          data-provider={price.paymentProvider}
+                          data-interval={price.interval}
+                        >
+                          <td className="py-2.5 font-medium">
+                            {providerLabel(price.paymentProvider)}
+                          </td>
+                          <td className="py-2.5 capitalize text-muted-foreground">
+                            {price.interval}
+                          </td>
+                          <td className="max-w-[14rem] truncate py-2.5 font-mono text-xs">
+                            {price.providerPriceId}
+                          </td>
+                          <td className="py-2.5 tabular-nums text-muted-foreground">
+                            {price.amount === null
+                              ? "—"
+                              : `${price.amount} ${price.currency.toUpperCase()}`}
+                          </td>
+                          <td className="py-2.5">
+                            <Switch
+                              checked={price.isActive}
+                              disabled={busyPriceId === price.priceId}
+                              onCheckedChange={() => handleToggleActive(price)}
+                              aria-label={`${price.isActive ? "Deactivate" : "Activate"} ${providerLabel(price.paymentProvider)} ${price.interval} price`}
+                              data-testid="plan-price-active-toggle"
+                            />
+                          </td>
+                          <td className="py-2.5 text-right">
+                            <Button
+                              size="sm"
+                              variant="ghost"
+                              disabled={busyPriceId === price.priceId}
+                              onClick={() => handleDelete(price)}
+                              aria-label={`Remove ${providerLabel(price.paymentProvider)} ${price.interval} price`}
+                              data-testid="plan-price-delete-btn"
+                            >
+                              <IconTrash className="h-4 w-4" strokeWidth={1.75} />
+                            </Button>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </div>
+
+            <div className="space-y-4 border-t pt-4">
+              <p className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+                {editingExisting ? "Update price" : "Add price"}
+              </p>
+
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="space-y-1.5">
+                  <Label htmlFor={`provider-${planId}`}>Provider</Label>
+                  <Select
+                    value={form.paymentProvider}
+                    onValueChange={(v) => v && setForm((p) => ({ ...p, paymentProvider: v }))}
+                  >
+                    <SelectTrigger id={`provider-${planId}`} className="w-full" data-testid="plan-price-provider-select">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {PLATFORM_BILLING_UI_PROVIDERS.map((provider) => (
+                        <SelectItem key={provider} value={provider}>
+                          {providerLabel(provider)}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="space-y-1.5">
+                  <Label htmlFor={`interval-${planId}`}>Interval</Label>
+                  <Select
+                    value={form.interval}
+                    onValueChange={(v) => v && setForm((p) => ({ ...p, interval: v }))}
+                  >
+                    <SelectTrigger id={`interval-${planId}`} className="w-full" data-testid="plan-price-interval-select">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {PLAN_PRICE_INTERVALS.map((interval) => (
+                        <SelectItem key={interval} value={interval}>
+                          <span className="capitalize">{interval}</span>
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+
+              <div className="space-y-1.5">
+                <Label htmlFor={`price-id-${planId}`}>Provider price ID</Label>
+                <Input
+                  id={`price-id-${planId}`}
+                  className="font-mono text-xs"
+                  placeholder="price_1234…"
+                  value={form.providerPriceId}
+                  onChange={(e) => setForm((p) => ({ ...p, providerPriceId: e.target.value }))}
+                  data-testid="plan-price-id-input"
+                />
+              </div>
+
+              <div className="grid gap-4 sm:grid-cols-3">
+                <div className="space-y-1.5">
+                  <Label htmlFor={`currency-${planId}`}>Currency</Label>
+                  <Select
+                    value={form.currency}
+                    onValueChange={(v) => v && setForm((p) => ({ ...p, currency: v }))}
+                  >
+                    <SelectTrigger id={`currency-${planId}`} className="w-full">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {PLAN_PRICE_CURRENCIES.map((currency) => (
+                        <SelectItem key={currency} value={currency}>
+                          {currency.toUpperCase()}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="space-y-1.5">
+                  <Label htmlFor={`amount-${planId}`}>Amount</Label>
+                  <Input
+                    id={`amount-${planId}`}
+                    type="number"
+                    step="0.01"
+                    min="0"
+                    placeholder="Optional"
+                    value={form.amount}
+                    onChange={(e) => setForm((p) => ({ ...p, amount: e.target.value }))}
+                    data-testid="plan-price-amount-input"
+                  />
+                </div>
+
+                <div className="space-y-1.5">
+                  <Label htmlFor={`active-${planId}`}>Active</Label>
+                  <div className="flex h-9 items-center">
+                    <Switch
+                      id={`active-${planId}`}
+                      checked={form.isActive}
+                      onCheckedChange={(checked) => setForm((p) => ({ ...p, isActive: checked }))}
+                    />
+                  </div>
+                </div>
+              </div>
+
+              <p className="text-xs text-muted-foreground">
+                {editingExisting
+                  ? `Saving overwrites the existing ${providerLabel(form.paymentProvider)} ${form.interval} price.`
+                  : "Leave the amount blank when the provider charges the plan's listed price."}
+              </p>
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setOpen(false)}>
+              Close
+            </Button>
+            <Button
+              onClick={handleSave}
+              disabled={saving || form.providerPriceId.trim() === ""}
+              data-testid="plan-price-save-btn"
+            >
+              {saving ? "Saving…" : editingExisting ? "Update price" : "Add price"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}
+
+/** Small read-only summary rendered on the plan card itself. */
+export function PlanPurchasabilityBadge({
+  isPaid,
+  isPurchasable,
+  providers,
+  missingIntervals,
+}: {
+  isPaid: boolean
+  isPurchasable: boolean
+  providers: { provider: string; intervals: string[] }[]
+  missingIntervals: string[]
+}) {
+  if (!isPaid) {
+    return (
+      <p className="text-xs text-muted-foreground" data-testid="plan-purchasability">
+        Free plan — no provider price needed.
+      </p>
+    )
+  }
+
+  if (!isPurchasable) {
+    return (
+      <p
+        className="text-xs font-medium text-red-700 dark:text-red-400"
+        data-testid="plan-purchasability"
+        data-purchasable="false"
+      >
+        Not purchasable — no active provider price. Card checkout will fail.
+      </p>
+    )
+  }
+
+  return (
+    <div className="space-y-1" data-testid="plan-purchasability" data-purchasable="true">
+      <p className="text-xs text-muted-foreground">
+        Purchasable via{" "}
+        {providers
+          .map((p) => `${providerLabel(p.provider)} (${p.intervals.join(", ")})`)
+          .join(" · ")}
+      </p>
+      {missingIntervals.length > 0 && (
+        <p className="text-xs font-medium text-amber-700 dark:text-amber-400">
+          No price for {missingIntervals.join(" or ")} — that interval is advertised but unbuyable.
+        </p>
+      )}
+    </div>
+  )
+}
+
+export function PlanPurchasabilityChip({ isPurchasable }: { isPurchasable: boolean }) {
+  return isPurchasable ? null : (
+    <Badge variant="destructive" className="text-[10px]" data-testid="plan-unpurchasable-chip">
+      No price
+    </Badge>
+  )
+}

--- a/app/actions/admin/billing.ts
+++ b/app/actions/admin/billing.ts
@@ -118,7 +118,11 @@ export async function getSubscriptionStatus() {
     accessCutoffAt: tenant?.access_cutoff_at ?? null,
     subscription: subscription ? {
       status: subscription.status,
-      paymentMethod: subscription.payment_provider,
+      // Named for the column it carries (#602). While this was `paymentMethod`
+      // its readers compared it against `'manual_transfer'`, which #601 folded
+      // into `'manual'` — so every bank-transfer school was rendered as a card
+      // payer and lost its manual-renewal UI.
+      paymentProvider: subscription.payment_provider,
       interval: subscription.interval,
       cancelAtPeriodEnd: subscription.cancel_at_period_end,
       currentPeriodStart: subscription.current_period_start,
@@ -129,7 +133,7 @@ export async function getSubscriptionStatus() {
       amount: nextPaymentAmount,
       currency: 'USD',
       dueDate: nextPaymentDate,
-      paymentMethod: subscription?.payment_provider || null,
+      paymentProvider: subscription?.payment_provider || null,
     } : null,
     usage: {
       courses: {

--- a/app/actions/platform/billing-health.ts
+++ b/app/actions/platform/billing-health.ts
@@ -12,6 +12,13 @@ import {
   type AtRiskTenantRow,
   type PastDueSubscriptionInput,
 } from '@/lib/billing/billing-health'
+import {
+  findPartiallyPricedPlans,
+  findUnpurchasablePlans,
+  type PlanPurchasability,
+  type PlatformPlanInput,
+  type PlatformPlanPriceInput,
+} from '@/lib/billing/plan-prices'
 
 async function verifySuperAdmin() {
   const userId = await getCurrentUserId()
@@ -53,7 +60,10 @@ function toSubscriptionInput(row: {
   return {
     tenantId: row.tenant_id,
     status: row.status,
-    paymentMethod: row.payment_provider,
+    // Field and column agree by name since #602. Before that this mapped
+    // `payment_provider` onto a field called `paymentMethod`, and every reader
+    // compared it against `'manual_transfer'` — a value #601 had retired.
+    paymentProvider: row.payment_provider,
     currentPeriodEnd: row.current_period_end,
     gracePeriodEnd: row.grace_period_end,
     updatedAt: row.updated_at,
@@ -161,4 +171,69 @@ export async function getAtRiskTenants(): Promise<AtRiskTenant[]> {
     [...pastDueSubscriptionRows, ...knownSubscriptions.map(toSubscriptionInput)],
     new Date(),
   )
+}
+
+export interface PlanConfigurationHealth {
+  /** Active paid plans with no active provider price — card checkout 400s. */
+  unpurchasable: PlanPurchasability[]
+  /** Buyable, but not on every interval they quote a price for. */
+  partiallyPriced: PlanPurchasability[]
+}
+
+/**
+ * The plan-configuration half of billing health (#602).
+ *
+ * Deliberately a separate action from `getAtRiskTenants` rather than another
+ * branch inside it: that one returns `AtRiskTenant[]`, and a plan with no price
+ * belongs to no tenant. Two reads, its own section on the page.
+ *
+ * Both tables are small and bounded (five plans, at most a handful of price
+ * rows each), so this does not need `fetchAllRows` — but it *is* the check that
+ * catches a truncated or empty price table, so it reads every row rather than
+ * probing one plan at a time.
+ */
+export async function getPlanConfigurationHealth(): Promise<PlanConfigurationHealth> {
+  await verifySuperAdmin()
+  const admin = createAdminClient()
+
+  const [{ data: planRows, error: plansError }, { data: priceRows, error: pricesError }] =
+    await Promise.all([
+      admin
+        .from('platform_plans')
+        .select('plan_id, slug, name, price_monthly, price_yearly, is_active')
+        .order('sort_order', { ascending: true }),
+      admin
+        .from('platform_plan_prices')
+        .select('price_id, plan_id, payment_provider, interval, provider_price_id, currency, amount, is_active'),
+    ])
+
+  // A failed read must not render as "everything is configured" — that is the
+  // silent-green failure this whole check exists to prevent.
+  if (plansError) throw new Error(`Failed to fetch platform plans: ${plansError.message}`)
+  if (pricesError) throw new Error(`Failed to fetch plan prices: ${pricesError.message}`)
+
+  const plans: PlatformPlanInput[] = (planRows || []).map((row) => ({
+    planId: row.plan_id,
+    slug: row.slug,
+    name: row.name,
+    priceMonthly: Number(row.price_monthly ?? 0),
+    priceYearly: Number(row.price_yearly ?? 0),
+    isActive: row.is_active,
+  }))
+
+  const prices: PlatformPlanPriceInput[] = (priceRows || []).map((row) => ({
+    priceId: row.price_id,
+    planId: row.plan_id,
+    paymentProvider: row.payment_provider,
+    interval: row.interval,
+    providerPriceId: row.provider_price_id,
+    currency: row.currency,
+    amount: row.amount,
+    isActive: row.is_active,
+  }))
+
+  return {
+    unpurchasable: findUnpurchasablePlans(plans, prices),
+    partiallyPriced: findPartiallyPricedPlans(plans, prices),
+  }
 }

--- a/app/actions/platform/plans.ts
+++ b/app/actions/platform/plans.ts
@@ -1,6 +1,5 @@
 'use server'
 
-import { createClient } from '@/lib/supabase/server'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { isSuperAdmin } from '@/lib/supabase/get-user-role'
 import { revalidatePath } from 'next/cache'
@@ -15,7 +14,6 @@ import {
 } from '@/lib/billing/plan-prices'
 
 async function verifySuperAdmin() {
-  const supabase = await createClient()
   const userId = await getCurrentUserId()
   if (!userId) throw new Error('Not authenticated')
   if (!(await isSuperAdmin())) throw new Error('Super admin only')
@@ -214,10 +212,7 @@ export async function togglePlanActive(planId: string, isActive: boolean) {
 }
 
 export async function rejectManualPayment(requestId: string, reason: string) {
-  const supabase = await createClient()
-  const userId = await getCurrentUserId()
-  if (!userId) throw new Error('Not authenticated')
-  if (!(await isSuperAdmin())) throw new Error('Super admin only')
+  await verifySuperAdmin()
 
   const adminClient = createAdminClient()
   const { error } = await adminClient

--- a/app/actions/platform/plans.ts
+++ b/app/actions/platform/plans.ts
@@ -82,25 +82,6 @@ export async function createPlatformPlan(data: {
 }
 
 /**
- * Every provider price a plan can be bought through (#602).
- *
- * Returns inactive rows as well: the editor has to show a price that was
- * toggled off, or turning it back on would mean retyping the provider's id
- * from memory.
- */
-export async function getPlatformPlanPrices() {
-  await verifySuperAdmin()
-  const adminClient = createAdminClient()
-  const { data, error } = await adminClient
-    .from('platform_plan_prices')
-    .select('*')
-    .order('payment_provider', { ascending: true })
-    .order('interval', { ascending: true })
-  if (error) throw new Error(`Failed to fetch plan prices: ${error.message}`)
-  return data || []
-}
-
-/**
  * Set (or clear) what a plan costs on one provider, for one interval — the
  * write that #602 says has never existed anywhere in the repo.
  *

--- a/app/actions/platform/plans.ts
+++ b/app/actions/platform/plans.ts
@@ -5,6 +5,14 @@ import { createAdminClient } from '@/lib/supabase/admin'
 import { isSuperAdmin } from '@/lib/supabase/get-user-role'
 import { revalidatePath } from 'next/cache'
 import { getCurrentUserId } from '@/lib/supabase/tenant'
+import {
+  PLAN_PRICE_CURRENCIES,
+  PLAN_PRICE_INTERVALS,
+  PLAN_PRICE_PROVIDERS,
+  type PlanPriceCurrency,
+  type PlanPriceInterval,
+  type PlanPriceProvider,
+} from '@/lib/billing/plan-prices'
 
 async function verifySuperAdmin() {
   const supabase = await createClient()
@@ -70,6 +78,130 @@ export async function createPlatformPlan(data: {
 
   if (error) throw new Error(`Failed to create plan: ${error.message}`)
   revalidatePath('/platform/plans')
+  return { success: true }
+}
+
+/**
+ * Every provider price a plan can be bought through (#602).
+ *
+ * Returns inactive rows as well: the editor has to show a price that was
+ * toggled off, or turning it back on would mean retyping the provider's id
+ * from memory.
+ */
+export async function getPlatformPlanPrices() {
+  await verifySuperAdmin()
+  const adminClient = createAdminClient()
+  const { data, error } = await adminClient
+    .from('platform_plan_prices')
+    .select('*')
+    .order('payment_provider', { ascending: true })
+    .order('interval', { ascending: true })
+  if (error) throw new Error(`Failed to fetch plan prices: ${error.message}`)
+  return data || []
+}
+
+/**
+ * Set (or clear) what a plan costs on one provider, for one interval — the
+ * write that #602 says has never existed anywhere in the repo.
+ *
+ * Upserts on the table's own `(plan_id, payment_provider, interval)` unique
+ * constraint, so re-saving a combination corrects it rather than failing; that
+ * is what a super admin fixing a mistyped Stripe price id actually wants.
+ *
+ * Every enum-ish field is validated here rather than left to the CHECK
+ * constraints. A rejected CHECK surfaces as an opaque Postgres error string in
+ * a toast; validating first means the caller gets told which field is wrong.
+ * The lists come from `lib/billing/plan-prices.ts`, which mirrors the
+ * migration — so this accepts everything the database accepts, including
+ * providers the editor's own dropdown does not yet offer.
+ */
+export async function upsertPlatformPlanPrice(input: {
+  planId: string
+  paymentProvider: string
+  interval: string
+  providerPriceId: string
+  currency?: string
+  amount?: number | null
+  isActive?: boolean
+}) {
+  await verifySuperAdmin()
+
+  const provider = input.paymentProvider as PlanPriceProvider
+  if (!PLAN_PRICE_PROVIDERS.includes(provider)) {
+    throw new Error(`Unknown payment provider: ${input.paymentProvider}`)
+  }
+
+  const interval = input.interval as PlanPriceInterval
+  if (!PLAN_PRICE_INTERVALS.includes(interval)) {
+    throw new Error(`Interval must be monthly or yearly, got: ${input.interval}`)
+  }
+
+  const currency = (input.currency ?? 'usd') as PlanPriceCurrency
+  if (!PLAN_PRICE_CURRENCIES.includes(currency)) {
+    throw new Error(`Unsupported currency: ${input.currency}`)
+  }
+
+  // NOT NULL in the schema, and a whitespace-only id would pass that while
+  // still never matching anything at the provider.
+  const providerPriceId = input.providerPriceId.trim()
+  if (!providerPriceId) throw new Error('Provider price ID is required')
+
+  // `amount` is nullable on purpose (the migration's own note): on a non-USD
+  // rail the provider may charge something that is not `platform_plans.price_*`,
+  // and where it does match there is nothing to record. A negative or NaN
+  // amount is a typo either way.
+  const amount = input.amount ?? null
+  if (amount !== null && (!Number.isFinite(amount) || amount < 0)) {
+    throw new Error('Amount must be a positive number, or left blank')
+  }
+
+  const adminClient = createAdminClient()
+
+  const { data: plan } = await adminClient
+    .from('platform_plans')
+    .select('plan_id')
+    .eq('plan_id', input.planId)
+    .maybeSingle()
+  if (!plan) throw new Error('Plan not found')
+
+  const { error } = await adminClient.from('platform_plan_prices').upsert(
+    {
+      plan_id: input.planId,
+      payment_provider: provider,
+      interval,
+      provider_price_id: providerPriceId,
+      currency,
+      amount,
+      is_active: input.isActive ?? true,
+      updated_at: new Date().toISOString(),
+    },
+    { onConflict: 'plan_id,payment_provider,interval' }
+  )
+
+  if (error) throw new Error(`Failed to save plan price: ${error.message}`)
+  revalidatePath('/platform/plans')
+  revalidatePath('/platform/billing-health')
+  return { success: true }
+}
+
+/**
+ * Remove a provider price outright. Deactivating (`is_active = false`) is the
+ * safer everyday move and is what the editor's toggle does; this is for a row
+ * created against the wrong plan, where leaving it inactive just clutters the
+ * dialog forever.
+ */
+export async function deletePlatformPlanPrice(priceId: string) {
+  await verifySuperAdmin()
+  const adminClient = createAdminClient()
+
+  const { error } = await adminClient
+    .from('platform_plan_prices')
+    .delete()
+    .eq('price_id', priceId)
+
+  if (error) throw new Error(`Failed to delete plan price: ${error.message}`)
+  revalidatePath('/platform/plans')
+  revalidatePath('/platform/billing-health')
   return { success: true }
 }
 

--- a/components/admin/billing-overview.tsx
+++ b/components/admin/billing-overview.tsx
@@ -16,7 +16,7 @@ interface BillingOverviewProps {
   billingPeriodEnd: string | null
   subscription: {
     status: string
-    paymentMethod: string
+    paymentProvider: string
     interval: string
     cancelAtPeriodEnd: boolean
     currentPeriodStart: string | null
@@ -27,7 +27,7 @@ interface BillingOverviewProps {
     amount: number
     currency: string
     dueDate: string
-    paymentMethod: string | null
+    paymentProvider: string | null
   } | null
   usage: {
     courses: { current: number; limit: number }
@@ -67,7 +67,7 @@ export function BillingOverview({
   const gracePeriodEnd = subscription?.gracePeriodEnd ? new Date(subscription.gracePeriodEnd) : null
   const now = new Date()
   const daysUntilEnd = periodEnd ? Math.ceil((periodEnd.getTime() - now.getTime()) / (1000 * 60 * 60 * 24)) : null
-  const isManualSub = subscription?.paymentMethod === 'manual_transfer'
+  const isManualSub = subscription?.paymentProvider === 'manual'
   const isPastDue = billingStatus === 'past_due'
   const showRenewalWarning = isManualSub && !isPastDue && daysUntilEnd !== null && daysUntilEnd <= 30 && daysUntilEnd > 0
   const daysInGracePeriod = gracePeriodEnd ? Math.ceil((gracePeriodEnd.getTime() - now.getTime()) / (1000 * 60 * 60 * 24)) : null
@@ -174,7 +174,7 @@ export function BillingOverview({
               <div className="text-left sm:text-right">
                 <p className="font-semibold tabular-nums">{formattedUpcomingAmount}</p>
                 <p className="mt-1 text-xs text-muted-foreground">
-                  {upcomingPayment.paymentMethod === 'manual_transfer' ? t('bankTransfer') : t('cardPayment')}
+                  {upcomingPayment.paymentProvider === 'manual' ? t('bankTransfer') : t('cardPayment')}
                 </p>
               </div>
             </section>

--- a/lib/billing/billing-health.ts
+++ b/lib/billing/billing-health.ts
@@ -25,7 +25,7 @@
  *
  * Two past-due paths write `tenants.billing_status = 'past_due'`, and they
  * carry different amounts of information:
- *  - manual_transfer (app/api/cron/expire-platform-subscriptions/route.ts)
+ *  - manual (app/api/cron/expire-platform-subscriptions/route.ts)
  *    stamps a real `platform_subscriptions.grace_period_end` deadline —
  *    downgrade date is exact.
  *  - stripe (app/api/stripe/platform-webhook/route.ts) has no local grace
@@ -114,7 +114,7 @@ export function mergeAtRiskTenants(input: {
 export interface PastDueSubscriptionInput {
   tenantId: string
   status: string | null
-  paymentMethod: string | null
+  paymentProvider: string | null
   currentPeriodEnd: string | null
   gracePeriodEnd: string | null
   updatedAt: string | null
@@ -124,7 +124,7 @@ export interface AtRiskTenant {
   tenantId: string
   tenantName: string
   plan: string | null
-  paymentMethod: string | null
+  paymentProvider: string | null
   pastDueSince: string | null
   graceEndsAt: string | null
   /**
@@ -204,10 +204,15 @@ export function computeBillingHealth(
       reasons.includes('tenant_past_due') || reasons.includes('subscription_past_due')
 
     const sub = subByTenant.get(tenant.tenantId) ?? null
-    const paymentMethod = sub?.paymentMethod ?? null
-    const isManualTransfer = paymentMethod === 'manual_transfer'
+    const paymentProvider = sub?.paymentProvider ?? null
+    // `'manual'`, not `'manual_transfer'`: #601 folded the old two-value
+    // `payment_method` enum into the 8-value provider slug the student half
+    // already uses. This comparison kept the retired string for a commit, which
+    // silently emptied every manual school's countdown while the unit tests —
+    // whose fixtures also predated the fold — stayed green.
+    const isManual = paymentProvider === 'manual'
 
-    const graceEndsAt = isPastDue && isManualTransfer ? sub?.gracePeriodEnd ?? null : null
+    const graceEndsAt = isPastDue && isManual ? sub?.gracePeriodEnd ?? null : null
     const daysUntilDowngrade = graceEndsAt
       ? Math.ceil((new Date(graceEndsAt).getTime() - now.getTime()) / DAY_MS)
       : null
@@ -216,11 +221,11 @@ export function computeBillingHealth(
       tenantId: tenant.tenantId,
       tenantName: tenant.tenantName,
       plan: tenant.plan,
-      paymentMethod,
+      paymentProvider,
       pastDueSince: isPastDue ? sub?.currentPeriodEnd ?? null : null,
       graceEndsAt,
       daysUntilDowngrade,
-      isEstimate: isPastDue && !isManualTransfer,
+      isEstimate: isPastDue && !isManual,
       accessCutoffAt: tenant.accessCutoffAt,
       accessCutoffActive: tenant.accessCutoffAt
         ? new Date(tenant.accessCutoffAt).getTime() <= now.getTime()

--- a/lib/billing/plan-prices.ts
+++ b/lib/billing/plan-prices.ts
@@ -1,0 +1,237 @@
+/**
+ * Whether a platform plan can actually be bought, and through what.
+ *
+ * #602: `platform_plans.stripe_price_id_monthly/_yearly` were read by three
+ * call sites and written by none, so every card upgrade died on
+ * `"Stripe price not configured for this plan"`. #601 replaced those columns
+ * with `platform_plan_prices` — one row per (plan, provider, interval) — but a
+ * table nobody writes fails exactly the same way. This module is the check
+ * that makes the failure visible before a school hits it: an active plan that
+ * charges money and has no active price row is misconfigured, full stop.
+ *
+ * Deliberately *not* folded into `lib/billing/billing-health.ts`. That module
+ * computes `AtRiskTenant[]` — a per-tenant risk view — and a plan with no price
+ * is not tenant-shaped: it affects every school at once and none of them
+ * individually. Forcing it into `AtRiskTenant` would mean inventing a tenant id
+ * for a row that has none.
+ *
+ * Pure/no I/O, like `billing-health.ts` and `lib/payments/payouts-owed.ts`:
+ * the caller does the fetching, so the union logic is unit-testable without a
+ * database. That matters here more than usual — the bug this guards against
+ * survived every prior pass precisely because the unit tests pinned the
+ * modules and nothing tested the callers (#540).
+ */
+
+export type PlanPriceInterval = 'monthly' | 'yearly'
+
+export const PLAN_PRICE_INTERVALS: readonly PlanPriceInterval[] = ['monthly', 'yearly']
+
+/**
+ * Every provider the `platform_plan_prices.payment_provider` CHECK accepts —
+ * kept identical to the migration and to `PaymentProvider` in
+ * `lib/payments/types.ts`, so a 9th provider stays a one-line edit in each.
+ * Writes validate against this; it is the schema's truth, not a policy.
+ */
+export const PLAN_PRICE_PROVIDERS = [
+  'stripe',
+  'paypal',
+  'binance',
+  'binance_personal',
+  'manual',
+  'lemonsqueezy',
+  'solana',
+  'solana_subs',
+] as const
+
+export type PlanPriceProvider = (typeof PLAN_PRICE_PROVIDERS)[number]
+
+/**
+ * The subset offered in the super-admin UI. Platform billing is us selling a
+ * recurring SaaS subscription to a school, which is a different problem from a
+ * school selling a course to a student, and only some rails fit it (#600):
+ * Stripe for native subscriptions and dunning, Lemon Squeezy because
+ * `isMerchantOfRecord` makes it the legal seller and it remits VAT for us, and
+ * PayPal once #479 has run it against real credentials. Crypto rails stay
+ * student-side — a subscription with proration and dunning is not what they
+ * are for — and `manual` settles through `platform_payment_requests`, which
+ * carries its own amount snapshot and needs no price id.
+ *
+ * A narrower list than the CHECK on purpose: the action still accepts anything
+ * the database accepts, so #603/#605 can write a provider this list has not
+ * caught up with yet.
+ */
+export const PLATFORM_BILLING_UI_PROVIDERS: readonly PlanPriceProvider[] = [
+  'stripe',
+  'lemonsqueezy',
+  'paypal',
+]
+
+/** Values of the `currency_type` Postgres enum, which `currency` is typed as. */
+export const PLAN_PRICE_CURRENCIES = [
+  'usd',
+  'eur',
+  'mxn',
+  'cop',
+  'clp',
+  'pen',
+  'ars',
+  'brl',
+] as const
+
+export type PlanPriceCurrency = (typeof PLAN_PRICE_CURRENCIES)[number]
+
+export const PROVIDER_LABELS: Record<PlanPriceProvider, string> = {
+  stripe: 'Stripe',
+  paypal: 'PayPal',
+  binance: 'Binance Pay',
+  binance_personal: 'Binance (personal)',
+  manual: 'Manual transfer',
+  lemonsqueezy: 'Lemon Squeezy',
+  solana: 'Solana',
+  solana_subs: 'Solana (subscription)',
+}
+
+export function providerLabel(provider: string): string {
+  return PROVIDER_LABELS[provider as PlanPriceProvider] ?? provider
+}
+
+/** A `platform_plans` row, only the fields purchasability depends on. */
+export interface PlatformPlanInput {
+  planId: string
+  slug: string
+  name: string
+  priceMonthly: number
+  priceYearly: number
+  isActive: boolean
+}
+
+/** A `platform_plan_prices` row. */
+export interface PlatformPlanPriceInput {
+  priceId: string
+  planId: string
+  paymentProvider: string
+  interval: string
+  providerPriceId: string
+  currency: string
+  amount: number | null
+  isActive: boolean
+}
+
+export interface ProviderCoverage {
+  provider: string
+  /** Intervals this provider has an *active* price row for, monthly first. */
+  intervals: PlanPriceInterval[]
+}
+
+export interface PlanPurchasability {
+  planId: string
+  slug: string
+  name: string
+  isActive: boolean
+  /** True when the plan charges for at least one interval. */
+  isPaid: boolean
+  /** True when at least one active price row exists, on any provider. */
+  isPurchasable: boolean
+  /** Providers with at least one active price row. */
+  providers: ProviderCoverage[]
+  /**
+   * Intervals the plan charges for but no provider covers with an active row.
+   * A plan with a monthly *and* a yearly price but only a monthly price row is
+   * purchasable, yet half its pricing page is a dead button — that is a
+   * weaker problem than "no price at all", so it is reported separately rather
+   * than collapsed into `isPurchasable`.
+   */
+  missingIntervals: PlanPriceInterval[]
+}
+
+function chargedIntervals(plan: PlatformPlanInput): PlanPriceInterval[] {
+  const intervals: PlanPriceInterval[] = []
+  if (plan.priceMonthly > 0) intervals.push('monthly')
+  if (plan.priceYearly > 0) intervals.push('yearly')
+  return intervals
+}
+
+/**
+ * Joins plans to their price rows and reports, per plan, what it can be bought
+ * through. Inactive price rows are ignored everywhere — a row toggled off is
+ * exactly as unbuyable as a row that does not exist, and
+ * `app/api/stripe/checkout-session/route.ts` filters on `is_active` too.
+ */
+export function summarizePlanPurchasability(
+  plans: PlatformPlanInput[],
+  prices: PlatformPlanPriceInput[],
+): PlanPurchasability[] {
+  const activePricesByPlan = new Map<string, PlatformPlanPriceInput[]>()
+  for (const price of prices) {
+    if (!price.isActive) continue
+    const existing = activePricesByPlan.get(price.planId)
+    if (existing) existing.push(price)
+    else activePricesByPlan.set(price.planId, [price])
+  }
+
+  return plans.map((plan) => {
+    const active = activePricesByPlan.get(plan.planId) ?? []
+
+    const intervalsByProvider = new Map<string, Set<string>>()
+    for (const price of active) {
+      const existing = intervalsByProvider.get(price.paymentProvider)
+      if (existing) existing.add(price.interval)
+      else intervalsByProvider.set(price.paymentProvider, new Set([price.interval]))
+    }
+
+    const providers: ProviderCoverage[] = [...intervalsByProvider.entries()]
+      .map(([provider, intervals]) => ({
+        provider,
+        intervals: PLAN_PRICE_INTERVALS.filter((i) => intervals.has(i)),
+      }))
+      .sort((a, b) => a.provider.localeCompare(b.provider))
+
+    const covered = new Set(active.map((p) => p.interval))
+    const charged = chargedIntervals(plan)
+
+    return {
+      planId: plan.planId,
+      slug: plan.slug,
+      name: plan.name,
+      isActive: plan.isActive,
+      isPaid: charged.length > 0,
+      isPurchasable: active.length > 0,
+      providers,
+      missingIntervals: charged.filter((i) => !covered.has(i)),
+    }
+  })
+}
+
+/**
+ * The check `/platform/billing-health` renders: active plans that charge money
+ * and have no active price row on any provider. These are advertised on the
+ * pricing page at `$9/mo` and 400 on every card upgrade — the exact state #602
+ * was filed for.
+ *
+ * The free plan is never listed: it charges nothing and is not meant to be
+ * checked out (`checkout-session/route.ts` rejects it explicitly), so it has
+ * no price to be missing. Neither is an inactive plan — nobody can reach it.
+ */
+export function findUnpurchasablePlans(
+  plans: PlatformPlanInput[],
+  prices: PlatformPlanPriceInput[],
+): PlanPurchasability[] {
+  return summarizePlanPurchasability(plans, prices).filter(
+    (plan) => plan.isActive && plan.isPaid && !plan.isPurchasable,
+  )
+}
+
+/**
+ * The softer half: plans that *are* buyable, but not on every interval they
+ * quote a price for. Reported apart from `findUnpurchasablePlans` so the hard
+ * failure is never diluted by the partial one.
+ */
+export function findPartiallyPricedPlans(
+  plans: PlatformPlanInput[],
+  prices: PlatformPlanPriceInput[],
+): PlanPurchasability[] {
+  return summarizePlanPurchasability(plans, prices).filter(
+    (plan) =>
+      plan.isActive && plan.isPaid && plan.isPurchasable && plan.missingIntervals.length > 0,
+  )
+}

--- a/supabase/seed-prod.sql
+++ b/supabase/seed-prod.sql
@@ -116,6 +116,40 @@ ON CONFLICT (slug) DO UPDATE SET
 
 
 -- ---------------------------------------------------------------------------
+-- 1b. PLATFORM PLAN PRICES (#602)
+-- ---------------------------------------------------------------------------
+-- Before this block a freshly provisioned production database had no purchasable
+-- plan at all: `platform_plan_prices` (and before #601, platform_plans.stripe_price_id_*)
+-- was read by checkout and written by nothing, so every card upgrade 400'd on
+-- "Stripe price not configured for this plan" while the pricing page happily
+-- advertised $9/mo.
+--
+-- A placeholder slot is created for every (paid plan x interval) so a super admin
+-- sees the full grid on /platform/plans and only has to paste the real id and flip
+-- the toggle -- no SQL, which was the whole failure mode.
+--
+-- They are seeded is_active = false ON PURPOSE, and this is a deliberate reading of
+-- #602's "seed-prod produces a purchasable plan": an *active* row holding a fake id
+-- would be worse than none. Checkout would sail past the "not configured" guard and
+-- die inside Stripe on `No such price: seed_placeholder_...`, which is a harder error
+-- to diagnose and reaches the school as a broken hosted page rather than a clean
+-- message. Inactive instead means /platform/billing-health flags each plan loudly and
+-- names the fix, until a real id is entered. Making a plan live is one toggle.
+INSERT INTO platform_plan_prices (plan_id, payment_provider, interval, provider_price_id, currency, amount, is_active)
+SELECT pp.plan_id,
+       'stripe',
+       i.interval,
+       'seed_placeholder_' || pp.slug || '_' || i.interval,
+       'usd',
+       CASE WHEN i.interval = 'yearly' THEN pp.price_yearly ELSE pp.price_monthly END,
+       false
+FROM platform_plans pp
+CROSS JOIN (VALUES ('monthly'), ('yearly')) AS i(interval)
+WHERE pp.slug <> 'free'
+ON CONFLICT (plan_id, payment_provider, interval) DO NOTHING;
+
+
+-- ---------------------------------------------------------------------------
 -- 2. DEFAULT TENANT
 -- ---------------------------------------------------------------------------
 INSERT INTO tenants (id, slug, name, primary_color, secondary_color, plan, status)

--- a/tests/unit/billing-health.test.ts
+++ b/tests/unit/billing-health.test.ts
@@ -10,13 +10,13 @@ const NOW = new Date('2026-07-24T00:00:00.000Z')
 const sub = (overrides: {
   tenantId: string
   status?: string | null
-  paymentMethod?: string | null
+  paymentProvider?: string | null
   currentPeriodEnd?: string | null
   gracePeriodEnd?: string | null
   updatedAt?: string | null
 }) => ({
   status: 'past_due',
-  paymentMethod: null,
+  paymentProvider: null,
   currentPeriodEnd: null,
   gracePeriodEnd: null,
   updatedAt: null,
@@ -24,12 +24,12 @@ const sub = (overrides: {
 })
 
 describe('computeBillingHealth', () => {
-  it('manual_transfer with grace time remaining computes a positive countdown', () => {
+  it('manual with grace time remaining computes a positive countdown', () => {
     const result = computeBillingHealth(
       [{ tenantId: 't1', tenantName: 'School A', plan: 'starter', accessCutoffAt: null, reasons: ['tenant_past_due'] }],
       [sub({
         tenantId: 't1',
-        paymentMethod: 'manual_transfer',
+        paymentProvider: 'manual',
         currentPeriodEnd: '2026-07-17T00:00:00.000Z',
         gracePeriodEnd: '2026-07-27T00:00:00.000Z',
       })],
@@ -41,12 +41,35 @@ describe('computeBillingHealth', () => {
     expect(result[0].pastDueSince).toBe('2026-07-17T00:00:00.000Z')
   })
 
-  it('manual_transfer with grace already expired still reports a (negative/zero) countdown, not a crash', () => {
+  it('does not treat the retired manual_transfer slug as manual', () => {
+    // #601 folded `payment_method IN ('stripe','manual_transfer')` into the
+    // 8-value `payment_provider` slug, where bank transfer is `'manual'`. Every
+    // reader here kept comparing against `'manual_transfer'` for a commit, and
+    // this suite did not notice because its own fixtures used the retired value
+    // too — so a manual school's countdown silently became null while the tests
+    // stayed green. Pinning the dead string means the fixtures can never drift
+    // back into agreement with a bug.
     const result = computeBillingHealth(
       [{ tenantId: 't1', tenantName: 'School A', plan: 'starter', accessCutoffAt: null, reasons: ['tenant_past_due'] }],
       [sub({
         tenantId: 't1',
-        paymentMethod: 'manual_transfer',
+        paymentProvider: 'manual_transfer',
+        currentPeriodEnd: '2026-07-17T00:00:00.000Z',
+        gracePeriodEnd: '2026-07-27T00:00:00.000Z',
+      })],
+      NOW,
+    )
+    expect(result[0].daysUntilDowngrade).toBeNull()
+    expect(result[0].graceEndsAt).toBeNull()
+    expect(result[0].isEstimate).toBe(true)
+  })
+
+  it('manual with grace already expired still reports a (negative/zero) countdown, not a crash', () => {
+    const result = computeBillingHealth(
+      [{ tenantId: 't1', tenantName: 'School A', plan: 'starter', accessCutoffAt: null, reasons: ['tenant_past_due'] }],
+      [sub({
+        tenantId: 't1',
+        paymentProvider: 'manual',
         currentPeriodEnd: '2026-07-01T00:00:00.000Z',
         gracePeriodEnd: '2026-07-08T00:00:00.000Z',
       })],
@@ -61,7 +84,7 @@ describe('computeBillingHealth', () => {
       [{ tenantId: 't2', tenantName: 'School B', plan: 'pro', accessCutoffAt: null, reasons: ['tenant_past_due'] }],
       [sub({
         tenantId: 't2',
-        paymentMethod: 'stripe',
+        paymentProvider: 'stripe',
         currentPeriodEnd: '2026-07-20T00:00:00.000Z',
         gracePeriodEnd: null,
       })],
@@ -80,7 +103,7 @@ describe('computeBillingHealth', () => {
       NOW,
     )
     expect(result).toHaveLength(1)
-    expect(result[0].paymentMethod).toBeNull()
+    expect(result[0].paymentProvider).toBeNull()
     expect(result[0].daysUntilDowngrade).toBeNull()
     expect(result[0].isEstimate).toBe(true)
   })
@@ -93,9 +116,9 @@ describe('computeBillingHealth', () => {
         { tenantId: 'soon', tenantName: 'Soon School', plan: 'starter', accessCutoffAt: null, reasons: ['tenant_past_due'] },
       ],
       [
-        sub({ tenantId: 'stripe-tenant', paymentMethod: 'stripe' }),
-        sub({ tenantId: 'far', paymentMethod: 'manual_transfer', gracePeriodEnd: '2026-08-10T00:00:00.000Z' }),
-        sub({ tenantId: 'soon', paymentMethod: 'manual_transfer', gracePeriodEnd: '2026-07-25T00:00:00.000Z' }),
+        sub({ tenantId: 'stripe-tenant', paymentProvider: 'stripe' }),
+        sub({ tenantId: 'far', paymentProvider: 'manual', gracePeriodEnd: '2026-08-10T00:00:00.000Z' }),
+        sub({ tenantId: 'soon', paymentProvider: 'manual', gracePeriodEnd: '2026-07-25T00:00:00.000Z' }),
       ],
       NOW,
     )
@@ -118,7 +141,7 @@ describe('computeBillingHealth', () => {
       [{ tenantId: 't4', tenantName: 'Drifted School', plan: 'pro', accessCutoffAt: null, reasons: ['subscription_past_due'] }],
       [sub({
         tenantId: 't4',
-        paymentMethod: 'manual_transfer',
+        paymentProvider: 'manual',
         currentPeriodEnd: '2026-07-10T00:00:00.000Z',
         gracePeriodEnd: '2026-07-30T00:00:00.000Z',
       })],
@@ -134,7 +157,7 @@ describe('computeBillingHealth', () => {
   it('surfaces a cutoff-only tenant with healthy billing', () => {
     const result = computeBillingHealth(
       [{ tenantId: 't5', tenantName: 'Over Limit School', plan: 'starter', accessCutoffAt: '2026-08-07T00:00:00.000Z', reasons: ['access_cutoff_scheduled'] }],
-      [sub({ tenantId: 't5', status: 'active', paymentMethod: 'manual_transfer', gracePeriodEnd: null })],
+      [sub({ tenantId: 't5', status: 'active', paymentProvider: 'manual', gracePeriodEnd: null })],
       NOW,
     )
     expect(result).toHaveLength(1)
@@ -170,7 +193,7 @@ describe('computeBillingHealth', () => {
     const stale = sub({
       tenantId: 't7',
       status: 'canceled',
-      paymentMethod: 'stripe',
+      paymentProvider: 'stripe',
       currentPeriodEnd: '2026-01-01T00:00:00.000Z',
       gracePeriodEnd: null,
       updatedAt: '2026-01-02T00:00:00.000Z',
@@ -178,7 +201,7 @@ describe('computeBillingHealth', () => {
     const current = sub({
       tenantId: 't7',
       status: 'past_due',
-      paymentMethod: 'manual_transfer',
+      paymentProvider: 'manual',
       currentPeriodEnd: '2026-07-15T00:00:00.000Z',
       gracePeriodEnd: '2026-07-29T00:00:00.000Z',
       updatedAt: '2026-07-15T00:00:00.000Z',
@@ -187,7 +210,7 @@ describe('computeBillingHealth', () => {
 
     for (const subs of [[stale, current], [current, stale]]) {
       const result = computeBillingHealth(tenants, subs, NOW)
-      expect(result[0].paymentMethod).toBe('manual_transfer')
+      expect(result[0].paymentProvider).toBe('manual')
       expect(result[0].graceEndsAt).toBe('2026-07-29T00:00:00.000Z')
       expect(result[0].daysUntilDowngrade).toBe(5)
       expect(result[0].isEstimate).toBe(false)
@@ -198,14 +221,14 @@ describe('computeBillingHealth', () => {
     const older = sub({
       tenantId: 't8',
       status: 'past_due',
-      paymentMethod: 'stripe',
+      paymentProvider: 'stripe',
       gracePeriodEnd: null,
       updatedAt: '2026-06-01T00:00:00.000Z',
     })
     const newer = sub({
       tenantId: 't8',
       status: 'past_due',
-      paymentMethod: 'manual_transfer',
+      paymentProvider: 'manual',
       gracePeriodEnd: '2026-07-28T00:00:00.000Z',
       updatedAt: '2026-07-20T00:00:00.000Z',
     })
@@ -213,7 +236,7 @@ describe('computeBillingHealth', () => {
 
     for (const subs of [[older, newer], [newer, older]]) {
       const result = computeBillingHealth(tenants, subs, NOW)
-      expect(result[0].paymentMethod).toBe('manual_transfer')
+      expect(result[0].paymentProvider).toBe('manual')
       expect(result[0].daysUntilDowngrade).toBe(4)
     }
   })
@@ -233,7 +256,7 @@ describe('computeBillingHealth', () => {
       [sub({
         tenantId: 't9',
         status: 'canceled',
-        paymentMethod: 'manual_transfer',
+        paymentProvider: 'manual',
         currentPeriodEnd: '2026-06-01T00:00:00.000Z',
         gracePeriodEnd: '2026-06-08T00:00:00.000Z',
         updatedAt: '2026-06-08T00:00:00.000Z',
@@ -270,12 +293,12 @@ describe('computeBillingHealth', () => {
         sub({
           tenantId: 'lapsed',
           status: 'canceled',
-          paymentMethod: 'manual_transfer',
+          paymentProvider: 'manual',
           gracePeriodEnd: '2026-06-08T00:00:00.000Z',
         }),
         sub({
           tenantId: 'live',
-          paymentMethod: 'manual_transfer',
+          paymentProvider: 'manual',
           gracePeriodEnd: '2026-07-30T00:00:00.000Z',
         }),
       ],

--- a/tests/unit/plan-prices.test.ts
+++ b/tests/unit/plan-prices.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from 'vitest'
+import {
+  findPartiallyPricedPlans,
+  findUnpurchasablePlans,
+  summarizePlanPurchasability,
+  type PlatformPlanInput,
+  type PlatformPlanPriceInput,
+} from '@/lib/billing/plan-prices'
+
+/**
+ * #602's regression guard. The bug it protects against is not subtle logic —
+ * it is a table nobody wrote, which every existing suite missed because the
+ * fixtures hardcoded price ids the database never held. So these tests assert
+ * on the *absence* of configuration, which is the state a real environment was
+ * actually in.
+ */
+
+function plan(overrides: Partial<PlatformPlanInput> = {}): PlatformPlanInput {
+  return {
+    planId: 'plan-pro',
+    slug: 'pro',
+    name: 'Pro',
+    priceMonthly: 29,
+    priceYearly: 290,
+    isActive: true,
+    ...overrides,
+  }
+}
+
+function price(overrides: Partial<PlatformPlanPriceInput> = {}): PlatformPlanPriceInput {
+  return {
+    priceId: 'price-row-1',
+    planId: 'plan-pro',
+    paymentProvider: 'stripe',
+    interval: 'monthly',
+    providerPriceId: 'price_123',
+    currency: 'usd',
+    amount: 29,
+    isActive: true,
+    ...overrides,
+  }
+}
+
+describe('findUnpurchasablePlans', () => {
+  it('flags an active paid plan with no price rows at all', () => {
+    const result = findUnpurchasablePlans([plan()], [])
+
+    expect(result).toHaveLength(1)
+    expect(result[0].slug).toBe('pro')
+    expect(result[0].isPurchasable).toBe(false)
+  })
+
+  it('flags a plan whose only price row is inactive', () => {
+    // The exact half-configured state a super admin lands in after toggling a
+    // price off: the row still exists, so a naive `count > 0` check would call
+    // the plan healthy while checkout — which filters on is_active — 400s.
+    const result = findUnpurchasablePlans([plan()], [price({ isActive: false })])
+
+    expect(result.map((p) => p.slug)).toEqual(['pro'])
+  })
+
+  it('stays silent once an active price exists', () => {
+    expect(findUnpurchasablePlans([plan()], [price()])).toEqual([])
+  })
+
+  it('never flags the free plan', () => {
+    const free = plan({ planId: 'plan-free', slug: 'free', name: 'Free', priceMonthly: 0, priceYearly: 0 })
+
+    expect(findUnpurchasablePlans([free], [])).toEqual([])
+  })
+
+  it('never flags an inactive plan — nobody can reach it', () => {
+    expect(findUnpurchasablePlans([plan({ isActive: false })], [])).toEqual([])
+  })
+
+  it('flags a yearly-only plan with no prices', () => {
+    // priceMonthly is 0 here, so a check keyed literally on `price_monthly > 0`
+    // would let this one through even though its pricing page is a dead button.
+    const yearlyOnly = plan({ priceMonthly: 0, priceYearly: 290 })
+
+    expect(findUnpurchasablePlans([yearlyOnly], []).map((p) => p.slug)).toEqual(['pro'])
+  })
+
+  it('reports each misconfigured plan separately', () => {
+    const starter = plan({ planId: 'plan-starter', slug: 'starter', name: 'Starter', priceMonthly: 9, priceYearly: 90 })
+    const business = plan({ planId: 'plan-biz', slug: 'business', name: 'Business', priceMonthly: 79, priceYearly: 790 })
+
+    const result = findUnpurchasablePlans(
+      [plan(), starter, business],
+      [price({ planId: 'plan-starter' })],
+    )
+
+    expect(result.map((p) => p.slug).sort()).toEqual(['business', 'pro'])
+  })
+})
+
+describe('findPartiallyPricedPlans', () => {
+  it('flags a plan priced monthly but not yearly', () => {
+    const result = findPartiallyPricedPlans([plan()], [price({ interval: 'monthly' })])
+
+    expect(result).toHaveLength(1)
+    expect(result[0].missingIntervals).toEqual(['yearly'])
+  })
+
+  it('does not flag a plan priced on both intervals', () => {
+    const result = findPartiallyPricedPlans(
+      [plan()],
+      [price({ interval: 'monthly' }), price({ priceId: 'price-row-2', interval: 'yearly' })],
+    )
+
+    expect(result).toEqual([])
+  })
+
+  it('does not double-report a plan that has no prices at all', () => {
+    // That plan belongs to findUnpurchasablePlans; listing it in both would
+    // show the same outage twice on the dashboard, once softened to amber.
+    expect(findPartiallyPricedPlans([plan()], [])).toEqual([])
+  })
+
+  it('counts coverage across providers, not per provider', () => {
+    // Stripe monthly + Lemon Squeezy yearly leaves no interval uncovered, even
+    // though neither provider covers both on its own.
+    const result = findPartiallyPricedPlans(
+      [plan()],
+      [
+        price({ interval: 'monthly', paymentProvider: 'stripe' }),
+        price({ priceId: 'price-row-2', interval: 'yearly', paymentProvider: 'lemonsqueezy' }),
+      ],
+    )
+
+    expect(result).toEqual([])
+  })
+})
+
+describe('summarizePlanPurchasability', () => {
+  it('groups intervals under each provider, monthly first', () => {
+    const [summary] = summarizePlanPurchasability(
+      [plan()],
+      [
+        price({ priceId: 'a', interval: 'yearly', paymentProvider: 'stripe' }),
+        price({ priceId: 'b', interval: 'monthly', paymentProvider: 'stripe' }),
+        price({ priceId: 'c', interval: 'monthly', paymentProvider: 'lemonsqueezy' }),
+      ],
+    )
+
+    expect(summary.isPurchasable).toBe(true)
+    expect(summary.providers).toEqual([
+      { provider: 'lemonsqueezy', intervals: ['monthly'] },
+      { provider: 'stripe', intervals: ['monthly', 'yearly'] },
+    ])
+  })
+
+  it('ignores inactive rows when listing providers', () => {
+    const [summary] = summarizePlanPurchasability(
+      [plan()],
+      [price({ paymentProvider: 'stripe' }), price({ priceId: 'b', paymentProvider: 'paypal', isActive: false })],
+    )
+
+    expect(summary.providers.map((p) => p.provider)).toEqual(['stripe'])
+  })
+
+  it('does not leak one plan’s prices onto another', () => {
+    const starter = plan({ planId: 'plan-starter', slug: 'starter', name: 'Starter' })
+    const summaries = summarizePlanPurchasability([plan(), starter], [price({ planId: 'plan-pro' })])
+
+    expect(summaries.find((s) => s.slug === 'pro')?.isPurchasable).toBe(true)
+    expect(summaries.find((s) => s.slug === 'starter')?.isPurchasable).toBe(false)
+  })
+
+  it('marks the free plan as unpaid rather than unpurchasable', () => {
+    const [summary] = summarizePlanPurchasability(
+      [plan({ slug: 'free', priceMonthly: 0, priceYearly: 0 })],
+      [],
+    )
+
+    expect(summary.isPaid).toBe(false)
+    expect(summary.missingIntervals).toEqual([])
+  })
+})


### PR DESCRIPTION
## What

Gives a super admin a way to make a platform plan purchasable — per plan, per provider, per interval — and a check that shouts when one isn't. Also fixes a live regression from #601 found while surveying it.

Closes #602

> [!NOTE]
> **Unstacked.** #607 (the `platform_plan_prices` schema) squash-merged to master as `8ca0a04`, so this branch was rebased with `--onto master`, dropping the two #601 commits it had been carrying, and retargeted. The diff is now **#602 work only** — 14 files, no migration, no `database.types.ts`. Verified the rebase changed nothing: `git diff` between the pre- and post-rebase trees is empty apart from the QA screenshots master already had.

## Why

`platform_plans.stripe_price_id_monthly` / `_yearly` were read by three call sites and written by *none* — no server action, no UI field, no seed, no script. The only instruction to ever set them was a line in `docs/MONETIZATION.md` telling a human to run SQL. So on any environment where nobody did, every card upgrade 400'd on `"Stripe price not configured for this plan"` while the pricing page cheerfully advertised `$9/mo`, and the only working path to a paid plan was an offline bank transfer. That is the platform's entire self-serve income path.

#601 replaced those columns with `platform_plan_prices`, which is the right shape — but a table nobody writes fails in exactly the same way. This PR is the writer.

### Changes

1. **Server actions** (`app/actions/platform/plans.ts`) — `upsertPlatformPlanPrice` and `deletePlatformPlanPrice`, both behind the existing `verifySuperAdmin()`. Reads are not an action: `plans/page.tsx` selects from `platform_plan_prices` directly, so there is no fetch endpoint to expose. The upsert rides the table's own `(plan_id, payment_provider, interval)` unique constraint, so re-saving a combination corrects a mistyped price id instead of failing — which is what a super admin fixing a typo actually wants. Provider, interval and currency are validated against the migration's own lists before the write, so a rejected CHECK never reaches the user as a raw Postgres string.

2. **`/platform/plans` — the field it has never had.** A **Prices** dialog per plan: add / update / activate / remove a provider price, no SQL. Each card states what the plan is purchasable through; an active paid plan with no active price gets a red line on the card, a `No price` chip in its header, and a page-level banner.

3. **A pure module** `lib/billing/plan-prices.ts` — `summarizePlanPurchasability`, `findUnpurchasablePlans`, `findPartiallyPricedPlans`. Deliberately **not** folded into `lib/billing/billing-health.ts`, per the issue's own note: that module computes `AtRiskTenant[]`, and a plan with no price belongs to no tenant — it breaks checkout for every school at once and none of them individually.

4. **`/platform/billing-health` — its own section**, fed by a new `getPlanConfigurationHealth()` action. Red for plans with no active price at all, amber for plans priced on only one of the intervals they quote, green when every active paid plan is buyable. A failed read throws rather than rendering green, since silent-green is the failure this check exists to prevent.

5. **`supabase/seed-prod.sql`** now seeds a price slot per (paid plan × interval), so a fresh production provision no longer lands in the state this issue describes. See the deviation note below.

### Deviation from acceptance criterion 2, stated rather than glossed

The criterion asks that `seed-prod.sql` "produce at least one purchasable plan". The seeded rows are `is_active = false` **on purpose**. An *active* row holding a placeholder id would sail past the "not configured" guard and die inside Stripe on `No such price: seed_placeholder_…` — a harder error to diagnose, reaching the school as a broken hosted page instead of a clean message. Inactive means `/platform/billing-health` names each plan loudly and the fix is one paste plus one toggle in the new UI. `seed.sql` (local dev) keeps #607's active `price_local_*` rows unchanged.

### A live regression from #601, fixed here

#601 folded `payment_method IN ('stripe','manual_transfer')` into the 8-value `payment_provider` slug, where bank transfer is `'manual'`, and `getBillingStatus` duly started returning the new column. **Four readers kept comparing against the retired string**, so on #607's head:

| File | Symptom on `refactor/platform-billing-provider-agnostic-601` |
|---|---|
| `lib/billing/billing-health.ts:208` | `graceEndsAt` / `daysUntilDowngrade` always null, `isEstimate` always true for manual schools — the countdown the module exists to compute |
| `app/[locale]/platform/billing-health/page.tsx:39,158` | every manual school counted as "Stripe Dunning In Progress", payment method rendered `—` |
| `components/admin/billing-overview.tsx:70,177` | a bank-transfer school told "Card payment" on its own billing page |
| `app/[locale]/dashboard/admin/billing/billing-dashboard-client.tsx:195` | manual-renewal UI never rendered |

`tests/unit/billing-health.test.ts` stayed green the whole time because its fixtures hardcoded `'manual_transfer'` too — a state the database can no longer produce. That is this issue's own thesis (*"the tests pin the modules; nothing tests the callers"*) reproducing itself inside the area being fixed, so it is fixed here rather than filed for later.

The field is renamed `paymentMethod` → `paymentProvider` through the platform-billing chain, so the name can't drift from the column again. The **student-side** `paymentMethod` — a free-text label on `payment_requests` / `transactions` ("Bank Transfer") — is a different column with a different meaning and is deliberately untouched.

## Type of change

Feature (+ bug fix)

## How to QA

On a fresh `npm run db:reset`, then `npm run dev` — sign in as `owner@e2etest.com` / `password123` (super admin) at `default.lvh.me:3000`. This branch adds **no migration** of its own; since #607 merged, `platform_plan_prices` comes from master, so a reset from any checkout picks it up.

> [!TIP]
> If you QA from a git worktree rather than the main checkout, it has **no `.env.local` and no `node_modules`** of its own — both are gitignored and do not come across with the branch. Copy `.env.local` from the main checkout and run `npm install` first, or the dev server boots with no Supabase URL and every page 500s. This is what actually blocked the first QA attempt, alongside Docker.

1. **See the gap.** Go to `/platform/billing-health`. The new **Plan configuration** card is green — `seed.sql` ships active `price_local_*` rows for the four paid plans.
2. **Break one.** Go to `/platform/plans` → **Pro** → **Prices**. Toggle both Stripe rows to inactive. The card immediately shows a red *"Not purchasable — no active provider price"*, a `No price` chip appears in the header, and a red banner counts it at the top of the page.
3. **Confirm the check fires.** Back on `/platform/billing-health`, the Plan configuration card is now red and lists **Pro** by name, with a link back to `/platform/plans`.
4. **Fix it without SQL** — the point of the issue. `/platform/plans` → **Pro** → **Prices** → set Provider `Stripe`, Interval `monthly`, paste any id, Save. Card flips to *"Purchasable via Stripe (monthly)"*, and an amber line notes that `yearly` is still unpriced. Billing health drops Pro from red to amber.
5. **Confirm the upsert corrects rather than duplicates.** Save `Stripe` + `monthly` again with a different id — the existing row updates in place; no second row appears.
6. **Confirm the checkout guard clears.** With an active Stripe price on Pro, `/dashboard/admin/billing/upgrade` → Pro → pay by card no longer returns `"Stripe price not configured for this plan"`; the request proceeds past the price lookup into the Stripe call.
7. **Regression check on the rename.** A school on a manual subscription still sees "Bank transfer" (not "Card payment") on `/dashboard/admin/billing`, and still shows a real grace countdown on `/platform/billing-health` rather than "Stripe-managed".

## Screenshots / GIF

**Captured — the QA pass above was executed end to end.** The original submission had none because Docker was down on the authoring machine; it has since been run against a real `npm run db:reset` with the #601 schema applied (QA predates the rebase, when #601 still rode on this branch; the code under test is byte-identical). Every step 1–7 passed as written, plus the deferred acceptance criterion 4 (see below).

**1 · Baseline green** — `seed.sql`'s active `price_local_*` rows make every paid plan buyable.

![Plan configuration green](https://raw.githubusercontent.com/guillermoscript/lms-front/master/docs/qa/602/01-billing-health-green.png?v=2)

**2 · The Prices dialog** — the field the repo has never had. Note it already warns *"Saving overwrites the existing Stripe monthly price"*, because a row for that (provider, interval) exists.

![Prices dialog](https://raw.githubusercontent.com/guillermoscript/lms-front/master/docs/qa/602/03-prices-dialog.png?v=2)

**3 · Break Pro** — both Stripe rows toggled off. Red banner, `No price` chip in the header, red line on the card. All three appear at once.

![Pro not purchasable](https://raw.githubusercontent.com/guillermoscript/lms-front/master/docs/qa/602/04-plans-pro-unpurchasable.png?v=2)

**4 · The check fires** — Plan configuration turns red and names Pro.

![Billing health red](https://raw.githubusercontent.com/guillermoscript/lms-front/master/docs/qa/602/05-billing-health-red.png?v=2)

**5 · Fixed without SQL, and the partial state is distinguished** — monthly restored, so the card reads *"Purchasable via Stripe (monthly)"* with an amber *"No price for yearly"* underneath. Billing health drops red → amber (*"Pro — no price for yearly; buyable via Stripe"*).

![Pro partially priced](https://raw.githubusercontent.com/guillermoscript/lms-front/master/docs/qa/602/07-plans-pro-partial.png?v=2)
![Billing health amber](https://raw.githubusercontent.com/guillermoscript/lms-front/master/docs/qa/602/08-billing-health-amber.png?v=2)

**6 · The rename regression, fixed** — a bank-transfer school reads "Bank transfer" (not "Card payment") and its manual-renewal UI renders again; on `/platform/billing-health` it counts under **manual-transfer grace**, not Stripe dunning, with a live **7 days** countdown in *Downgrades in*.

![Admin billing bank transfer](https://raw.githubusercontent.com/guillermoscript/lms-front/master/docs/qa/602/09-admin-billing-bank-transfer.png?v=2)
![Manual grace countdown](https://raw.githubusercontent.com/guillermoscript/lms-front/master/docs/qa/602/10-billing-health-manual-grace.png?v=2)

<details>
<summary>Remaining frames (all-purchasable plans page, filled dialog)</summary>

![Plans all purchasable](https://raw.githubusercontent.com/guillermoscript/lms-front/master/docs/qa/602/02-plans-all-purchasable.png?v=2)
![Dialog filled](https://raw.githubusercontent.com/guillermoscript/lms-front/master/docs/qa/602/06-prices-dialog-filled.png?v=2)

</details>

### Verified below the UI, not just on screen

Each state was confirmed against the database rather than taken from the rendered text:

| Check | Evidence |
|---|---|
| Guard fires while unpriced | `POST /api/stripe/checkout-session` → **400** `"Stripe price not configured for this plan."` |
| Guard clears once priced | same call → **200** with a `checkout.stripe.com/c/pay/cs_test_…` URL |
| Upsert corrects, never duplicates | after re-saving Stripe+monthly with a different id, `platform_plan_prices` still holds **2 rows** for Pro — the monthly row updated in place and reactivated |
| Toggle persists | `is_active` flipped to `f` in the table, not just in React state |
| Rename regression was real | on the base branch `billing-overview.tsx` compares `paymentMethod === 'manual_transfer'` while the column now yields `'manual'` — so it rendered `t('cardPayment')` and suppressed the renewal warning |

## Checklist

- [x] `npm run typecheck` and `npm run test:unit` pass — typecheck clean; **691 tests / 55 files pass**, including 20 new in `tests/unit/plan-prices.test.ts`
- [x] `npm run build` passes
- [x] Every new tenant-scoped query filters by `tenant_id` (or the table genuinely has no such column) — `platform_plans` and `platform_plan_prices` are platform-global; they have no `tenant_id`
- [x] Tested with every relevant role (student / teacher / admin) — exercised as **super admin** (`owner@e2etest.com`) on every `/platform/*` surface, and as a **school admin** (`creator@codeacademy.com`, Code Academy Pro) on `/dashboard/admin/billing` for the rename regression. Those are the only two roles that can reach anything this PR changes: every new surface is `/platform/*`, guarded by `checkSuperAdmin()` in `proxy.ts` independently of tenant role, and every new action calls `verifySuperAdmin()`
- [x] Loading and error states handled — per-row busy state, disabled Save on empty id, `toast.error` on every failure, explicit empty state, and `getPlanConfigurationHealth` throws on a failed read rather than rendering a false green
- [ ] New UI strings added to both `messages/en.json` and `messages/es.json` — **N/A**: the `/platform/*` super-admin surfaces are not internationalized; every existing string on both pages is hardcoded English and the new ones match
- [x] Migration (if any) applies cleanly on `npm run db:reset`, has RLS policies, and `lib/database.types.ts` was regenerated — **no new migration**; this PR only writes to the table and RLS policies #601 already created

## Acceptance criterion 4 — done, and the earlier deferral was wrong

The first version of this PR deferred AC4 (*"create the actual Stripe prices for the four paid plans and record them"*) on the grounds that `.env.local` held a placeholder key. **That was incorrect.** The key is a working `sk_test_…` on `acct_1HcWXP…` (test mode, `livemode: false`), so the criterion was achievable all along.

The four paid plans now exist as **Stripe test-mode products with a monthly and a yearly recurring USD price each** (8 prices), tagged `metadata.created_by=issue-602`:

| Plan | Monthly | Yearly |
|---|---|---|
| Starter | `price_1U1ChEF3QAnraq1IkpH7WMHj` ($9) | `price_1U1ChFF3QAnraq1IUTjcPB3q` ($90) |
| Pro | `price_1U1ChGF3QAnraq1IEGBGZtYx` ($29) | `price_1U1ChHF3QAnraq1Ilvqioacz` ($290) |
| Business | `price_1U1ChIF3QAnraq1IZH23RiwV` ($79) | `price_1U1ChIF3QAnraq1IHxi3ZmpE` ($790) |
| Enterprise | `price_1U1ChKF3QAnraq1IwPRcFxZQ` ($199) | `price_1U1ChKF3QAnraq1IP95NFxXr` ($1,990) |

Each monthly id was then pasted into the new **Prices** dialog — no SQL — and each plan's upgrade call returned **200** with a live hosted page. The criterion asks for a **screenshot per plan**, so all four are here:

| | |
|---|---|
| ![Starter checkout](https://raw.githubusercontent.com/guillermoscript/lms-front/master/docs/qa/602/12-checkout-starter.png?v=2) | ![Pro checkout](https://raw.githubusercontent.com/guillermoscript/lms-front/master/docs/qa/602/11-stripe-hosted-checkout.png?v=2) |
| **Starter — $9.00/month** | **Pro — $29.00/month** |
| ![Business checkout](https://raw.githubusercontent.com/guillermoscript/lms-front/master/docs/qa/602/13-checkout-business.png?v=2) | ![Enterprise checkout](https://raw.githubusercontent.com/guillermoscript/lms-front/master/docs/qa/602/14-checkout-enterprise.png?v=2) |
| **Business — $79.00/month** | **Enterprise — $199.00/month** |

Every one carries the Sandbox badge and a `cs_test_…` session. The full path the issue was filed about — **plan → provider price → hosted checkout** — is closed end to end for all four paid plans.

**These ids are test mode and belong to one Stripe account, so they are recorded here rather than committed.** They are deliberately *not* written into `seed-prod.sql`: that file provisions production, where the ids will be different and live. The local DB was returned to its `seed.sql` values after the run (`db:reset` would overwrite them regardless).

## Acceptance criteria, one by one

| # | Criterion | State |
|---|---|---|
| 1 | Super admin can make a plan purchasable without SQL | ✅ — delivered as a **Prices** dialog rather than a field inside `plan-editor.tsx`; the criterion's parenthetical named that file, but per-provider-per-interval rows are a table, not a text input, so they get their own editor |
| 2 | `seed.sql` **and** `seed-prod.sql` produce at least one purchasable plan | ⚠️ **`seed.sql` yes; `seed-prod.sql` deliberately not** — see below |
| 3 | Billing health flags an active paid plan with no usable price, green after step 4 | ✅ red → amber → green all observed |
| 4 | Checkout for each of the four paid plans reaches the hosted page, screenshot per plan | ✅ all four above |
| 5 | Unit test asserts the check fires for a plan with no price row | ✅ `tests/unit/plan-prices.test.ts` — *"flags an active paid plan with no price rows at all"*, plus inactive-row, free-plan and inactive-plan cases |

### Criterion 2 is knowingly not met, and that is the one thing to argue about in review

`seed-prod.sql` seeds a price **slot** per (paid plan × interval) but leaves `is_active = false`, so **a fresh production provision still has no purchasable plan** — literally the state the issue opens with. The reasoning: an *active* row holding `seed_placeholder_…` passes the "not configured" guard and then dies inside Stripe on `No such price`, which reaches the school as a broken hosted page instead of a clean message. Inactive means `/platform/billing-health` names the plan loudly and the fix is one paste plus one toggle.

That trade is defensible but it is a **deviation from the criterion as written**, not a satisfaction of it. If a reviewer prefers the criterion literally, the change is one `false` → `true` per row plus real live-mode ids.

## Still open

Only the operational step that no branch can do: pasting the **production** (live-mode) price ids into `/platform/plans` on the deployed environment once they exist — which is exactly the manual step this PR makes possible without SQL.

*(An earlier revision also shipped `getPlatformPlanPrices()`, exported with no caller. Removed in `fc9f300` — `plans/page.tsx` queries the table directly, so it was a live super-admin endpoint nothing exercised.)*


