### PR TITLE
fix(billing): show Business and Enterprise their real 0% transaction fee (#613)

### DIFF
--- a/app/actions/admin/billing.ts
+++ b/app/actions/admin/billing.ts
@@ -142,7 +142,12 @@ export async function getSubscriptionStatus() {
       },
     },
     features: planDetails?.features || {},
-    transactionFeePercent: planDetails?.transaction_fee_percent || 10,
+    // `??`, never `||` (#613). Business and Enterprise carry a genuine 0% fee,
+    // and `0 || 10` is 10 — so the two plans whose zero fee is the reason to buy
+    // them were the only two told they pay the Free-plan rate. The 10 here is
+    // the fallback for a tenant whose `plan` slug matches no platform_plans row,
+    // which is the only case it was ever meant to cover.
+    transactionFeePercent: planDetails?.transaction_fee_percent ?? 10,
   }
 }
 

--- a/tests/unit/plan-fee-display.test.ts
+++ b/tests/unit/plan-fee-display.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { createFakeSupabase, type Db } from './support/fake-supabase'
+
+/**
+ * Issue #613 — the transaction fee a school reads on its own billing page.
+ *
+ * `getSubscriptionStatus()` defaulted the fee with `||`, so a plan whose fee is
+ * legitimately `0` was indistinguishable from a missing plan row and fell
+ * through to the Free-plan rate. Business and Enterprise are exactly the two
+ * plans with a 0% fee, so the only schools shown a wrong number were the two
+ * paying the most for a 0% fee — while `usePlanFeatures()`, reading the same
+ * column with `??` one file over, told them 0%.
+ *
+ * The fallback itself is still wanted: a tenant whose `plan` slug matches no
+ * `platform_plans` row must read 10%, not `undefined%`.
+ */
+
+const TENANT = '00000000-0000-0000-0000-000000000001'
+const USER = 'user-admin-1'
+
+let db: Db
+
+function makeClient() {
+  return createFakeSupabase(db, {
+    embeds: {
+      platform_plans: { table: 'platform_plans', localKey: 'plan_id', foreignKey: 'plan_id' },
+    },
+    conflictKeys: { platform_subscriptions: 'tenant_id', revenue_splits: 'tenant_id' },
+  }).client
+}
+
+vi.mock('@/lib/supabase/server', () => ({ createClient: () => Promise.resolve(makeClient()) }))
+vi.mock('@/lib/supabase/admin', () => ({ createAdminClient: () => makeClient() }))
+vi.mock('@/lib/supabase/tenant', () => ({
+  getCurrentTenantId: () => Promise.resolve(TENANT),
+  getCurrentUserId: () => Promise.resolve(USER),
+}))
+vi.mock('@/lib/supabase/get-user-role', () => ({ getUserRole: () => Promise.resolve('admin') }))
+vi.mock('next/cache', () => ({ revalidatePath: () => {} }))
+vi.mock('@/lib/email/send', () => ({ sendEmail: () => Promise.resolve(true) }))
+vi.mock('@/lib/billing/access-cutoff', () => ({
+  reconcileAccessCutoff: () => Promise.resolve({ action: 'none' }),
+}))
+
+import { getSubscriptionStatus } from '@/app/actions/admin/billing'
+
+/** The seeded fees, including the two zeroes that triggered the bug. */
+const PLANS = [
+  { slug: 'free', name: 'Free', fee: 10, limits: { max_courses: 5, max_students: 50 } },
+  { slug: 'starter', name: 'Starter', fee: 5, limits: { max_courses: 15, max_students: 200 } },
+  { slug: 'pro', name: 'Pro', fee: 2, limits: { max_courses: 100, max_students: 1000 } },
+  { slug: 'business', name: 'Business', fee: 0, limits: { max_courses: -1, max_students: 5000 } },
+  { slug: 'enterprise', name: 'Enterprise', fee: 0, limits: { max_courses: -1, max_students: -1 } },
+]
+
+beforeEach(() => {
+  db = {
+    tenants: [{ id: TENANT, name: 'Test School', plan: 'business', billing_status: 'active' }],
+    tenant_users: [{ tenant_id: TENANT, user_id: USER, role: 'admin', status: 'active' }],
+    platform_plans: PLANS.map((p) => ({
+      plan_id: `plan-${p.slug}`,
+      slug: p.slug,
+      name: p.name,
+      is_active: true,
+      price_monthly: 0,
+      price_yearly: 0,
+      transaction_fee_percent: p.fee,
+      limits: p.limits,
+      features: {},
+    })),
+    platform_subscriptions: [],
+    courses: [],
+    platform_payment_requests: [],
+    revenue_splits: [],
+  }
+})
+
+describe('#613 — the fee shown on the billing page', () => {
+  it('reports 0 for Business rather than the Free-plan default', async () => {
+    const status = await getSubscriptionStatus()
+
+    expect(status.plan).toBe('business')
+    expect(status.transactionFeePercent).toBe(0)
+  })
+
+  it('reports 0 for Enterprise too', async () => {
+    db.tenants[0].plan = 'enterprise'
+
+    const status = await getSubscriptionStatus()
+
+    expect(status.plan).toBe('enterprise')
+    expect(status.transactionFeePercent).toBe(0)
+  })
+
+  it('still reports each paid plan its own non-zero fee', async () => {
+    // Guards the other direction: the fix must not blanket-zero the fee.
+    for (const { slug, fee } of PLANS) {
+      db.tenants[0].plan = slug
+      expect((await getSubscriptionStatus()).transactionFeePercent).toBe(fee)
+    }
+  })
+
+  it('keeps the 10% fallback when the tenant is on a plan with no row', async () => {
+    db.tenants[0].plan = 'a-slug-that-was-deleted'
+
+    const status = await getSubscriptionStatus()
+
+    expect(status.transactionFeePercent).toBe(10)
+  })
+})


