### PR TITLE
MVP acceptance: the complete money loop — two money-losing defects fixed, manual rail pinned (#605)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,9 +18,12 @@ STRIPE_SECRET_KEY=                                 # Required for payment featur
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=                # Required for payment features
 STRIPE_WEBHOOK_SECRET=                             # Required — student payment webhook (/api/stripe/webhook)
 
-# ─── STRIPE — SCHOOL BILLING (Platform) ───────────────────────────────────────
-# Schools pay the platform via Stripe Billing (Checkout + Subscriptions)
-STRIPE_PLATFORM_WEBHOOK_SECRET=                    # Required for school billing webhook (/api/stripe/platform-webhook)
+# ─── SCHOOL BILLING (Platform) ────────────────────────────────────────────────
+# Schools pay the platform on any priced rail (#600): Stripe, Lemon Squeezy,
+# Binance Pay, Solana, or offline bank transfer. Each rail's credentials live in
+# its own section below; only Stripe needs a SECOND webhook secret, because the
+# other rails sign both money loops with the one secret their section already has.
+STRIPE_PLATFORM_WEBHOOK_SECRET=                    # Required for school billing webhook (/api/billing/webhook/stripe)
 
 # ─── PLATFORM ─────────────────────────────────────────────────────────────────
 NEXT_PUBLIC_PLATFORM_DOMAIN=lvh.me                 # Has-Default — subdomain base (lvh.me for local, yourdomain.com in prod)

--- a/app/[locale]/dashboard/teacher/revenue/page.tsx
+++ b/app/[locale]/dashboard/teacher/revenue/page.tsx
@@ -101,7 +101,7 @@ export default async function RevenuePage() {
       accent: 'group-hover:ring-blue-200 dark:group-hover:ring-blue-800',
     },
     {
-      title: t('stats.yourShare', { percentage: split?.school_percentage || 80 }),
+      title: t('stats.yourShare', { percentage: split?.school_percentage ?? 80 }),
       value: `$${schoolRevenue.toFixed(2)}`,
       valueColor: 'text-emerald-600 dark:text-emerald-400',
       sub: t('stats.yourShareSub'),
@@ -201,7 +201,7 @@ export default async function RevenuePage() {
             <div className="rounded-xl bg-muted/40 p-4 space-y-2">
               <div className="flex items-center justify-between">
                 <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">{t('split.platformFee')}</span>
-                <Badge variant="secondary" className="text-[10px]">{split?.platform_percentage || 20}%</Badge>
+                <Badge variant="secondary" className="text-[10px]">{split?.platform_percentage ?? 20}%</Badge>
               </div>
               <div className="text-2xl font-bold tabular-nums text-muted-foreground">
                 ${platformFee.toFixed(2)}
@@ -214,7 +214,7 @@ export default async function RevenuePage() {
             <div className="rounded-xl bg-emerald-50/50 dark:bg-emerald-950/20 p-4 ring-1 ring-emerald-100 dark:ring-emerald-900/40 space-y-2">
               <div className="flex items-center justify-between">
                 <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">{t('split.yourRevenue')}</span>
-                <Badge variant="default" className="text-[10px] bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-400">{split?.school_percentage || 80}%</Badge>
+                <Badge variant="default" className="text-[10px] bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-400">{split?.school_percentage ?? 80}%</Badge>
               </div>
               <div className="text-2xl font-bold tabular-nums text-emerald-600 dark:text-emerald-400">
                 ${schoolRevenue.toFixed(2)}

--- a/app/api/stripe/create-payment-intent/route.ts
+++ b/app/api/stripe/create-payment-intent/route.ts
@@ -5,6 +5,7 @@ import { createAdminClient } from '@/lib/supabase/admin'
 import { getCurrentTenantId } from '@/lib/supabase/tenant'
 import { toCents } from '@/lib/currency'
 import { getPaymentProvider } from '@/lib/payments'
+import { resolvePlatformPercentage } from '@/lib/payments/revenue-share'
 import {
   findConflictingSubscription,
   PARALLEL_SUBSCRIPTION_CODE,
@@ -132,8 +133,10 @@ export async function POST(req: NextRequest) {
       .eq('tenant_id', tenantId)
       .single()
 
-    // Calculate platform fee (default to 20% if not configured)
-    const platformPercentage = split?.platform_percentage || 20
+    // Calculate platform fee. `resolvePlatformPercentage`, not `|| 20`: a 0%
+    // fee is a real configuration — it is what Business and Enterprise pay for —
+    // and reading it as "unset" charged those schools 20% on every sale (#605).
+    const platformPercentage = resolvePlatformPercentage(split)
     const platformFee = Math.round((amount * platformPercentage) / 100)
 
     // Create transaction record (pending).

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -159,8 +159,23 @@ STRIPE_SECRET_KEY=sk_live_...
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_live_...
 STRIPE_WEBHOOK_SECRET=whsec_...
 
-# Stripe — Platform Billing
-STRIPE_PLATFORM_WEBHOOK_SECRET=whsec_...
+# Platform Billing (school pays the platform) — one section per rail.
+# Only the rails you actually price in Platform → Plans need to be set.
+STRIPE_PLATFORM_WEBHOOK_SECRET=whsec_...        # Stripe; separate registration from the Connect webhook above
+LEMONSQUEEZY_API_KEY=
+LEMONSQUEEZY_STORE_ID=
+LEMONSQUEEZY_WEBHOOK_SECRET=
+# Lemon Squeezy and Binance Pay share one merchant account with the student→school loop;
+# the two are kept apart by the platform:<provider> webhook_events namespace — no second account needed.
+BINANCE_PAY_API_KEY=
+BINANCE_PAY_API_SECRET=
+# Solana has no webhook — do not register one. Payments are proven on chain by
+# /api/billing/solana/verify, which the school's browser polls.
+SOLANA_RPC_URL=
+SOLANA_PLATFORM_WALLET=
+SOLANA_USDC_MINT=                               # Set = settle in USDC (recommended, no price oracle). Unset = settle in native SOL at the Pyth quote locked at checkout.
+# PayPal is coded but its platform-billing checkout is capability-disabled pending #479 —
+# no PAYPAL_* needed here; PayPal is still used for student→school payments (configured elsewhere in this file).
 
 # OpenAI (AI grading)
 OPENAI_API_KEY=sk-...
@@ -440,9 +455,14 @@ The LMS relies on `custom_access_token_hook()` for JWT claims:
 
 ---
 
-## 6. Stripe Webhook Configuration
+## 6. Payment Webhook Configuration
 
-Create two webhook endpoints in the Stripe Dashboard:
+Register one endpoint per provider per money loop. Stripe is the only provider
+needing two registrations — the others sign both loops with a single secret, and
+the two loops are kept apart by the `platform:<provider>` `webhook_events`
+namespace rather than by separate credentials.
+
+Both of these are in the Stripe Dashboard:
 
 **Student Payments (Connect):**
 - URL: `https://lmsplatform.com/api/stripe/webhook`

--- a/docs/MONETIZATION.md
+++ b/docs/MONETIZATION.md
@@ -10,7 +10,7 @@
 ## Executive Summary
 
 Implemented the full business monetization stack for the LMS platform:
-- **School billing** via Stripe Checkout (card) and manual bank transfer
+- **School billing** on any priced rail — Stripe, Lemon Squeezy, Binance Pay, Solana or manual bank transfer (#600)
 - **5-tier pricing** (Free → Enterprise) with feature gating
 - **Dynamic transaction fees** that decrease with higher plans
 - **LATAM payment support** with multi-currency and structured bank details
@@ -50,13 +50,15 @@ Yearly pricing: ~17% discount (e.g. Starter $90/year instead of $108).
 
 | Table | Purpose |
 |-------|---------|
-| `platform_plans` | Plan definitions: slug, name, prices (monthly/yearly), Stripe price IDs, features JSONB, limits JSONB, transaction_fee_percent |
-| `platform_subscriptions` | One per tenant. Tracks Stripe subscription ID, status, payment method, billing period. `UNIQUE(tenant_id)` |
+| `platform_plans` | Plan definitions: slug, name, list prices (monthly/yearly), features JSONB, limits JSONB, transaction_fee_percent. Carries **no** provider price ids — those moved to `platform_plan_prices` in #601 |
+| `platform_plan_prices` | One row per (plan, provider, interval): `provider_price_id` for catalog rails, `amount` for catalog-less ones. An active row is what makes a rail selectable at checkout (#602) |
+| `platform_subscriptions` | One per tenant. Tracks `payment_provider`, `provider_subscription_id`, status, interval, billing period, `cancel_at_period_end`, `grace_period_end`. `UNIQUE(tenant_id)` |
+| `tenant_billing_customers` | The tenant's customer id **per provider** (#601) — replaces the single `tenants.stripe_customer_id` column, which no longer exists |
 | `platform_payment_requests` | Manual bank transfer requests for plan upgrades. Status flow: `pending` → `instructions_sent` → `payment_received` → `confirmed` |
 
 ### Altered Tables
 
-- **`tenants`** — Added: `stripe_customer_id`, `billing_email`, `billing_period_end`, `billing_status`
+- **`tenants`** — Added: `billing_email`, `billing_period_end`, `billing_status` (and `stripe_customer_id`, since dropped by #601 in favour of `tenant_billing_customers`)
 - **`currency_type` enum** — Added: `mxn`, `cop`, `clp`, `pen`, `ars`, `brl`
 
 ### Which rails a school can pay the platform with
@@ -98,16 +100,35 @@ fresh production database has none. The go-live checklist (credentials, webhook
 registration, wallet, the mainnet USDC mint, and how to revert) is in
 [`DEPLOYMENT.md → Going live with the crypto rails`](DEPLOYMENT.md#going-live-with-the-crypto-rails--checklist).
 
-### Key Distinction: Two Stripe Integrations
+### Key Distinction: Two Money Loops
 
-| | School Billing (NEW) | Student Payments (EXISTING) |
+Both loops are provider-agnostic — the student loop since #280, the school loop
+since #600. They are separate *loops*, not separate Stripe integrations, and the
+only thing they share is the `IPaymentProvider` contract in `lib/payments`.
+
+| | School Billing (school → platform) | Student Payments (student → school) |
 |--|--|--|
-| **Who pays** | School admin pays platform | Student pays school |
-| **Stripe mode** | Stripe Billing (Checkout + Subscriptions) | Stripe Connect (PaymentIntents) |
-| **Webhook** | `/api/billing/webhook/stripe` | `/api/stripe/webhook` |
-| **Webhook secret** | `STRIPE_PLATFORM_WEBHOOK_SECRET` | `STRIPE_WEBHOOK_SECRET` |
-| **Customer ID stored in** | `tenants.stripe_customer_id` | `profiles.stripe_customer_id` |
-| **Revenue** | Platform revenue (SaaS fees) | School revenue (course sales) |
+| **Who pays** | School admin pays the platform | Student pays the school |
+| **Rails** | Stripe, Lemon Squeezy, Binance Pay, Solana, manual bank transfer (PayPal coded, off until #479) | Stripe Connect, PayPal, Lemon Squeezy, Binance Pay, `binance_personal`, Solana, `solana_subs`, manual |
+| **Which rail** | whichever has an active `platform_plan_prices` row and `supportsPlatformBillingCheckout` | `products.payment_provider` / `plans.payment_provider`, enabled per tenant in `tenant_settings` |
+| **Entry point** | `POST /api/billing/checkout` | `components/public/checkout-form.tsx` |
+| **Webhook** | `/api/billing/webhook/[provider]`, namespaced `platform:<provider>` | `/api/payments/webhook/[provider]`; Stripe Connect also on `/api/stripe/webhook` |
+| **Applier** | `dispatchPlatformBillingEvent` | `dispatchBillingEvent` |
+| **Customer ID stored in** | `tenant_billing_customers(tenant_id, payment_provider, provider_customer_id)` — per rail since #601 | `profiles.stripe_customer_id` |
+| **Grants** | `tenants.plan` + `platform_subscriptions` → plan features and limits | `entitlements` → course access |
+| **Revenue** | Platform revenue (SaaS subscription fees) | School revenue, less the platform's transaction fee |
+
+Where Stripe *is* still special, it is special twice over, and the two must not be
+confused: school billing uses **Stripe Billing** on the platform account with
+`STRIPE_PLATFORM_WEBHOOK_SECRET`, while student payments use **Stripe Connect** with
+`STRIPE_WEBHOOK_SECRET` and the school's connected account. Two registrations, two
+secrets, one Stripe account.
+
+The two loops can run on the same merchant account for a Merchant-of-Record or crypto
+rail (Lemon Squeezy, Binance Pay), which is why `webhook_events` namespaces the
+platform loop as `platform:<provider>`: the same provider event id can legitimately
+arrive at both endpoints, and one shared key space would let whichever route ran first
+mark it processed and make the other skip work it had not done.
 
 ### Single Source of Truth: `get_plan_features()`
 
@@ -191,43 +212,73 @@ All plan checks should go through this function, NOT hardcoded constants.
 
 ## How Plan Changes Work
 
-### Via Stripe Checkout (Card Payment)
+### Via hosted checkout (any priced rail)
+
+One path for every rail that carries `supportsPlatformBillingCheckout` — Stripe,
+Lemon Squeezy, Binance Pay, Solana. Which one runs is resolved from
+`platform_plan_prices` by `resolveCheckoutProvider`, never from a provider name in
+the route.
 
 ```
-Admin clicks "Subscribe" → POST /api/billing/checkout
-  → Creates Stripe Checkout Session
-  → Redirects to Stripe hosted page
-  → Student pays
-  → Stripe fires checkout.session.completed webhook
-  → platform-webhook handler:
-    1. Upserts platform_subscriptions
-    2. Updates tenants.plan = new slug
-    3. Updates tenants.billing_status = 'active'
-    4. Updates revenue_splits.platform_percentage to match new plan's fee
+Admin picks a plan, then a payment method → POST /api/billing/checkout
+  → resolveCheckoutProvider(prices, interval): explicit choice > rail already on
+    file > the only priced one
+  → provider.createCheckoutSession({ hosted: true })
+  → school pays on the provider's page (or scans the QR, for Solana)
+  → confirmation arrives:
+      webhook rails  → POST /api/billing/webhook/[provider]  (signature verified,
+                       deduped in webhook_events under `platform:<provider>`)
+      Solana         → the QR page polls POST /api/billing/solana/verify, which
+                       proves the transfer on chain
+  → both call dispatchPlatformBillingEvent, which:
+    1. Upserts platform_subscriptions (provider, ids, status, period)
+    2. Updates tenants.plan / billing_status / billing_period_end
+    3. Rewrites revenue_splits to the new plan's transaction_fee_percent
+    4. Reconciles any access cutoff left over from being over-limit
 ```
 
-### Via Manual Bank Transfer
+On a rail with no subscription object of its own (`selfManagedPeriod` — Binance Pay,
+Solana), step 1 *derives* `current_period_end` from the interval, because the provider
+reports no period. A subscription with a NULL period end never lapses, never reminds
+and shows no next-payment date, so this is the whole difference between a paid month
+and a free one.
+
+### Via manual bank transfer
 
 ```
-Admin clicks "Pay via bank transfer" → requestManualPlanUpgrade()
-  → Creates platform_payment_requests row (status: 'pending')
-  → Platform sends bank instructions via email (manual step)
-  → Admin makes bank transfer
-  → Super admin calls confirmManualPayment(requestId)
+Admin clicks "Bank transfer" → requestManualPlanUpgrade()
+  → Creates platform_payment_requests row (status 'pending', expires_at +14d)
+  → Super admin marks instructions sent → 'instructions_sent'
+  → School transfers, optionally uploads proof → 'payment_received'
+  → Super admin calls confirmManualPayment(requestId) on /platform/billing
+    0. Blocks if the tenant is over the target plan's limits
     1. Updates request status to 'confirmed'
-    2. Upserts platform_subscriptions (payment_method: 'manual_transfer')
-    3. Updates tenants.plan
-    4. Updates revenue_splits
+    2. Upserts platform_subscriptions (payment_provider: 'manual'), extending
+       from the old period end on a renewal rather than restarting it
+    3. Updates tenants.plan / billing_status / billing_period_end
+    4. Rewrites revenue_splits
+    5. Reconciles the access cutoff
 ```
 
-### Cancellation
+### Cancellation and lapse
 
 ```
 Admin clicks "Cancel" → cancelSubscription()
-  → If Stripe: sets cancel_at_period_end on Stripe subscription
-  → If manual: marks cancel_at_period_end in DB
-  → At period end, Stripe fires customer.subscription.deleted
-  → Webhook downgrades to free plan
+  → supportsNativeSubscriptions (Stripe, Lemon Squeezy, PayPal):
+      cancel at period end AT THE PROVIDER; its renewal webhook stops arriving
+      and the terminal event downgrades us
+  → selfManagedPeriod (manual, Binance Pay, Solana):
+      set cancel_at_period_end in the DB; nothing renews it anyway
+  → either way cancel_at_period_end is the ONLY signal a cancel is scheduled
+    (#545); cancel_at is informational and the two are cleared together
+
+/api/cron/expire-platform-subscriptions sweeps every selfManagedPeriod rail daily:
+  phase 0  retire payment requests past expires_at
+  phase 1  remind, once, within 7 days of period end
+  phase 2  period end passed → 'past_due' + 7-day grace window
+  phase 3  grace closed → downgradeTenantToFree(), unless a renewal request is
+           still open (a school that has already sent money is not cut off)
+  phase 4  cancel_at_period_end and the period has ended → downgradeTenantToFree()
 ```
 
 ---
@@ -372,20 +423,47 @@ The `getRoutingNumberLabel(countryCode)` function returns country-specific label
 
 ## Environment Variables
 
-### New (Required for Stripe billing)
+### Required for school billing
+
+Per rail, and only for the rails you actually price. The full annotated list is in
+[`DEPLOYMENT.md → Environment Variables`](DEPLOYMENT.md#33-environment-variables).
 
 ```env
-STRIPE_PLATFORM_WEBHOOK_SECRET=whsec_...   # Separate from Connect webhook
+STRIPE_PLATFORM_WEBHOOK_SECRET=whsec_...   # Stripe — separate from the Connect webhook
+LEMONSQUEEZY_API_KEY=                      # Lemon Squeezy — same account as the student loop
+LEMONSQUEEZY_STORE_ID=
+LEMONSQUEEZY_WEBHOOK_SECRET=
+BINANCE_PAY_API_KEY=                       # Binance Pay — same merchant account as the student loop
+BINANCE_PAY_API_SECRET=
+SOLANA_RPC_URL=                            # Solana — no webhook exists; /api/billing/solana/verify proves it on chain
+SOLANA_PLATFORM_WALLET=
+SOLANA_USDC_MINT=
 ```
 
-### Stripe Setup Steps
+Manual bank transfer needs no credentials at all — it settles through
+`platform_payment_requests` under a super admin's eye.
 
-1. Create Stripe Product "LMS Platform Subscription" in dashboard
-2. Create 8 Prices (4 monthly + 4 yearly for Starter/Pro/Business/Enterprise)
-3. Store price IDs in `platform_plans.stripe_price_id_monthly` / `stripe_price_id_yearly`
-4. Create webhook endpoint at `https://yourdomain.com/api/billing/webhook/stripe`
+### Stripe setup steps
+
+1. Create a Stripe Product, e.g. "LMS Platform Subscription"
+2. Create 8 Prices (4 monthly + 4 yearly, for Starter / Pro / Business / Enterprise)
+3. Enter each price id in **Platform → Plans → Edit plan → Prices**, which writes
+   `platform_plan_prices(plan_id, payment_provider, interval, provider_price_id)`.
+   **Do not look for a price column on `platform_plans`** — there is none, and
+   there never was one anything wrote, which is what made every card upgrade 400
+   until #602. A plan with no active price row for a rail simply does not offer
+   that rail; it no longer fails at checkout.
+4. Create a webhook endpoint at `https://yourdomain.com/api/billing/webhook/stripe`
 5. Subscribe to events: `checkout.session.completed`, `customer.subscription.updated`, `customer.subscription.deleted`, `invoice.payment_failed`, `invoice.paid`
-6. Copy webhook signing secret to `STRIPE_PLATFORM_WEBHOOK_SECRET`
+6. Copy the webhook signing secret to `STRIPE_PLATFORM_WEBHOOK_SECRET`
+
+### Other rails
+
+Same shape, one step shorter. Lemon Squeezy takes its variant id in the same
+Prices editor; Binance Pay and Solana have no catalog, so their rows carry a plain
+`amount` and no `provider_price_id`. Registering the webhook (or, for Solana,
+deliberately not registering one) is covered in
+[`DEPLOYMENT.md → Payment Webhook Configuration`](DEPLOYMENT.md#6-payment-webhook-configuration).
 
 ---
 
@@ -405,8 +483,8 @@ Both `messages/en.json` and `messages/es.json` received:
 
 1. As school admin → `/dashboard/admin/billing` shows free plan with 5/5 courses, 0/50 students
 2. Click "Upgrade" → plan comparison page renders with monthly/yearly toggle
-3. Select Starter ($9/mo) → Stripe Checkout opens
-4. Pay with test card `4242 4242 4242 4242` → webhook fires → `tenants.plan` = `starter`
+3. Select Starter ($9/mo) → the payment-method dialog lists every rail with an active price row, plus bank transfer
+4. Pick Stripe, pay with test card `4242 4242 4242 4242` → webhook fires → `tenants.plan` = `starter`. On a crypto rail the same assertion holds once the QR / hosted order settles; on bank transfer, once a super admin confirms
 5. Billing page now shows Starter, next billing date, usage meters updated (15 courses max)
 6. `revenue_splits.platform_percentage` updated from 10 to 5
 7. Test manual transfer: request upgrade to Pro → `platform_payment_requests` created → super admin confirms → plan activates

--- a/lib/billing/platform-webhook-dispatch.ts
+++ b/lib/billing/platform-webhook-dispatch.ts
@@ -215,6 +215,27 @@ async function applyRevenueSplit(admin: SupabaseClient, tenantId: string, planId
   )
 }
 
+/**
+ * Last-resort plan resolution for an event that names a price but no plan, on a
+ * tenant we hold no subscription row for. Only reachable when a provider's
+ * subscription event overtakes its own checkout event.
+ */
+async function planIdForPrice(
+  admin: SupabaseClient,
+  provider: string,
+  providerPriceId: string | undefined,
+): Promise<string | undefined> {
+  if (!providerPriceId) return undefined
+  const { data } = await admin
+    .from('platform_plan_prices')
+    .select('plan_id')
+    .eq('payment_provider', provider)
+    .eq('provider_price_id', providerPriceId)
+    .limit(1)
+    .maybeSingle()
+  return (data as { plan_id: string } | null)?.plan_id ?? undefined
+}
+
 /** Email every active admin of the school that its platform payment failed. */
 async function notifyPaymentFailed(
   admin: SupabaseClient,
@@ -353,11 +374,40 @@ export async function dispatchPlatformBillingEvent(
   const effectiveStart = periodStart ?? derived?.start.toISOString()
   const effectiveEnd = periodEnd ?? derived?.end.toISOString()
 
+  // The plan the ROW must carry, which is a different question from `planId`
+  // above. That one answers "is this event moving the school to a new plan?" and
+  // is deliberately undefined on every event after the first; this one answers
+  // "what plan is this subscription on?", which on those same events is simply
+  // the plan already stored.
+  //
+  // They have to be separate because the upsert below needs a non-NULL plan_id
+  // on EVERY write. PostgREST sends `INSERT … ON CONFLICT DO UPDATE`, and
+  // Postgres NOT NULL-checks the proposed insert tuple before it ever resolves
+  // the conflict — so omitting plan_id on what is logically an update fails the
+  // whole statement, not just that column. Sharing one variable made every
+  // Stripe `customer.subscription.updated` and `invoice.paid` after the first
+  // one throw, which meant: `current_period_end` stayed NULL forever (the
+  // checkout event carries no period, only the subscription event does), the
+  // period never advanced on renewal, and the provider kept retrying a 500
+  // until it disabled the endpoint (#605).
+  const rowPlanId =
+    planId ?? stored?.plan_id ?? (await planIdForPrice(admin, provider, event.providerPriceId))
+
+  if (!rowPlanId) {
+    // Nothing to write a subscription row against, and a row without a plan
+    // cannot exist. Dropping the event beats throwing: a 500 here would have the
+    // provider redeliver an event we can never apply.
+    console.warn(
+      `[platform-webhook] ${event.type} on ${provider} for tenant ${tenantId} resolved no plan — ignoring`,
+    )
+    return
+  }
+
   const subscriptionPatch: Record<string, unknown> = {
     status,
     payment_provider: provider,
+    plan_id: rowPlanId,
     updated_at: now,
-    ...(planId ? { plan_id: planId } : {}),
     ...(event.providerSubscriptionId ? { provider_subscription_id: event.providerSubscriptionId } : {}),
     ...(event.providerCustomerId ? { provider_customer_id: event.providerCustomerId } : {}),
     ...(interval ? { interval } : {}),

--- a/lib/payments/revenue-share.ts
+++ b/lib/payments/revenue-share.ts
@@ -105,3 +105,30 @@ export function computeRevenueTotals(
   platformFees = roundMoney(platformFees)
   return { grossRevenue, platformFees, netRevenue: roundMoney(grossRevenue - platformFees) }
 }
+
+/** The split fallback used when a tenant has no `revenue_splits` row at all. */
+export const DEFAULT_PLATFORM_PERCENTAGE = 20
+
+/**
+ * The platform's cut of a sale, as a percentage.
+ *
+ * Exists because the obvious spelling is wrong in a way that costs a school
+ * real money: `split?.platform_percentage || 20` reads a legitimate **0%** as
+ * missing, because PostgREST returns `numeric` as a JSON number and `0` is
+ * falsy. Business and Enterprise are 0%-fee plans, so the schools paying us the
+ * most were the ones charged a 20% platform fee on every student sale (#605).
+ *
+ * The fallback applies only when there is genuinely no split on file. Note that
+ * it is a flat 20% rather than the tenant's plan fee — a tenant whose
+ * `revenue_splits` row was never written is misconfigured either way, and every
+ * writer of that table (`downgradeTenantToFree`, `confirmManualPayment`,
+ * `dispatchPlatformBillingEvent`) sets it from the plan.
+ */
+export function resolvePlatformPercentage(
+  split: { platform_percentage?: number | string | null } | null | undefined,
+): number {
+  const raw = split?.platform_percentage
+  if (raw === null || raw === undefined || raw === '') return DEFAULT_PLATFORM_PERCENTAGE
+  const value = Number(raw)
+  return Number.isFinite(value) ? value : DEFAULT_PLATFORM_PERCENTAGE
+}

--- a/tests/playwright/platform-billing-manual-lifecycle.spec.ts
+++ b/tests/playwright/platform-billing-manual-lifecycle.spec.ts
@@ -1,0 +1,550 @@
+/**
+ * The manual-provider platform-subscription lifecycle, end to end (issue #605).
+ *
+ * Manual bank transfer is the one school → platform rail that needs no external
+ * credentials, so it is the only one that can guard this loop in CI forever.
+ * Everything it exercises is shared with the crypto rails: `confirmManualPayment`
+ * and `dispatchPlatformBillingEvent` write the same columns, and
+ * `/api/cron/expire-platform-subscriptions` reminds, grace-windows and downgrades
+ * every provider with `selfManagedPeriod` — `manual` among them. A regression
+ * caught here is a regression on Binance Pay and Solana too.
+ *
+ * What it covers:
+ *   request → super admin confirms in the real UI → plan active, tenant billing
+ *   columns written, revenue split rewritten to the plan's fee, features unlock;
+ *   the reject path; a renewal extending the period rather than restarting it;
+ *   and the lapse ladder (reminder → grace → downgrade to free), including the
+ *   pause while a renewal request is still open and the idempotency of a replay.
+ *
+ * Runs against a DEDICATED tenant rather than a seeded one. The default and
+ * code-academy tenants are load-bearing for a dozen other specs — a test that
+ * moves `tenants.plan` on them is a test that breaks its neighbours under CI's
+ * `fullyParallel`.
+ *
+ * Not covered here, deliberately: the school-facing request form. It is a
+ * base-ui dialog whose submit does not reliably fire under headless Playwright
+ * (see the `clickByText` note in platform-billing-provider-choice.spec.ts, which
+ * owns that surface). This spec starts from the row that form produces, so the
+ * state machine behind it is pinned regardless.
+ */
+import { test, expect } from '@playwright/test'
+import { createClient as createSupabaseClient, type SupabaseClient } from '@supabase/supabase-js'
+import { login } from './utils/auth'
+import { BASE, LOCALE, ACCOUNTS } from './utils/constants'
+
+/* ------------------------------------------------------------------ */
+/*  Constants                                                          */
+/* ------------------------------------------------------------------ */
+
+/** owner@e2etest.com — the seeded super admin (supabase/seed.sql). */
+const SUPER_ADMIN_ID = 'a1000000-0000-0000-0000-000000000002'
+
+/** Dedicated to this spec so no other spec's tenant state is disturbed. */
+const QA_TENANT_ID = '00000000-0000-0000-0000-0000000006e5'
+const QA_TENANT_SLUG = 'qa-manual-lifecycle'
+
+const GRACE_DAYS = 7
+const DAY_MS = 24 * 60 * 60 * 1000
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY!
+const cronSecret = process.env.CRON_SECRET
+
+function getAdmin(): SupabaseClient {
+  return createSupabaseClient(supabaseUrl, serviceRoleKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  })
+}
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+async function planBySlug(admin: SupabaseClient, slug: string) {
+  const { data, error } = await admin
+    .from('platform_plans')
+    .select('plan_id, slug, name, price_monthly, transaction_fee_percent')
+    .eq('slug', slug)
+    .single()
+  if (error) throw new Error(`plan "${slug}" not found: ${error.message}`)
+  return data
+}
+
+/**
+ * The row the school's bank-transfer form produces. Written directly rather
+ * than through the form for the reason in the file header; the shape mirrors
+ * `requestManualPlanUpgrade` (app/actions/admin/billing.ts).
+ */
+async function createPendingRequest(
+  admin: SupabaseClient,
+  opts: {
+    planId: string
+    amount: number
+    requestType?: 'upgrade' | 'downgrade' | 'renewal'
+    status?: string
+    expiresAt?: Date
+  },
+) {
+  const { data, error } = await admin
+    .from('platform_payment_requests')
+    .insert({
+      tenant_id: QA_TENANT_ID,
+      plan_id: opts.planId,
+      requested_by: SUPER_ADMIN_ID,
+      interval: 'monthly',
+      amount: opts.amount,
+      currency: 'usd',
+      status: opts.status ?? 'pending',
+      request_type: opts.requestType ?? 'upgrade',
+      payment_provider: 'manual',
+      bank_reference: 'E2E-MANUAL-LIFECYCLE',
+      expires_at: (opts.expiresAt ?? new Date(Date.now() + 14 * DAY_MS)).toISOString(),
+    })
+    .select('request_id')
+    .single()
+  if (error) throw new Error(`could not create payment request: ${error.message}`)
+  return data.request_id as string
+}
+
+async function getRequest(admin: SupabaseClient, requestId: string) {
+  const { data } = await admin
+    .from('platform_payment_requests')
+    .select('status, notes, confirmed_by, confirmed_at')
+    .eq('request_id', requestId)
+    .single()
+  return data
+}
+
+async function getSubscription(admin: SupabaseClient) {
+  const { data } = await admin
+    .from('platform_subscriptions')
+    .select(
+      'plan_id, status, payment_provider, interval, current_period_start, current_period_end, cancel_at_period_end, canceled_at, grace_period_end, renewal_reminder_sent_at',
+    )
+    .eq('tenant_id', QA_TENANT_ID)
+    .maybeSingle()
+  return data
+}
+
+async function getTenant(admin: SupabaseClient) {
+  const { data } = await admin
+    .from('tenants')
+    .select('plan, billing_status, billing_period_end')
+    .eq('id', QA_TENANT_ID)
+    .single()
+  return data
+}
+
+async function getSplit(admin: SupabaseClient) {
+  const { data } = await admin
+    .from('revenue_splits')
+    .select('platform_percentage, school_percentage')
+    .eq('tenant_id', QA_TENANT_ID)
+    .maybeSingle()
+  return data
+}
+
+/** Put the tenant back on free with no subscription and no open requests. */
+async function resetTenant(admin: SupabaseClient) {
+  await admin.from('platform_payment_requests').delete().eq('tenant_id', QA_TENANT_ID)
+  await admin.from('platform_subscriptions').delete().eq('tenant_id', QA_TENANT_ID)
+  await admin.from('revenue_splits').delete().eq('tenant_id', QA_TENANT_ID)
+  await admin
+    .from('tenants')
+    .update({ plan: 'free', billing_status: 'free', billing_period_end: null, access_cutoff_at: null })
+    .eq('id', QA_TENANT_ID)
+}
+
+/**
+ * The action buttons are `@/components/ui/button`, i.e. base-ui — Playwright's
+ * synthesized click lands on them unreliably, so dispatch a real DOM click the
+ * way the other specs in this directory do.
+ */
+async function domClick(page: import('@playwright/test').Page, selector: string) {
+  await page.waitForSelector(selector)
+  await page.evaluate((sel) => {
+    const el = document.querySelector<HTMLElement>(sel)
+    if (!el) throw new Error(`no element matching ${sel}`)
+    el.click()
+  }, selector)
+}
+
+/**
+ * The request list. Always the "all" tab: the default tab filters to the open
+ * statuses, so a row would vanish on confirm instead of changing state, and the
+ * assertions could not tell "confirmed" from "never rendered".
+ */
+async function openRequestList(page: import('@playwright/test').Page, requestId: string) {
+  await page.goto(`${BASE}/${LOCALE}/platform/billing?tab=all`)
+  await page.waitForSelector('[data-testid="platform-billing-page"]')
+  const rowSelector = `[data-testid="billing-request-row"][data-request-id="${requestId}"]`
+  await expect(page.locator(rowSelector)).toBeVisible()
+  return rowSelector
+}
+
+async function confirmInUi(page: import('@playwright/test').Page, requestId: string) {
+  const rowSelector = await openRequestList(page, requestId)
+  await domClick(page, `${rowSelector} [data-testid="confirm-payment-btn"]`)
+  await expect(page.locator(rowSelector)).toHaveAttribute('data-status', 'confirmed', {
+    timeout: 20_000,
+  })
+}
+
+async function rejectInUi(
+  page: import('@playwright/test').Page,
+  requestId: string,
+  reason: string,
+) {
+  const rowSelector = await openRequestList(page, requestId)
+  await domClick(page, `${rowSelector} [data-testid="reject-payment-btn"]`)
+
+  const dialog = page.getByTestId('reject-payment-dialog')
+  await expect(dialog).toBeVisible()
+  await dialog.getByTestId('reject-reason-input').fill(reason)
+  await domClick(page, '[data-testid="confirm-reject-btn"]')
+
+  await expect(page.locator(rowSelector)).toHaveAttribute('data-status', 'rejected', {
+    timeout: 20_000,
+  })
+}
+
+/** GET the expiry cron the way GitHub Actions does. */
+async function runExpiryCron(request: import('@playwright/test').APIRequestContext) {
+  const res = await request.get(`${BASE}/api/cron/expire-platform-subscriptions`, {
+    headers: { Authorization: `Bearer ${cronSecret}` },
+  })
+  expect(res.status(), await res.text()).toBe(200)
+  return (await res.json()) as {
+    success: boolean
+    requestsExpired: number
+    reminded: number
+    graceStarted: number
+    downgraded: number
+    canceled: number
+    skippedPendingRenewal: number
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/*  Suite                                                              */
+/* ------------------------------------------------------------------ */
+
+// Every test moves the same tenant through the same state machine, so they must
+// not interleave even when CI runs fullyParallel.
+test.describe.configure({ mode: 'serial' })
+
+test.describe('platform billing — manual provider lifecycle (#605)', () => {
+  test.beforeAll(async () => {
+    const admin = getAdmin()
+    const { error } = await admin.from('tenants').upsert(
+      {
+        id: QA_TENANT_ID,
+        slug: QA_TENANT_SLUG,
+        name: 'QA Manual Lifecycle',
+        plan: 'free',
+        status: 'active',
+        billing_status: 'free',
+      },
+      { onConflict: 'id' },
+    )
+    if (error) throw new Error(`could not create QA tenant: ${error.message}`)
+    await resetTenant(admin)
+  })
+
+  test.afterAll(async () => {
+    const admin = getAdmin()
+    await resetTenant(admin)
+    await admin.from('tenants').delete().eq('id', QA_TENANT_ID)
+  })
+
+  test.beforeEach(async ({}, testInfo) => {
+    // The DB state is shared, so this must not run once per Playwright project.
+    test.skip(testInfo.project.name !== 'desktop-chromium', 'runs once — DB state is shared')
+    await resetTenant(getAdmin())
+  })
+
+  test('a confirmed bank transfer activates the plan and rewrites the revenue split', async ({
+    page,
+  }) => {
+    const admin = getAdmin()
+    const starter = await planBySlug(admin, 'starter')
+    const requestId = await createPendingRequest(admin, {
+      planId: starter.plan_id,
+      amount: starter.price_monthly,
+    })
+
+    await login(page, ACCOUNTS.superAdmin.email, ACCOUNTS.superAdmin.password, BASE)
+    await confirmInUi(page, requestId)
+
+    const request = await getRequest(admin, requestId)
+    expect(request?.status).toBe('confirmed')
+    expect(request?.confirmed_by).toBe(SUPER_ADMIN_ID)
+    expect(request?.confirmed_at).not.toBeNull()
+
+    const sub = await getSubscription(admin)
+    expect(sub?.status).toBe('active')
+    expect(sub?.payment_provider).toBe('manual')
+    expect(sub?.interval).toBe('monthly')
+    expect(sub?.plan_id).toBe(starter.plan_id)
+    // #545: a fresh paid period must carry no scheduled cancel and no grace.
+    expect(sub?.cancel_at_period_end).toBe(false)
+    expect(sub?.canceled_at).toBeNull()
+    expect(sub?.grace_period_end).toBeNull()
+    expect(sub?.renewal_reminder_sent_at).toBeNull()
+
+    // A month of access, not a NULL that never lapses and shows no next payment.
+    const periodEnd = new Date(sub!.current_period_end as string).getTime()
+    expect(periodEnd).toBeGreaterThan(Date.now() + 27 * DAY_MS)
+    expect(periodEnd).toBeLessThan(Date.now() + 32 * DAY_MS)
+
+    const tenant = await getTenant(admin)
+    expect(tenant?.plan).toBe('starter')
+    expect(tenant?.billing_status).toBe('active')
+    // The tenant's own copy of the period must agree with the subscription's —
+    // the billing header reads this one.
+    expect(tenant?.billing_period_end).not.toBeNull()
+    expect(new Date(tenant!.billing_period_end as string).getTime()).toBe(periodEnd)
+
+    // The school's transaction fee follows the plan it just bought.
+    const split = await getSplit(admin)
+    expect(Number(split?.platform_percentage)).toBe(Number(starter.transaction_fee_percent))
+    expect(Number(split?.school_percentage)).toBe(100 - Number(starter.transaction_fee_percent))
+  })
+
+  test('activation unlocks the features the new plan carries', async ({ page }) => {
+    const admin = getAdmin()
+
+    // `community` is false on free and true from starter up (supabase/seed.sql).
+    const before = await admin.rpc('get_plan_features', { _tenant_id: QA_TENANT_ID })
+    expect(before.error, before.error?.message).toBeNull()
+    expect(before.data?.features?.community).toBe(false)
+
+    const starter = await planBySlug(admin, 'starter')
+    const requestId = await createPendingRequest(admin, {
+      planId: starter.plan_id,
+      amount: starter.price_monthly,
+    })
+
+    await login(page, ACCOUNTS.superAdmin.email, ACCOUNTS.superAdmin.password, BASE)
+    await confirmInUi(page, requestId)
+
+    const after = await admin.rpc('get_plan_features', { _tenant_id: QA_TENANT_ID })
+    expect(after.error, after.error?.message).toBeNull()
+    expect(after.data?.features?.community).toBe(true)
+    expect(after.data?.plan).toBe('starter')
+  })
+
+  test('a rejected transfer records the reason and leaves the plan untouched', async ({ page }) => {
+    const admin = getAdmin()
+    const pro = await planBySlug(admin, 'pro')
+    const requestId = await createPendingRequest(admin, {
+      planId: pro.plan_id,
+      amount: pro.price_monthly,
+    })
+
+    await login(page, ACCOUNTS.superAdmin.email, ACCOUNTS.superAdmin.password, BASE)
+    await rejectInUi(page, requestId, 'No transfer received')
+
+    const request = await getRequest(admin, requestId)
+    expect(request?.status).toBe('rejected')
+    expect(request?.notes).toContain('No transfer received')
+
+    // Nothing was granted.
+    expect(await getSubscription(admin)).toBeNull()
+    const tenant = await getTenant(admin)
+    expect(tenant?.plan).toBe('free')
+    expect(tenant?.billing_status).toBe('free')
+  })
+
+  test('a confirmed renewal extends the paid period instead of restarting it', async ({ page }) => {
+    const admin = getAdmin()
+    const starter = await planBySlug(admin, 'starter')
+
+    // A subscription with 10 days still to run.
+    const currentEnd = new Date(Date.now() + 10 * DAY_MS)
+    await admin.from('platform_subscriptions').insert({
+      tenant_id: QA_TENANT_ID,
+      plan_id: starter.plan_id,
+      status: 'active',
+      payment_provider: 'manual',
+      interval: 'monthly',
+      current_period_start: new Date(Date.now() - 20 * DAY_MS).toISOString(),
+      current_period_end: currentEnd.toISOString(),
+      cancel_at_period_end: false,
+    })
+    await admin
+      .from('tenants')
+      .update({ plan: 'starter', billing_status: 'active', billing_period_end: currentEnd.toISOString() })
+      .eq('id', QA_TENANT_ID)
+
+    const requestId = await createPendingRequest(admin, {
+      planId: starter.plan_id,
+      amount: starter.price_monthly,
+      requestType: 'renewal',
+    })
+
+    await login(page, ACCOUNTS.superAdmin.email, ACCOUNTS.superAdmin.password, BASE)
+    await confirmInUi(page, requestId)
+
+    const sub = await getSubscription(admin)
+    const newEnd = new Date(sub!.current_period_end as string).getTime()
+    // Paying early must not cost the school the 10 days it had left: the new
+    // period runs from the old end, not from today.
+    expect(newEnd).toBeGreaterThan(currentEnd.getTime() + 27 * DAY_MS)
+    expect(sub?.status).toBe('active')
+  })
+
+  test('the cron opens a grace window when a self-managed period lapses', async ({ request }) => {
+    test.skip(!cronSecret, 'CRON_SECRET is not set in .env.local')
+    const admin = getAdmin()
+    const starter = await planBySlug(admin, 'starter')
+
+    const lapsedEnd = new Date(Date.now() - 1 * DAY_MS)
+    await admin.from('platform_subscriptions').insert({
+      tenant_id: QA_TENANT_ID,
+      plan_id: starter.plan_id,
+      status: 'active',
+      payment_provider: 'manual',
+      interval: 'monthly',
+      current_period_start: new Date(Date.now() - 31 * DAY_MS).toISOString(),
+      current_period_end: lapsedEnd.toISOString(),
+      cancel_at_period_end: false,
+    })
+    await admin
+      .from('tenants')
+      .update({ plan: 'starter', billing_status: 'active' })
+      .eq('id', QA_TENANT_ID)
+
+    const result = await runExpiryCron(request)
+    expect(result.graceStarted).toBeGreaterThanOrEqual(1)
+
+    const sub = await getSubscription(admin)
+    expect(sub?.status).toBe('past_due')
+    expect(sub?.grace_period_end).not.toBeNull()
+    const grace = new Date(sub!.grace_period_end as string).getTime()
+    expect(grace).toBeGreaterThan(Date.now() + (GRACE_DAYS - 1) * DAY_MS)
+
+    // Still on the plan during grace — dunning is not a downgrade.
+    const tenant = await getTenant(admin)
+    expect(tenant?.plan).toBe('starter')
+    expect(tenant?.billing_status).toBe('past_due')
+  })
+
+  test('the cron downgrades to free once the grace window closes', async ({ request }) => {
+    test.skip(!cronSecret, 'CRON_SECRET is not set in .env.local')
+    const admin = getAdmin()
+    const starter = await planBySlug(admin, 'starter')
+    const free = await planBySlug(admin, 'free')
+
+    await admin.from('platform_subscriptions').insert({
+      tenant_id: QA_TENANT_ID,
+      plan_id: starter.plan_id,
+      status: 'past_due',
+      payment_provider: 'manual',
+      interval: 'monthly',
+      current_period_start: new Date(Date.now() - 40 * DAY_MS).toISOString(),
+      current_period_end: new Date(Date.now() - 10 * DAY_MS).toISOString(),
+      grace_period_end: new Date(Date.now() - 1 * DAY_MS).toISOString(),
+      cancel_at_period_end: false,
+    })
+    await admin
+      .from('tenants')
+      .update({ plan: 'starter', billing_status: 'past_due' })
+      .eq('id', QA_TENANT_ID)
+
+    const result = await runExpiryCron(request)
+    expect(result.downgraded).toBeGreaterThanOrEqual(1)
+
+    const sub = await getSubscription(admin)
+    expect(sub?.status).toBe('canceled')
+
+    const tenant = await getTenant(admin)
+    expect(tenant?.plan).toBe('free')
+    expect(tenant?.billing_status).toBe('free')
+    expect(tenant?.billing_period_end).toBeNull()
+
+    // Back to the free plan's fee — the school keeps selling, we take the free cut.
+    const split = await getSplit(admin)
+    expect(Number(split?.platform_percentage)).toBe(Number(free.transaction_fee_percent))
+
+    // Idempotent: a second pass has nothing left to do for this tenant.
+    const replay = await runExpiryCron(request)
+    expect(replay.success).toBe(true)
+    expect((await getTenant(admin))?.plan).toBe('free')
+  })
+
+  test('the cron holds the downgrade while a renewal request is still open', async ({ request }) => {
+    test.skip(!cronSecret, 'CRON_SECRET is not set in .env.local')
+    const admin = getAdmin()
+    const starter = await planBySlug(admin, 'starter')
+
+    await admin.from('platform_subscriptions').insert({
+      tenant_id: QA_TENANT_ID,
+      plan_id: starter.plan_id,
+      status: 'past_due',
+      payment_provider: 'manual',
+      interval: 'monthly',
+      current_period_start: new Date(Date.now() - 40 * DAY_MS).toISOString(),
+      current_period_end: new Date(Date.now() - 10 * DAY_MS).toISOString(),
+      grace_period_end: new Date(Date.now() - 1 * DAY_MS).toISOString(),
+      cancel_at_period_end: false,
+    })
+    await admin
+      .from('tenants')
+      .update({ plan: 'starter', billing_status: 'past_due' })
+      .eq('id', QA_TENANT_ID)
+
+    // The school has paid by transfer and is waiting on a super admin. Cutting
+    // it off now would be cutting off money already sent.
+    await createPendingRequest(admin, {
+      planId: starter.plan_id,
+      amount: starter.price_monthly,
+      requestType: 'renewal',
+    })
+
+    const result = await runExpiryCron(request)
+    expect(result.skippedPendingRenewal).toBeGreaterThanOrEqual(1)
+
+    const tenant = await getTenant(admin)
+    expect(tenant?.plan).toBe('starter')
+  })
+
+  test('the cron expires a request that outlived its TTL, which unblocks the downgrade', async ({
+    request,
+  }) => {
+    test.skip(!cronSecret, 'CRON_SECRET is not set in .env.local')
+    const admin = getAdmin()
+    const starter = await planBySlug(admin, 'starter')
+
+    await admin.from('platform_subscriptions').insert({
+      tenant_id: QA_TENANT_ID,
+      plan_id: starter.plan_id,
+      status: 'past_due',
+      payment_provider: 'manual',
+      interval: 'monthly',
+      current_period_start: new Date(Date.now() - 40 * DAY_MS).toISOString(),
+      current_period_end: new Date(Date.now() - 10 * DAY_MS).toISOString(),
+      grace_period_end: new Date(Date.now() - 1 * DAY_MS).toISOString(),
+      cancel_at_period_end: false,
+    })
+    await admin
+      .from('tenants')
+      .update({ plan: 'starter', billing_status: 'past_due' })
+      .eq('id', QA_TENANT_ID)
+
+    // An open renewal request that expired yesterday: phase 0 must retire it in
+    // the same pass, so phase 3 is not paused by a promise nobody kept.
+    const staleId = await createPendingRequest(admin, {
+      planId: starter.plan_id,
+      amount: starter.price_monthly,
+      requestType: 'renewal',
+      expiresAt: new Date(Date.now() - 1 * DAY_MS),
+    })
+
+    const result = await runExpiryCron(request)
+    expect(result.requestsExpired).toBeGreaterThanOrEqual(1)
+    expect((await getRequest(admin, staleId))?.status).toBe('expired')
+    expect(result.downgraded).toBeGreaterThanOrEqual(1)
+    expect((await getTenant(admin))?.plan).toBe('free')
+  })
+})

--- a/tests/unit/platform-billing-crypto-rails.test.ts
+++ b/tests/unit/platform-billing-crypto-rails.test.ts
@@ -167,6 +167,10 @@ function client() {
       revenue_splits: 'tenant_id',
       tenant_billing_customers: 'tenant_id',
     },
+    // The only two columns on the table that are NOT NULL with no default. The
+    // upsert has to satisfy them on every write, including the ones that are
+    // logically updates — see the notNull docs in support/fake-supabase.ts.
+    notNull: { platform_subscriptions: ['tenant_id', 'plan_id'] },
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   }).client as any
 }
@@ -181,6 +185,7 @@ beforeEach(() => {
       { plan_id: PLAN_PRO, slug: 'pro', name: 'Pro', transaction_fee_percent: 2 },
       { plan_id: PLAN_BIZ, slug: 'business', name: 'Business', transaction_fee_percent: 0 },
     ],
+    platform_plan_prices: [],
     platform_subscriptions: [],
     tenant_billing_customers: [],
     revenue_splits: [],
@@ -308,6 +313,112 @@ describe('dispatchPlatformBillingEvent on a self-managed rail', () => {
     )
 
     expect(sub().plan_id).toBe(PLAN_BIZ)
+  })
+})
+
+describe('dispatchPlatformBillingEvent on a webhook-driven rail (#605)', () => {
+  // Distrusting stale metadata means `plan_id` is absent from the event on
+  // every Stripe / Lemon Squeezy delivery after the first. The row still has to
+  // carry one: the upsert is INSERT … ON CONFLICT DO UPDATE, and Postgres
+  // NOT NULL-checks the proposed insert tuple before it resolves the conflict.
+  // When these two facts were served by one variable, every subscription
+  // update and every renewal threw.
+
+  const existingStripeSub = (over: Record<string, unknown> = {}) => {
+    db.platform_subscriptions.push({
+      tenant_id: TENANT,
+      plan_id: PLAN_PRO,
+      status: 'active',
+      payment_provider: 'stripe',
+      interval: 'monthly',
+      current_period_end: new Date(Date.now() + 5 * DAY).toISOString(),
+      ...over,
+    })
+  }
+
+  it('records the period the checkout event never carried', async () => {
+    // checkout.session.completed has a subscription id and our metadata but no
+    // period — only the subscription event that follows it reports one. If that
+    // second event cannot land, current_period_end stays NULL for the life of
+    // the subscription: no next-payment date, and nothing for billing-health to
+    // read.
+    existingStripeSub({ current_period_end: null })
+    const periodEnd = new Date(Date.now() + 30 * DAY)
+
+    await dispatchPlatformBillingEvent(
+      { ...activation(), providerEventId: 'evt-period', periodStart: new Date(), periodEnd },
+      { provider: 'stripe', admin: client() },
+    )
+
+    expect(sub().current_period_end).toBe(periodEnd.toISOString())
+    expect(db.tenants[0].billing_period_end).toBe(periodEnd.toISOString())
+    // Unchanged: the event was not allowed to move the plan.
+    expect(sub().plan_id).toBe(PLAN_PRO)
+  })
+
+  it('advances the period on renewal instead of throwing', async () => {
+    // The failure mode this replaces was not a wrong value, it was a 500 — so
+    // the provider retried the same event until it disabled the endpoint.
+    existingStripeSub()
+    const renewedTo = new Date(Date.now() + 35 * DAY)
+
+    await expect(
+      dispatchPlatformBillingEvent(
+        {
+          ...activation(),
+          type: 'subscription.renewed',
+          providerEventId: 'evt-renew',
+          periodEnd: renewedTo,
+        },
+        { provider: 'stripe', admin: client() },
+      ),
+    ).resolves.toBeUndefined()
+
+    expect(sub().current_period_end).toBe(renewedTo.toISOString())
+    expect(sub().status).toBe('active')
+  })
+
+  it('falls back to the plan the price belongs to when no row exists yet', async () => {
+    // Delivery order is not guaranteed. A subscription event that overtakes its
+    // own checkout event has no stored row and no plan in metadata, but it does
+    // name a price, and that price belongs to exactly one plan.
+    db.platform_plan_prices = [
+      { plan_id: PLAN_BIZ, payment_provider: 'stripe', provider_price_id: 'price_biz_m' },
+    ]
+
+    await dispatchPlatformBillingEvent(
+      {
+        ...activation(),
+        providerEventId: 'evt-oo',
+        metadata: { tenant_id: TENANT },
+        providerPriceId: 'price_biz_m',
+        periodEnd: new Date(Date.now() + 30 * DAY),
+      },
+      { provider: 'stripe', admin: client() },
+    )
+
+    expect(sub().plan_id).toBe(PLAN_BIZ)
+  })
+
+  it('drops an event it can resolve no plan for rather than 500ing forever', async () => {
+    // Nothing to write the row against, and a subscription row without a plan
+    // cannot exist. Throwing would just have the provider redeliver an event
+    // that can never be applied.
+    db.platform_plan_prices = []
+
+    await expect(
+      dispatchPlatformBillingEvent(
+        {
+          ...activation(),
+          providerEventId: 'evt-noplan',
+          metadata: { tenant_id: TENANT },
+          providerPriceId: 'price_unknown',
+        },
+        { provider: 'stripe', admin: client() },
+      ),
+    ).resolves.toBeUndefined()
+
+    expect(db.platform_subscriptions).toHaveLength(0)
   })
 
   it('un-cancels a subscription the school has just paid to keep', async () => {

--- a/tests/unit/platform-billing-webhook-route.test.ts
+++ b/tests/unit/platform-billing-webhook-route.test.ts
@@ -27,6 +27,7 @@ const state: {
   existingEvent: { id: string; processed_at: string | null } | null
   insertErrorCode: string | null
   storedSub: Record<string, unknown> | null
+  planPriceRow: { plan_id: string } | null
   plan: { transaction_fee_percent: number } | null
   adminUsers: string[]
   failOn: ((w: Write) => { message: string } | null) | null
@@ -36,6 +37,7 @@ const state: {
   existingEvent: null,
   insertErrorCode: null,
   storedSub: null,
+  planPriceRow: null,
   plan: null,
   adminUsers: [],
   failOn: null,
@@ -46,6 +48,8 @@ const state: {
 function readRow(table: string, cols: string): unknown {
   if (table === 'webhook_events') return state.existingEvent
   if (table === 'platform_plans') return state.plan
+  // Only read when an event names a price but resolves no plan any other way.
+  if (table === 'platform_plan_prices') return state.planPriceRow
   if (table === 'platform_subscriptions') {
     // The dunning email joins the plan name off the same table.
     if (cols.includes('platform_plans')) return { platform_plans: { name: 'Pro' } }
@@ -97,6 +101,7 @@ function makeAdmin() {
         return b
       },
       eq: () => b,
+      limit: () => b,
       maybeSingle: () => Promise.resolve(settle()),
       single: () => Promise.resolve(settle()),
       then: (resolve: (v: unknown) => unknown) => Promise.resolve(settle()).then(resolve),
@@ -217,6 +222,7 @@ beforeEach(() => {
   state.existingEvent = null
   state.insertErrorCode = null
   state.storedSub = null
+  state.planPriceRow = null
   state.plan = { transaction_fee_percent: 2 }
   state.adminUsers = []
   state.failOn = null
@@ -383,7 +389,23 @@ describe('platform billing webhook — activation', () => {
 })
 
 describe('platform billing webhook — subscription updates', () => {
+  // A subscription update always follows an activation, so these start from a
+  // row that already exists. That is not decoration: `platform_subscriptions`
+  // has a NOT NULL `plan_id`, and the upsert PostgREST sends must satisfy it on
+  // every write. A test that updates a subscription no row was ever written for
+  // is testing a state the database cannot hold (#605).
+  const withStoredSub = (over: Record<string, unknown> = {}) => {
+    state.storedSub = {
+      tenant_id: TENANT,
+      plan_id: PLAN_ID,
+      status: 'active',
+      current_period_end: null,
+      ...over,
+    }
+  }
+
   it('writes status, interval and both periods off the clover item', async () => {
+    withStoredSub()
     const res = await POST(
       makeReq(makeEvent('customer.subscription.updated', cloverSubscription())),
       params(),
@@ -428,12 +450,18 @@ describe('platform billing webhook — subscription updates', () => {
     }
     await POST(makeReq(makeEvent('customer.subscription.updated', withMetadata)), params())
 
-    expect(writesTo('platform_subscriptions', 'upsert')[0].values).not.toHaveProperty('plan_id')
+    // The row keeps the plan it is ON, not the plan the metadata still claims.
+    // Asserting plan_id is merely absent would be wrong now and was always
+    // unachievable: the column is NOT NULL, so an upsert omitting it fails the
+    // whole event rather than leaving the value alone (#605).
+    expect(writesTo('platform_subscriptions', 'upsert')[0].values.plan_id).toBe('a-different-plan')
+    expect(writesTo('platform_subscriptions', 'upsert')[0].values.plan_id).not.toBe(PLAN_ID)
     expect(writesTo('tenants', 'update')[0].values).not.toHaveProperty('plan')
     expect(applyPortalPlanChange).toHaveBeenCalledTimes(1)
   })
 
   it('tracks a monthly → yearly interval switch off the item price', async () => {
+    withStoredSub()
     const yearly = cloverSubscription({ priceId: 'price_pro_y', recurringInterval: 'year' })
     await POST(makeReq(makeEvent('customer.subscription.updated', yearly)), params())
     expect(writesTo('platform_subscriptions', 'upsert')[0].values.interval).toBe('yearly')
@@ -466,6 +494,7 @@ describe('platform billing webhook — subscription updates', () => {
   })
 
   it('passes a canceled_at through as an ISO date', async () => {
+    withStoredSub()
     const canceled = {
       ...cloverSubscription(),
       canceled_at: PERIOD_START,

--- a/tests/unit/revenue-share.test.ts
+++ b/tests/unit/revenue-share.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest'
-import { computeRevenueTotals, bearsPlatformFee, FEE_BEARING_PROVIDERS } from '@/lib/payments/revenue-share'
+import {
+  computeRevenueTotals,
+  bearsPlatformFee,
+  FEE_BEARING_PROVIDERS,
+  resolvePlatformPercentage,
+  DEFAULT_PLATFORM_PERCENTAGE,
+} from '@/lib/payments/revenue-share'
 import { computeOwedBalances } from '@/lib/payments/payouts-owed'
 import { PROVIDER_CAPABILITIES, type PaymentProvider } from '@/lib/payments/types'
 
@@ -140,5 +146,46 @@ describe('#547: the school view and the platform view reconcile', () => {
     const owed = platformSide[0].balances.find((b) => b.currency === 'usd')!
     expect(schoolSide.netRevenue).toBe(owed.grossOwed)
     expect(schoolSide.grossRevenue).toBe(owed.grossCollected)
+  })
+})
+
+describe('resolvePlatformPercentage (#605)', () => {
+  it('keeps a configured 0% instead of falling back', () => {
+    // The bug this replaces, in one line: `split?.platform_percentage || 20`.
+    // Business and Enterprise are 0%-fee plans, PostgREST returns numeric as a
+    // JSON number, and 0 is falsy — so the schools paying us the most were
+    // charged 20% of every student sale as an application_fee_amount.
+    expect(resolvePlatformPercentage({ platform_percentage: 0 })).toBe(0)
+  })
+
+  it('keeps 0 arriving as a numeric string', () => {
+    expect(resolvePlatformPercentage({ platform_percentage: '0.00' })).toBe(0)
+  })
+
+  it('passes ordinary rates through', () => {
+    expect(resolvePlatformPercentage({ platform_percentage: 5 })).toBe(5)
+    expect(resolvePlatformPercentage({ platform_percentage: '2.50' })).toBe(2.5)
+  })
+
+  it('falls back only when there is genuinely no split on file', () => {
+    expect(resolvePlatformPercentage(null)).toBe(DEFAULT_PLATFORM_PERCENTAGE)
+    expect(resolvePlatformPercentage(undefined)).toBe(DEFAULT_PLATFORM_PERCENTAGE)
+    expect(resolvePlatformPercentage({})).toBe(DEFAULT_PLATFORM_PERCENTAGE)
+    expect(resolvePlatformPercentage({ platform_percentage: null })).toBe(DEFAULT_PLATFORM_PERCENTAGE)
+  })
+
+  it('falls back rather than producing NaN on a junk value', () => {
+    // NaN would reach Stripe as application_fee_amount: NaN and fail the charge.
+    expect(resolvePlatformPercentage({ platform_percentage: 'not-a-number' })).toBe(
+      DEFAULT_PLATFORM_PERCENTAGE,
+    )
+  })
+
+  it('produces a zero application fee for a 0%-fee school', () => {
+    // The arithmetic the checkout route runs, at $49.99.
+    const amount = 4999
+    expect(Math.round((amount * resolvePlatformPercentage({ platform_percentage: 0 })) / 100)).toBe(0)
+    // What it used to charge instead.
+    expect(Math.round((amount * (0 || 20)) / 100)).toBe(1000)
   })
 })

--- a/tests/unit/support/fake-supabase.ts
+++ b/tests/unit/support/fake-supabase.ts
@@ -36,6 +36,20 @@ export interface FakeSupabaseOptions {
     table: string,
     op: 'insert' | 'update' | 'upsert'
   ) => { code: string; message: string } | null
+  /**
+   * NOT NULL columns per table, enforced on `insert` and `upsert` (#605).
+   *
+   * Modelled because an upsert that omits a NOT NULL column fails even when the
+   * conflicting row already exists and already has a value for it: PostgREST
+   * sends `INSERT … ON CONFLICT DO UPDATE`, and Postgres checks the proposed
+   * insert tuple before it resolves the conflict. Without this the fake merges
+   * the omitted column away silently and a test cannot tell a working upsert
+   * from one that 500s in production.
+   *
+   * `update` is deliberately not checked — an UPDATE touches only the columns
+   * it names, so omitting one is not a violation.
+   */
+  notNull?: Record<string, string[]>
 }
 
 type Predicate = (row: Row) => boolean
@@ -124,6 +138,22 @@ export function createFakeSupabase(db: Db, opts: FakeSupabaseOptions = {}) {
           // what an RLS refusal looks like to the caller.
           pending = null
           return { data: null, error: failure }
+        }
+        if (pending.op === 'insert' || pending.op === 'upsert') {
+          const values = pending.values ?? {}
+          const missing = (opts.notNull?.[table] ?? []).find(
+            (col) => values[col] === undefined || values[col] === null
+          )
+          if (missing) {
+            pending = null
+            return {
+              data: null,
+              error: {
+                code: '23502',
+                message: `null value in column "${missing}" of relation "${table}" violates not-null constraint`,
+              },
+            }
+          }
         }
         const rows = applyWrite()
         return { data: embed(cols, rows), error: null }


### PR DESCRIPTION
## What

MVP acceptance for the money loop (#605): walked both halves end to end on one environment, found **three defects, two of them taking money**, fixed two of them, and left behind the CI guard the issue asked for.

Closes #605

Also lands the two deliverables #605 lists: the manual-provider lifecycle spec, and the docs that still described school billing as Stripe-only.

The blocking prerequisite is already done separately — **PR #519 is rebased, resolved and merged** (`1ca08a99`). Its workflow is merged **disabled**; see "Before the cron is switched on" below.

## Why

### 1. Every platform webhook after the first one 500'd

The dispatcher stops trusting checkout metadata once a tenant has a plan on file (#603, so a portal plan change is not reverted by stale metadata). That made `planId` undefined on every event after the first — and the same variable was the only source for the row's `plan_id`, so those events built an upsert carrying no `plan_id`.

That cannot work. PostgREST sends `INSERT … ON CONFLICT DO UPDATE`, and Postgres NOT NULL-checks the proposed insert tuple *before* it resolves the conflict, so the statement fails even though the conflicting row exists and already holds a `plan_id`:

```sql
insert into platform_subscriptions (tenant_id, status, payment_provider)
  values ('…','active','stripe')
  on conflict (tenant_id) do update set status='active';
ERROR:  null value in column "plan_id" … violates not-null constraint
```

`checkout.session.completed` carries no period — only the `customer.subscription.updated` that follows it does. So `current_period_end` and `tenants.billing_period_end` stayed NULL for the life of every Stripe subscription, the period never advanced on renewal, and Stripe retried a 500 until it would have disabled the endpoint.

The fix separates the two questions one variable was answering: `planId` still means "is this event moving the school to a new plan?" and still gates the split rewrite and the portal reconciler; `rowPlanId` means "what plan is this subscription on?", resolved as metadata → stored row → the plan the event's price belongs to.

### 2. A 0%-fee school was charged 20% on every student sale

```ts
const platformPercentage = split?.platform_percentage || 20
```

`platform_percentage` is `numeric`, PostgREST returns it as a JSON number, and `0` is falsy. **Business and Enterprise are the 0%-fee plans** — so the schools paying us the most had a 20% `application_fee_amount` taken from every student payment. $10.00 out of a $49.99 sale, silently.

It also broke reconciliation: `set_transaction_split_snapshot` uses `COALESCE`, which handles 0 correctly, so the row was stamped `school_percentage_snapshot = 100` while Stripe took 20%. The school's ledger and `getPayoutsOwed` both said it was owed all of it. This is the charging counterpart of #613, which fixed only the displayed number.

Every other call site already used `?? 20`. Two were outliers — this one, and two displays on the teacher revenue page.

### 3. A confirmed payment can be rejected afterwards — filed, not fixed

`rejectManualPayment` has no status guard and `/platform/billing` shows Reject on rows of every status, so a confirmed request can be flipped to `rejected` while the tenant keeps the plan. Audit-record only, and a behaviour change to a super-admin action, so it is reported on #605 rather than folded in here.

## How to QA

On a fresh `npm run db:reset`, with `npm run dev` on `lvh.me:3000`.

**The regression suite (fastest path):**

1. `npm run test:unit` — 807 pass. The new cases are in `tests/unit/revenue-share.test.ts` (`resolvePlatformPercentage`) and `tests/unit/platform-billing-crypto-rails.test.ts` (the webhook-driven rail block).
2. `E2E_BASE_URL=http://lvh.me:3000 BASE_URL=http://lvh.me:3000 npx playwright test tests/playwright/platform-billing-manual-lifecycle.spec.ts --project=desktop-chromium --workers=1` — 8 pass. Note the `E2E_BASE_URL` override: `.env.local` pins E2E to port 3005.

**To watch defect 1 fail on the old code:**

```bash
git stash                       # or check out the commit before ed664959
npx vitest run tests/unit/platform-billing-crypto-rails.test.ts
```

Three of the four new cases go red, and so does one pre-existing test — the bug was always reachable, the shared Supabase fake just merged the omitted column away. It now models NOT NULL on insert and upsert.

**To watch defect 2 by hand:**

```sql
-- as owner@e2etest.com's tenant, put the school on a 0% plan
update revenue_splits set platform_percentage = 0, school_percentage = 100
  where tenant_id = '00000000-0000-0000-0000-000000000001';
```

Then start a student checkout on that tenant and read `application_fee_amount` on the PaymentIntent: `0` on this branch, `20%` of the charge on `master`. Or just: `node -e "console.log(0 || 20)"`.

**The manual rail through the UI**, which is what the new spec automates:

1. Sign in as `owner@e2etest.com` on `lvh.me:3000` (admin **and** super admin)
2. Billing → Upgrade → choose Starter → **Bank transfer** → submit
3. Go to `/en/platform/billing?tab=all`, hit **Confirm** on the row
4. Expect: `tenants.plan = 'starter'`, `billing_status = 'active'`, `billing_period_end` equal to `platform_subscriptions.current_period_end`, `revenue_splits` 5/95, and `community` flipping true in `get_plan_features`

## Screenshots / GIF

No user-visible change. The two display fixes on the teacher revenue page swap `||` for `??`, which is only observable on a 0%-fee school — the numbers change from a wrong 20% / 80% to the correct 0% / 100%. The rest is a webhook dispatcher, a fee calculation, tests and docs.

The one screen this run exercised by hand and did not change is the payment-method dialog, verified listing Binance Pay, Solana, Stripe and Bank transfer off `platform_plan_prices`.

## Before the cron is switched on

#519 merged its workflow **disabled** on purpose — its `*/10` reconcilers would otherwise fail loudly every ten minutes, because the settings they need do not exist. To enable:

1. Secret `CRON_SECRET`, matching the Dokploy app's env var
2. Variable `CRON_BASE_URL`, the production origin
3. `gh workflow enable cron.yml`
4. `workflow_dispatch` `expire-platform-subscriptions` and confirm 200, not 401

## Checklist

- [x] `npm run typecheck` and `npm run test:unit` pass — 807/807
- [x] `npm run build` passes
- [x] Every new tenant-scoped query filters by `tenant_id` — `planIdForPrice` reads `platform_plan_prices`, which is global catalog data with no `tenant_id`; the new spec scopes every read to its own tenant
- [x] Tested with every relevant role — school admin and super admin, both through the real UI
- [x] Loading and error states handled — the new dispatch path logs and drops rather than throwing a 500 the provider would retry forever
- [ ] New UI strings added to both `messages/en.json` and `messages/es.json` — n/a, no new strings
- [ ] Migration — n/a, no schema change

## Not verified

Stated plainly, per the issue's closing instruction. A real Stripe card charge (seeded price ids are placeholders), Lemon Squeezy / PayPal / Binance Pay (no credentials; PayPal is additionally capability-disabled pending #479), Solana beyond QR minting, Stripe Connect onboarding and the student purchase chain behind it, `/platform/payouts` Mark as Paid, and the #517 reminder emails. Full list on #605.