### PR DESCRIPTION
## What

`getSubscriptionStatus()` now reads the plan's transaction fee with `??` instead of `||`, so a plan whose fee is legitimately `0` is no longer mistaken for a missing plan row and defaulted to 10%.

Closes #613

## Why

`platform_plans.transaction_fee_percent` is `0.00` for `business` and `enterprise`, and `0 || 10` is `10`. The two plans whose zero fee is the reason to buy them were the only two told they pay the Free-plan rate — the bug is invisible on `free`, `starter` and `pro`, whose fees are non-zero. A Business school reading its own billing page saw:

> Current Plan · Business · **10%** transaction fee on student payments

That number contradicted the pricing page and `usePlanFeatures()`, which reads the same column with `??` in `lib/hooks/use-plan-features.ts:92` and correctly returned 0. It also understates the value of the tier: 0% platform fee is the headline reason to pay $79/month over $29.

The `10` is kept, because it is still wanted — just as the fallback for a tenant whose `plan` slug matches no `platform_plans` row (which would otherwise render `undefined% transaction fee`), not as a floor under the column's value.

**Scope of the bug.** Display only. The value flows `getSubscriptionStatus()` → `billing-dashboard-client.tsx:223` → `paidPlanDescription` in `billing-overview.tsx:92`, and nowhere else. No revenue split, payout or invoice was ever computed from it — those read `transaction_fee_percent` directly off the plan row.

**The audit the issue asked for.** The neighbouring `||` defaults on the same lines (`limits`, `planName`, `features`) take objects and a non-empty string, which have no falsy value they can legitimately hold, so they are correct as written and I left them alone rather than churn the diff. The other three readers of this column were already correct and are unchanged: `lib/hooks/use-plan-features.ts:92` (`??`), `lib/billing/downgrade-tenant.ts:32` (`??`), and `lib/billing/platform-webhook-dispatch.ts:199` (an explicit `if (fee == null) return`). After this change all four agree.

## How to QA

The seeded Default School is on `free`, so you have to put a tenant on a zero-fee plan to see either the bug or the fix.

1. `npm run db:reset`, then `npm run dev`.
2. Put the Default School on Business:
   ```sql
   update tenants set plan = 'business', billing_status = 'active'
   where id = '00000000-0000-0000-0000-000000000001';
   ```
   (`docker exec -i supabase_db_lms-front psql -U postgres -d postgres -c "…"`)
3. Sign in as `owner@e2etest.com` / `password123` at `default.lvh.me:3000` and open **Settings → Billing** (`/en/dashboard/admin/billing`).
4. The Current Plan card reads **`0% transaction fee on student payments`**. On `master` the same screen reads `10%`.
5. Repeat with `plan = 'enterprise'` — also `0%`.
6. Regression, the other direction: `plan = 'pro'` still reads `2%`, and `plan = 'starter'` still reads `5%`. The fix must not blanket-zero the fee.
7. Restore: `update tenants set plan = 'free', billing_status = 'free' where id = '00000000-0000-0000-0000-000000000001';`

Unit coverage: `npx vitest run tests/unit/plan-fee-display.test.ts`. Three of its four cases fail if you flip the operator back to `||`.

## Screenshots / GIF

Before and after, same screen, Default School on `business` — posted as a comment below. No GIF: the change is one static string with no interaction to record, and the two stills carry everything a moving image would.

## Checklist

- [x] `npm run typecheck` and `npm run test:unit` pass — 60 files, 793 tests, all green
- [x] `npm run build` passes
- [x] Every new tenant-scoped query filters by `tenant_id` (or the table genuinely has no such column) — no new queries
- [x] Tested with every relevant role (student / teacher / admin) — admin-only screen; `getSubscriptionStatus()` is behind `verifyAdminAccess()`
- [x] Loading and error states handled — unchanged
- [x] New UI strings added to both `messages/en.json` and `messages/es.json` — no new strings; the existing `paidPlanDescription` interpolation is what carries the number
- [x] Migration (if any) applies cleanly on `npm run db:reset`, has RLS policies, and `lib/database.types.ts` was regenerated — no migration
