### PR TITLE
fix(payments): gate student checkout and paid publish on Stripe Connect readiness (#606)

### DIFF
--- a/app/actions/admin/plans.ts
+++ b/app/actions/admin/plans.ts
@@ -5,6 +5,7 @@ import { verifyAdminAccess, createAdminClient, type ActionResult } from '@/lib/s
 import { getPaymentProvider, PaymentProvider, PROVIDER_CAPABILITIES } from '@/lib/payments'
 import { getCurrentTenantId } from '@/lib/supabase/tenant'
 import { isSuperAdmin } from '@/lib/supabase/get-user-role'
+import { assertReadyToPublish } from '@/lib/payments/tenant-payment-readiness'
 
 interface PlanFormData {
   plan_name: string
@@ -60,6 +61,10 @@ export async function createPlan(formData: PlanFormData): Promise<ActionResult<P
     const providerType = formData.paymentProvider || 'stripe'
     const caps = PROVIDER_CAPABILITIES[providerType]
     const adminClient = createAdminClient()
+
+    // Don't publish a paid plan on a rail that cannot be paid (#606). Same
+    // shape as the Solana wallet guard below, one level up.
+    await assertReadyToPublish(tenantId, providerType)
 
     // Resolve provider catalog ids by CAPABILITY, never by provider name:
     //  - createsCatalog (Stripe/PayPal) → auto-create product + recurring price.

--- a/app/actions/admin/products.ts
+++ b/app/actions/admin/products.ts
@@ -5,6 +5,7 @@ import { verifyAdminAccess, createAdminClient, type ActionResult } from '@/lib/s
 import { getPaymentProvider, PROVIDER_CAPABILITIES, type Currency, type PaymentProvider } from '@/lib/payments'
 import { getCurrentTenantId, getCurrentUserId } from '@/lib/supabase/tenant'
 import { isSuperAdmin } from '@/lib/supabase/get-user-role'
+import { assertReadyToPublish } from '@/lib/payments/tenant-payment-readiness'
 import { checkCourseLimit } from '@/app/actions/teacher/courses'
 import { getProductCreationReadiness } from '@/lib/admin/product-creation/validation'
 import type {
@@ -113,6 +114,12 @@ export async function createProduct(formData: ProductFormData): Promise<ActionRe
     const providerType = formData.paymentProvider || 'stripe'
     const caps = PROVIDER_CAPABILITIES[providerType]
     const adminClient = createAdminClient()
+
+    // Don't publish a paid offering on a rail that cannot be paid (#606). Same
+    // shape as the Solana wallet guard below, one level up: where Solana needs a
+    // receiving address, a `requiresConnectedAccount` rail needs an onboarded
+    // account, and `stripe_account_id` being set is not that.
+    await assertReadyToPublish(tenantId, providerType)
 
     // Resolve provider catalog ids by CAPABILITY, never by provider name:
     //  - createsCatalog (Stripe/PayPal) → auto-create product + one-time price.
@@ -513,6 +520,16 @@ export async function saveProductCreationWizard(
     // constructor may require env credentials.
     const providerType: PaymentProvider = input.pricing.paymentProvider || 'manual'
     const caps = PROVIDER_CAPABILITIES[providerType]
+
+    // Don't PUBLISH a paid offering on a rail that cannot be paid (#606). Only
+    // on `publish`: a draft is not on sale, so a school can keep building one
+    // while its Stripe onboarding is still in review. `getProductCreationReadiness`
+    // is a pure, client-shared validator, so this per-tenant, async check lives
+    // here rather than inside it.
+    if (input.intent === 'publish') {
+      await assertReadyToPublish(tenantId, providerType)
+    }
+
     const nextPrice = input.pricing.price!
     const nextCurrency = input.pricing.currency! as Currency
 

--- a/app/api/payments/checkout/route.ts
+++ b/app/api/payments/checkout/route.ts
@@ -33,6 +33,11 @@ import {
   PARALLEL_SUBSCRIPTION_CODE,
   PARALLEL_SUBSCRIPTION_MESSAGE,
 } from '@/lib/payments/subscription-guard'
+import {
+  isReadyToAcceptPayments,
+  READINESS_CODE,
+  READINESS_MESSAGE,
+} from '@/lib/payments/tenant-payment-readiness'
 
 // Providers whose checkout this route owns. Stripe + manual have their own paths.
 const HANDLED: PaymentProvider[] = ['lemonsqueezy', 'solana', 'solana_subs', 'paypal', 'binance', 'binance_personal']
@@ -116,6 +121,23 @@ export async function POST(req: NextRequest) {
       itemName = product.name
       providerSlug = product.payment_provider || 'stripe'
       providerPriceId = product.provider_price_id || ''
+    }
+
+    // Connected-account readiness gate (#606). A no-op for every rail this
+    // route currently handles — none of them `requiresConnectedAccount`, so the
+    // helper short-circuits without a query. It lives here anyway so the rule
+    // is a property of "starting a payment" rather than of whichever route
+    // happened to remember it: the next marketplace rail we add inherits the
+    // gate instead of repeating the #606 bug.
+    const readiness = await isReadyToAcceptPayments(tenantId, providerSlug as PaymentProvider)
+    if (!readiness.ready) {
+      return NextResponse.json(
+        {
+          error: READINESS_MESSAGE[readiness.reason],
+          code: READINESS_CODE[readiness.reason],
+        },
+        { status: 400 },
+      )
     }
 
     if (!HANDLED.includes(providerSlug as PaymentProvider)) {

--- a/app/api/stripe/create-payment-intent/route.ts
+++ b/app/api/stripe/create-payment-intent/route.ts
@@ -11,6 +11,11 @@ import {
   PARALLEL_SUBSCRIPTION_CODE,
   PARALLEL_SUBSCRIPTION_MESSAGE,
 } from '@/lib/payments/subscription-guard'
+import {
+  isReadyToAcceptPayments,
+  READINESS_CODE,
+  READINESS_MESSAGE,
+} from '@/lib/payments/tenant-payment-readiness'
 
 export async function POST(req: NextRequest) {
   try {
@@ -46,6 +51,28 @@ export async function POST(req: NextRequest) {
       }
     }
 
+    // Connected-account readiness gate (#606). Above the Stripe customer call
+    // and the pending transaction on purpose: this route is only reachable for
+    // a `stripe` offering, and Stripe `requiresConnectedAccount`, so a school
+    // whose Express onboarding was abandoned must cost ZERO side effects. The
+    // old check tested `stripe_account_id` for presence — that column is
+    // written before onboarding even starts, so it passed, and the request ran
+    // on to build a PaymentIntent whose `transfer_data.destination` Stripe then
+    // rejected. The student saw a generic payment failure.
+    //
+    // Deliberately AFTER the parallel-subscription guard: a student with a
+    // conflicting subscription should still get the 409 that explains it.
+    const readiness = await isReadyToAcceptPayments(tenantId, 'stripe')
+    if (!readiness.ready) {
+      return NextResponse.json(
+        {
+          error: READINESS_MESSAGE[readiness.reason],
+          code: READINESS_CODE[readiness.reason],
+        },
+        { status: 400 },
+      )
+    }
+
     // Get or create Stripe customer
     const { data: profile } = await supabase
       .from('profiles')
@@ -70,21 +97,17 @@ export async function POST(req: NextRequest) {
         .eq('id', user.id)
     }
 
-    // Get tenant's Stripe Connect account
+    // Get tenant's Stripe Connect account — the readiness gate above already
+    // proved it exists and can charge; this reads the id itself for routing.
     const { data: tenant, error: tenantError } = await supabase
       .from('tenants')
       .select('stripe_account_id')
       .eq('id', tenantId)
       .single()
 
-    if (tenantError || !tenant) {
+    const destinationAccount = tenant?.stripe_account_id
+    if (tenantError || !destinationAccount) {
       return NextResponse.json({ error: 'School not found' }, { status: 404 })
-    }
-
-    if (!tenant.stripe_account_id) {
-      return NextResponse.json({
-        error: 'School has not connected their payment account. Please contact school admin to set up payments.'
-      }, { status: 400 })
     }
 
     // Get price based on plan or product
@@ -183,7 +206,7 @@ export async function POST(req: NextRequest) {
           currency,
           reference: transaction.transaction_id.toString(),
           providerCustomerId: stripeCustomerId,
-          destinationAccount: tenant.stripe_account_id,
+          destinationAccount,
           applicationFeePercent: platformPercentage,
           metadata: {
             transactionId: transaction.transaction_id.toString(),
@@ -229,7 +252,7 @@ export async function POST(req: NextRequest) {
       customer: stripeCustomerId,
       automatic_payment_methods: { enabled: true },
       transfer_data: {
-        destination: tenant.stripe_account_id, // Money goes to school
+        destination: destinationAccount, // Money goes to school
       },
       metadata: {
         transactionId: transaction.transaction_id.toString(),

--- a/components/admin/stripe-connect-card.tsx
+++ b/components/admin/stripe-connect-card.tsx
@@ -26,7 +26,11 @@ export default async function StripeConnectCard({
 
   if (accountId && chargesEnabled) {
     return (
-      <div className="rounded-xl bg-emerald-50 dark:bg-emerald-950/30 p-5 ring-1 ring-emerald-200 dark:ring-emerald-800">
+      <div
+        className="rounded-xl bg-emerald-50 dark:bg-emerald-950/30 p-5 ring-1 ring-emerald-200 dark:ring-emerald-800"
+        data-testid="stripe-connect-card"
+        data-connect-state="ready"
+      >
         <div className="flex items-start gap-3">
           <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-emerald-100 dark:bg-emerald-900/50">
             <IconCheck className="h-[18px] w-[18px] text-emerald-600 dark:text-emerald-400" />
@@ -53,10 +57,21 @@ export default async function StripeConnectCard({
   }
 
   if (accountId) {
-    // Account exists but onboarding is incomplete — the Account Link resumes
-    // where the admin left off (Express progressive KYC).
+    // Account exists but Stripe will not let it charge yet — the Account Link
+    // resumes where the admin left off (Express progressive KYC).
+    //
+    // Two things this state must say out loud (#606): what is BLOCKED, and what
+    // to do about it. The account id alone used to look like success, and when
+    // `details_submitted` was true the card offered no action at all — stranding
+    // exactly the admins whose account is blocked on outstanding requirements.
+    // `/api/stripe/connect` mints a FRESH account link for an existing account,
+    // so the button is safe (and useful) in both sub-states.
     return (
-      <div className="rounded-xl bg-sky-50 dark:bg-sky-950/30 p-5 ring-1 ring-sky-200 dark:ring-sky-800">
+      <div
+        className="rounded-xl bg-sky-50 dark:bg-sky-950/30 p-5 ring-1 ring-sky-200 dark:ring-sky-800"
+        data-testid="stripe-connect-card"
+        data-connect-state="incomplete"
+      >
         <div className="flex items-start gap-3">
           <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-sky-100 dark:bg-sky-900/50">
             <IconProgress className="h-[18px] w-[18px] text-sky-600 dark:text-sky-400" />
@@ -68,16 +83,18 @@ export default async function StripeConnectCard({
             <p className="mt-0.5 text-xs text-sky-700 dark:text-sky-400">
               {detailsSubmitted ? t('pendingReviewDesc') : t('pendingDesc')}
             </p>
-            {!detailsSubmitted && (
-              /* Plain <a>: this is an API redirect endpoint, not a page — Link would client-navigate */
-              /* eslint-disable-next-line @next/next/no-html-link-for-pages */
-              <a
-                href="/api/stripe/connect"
-                className="mt-3 inline-flex items-center justify-center rounded-lg text-xs font-medium bg-sky-600 text-white hover:bg-sky-700 h-8 px-4 transition-colors"
-              >
-                {t('resumeButton')}
-              </a>
-            )}
+            <p className="mt-2 flex items-start gap-1.5 rounded-lg bg-amber-100/70 px-2.5 py-2 text-xs font-medium text-amber-900 dark:bg-amber-950/40 dark:text-amber-200">
+              <IconAlertCircle className="mt-px h-3.5 w-3.5 shrink-0" />
+              {t('blockedNotice')}
+            </p>
+            {/* Plain <a>: this is an API redirect endpoint, not a page — Link would client-navigate */}
+            {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
+            <a
+              href="/api/stripe/connect"
+              className="mt-3 inline-flex items-center justify-center rounded-lg text-xs font-medium bg-sky-600 text-white hover:bg-sky-700 h-8 px-4 transition-colors"
+            >
+              {detailsSubmitted ? t('checkStatusButton') : t('resumeButton')}
+            </a>
           </div>
         </div>
       </div>
@@ -85,7 +102,11 @@ export default async function StripeConnectCard({
   }
 
   return (
-    <div className="rounded-xl bg-amber-50 dark:bg-amber-950/30 p-5 ring-1 ring-amber-200 dark:ring-amber-800">
+    <div
+      className="rounded-xl bg-amber-50 dark:bg-amber-950/30 p-5 ring-1 ring-amber-200 dark:ring-amber-800"
+      data-testid="stripe-connect-card"
+      data-connect-state="not-connected"
+    >
       <div className="flex items-start gap-3">
         <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-amber-100 dark:bg-amber-900/50">
           <IconAlertCircle className="h-[18px] w-[18px] text-amber-600 dark:text-amber-400" />

--- a/components/public/stripe-payment-form.tsx
+++ b/components/public/stripe-payment-form.tsx
@@ -17,6 +17,16 @@ import {
     IconBuildingBank,
 } from '@tabler/icons-react';
 import { Button } from '@/components/ui/button';
+import {
+    PAYMENTS_NOT_CONNECTED_CODE,
+    PAYMENTS_ONBOARDING_INCOMPLETE_CODE,
+} from '@/lib/payments/payment-readiness-codes';
+
+/** Readiness codes (#606) → translation keys under the `checkout` namespace. */
+const READINESS_MESSAGE_KEY: Record<string, string> = {
+    [PAYMENTS_NOT_CONNECTED_CODE]: 'stripe.schoolNotConnected',
+    [PAYMENTS_ONBOARDING_INCOMPLETE_CODE]: 'stripe.schoolSetupIncomplete',
+};
 
 interface StripePaymentFormProps {
     productId?: number | string;
@@ -66,7 +76,14 @@ export function StripePaymentForm({
                 });
                 const data = await res.json();
                 if (!res.ok || !data.clientSecret) {
-                    throw new Error(data.error || t('stripe.initError'));
+                    // The readiness gate (#606) returns a machine-readable code so
+                    // the two "this school can't take card payments" cases get
+                    // translated copy instead of an English server string — and so
+                    // "still finishing setup" never reads as "contact the admin".
+                    const localized = READINESS_MESSAGE_KEY[data.code as string];
+                    throw new Error(
+                        localized ? t(localized) : data.error || t('stripe.initError'),
+                    );
                 }
                 if (cancelled) return;
                 setClientSecret(data.clientSecret);

--- a/lib/payments/binance-personal-provider.ts
+++ b/lib/payments/binance-personal-provider.ts
@@ -104,6 +104,7 @@ export class BinancePersonalProvider implements IPaymentProvider {
     supportsProrationPreview: false, // no mid-period quote API
     bearsPlatformFee: false, // money never reaches a platform account
     settlesToPlatformAccount: false,
+    requiresConnectedAccount: false, // the school's own Pay ID, saved in Settings — no onboarding flow
   }
 
   private readonly apiKey?: string

--- a/lib/payments/binance-provider.ts
+++ b/lib/payments/binance-provider.ts
@@ -175,6 +175,7 @@ export class BinancePayProvider implements IPaymentProvider {
     supportsProrationPreview: false, // no mid-period quote API
     bearsPlatformFee: true, // platform holds 100%, school paid out manually
     settlesToPlatformAccount: true,
+    requiresConnectedAccount: false, // one global platform merchant account — nothing per-tenant to onboard
   }
 
   private readonly apiKey: string

--- a/lib/payments/lemonsqueezy-provider.ts
+++ b/lib/payments/lemonsqueezy-provider.ts
@@ -54,6 +54,7 @@ export class LemonSqueezyProvider implements IPaymentProvider {
     supportsProrationPreview: false, // no mid-period quote API
     bearsPlatformFee: true, // platform holds 100%, school paid out manually
     settlesToPlatformAccount: true,
+    requiresConnectedAccount: false, // Merchant of Record — the platform's own store sells on the school's behalf
   }
 
   private readonly apiKey: string

--- a/lib/payments/manual-provider.ts
+++ b/lib/payments/manual-provider.ts
@@ -35,6 +35,7 @@ export class ManualPaymentProvider implements IPaymentProvider {
     supportsProrationPreview: false, // no mid-period quote API
     bearsPlatformFee: false, // money never reaches a platform account
     settlesToPlatformAccount: false,
+    requiresConnectedAccount: false, // bank transfer to the school's own account — no provider onboarding at all
   }
 
   convertAmount(amount: number, fromUnit: 'base' | 'major'): number {

--- a/lib/payments/payment-readiness-codes.ts
+++ b/lib/payments/payment-readiness-codes.ts
@@ -1,0 +1,48 @@
+/**
+ * Connected-account readiness vocabulary — issue #606.
+ *
+ * Split out from `tenant-payment-readiness.ts` on purpose: that module imports
+ * `createAdminClient` (service-role key), so a client component that only needs
+ * the response codes must NOT import it. This file has no dependencies at all
+ * and is safe on both sides of the boundary.
+ */
+
+/** Why a school cannot be paid — the two cases need different words. */
+export type PaymentReadinessReason =
+  /** No connected account at all: the admin never started onboarding. */
+  | 'not_connected'
+  /** Account exists but the provider will not let it charge yet. */
+  | 'onboarding_incomplete'
+
+export type PaymentReadiness =
+  | { ready: true }
+  | { ready: false; reason: PaymentReadinessReason }
+
+/**
+ * Machine-readable codes returned alongside the message so the client can
+ * translate rather than echo an English server string — same contract as
+ * `PARALLEL_SUBSCRIPTION_CODE` (#459).
+ */
+export const PAYMENTS_NOT_CONNECTED_CODE = 'SCHOOL_PAYMENTS_NOT_CONNECTED'
+export const PAYMENTS_ONBOARDING_INCOMPLETE_CODE = 'SCHOOL_PAYMENTS_INCOMPLETE'
+
+export const READINESS_CODE: Record<PaymentReadinessReason, string> = {
+  not_connected: PAYMENTS_NOT_CONNECTED_CODE,
+  onboarding_incomplete: PAYMENTS_ONBOARDING_INCOMPLETE_CODE,
+}
+
+/** Student-facing fallback copy, used when the client has no translation. */
+export const READINESS_MESSAGE: Record<PaymentReadinessReason, string> = {
+  not_connected:
+    'This school has not connected a payment account yet. Please contact the school admin to set up payments.',
+  onboarding_incomplete:
+    'This school is still finishing its payment setup, so card payments are not available yet. Please try again later or contact the school admin.',
+}
+
+/** Admin-facing copy for the publish path — says what to do, and where. */
+export const READINESS_ADMIN_MESSAGE: Record<PaymentReadinessReason, string> = {
+  not_connected:
+    'Connect your Stripe account in Settings → Payments before publishing a paid Stripe offering.',
+  onboarding_incomplete:
+    'Finish your Stripe setup in Settings → Payments before publishing a paid Stripe offering — Stripe will not accept card payments until onboarding is complete.',
+}

--- a/lib/payments/paypal-provider.ts
+++ b/lib/payments/paypal-provider.ts
@@ -89,6 +89,7 @@ export class PayPalPaymentProvider implements IPaymentProvider {
     supportsProrationPreview: false, // no mid-period quote API
     bearsPlatformFee: true, // platform holds 100%, school paid out manually
     settlesToPlatformAccount: true,
+    requiresConnectedAccount: false, // one global platform merchant account — nothing per-tenant to onboard
   }
 
   private readonly clientId: string

--- a/lib/payments/solana-provider.ts
+++ b/lib/payments/solana-provider.ts
@@ -60,6 +60,7 @@ export class SolanaProvider implements IPaymentProvider {
     supportsProrationPreview: false, // no mid-period quote API
     bearsPlatformFee: true, // platform wallet receives its slice in the same on-chain tx
     settlesToPlatformAccount: false,
+    requiresConnectedAccount: false, // wallet address pasted in Settings — live the moment it is saved
   }
 
   private readonly rpcUrl: string

--- a/lib/payments/solana-subscriptions-provider.ts
+++ b/lib/payments/solana-subscriptions-provider.ts
@@ -58,6 +58,7 @@ export class SolanaSubscriptionsProvider implements IPaymentProvider {
     supportsProrationPreview: false, // no mid-period quote API
     bearsPlatformFee: true, // platform wallet receives its slice on each pull
     settlesToPlatformAccount: false,
+    requiresConnectedAccount: false, // wallet address pasted in Settings — live the moment it is saved
   }
 
   /**

--- a/lib/payments/stripe-provider.ts
+++ b/lib/payments/stripe-provider.ts
@@ -47,6 +47,7 @@ export class StripePaymentProvider implements IPaymentProvider {
     supportsProrationPreview: true, // invoices.createPreview
     bearsPlatformFee: true, // application_fee_amount on the Connect charge
     settlesToPlatformAccount: false,
+    requiresConnectedAccount: true, // Connect Express — per-tenant account with progressive KYC the school can abandon
   }
   private stripe: Stripe
   /**
@@ -77,9 +78,16 @@ export class StripePaymentProvider implements IPaymentProvider {
    */
   async createProduct(params: CreateProductParams): Promise<PaymentProduct> {
     try {
+      // Omit `description` when blank rather than sending ''. Stripe reads an
+      // empty string as "unset this parameter" and rejects it outright
+      // ("'description' cannot be unset"), so every caller that passes
+      // `description ?? ''` — both product create paths do — failed to publish a
+      // paid Stripe offering whose course had no description yet. Surfaced while
+      // verifying #606; the two callers keep their `|| ''` and this maps it.
+      const description = params.description?.trim()
       const stripeProduct = await this.stripe.products.create({
         name: params.name,
-        description: params.description,
+        ...(description ? { description } : {}),
         images: params.images || [],
         metadata: params.metadata || {},
       })

--- a/lib/payments/tenant-payment-readiness.ts
+++ b/lib/payments/tenant-payment-readiness.ts
@@ -1,0 +1,102 @@
+/**
+ * Can this school actually be paid on this rail? — issue #606.
+ *
+ * `tenants.stripe_account_id` is written the instant `stripe.accounts.create`
+ * returns, which is BEFORE the admin is even handed the hosted onboarding link
+ * (`app/api/stripe/connect/route.ts`). So it answers "did an Express account
+ * object get minted", not "can this school charge a card". An admin who opens
+ * onboarding and closes the tab leaves a tenant that looks payment-ready and is
+ * not — the student reaches the card form, submits, and Stripe rejects the
+ * PaymentIntent because `transfer_data.destination` points at an account with
+ * `charges_enabled: false`.
+ *
+ * The readiness signal already exists and is already synced two ways: the
+ * `account.updated` webhook (`app/api/stripe/webhook/route.ts`) and
+ * `syncConnectAccountStatus()` (`lib/stripe-connect.ts`), which the Settings →
+ * Payments page force-runs whenever charges are still disabled. This module is
+ * the single place that READS it, so checkout and the publish path can never
+ * drift apart on what "ready" means.
+ *
+ * Capability-driven, never provider-name-driven: the branch is
+ * `ProviderCapabilities.requiresConnectedAccount`. Rails without a per-tenant
+ * account to onboard (manual, the platform-settled trio, both Solana rails)
+ * short-circuit to ready without touching the database.
+ *
+ * SERVER ONLY — it reaches for the service-role client. Client components that
+ * just need the response codes import `./payment-readiness-codes` instead.
+ */
+
+import { createAdminClient } from '@/lib/supabase/admin'
+import { PROVIDER_CAPABILITIES, type PaymentProvider } from './types'
+import {
+  READINESS_ADMIN_MESSAGE,
+  type PaymentReadiness,
+} from './payment-readiness-codes'
+
+export * from './payment-readiness-codes'
+
+/** The subset of the tenant row that decides readiness. */
+export interface ConnectedAccountRow {
+  stripe_account_id: string | null
+  stripe_charges_enabled: boolean | null
+}
+
+/**
+ * Pure half of the check: given the tenant's connected-account columns, is the
+ * school ready? Split out so the truth table is unit-testable without a database.
+ *
+ * `charges_enabled` and not `details_submitted`: an Express account can have
+ * submitted its details and still be blocked (Stripe review, or fresh
+ * `currently_due` requirements). Only `charges_enabled` means money can move.
+ */
+export function evaluateConnectedAccountReadiness(
+  row: ConnectedAccountRow | null | undefined
+): PaymentReadiness {
+  if (!row?.stripe_account_id) return { ready: false, reason: 'not_connected' }
+  if (!row.stripe_charges_enabled) return { ready: false, reason: 'onboarding_incomplete' }
+  return { ready: true }
+}
+
+/**
+ * Is `tenantId` able to accept a payment on `provider` right now?
+ *
+ * Call this BEFORE any provider side effect (customer creation, PaymentIntent,
+ * pending transaction row) and before publishing a paid offering.
+ */
+export async function isReadyToAcceptPayments(
+  tenantId: string,
+  provider: PaymentProvider
+): Promise<PaymentReadiness> {
+  // Rails with no per-tenant account to onboard are always ready — and cost no
+  // query to say so.
+  if (!PROVIDER_CAPABILITIES[provider]?.requiresConnectedAccount) {
+    return { ready: true }
+  }
+
+  const { data, error } = await createAdminClient()
+    .from('tenants')
+    .select('stripe_account_id, stripe_charges_enabled')
+    .eq('id', tenantId)
+    .single()
+
+  // A tenant we cannot read is not a tenant we can route money to. Refuse as
+  // "not connected" rather than falling open.
+  if (error || !data) return { ready: false, reason: 'not_connected' }
+
+  return evaluateConnectedAccountReadiness(data)
+}
+
+/**
+ * Publish-path form of the same gate: throws with admin-facing, actionable copy
+ * so a school cannot publish a paid offering on a rail it cannot be paid on.
+ * The server actions already surface a thrown message to the admin verbatim.
+ */
+export async function assertReadyToPublish(
+  tenantId: string,
+  provider: PaymentProvider
+): Promise<void> {
+  const readiness = await isReadyToAcceptPayments(tenantId, provider)
+  if (!readiness.ready) {
+    throw new Error(READINESS_ADMIN_MESSAGE[readiness.reason])
+  }
+}

--- a/lib/payments/types.ts
+++ b/lib/payments/types.ts
@@ -246,6 +246,26 @@ export interface ProviderCapabilities {
    * (see `lib/payments/payouts-owed.ts`) rather than arriving automatically.
    */
   settlesToPlatformAccount: boolean
+  /**
+   * Money for a sale on this rail lands in a per-tenant account the school must
+   * ONBOARD with the provider before the rail works — Stripe Connect Express and
+   * its progressive KYC. The account object exists from the admin's first click
+   * (`stripe.accounts.create` persists `tenants.stripe_account_id` before the
+   * hosted onboarding link is even handed over), so its presence proves nothing;
+   * readiness is a separate, provider-synced fact.
+   *
+   * Deliberately NOT derived from `settlesToPlatformAccount: false`, which is
+   * also true of both Solana rails: there the school's "account" is a wallet
+   * address it pastes into Settings — live the moment it is saved, with no
+   * onboarding session to abandon. The distinction is whether there is a
+   * multi-step approval the school can walk away from half-finished.
+   *
+   * When true, every entry point that starts a payment or publishes a paid
+   * offering must clear `isReadyToAcceptPayments()` first (#606); otherwise a
+   * school whose onboarding was abandoned looks payment-ready and the student
+   * only finds out when the provider rejects the charge.
+   */
+  requiresConnectedAccount: boolean
 }
 
 /**
@@ -269,6 +289,7 @@ export const PROVIDER_CAPABILITIES: Record<PaymentProvider, ProviderCapabilities
     supportsProrationPreview: true, // invoices.createPreview
     bearsPlatformFee: true, // application_fee_amount on the Connect charge
     settlesToPlatformAccount: false, // school's own Connect account
+    requiresConnectedAccount: true, // Connect Express — per-tenant account with progressive KYC the school can abandon
   },
   paypal: {
     supportsNativeSubscriptions: true,
@@ -284,6 +305,7 @@ export const PROVIDER_CAPABILITIES: Record<PaymentProvider, ProviderCapabilities
     supportsProrationPreview: false, // no mid-period quote API
     bearsPlatformFee: true, // platform holds 100%, school paid out manually
     settlesToPlatformAccount: true, // one global PAYPAL_CLIENT_ID/SECRET — no per-tenant merchant onboarding
+    requiresConnectedAccount: false, // one global platform merchant account — nothing per-tenant to onboard
   },
   lemonsqueezy: {
     supportsNativeSubscriptions: true,
@@ -299,6 +321,7 @@ export const PROVIDER_CAPABILITIES: Record<PaymentProvider, ProviderCapabilities
     supportsProrationPreview: false, // no mid-period quote API
     bearsPlatformFee: true, // platform holds 100%, school paid out manually
     settlesToPlatformAccount: true, // one global LS store — Merchant of Record, single platform-owned account
+    requiresConnectedAccount: false, // Merchant of Record — the platform's own store sells on the school's behalf
   },
   solana: {
     supportsNativeSubscriptions: false,
@@ -318,6 +341,7 @@ export const PROVIDER_CAPABILITIES: Record<PaymentProvider, ProviderCapabilities
     supportsProrationPreview: false, // no mid-period quote API
     bearsPlatformFee: true, // platform wallet receives its slice in the same on-chain tx
     settlesToPlatformAccount: false, // split on-chain in one tx (lib/payments/solana-split.ts)
+    requiresConnectedAccount: false, // wallet address pasted in Settings — live the moment it is saved
   },
   // Native on-chain auto-pull subscriptions (solana-program/subscriptions). WE
   // drive renewal via an off-chain crank cron (no provider webhook, no on-chain
@@ -339,6 +363,7 @@ export const PROVIDER_CAPABILITIES: Record<PaymentProvider, ProviderCapabilities
     supportsProrationPreview: false, // no mid-period quote API
     bearsPlatformFee: true, // platform wallet receives its slice on each pull
     settlesToPlatformAccount: false, // split on-chain per pull (lib/payments/solana-subscription-pull.ts)
+    requiresConnectedAccount: false, // wallet address pasted in Settings — live the moment it is saved
   },
   manual: {
     supportsNativeSubscriptions: false,
@@ -354,6 +379,7 @@ export const PROVIDER_CAPABILITIES: Record<PaymentProvider, ProviderCapabilities
     supportsProrationPreview: false, // no mid-period quote API
     bearsPlatformFee: false, // money never reaches a platform account
     settlesToPlatformAccount: false, // bank transfer straight to the school's own account
+    requiresConnectedAccount: false, // bank transfer to the school's own account — no provider onboarding at all
   },
   // Binance Pay: hosted crypto checkout (USDT-denominated). No native
   // recurring billing — plan purchases are one-time payments whose period WE
@@ -376,6 +402,7 @@ export const PROVIDER_CAPABILITIES: Record<PaymentProvider, ProviderCapabilities
     supportsProrationPreview: false, // no mid-period quote API
     bearsPlatformFee: true, // platform holds 100%, school paid out manually
     settlesToPlatformAccount: true, // one global BINANCE_PAY_API_KEY/SECRET merchant account — no sub-merchant split
+    requiresConnectedAccount: false, // one global platform merchant account — nothing per-tenant to onboard
   },
   // Binance Pay on a PERSONAL (non-merchant, no-KYB) account. No hosted
   // checkout and no webhooks: the buyer transfers manually to the school's
@@ -397,6 +424,7 @@ export const PROVIDER_CAPABILITIES: Record<PaymentProvider, ProviderCapabilities
     supportsProrationPreview: false, // no mid-period quote API
     bearsPlatformFee: false, // money never reaches a platform account
     settlesToPlatformAccount: false, // per-tenant Pay ID — straight to the school's own account
+    requiresConnectedAccount: false, // the school's own Pay ID, saved in Settings — no onboarding flow
   },
 }
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -3061,7 +3061,9 @@
               "pendingDesc": "Your Stripe account was created but onboarding isn't finished. Resume where you left off — it only takes a few minutes.",
               "pendingReviewDesc": "Your details were submitted and Stripe is reviewing them. Card payments will be enabled automatically once the review completes.",
               "resumeButton": "Finish Stripe setup",
-              "payoutsPending": "Payouts are not enabled yet — Stripe may need additional information before transferring funds to your bank."
+              "payoutsPending": "Payouts are not enabled yet — Stripe may need additional information before transferring funds to your bank.",
+              "blockedNotice": "Until Stripe enables charges, students can't complete a card checkout and you can't publish a paid Stripe offering.",
+              "checkStatusButton": "Check setup status"
             }
           },
           "enrollment": {
@@ -4944,7 +4946,9 @@
       "unavailableTitle": "Card payments unavailable",
       "tryManual": "Pay another way",
       "payButton": "Pay {price}",
-      "paymentError": "Payment could not be completed. Please try again."
+      "paymentError": "Payment could not be completed. Please try again.",
+      "schoolNotConnected": "This school has not connected a payment account yet. Please contact the school admin to set up payments.",
+      "schoolSetupIncomplete": "This school is still finishing its payment setup, so card payments are not available yet. Please try again later or contact the school admin."
     },
     "empty": {
       "title": "No Product Selected",

--- a/messages/es.json
+++ b/messages/es.json
@@ -3057,7 +3057,9 @@
               "pendingDesc": "Tu cuenta de Stripe fue creada pero la configuración no está terminada. Retómala donde la dejaste — solo toma unos minutos.",
               "pendingReviewDesc": "Tus datos fueron enviados y Stripe los está revisando. Los pagos con tarjeta se habilitarán automáticamente cuando termine la revisión.",
               "resumeButton": "Terminar configuración de Stripe",
-              "payoutsPending": "Los retiros aún no están habilitados — Stripe podría necesitar información adicional antes de transferir fondos a tu banco."
+              "payoutsPending": "Los retiros aún no están habilitados — Stripe podría necesitar información adicional antes de transferir fondos a tu banco.",
+              "blockedNotice": "Hasta que Stripe habilite los cobros, los estudiantes no pueden completar un pago con tarjeta y no puedes publicar una oferta de pago con Stripe.",
+              "checkStatusButton": "Ver estado de la configuración"
             }
           },
           "enrollment": {
@@ -4937,7 +4939,9 @@
       "unavailableTitle": "Pagos con tarjeta no disponibles",
       "tryManual": "Pagar de otra forma",
       "payButton": "Pagar {price}",
-      "paymentError": "No se pudo completar el pago. Inténtalo de nuevo."
+      "paymentError": "No se pudo completar el pago. Inténtalo de nuevo.",
+      "schoolNotConnected": "Esta escuela aún no ha conectado una cuenta de pago. Contacta al administrador de la escuela para configurar los pagos.",
+      "schoolSetupIncomplete": "Esta escuela todavía está terminando la configuración de pagos, por eso los pagos con tarjeta aún no están disponibles. Intenta más tarde o contacta al administrador de la escuela."
     },
     "empty": {
       "title": "No hay producto seleccionado",

--- a/tests/playwright/payment-flows.spec.ts
+++ b/tests/playwright/payment-flows.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test'
+import { createClient as createSupabaseClient } from '@supabase/supabase-js'
 import { login, loginAsStudent, loginAsTenantStudent } from './utils/auth'
 import { BASE, TENANT_BASE, ACCOUNTS } from './utils/constants'
 
@@ -59,5 +60,159 @@ test.describe('Payment Flows', () => {
     const body = await page.locator('body').textContent()
     // Default tenant product names should not appear
     expect(body).not.toContain('Default School Premium')
+  })
+})
+
+/**
+ * Abandoned Stripe onboarding — issue #606.
+ *
+ * `tenants.stripe_account_id` is written the moment the Express account is
+ * CREATED, before the admin has even been handed the hosted onboarding link. An
+ * admin who opens onboarding and closes the tab leaves a tenant that looks
+ * payment-ready and is not: checkout used to gate on that column's presence, so
+ * the student reached the card form, submitted, and Stripe rejected the
+ * PaymentIntent because `transfer_data.destination` pointed at an account with
+ * `charges_enabled: false`. Generic failure on the school's storefront, no
+ * explanation for either party.
+ *
+ * These tests drive the real route with a real student session and flip the
+ * tenant's Connect columns around it. The two refusals must stay distinct, and
+ * neither may leave a pending `transactions` row behind — the gate runs before
+ * any Stripe call and before the insert.
+ */
+test.describe('Stripe Connect readiness gate (#606)', () => {
+  const CODE_ACADEMY_TENANT = '00000000-0000-0000-0000-000000000002'
+  const ALICE_ID = 'a1000000-0000-0000-0000-000000000004'
+  const STRIPE_PRODUCT = 2001 // Python Mastery Bundle, $49, payment_provider 'stripe'
+  const FAKE_ACCOUNT = 'acct_e2e606AbandonedOnboarding'
+
+  function getAdmin() {
+    return createSupabaseClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.SUPABASE_SERVICE_ROLE_KEY!,
+      { auth: { autoRefreshToken: false, persistSession: false } }
+    )
+  }
+
+  async function setConnectState(state: {
+    stripe_account_id: string | null
+    stripe_charges_enabled: boolean
+    stripe_details_submitted?: boolean
+  }) {
+    const { error } = await getAdmin()
+      .from('tenants')
+      .update({ stripe_details_submitted: false, ...state })
+      .eq('id', CODE_ACADEMY_TENANT)
+    expect(error).toBeNull()
+  }
+
+  /** Pending rows the gate must never have created (and #605's cleanup habit). */
+  async function pendingRowsForAlice() {
+    const { data } = await getAdmin()
+      .from('transactions')
+      .select('transaction_id')
+      .eq('user_id', ALICE_ID)
+      .eq('product_id', STRIPE_PRODUCT)
+      .eq('status', 'pending')
+    return data ?? []
+  }
+
+  async function clearPendingRows() {
+    await getAdmin()
+      .from('transactions')
+      .delete()
+      .eq('user_id', ALICE_ID)
+      .eq('product_id', STRIPE_PRODUCT)
+      .eq('status', 'pending')
+  }
+
+  let original: {
+    stripe_account_id: string | null
+    stripe_charges_enabled: boolean
+    stripe_details_submitted: boolean
+  }
+
+  test.beforeAll(async () => {
+    const { data, error } = await getAdmin()
+      .from('tenants')
+      .select('stripe_account_id, stripe_charges_enabled, stripe_details_submitted')
+      .eq('id', CODE_ACADEMY_TENANT)
+      .single()
+    expect(error).toBeNull()
+    original = data!
+  })
+
+  test.afterAll(async () => {
+    await clearPendingRows()
+    await getAdmin().from('tenants').update(original).eq('id', CODE_ACADEMY_TENANT)
+  })
+
+  test('refuses checkout for a school whose onboarding was abandoned', async ({ page }) => {
+    // The account id IS set — exactly what the old presence check accepted.
+    await setConnectState({
+      stripe_account_id: FAKE_ACCOUNT,
+      stripe_charges_enabled: false,
+      stripe_details_submitted: true,
+    })
+    await clearPendingRows()
+    await loginAsTenantStudent(page)
+
+    const res = await page.request.post(
+      `${TENANT_BASE}/api/stripe/create-payment-intent`,
+      { data: { productId: STRIPE_PRODUCT } }
+    )
+    expect(res.status()).toBe(400)
+
+    const body = await res.json()
+    expect(body.code).toBe('SCHOOL_PAYMENTS_INCOMPLETE')
+    // Distinct from the never-connected wording: "still finishing setup", not
+    // "contact the admin to set up payments".
+    expect(body.error).toMatch(/still finishing/i)
+    expect(body.clientSecret).toBeUndefined()
+
+    // Refused before any Stripe call, so no pending transaction was created.
+    expect(await pendingRowsForAlice()).toHaveLength(0)
+  })
+
+  test('gives a school that never connected a different, distinct refusal', async ({ page }) => {
+    await setConnectState({ stripe_account_id: null, stripe_charges_enabled: false })
+    await clearPendingRows()
+    await loginAsTenantStudent(page)
+
+    const res = await page.request.post(
+      `${TENANT_BASE}/api/stripe/create-payment-intent`,
+      { data: { productId: STRIPE_PRODUCT } }
+    )
+    expect(res.status()).toBe(400)
+
+    const body = await res.json()
+    expect(body.code).toBe('SCHOOL_PAYMENTS_NOT_CONNECTED')
+    expect(body.error).toMatch(/not connected/i)
+    expect(await pendingRowsForAlice()).toHaveLength(0)
+  })
+
+  test('leaves a school with charges enabled unchanged', async ({ page }) => {
+    await setConnectState({
+      stripe_account_id: FAKE_ACCOUNT,
+      stripe_charges_enabled: true,
+      stripe_details_submitted: true,
+    })
+    await clearPendingRows()
+    await loginAsTenantStudent(page)
+
+    const res = await page.request.post(
+      `${TENANT_BASE}/api/stripe/create-payment-intent`,
+      { data: { productId: STRIPE_PRODUCT } }
+    )
+    const body = await res.json()
+
+    // The account id here is synthetic, so Stripe itself will still reject the
+    // PaymentIntent downstream — what this asserts is that the READINESS gate
+    // did not fire. A real connected account cannot be seeded in E2E, so
+    // "unchanged" means "not refused by #606", not "payment succeeds".
+    expect(body.code).not.toBe('SCHOOL_PAYMENTS_INCOMPLETE')
+    expect(body.code).not.toBe('SCHOOL_PAYMENTS_NOT_CONNECTED')
+
+    await clearPendingRows()
   })
 })

--- a/tests/unit/admin-provider-actions.test.ts
+++ b/tests/unit/admin-provider-actions.test.ts
@@ -19,10 +19,17 @@ interface FakeAdmin {
 const state: {
   admin: FakeAdmin
   walletRow: { wallet_address: string } | null
+  /**
+   * The tenant's Stripe Connect columns, read by the #606 readiness gate on the
+   * publish path. Defaults to an onboarded school so the capability-branch tests
+   * below exercise what they are about; the gate itself is pinned separately.
+   */
+  tenantRow: { stripe_account_id: string | null; stripe_charges_enabled: boolean }
   providerCalls: { createProduct: number; createPrice: number }
 } = {
   admin: makeFakeAdmin(),
   walletRow: null,
+  tenantRow: { stripe_account_id: 'acct_ready', stripe_charges_enabled: true },
   providerCalls: { createProduct: 0, createPrice: 0 },
 }
 
@@ -46,6 +53,9 @@ function makeFakeAdmin(): FakeAdmin {
         })
       },
       single() {
+        if (table === 'tenants') {
+          return Promise.resolve({ data: state.tenantRow, error: null })
+        }
         const row = (Array.isArray(pendingInsert) ? pendingInsert[0] : pendingInsert) || {}
         const idKey = table === 'plans' ? 'plan_id' : 'product_id'
         return Promise.resolve({ data: { ...row, [idKey]: 1 }, error: null })
@@ -101,6 +111,7 @@ const baseProduct = {
 beforeEach(() => {
   state.admin = makeFakeAdmin()
   state.walletRow = null
+  state.tenantRow = { stripe_account_id: 'acct_ready', stripe_charges_enabled: true }
   state.providerCalls = { createProduct: 0, createPrice: 0 }
 })
 
@@ -193,5 +204,65 @@ describe('createProduct — capability branch', () => {
     const row = state.admin._inserted.find(i => i.table === 'products')!.values
     expect(row.provider_product_id).toBeNull()
     expect(row.provider_price_id).toBeNull()
+  })
+})
+
+/**
+ * The publish path must not put a paid offering on a rail that cannot be paid
+ * (#606). A school whose Stripe Express onboarding was abandoned still has
+ * `stripe_account_id` set — that column is written before onboarding starts —
+ * so the gate reads `stripe_charges_enabled`, and it fires BEFORE any catalog
+ * object is created on the provider or any row is inserted.
+ *
+ * Capability-driven: rails with no per-tenant account to onboard are untouched
+ * by this, which the last two cases pin.
+ */
+describe('publish gate — connected-account readiness', () => {
+  const ABANDONED = { stripe_account_id: 'acct_unfinished', stripe_charges_enabled: false }
+  const NEVER_CONNECTED = { stripe_account_id: null, stripe_charges_enabled: false }
+
+  it('createProduct — refuses a paid Stripe offering while onboarding is incomplete', async () => {
+    state.tenantRow = ABANDONED
+    const r = await createProduct({ ...baseProduct, paymentProvider: 'stripe' })
+    expect(r.success).toBe(false)
+    // Actionable: names the screen to fix it on, not just the problem.
+    expect(r.success ? '' : r.error).toMatch(/Settings/)
+    expect(r.success ? '' : r.error).toMatch(/finish your stripe setup/i)
+    // Nothing created on Stripe, nothing written to the database.
+    expect(state.providerCalls).toEqual({ createProduct: 0, createPrice: 0 })
+    expect(state.admin._inserted).toEqual([])
+  })
+
+  it('createPlan — refuses a paid Stripe plan while onboarding is incomplete', async () => {
+    state.tenantRow = ABANDONED
+    const r = await createPlan({ ...basePlan, paymentProvider: 'stripe' })
+    expect(r.success).toBe(false)
+    expect(r.success ? '' : r.error).toMatch(/Settings/)
+    expect(state.providerCalls).toEqual({ createProduct: 0, createPrice: 0 })
+    expect(state.admin._inserted).toEqual([])
+  })
+
+  it('distinguishes a school that never connected from one mid-onboarding', async () => {
+    state.tenantRow = NEVER_CONNECTED
+    const r = await createProduct({ ...baseProduct, paymentProvider: 'stripe' })
+    expect(r.success).toBe(false)
+    expect(r.success ? '' : r.error).toMatch(/connect your stripe account/i)
+  })
+
+  it('leaves rails without a connected account alone', async () => {
+    // Same unusable Stripe state — irrelevant to a rail that has nothing to
+    // onboard, so these must still publish.
+    state.tenantRow = ABANDONED
+    state.walletRow = { wallet_address: 'So1aNaWa11et1111111111111111111111111111111' }
+
+    const solana = await createProduct({ ...baseProduct, paymentProvider: 'solana' })
+    expect(solana.success).toBe(true)
+
+    const lemon = await createProduct({
+      ...baseProduct,
+      paymentProvider: 'lemonsqueezy',
+      providerPriceId: 'variant_1',
+    })
+    expect(lemon.success).toBe(true)
   })
 })

--- a/tests/unit/connected-account-readiness.test.ts
+++ b/tests/unit/connected-account-readiness.test.ts
@@ -1,0 +1,256 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Connected-account readiness gate — issue #606.
+ *
+ * `tenants.stripe_account_id` is persisted by `stripe.accounts.create` BEFORE
+ * the admin is handed the hosted onboarding link, so its presence proves an
+ * account object exists, not that the school can charge. Student checkout gated
+ * on presence, so an abandoned onboarding sailed through to a PaymentIntent
+ * whose `transfer_data.destination` Stripe then rejected — the student saw a
+ * generic payment failure on the school's storefront and nothing in the product
+ * told either party why.
+ *
+ * These tests pin the fix:
+ *  - readiness is `charges_enabled`, NOT account presence and NOT
+ *    `details_submitted` (an Express account can submit details and still be
+ *    blocked on review or fresh requirements);
+ *  - the two refusals stay DISTINCT, because "never connected" and "still
+ *    finishing setup" need different words on the storefront;
+ *  - the branch is the `requiresConnectedAccount` CAPABILITY — a rail with no
+ *    per-tenant account to onboard is ready without a database read at all;
+ *  - a tenant row that cannot be read fails CLOSED;
+ *  - and no `payment_provider === 'stripe'` string comparison creeps back into
+ *    the gated call sites, which is the whole point of naming the ability.
+ */
+
+const single = vi.fn()
+const createAdminClient = vi.fn(() => ({
+  from: () => ({ select: () => ({ eq: () => ({ single }) }) }),
+}))
+
+vi.mock('@/lib/supabase/admin', () => ({ createAdminClient }))
+
+const {
+  evaluateConnectedAccountReadiness,
+  isReadyToAcceptPayments,
+  assertReadyToPublish,
+  PAYMENTS_NOT_CONNECTED_CODE,
+  PAYMENTS_ONBOARDING_INCOMPLETE_CODE,
+  READINESS_CODE,
+  READINESS_MESSAGE,
+  READINESS_ADMIN_MESSAGE,
+} = await import('@/lib/payments/tenant-payment-readiness')
+
+const { PROVIDER_CAPABILITIES } = await import('@/lib/payments/types')
+
+const TENANT = '00000000-0000-0000-0000-000000000001'
+
+beforeEach(() => {
+  single.mockReset()
+  createAdminClient.mockClear()
+})
+
+describe('evaluateConnectedAccountReadiness', () => {
+  it('refuses a tenant with no connected account as not_connected', () => {
+    expect(
+      evaluateConnectedAccountReadiness({
+        stripe_account_id: null,
+        stripe_charges_enabled: false,
+      }),
+    ).toEqual({ ready: false, reason: 'not_connected' })
+  })
+
+  it('refuses an abandoned onboarding as onboarding_incomplete, not not_connected', () => {
+    // The #606 case exactly: the account id is set, so the OLD presence check
+    // passed. The two reasons must not collapse — the storefront says
+    // "still finishing setup", not "contact the admin".
+    expect(
+      evaluateConnectedAccountReadiness({
+        stripe_account_id: 'acct_live_but_unfinished',
+        stripe_charges_enabled: false,
+      }),
+    ).toEqual({ ready: false, reason: 'onboarding_incomplete' })
+  })
+
+  it('accepts a tenant whose account can charge', () => {
+    expect(
+      evaluateConnectedAccountReadiness({
+        stripe_account_id: 'acct_ok',
+        stripe_charges_enabled: true,
+      }),
+    ).toEqual({ ready: true })
+  })
+
+  it('treats a missing row as not_connected rather than falling open', () => {
+    expect(evaluateConnectedAccountReadiness(null)).toEqual({
+      ready: false,
+      reason: 'not_connected',
+    })
+  })
+})
+
+describe('isReadyToAcceptPayments', () => {
+  it('short-circuits every rail without a connected account, with no database read', async () => {
+    const railsWithoutOnboarding = (
+      Object.keys(PROVIDER_CAPABILITIES) as (keyof typeof PROVIDER_CAPABILITIES)[]
+    ).filter((slug) => !PROVIDER_CAPABILITIES[slug].requiresConnectedAccount)
+
+    // Sanity: the filter is not silently empty.
+    expect(railsWithoutOnboarding.length).toBeGreaterThan(0)
+
+    for (const slug of railsWithoutOnboarding) {
+      await expect(isReadyToAcceptPayments(TENANT, slug)).resolves.toEqual({ ready: true })
+    }
+    expect(createAdminClient).not.toHaveBeenCalled()
+  })
+
+  it('reads the tenant row for a rail that requires a connected account', async () => {
+    single.mockResolvedValue({
+      data: { stripe_account_id: 'acct_ok', stripe_charges_enabled: true },
+      error: null,
+    })
+    await expect(isReadyToAcceptPayments(TENANT, 'stripe')).resolves.toEqual({ ready: true })
+    expect(createAdminClient).toHaveBeenCalledTimes(1)
+  })
+
+  it('refuses an account whose charges are still disabled', async () => {
+    single.mockResolvedValue({
+      data: { stripe_account_id: 'acct_unfinished', stripe_charges_enabled: false },
+      error: null,
+    })
+    await expect(isReadyToAcceptPayments(TENANT, 'stripe')).resolves.toEqual({
+      ready: false,
+      reason: 'onboarding_incomplete',
+    })
+  })
+
+  it('fails closed when the tenant row cannot be read', async () => {
+    single.mockResolvedValue({ data: null, error: { message: 'nope' } })
+    await expect(isReadyToAcceptPayments(TENANT, 'stripe')).resolves.toEqual({
+      ready: false,
+      reason: 'not_connected',
+    })
+  })
+})
+
+describe('assertReadyToPublish', () => {
+  it('blocks a paid Stripe offering with actionable copy while onboarding is incomplete', async () => {
+    single.mockResolvedValue({
+      data: { stripe_account_id: 'acct_unfinished', stripe_charges_enabled: false },
+      error: null,
+    })
+    await expect(assertReadyToPublish(TENANT, 'stripe')).rejects.toThrow(
+      READINESS_ADMIN_MESSAGE.onboarding_incomplete,
+    )
+    // Actionable means it names the place to go, not just the problem.
+    expect(READINESS_ADMIN_MESSAGE.onboarding_incomplete).toMatch(/Settings/)
+    expect(READINESS_ADMIN_MESSAGE.not_connected).toMatch(/Settings/)
+  })
+
+  it('lets a ready school publish', async () => {
+    single.mockResolvedValue({
+      data: { stripe_account_id: 'acct_ok', stripe_charges_enabled: true },
+      error: null,
+    })
+    await expect(assertReadyToPublish(TENANT, 'stripe')).resolves.toBeUndefined()
+  })
+
+  it('never blocks a rail with nothing to onboard', async () => {
+    await expect(assertReadyToPublish(TENANT, 'manual')).resolves.toBeUndefined()
+    await expect(assertReadyToPublish(TENANT, 'solana')).resolves.toBeUndefined()
+    expect(createAdminClient).not.toHaveBeenCalled()
+  })
+})
+
+describe('the response contract', () => {
+  it('keeps the two refusals on separate codes and separate messages', () => {
+    expect(READINESS_CODE.not_connected).toBe(PAYMENTS_NOT_CONNECTED_CODE)
+    expect(READINESS_CODE.onboarding_incomplete).toBe(PAYMENTS_ONBOARDING_INCOMPLETE_CODE)
+    expect(PAYMENTS_NOT_CONNECTED_CODE).not.toBe(PAYMENTS_ONBOARDING_INCOMPLETE_CODE)
+    expect(READINESS_MESSAGE.not_connected).not.toBe(READINESS_MESSAGE.onboarding_incomplete)
+  })
+})
+
+describe('the capability table', () => {
+  it('marks exactly the rails whose school must onboard a per-tenant account', () => {
+    const requiring = Object.entries(PROVIDER_CAPABILITIES)
+      .filter(([, caps]) => caps.requiresConnectedAccount)
+      .map(([slug]) => slug)
+      .sort()
+
+    // Stripe Connect Express is the only rail today with an onboarding session a
+    // school can walk away from half-finished. Both Solana rails also settle
+    // outside the platform account, but their "account" is a wallet address
+    // pasted into Settings — live the moment it is saved. Adding a rail here is
+    // a deliberate act, so this list is pinned rather than derived.
+    expect(requiring).toEqual(['stripe'])
+  })
+
+  it('declares the key on every provider class, matching the static table', () => {
+    // Provider classes cannot be instantiated in a unit test (their constructors
+    // demand API credentials), so the two declarations are compared at the
+    // source level — the drift the `PROVIDER_CAPABILITIES` doc-comment warns about.
+    const files: Record<string, string> = {
+      stripe: 'stripe-provider.ts',
+      paypal: 'paypal-provider.ts',
+      lemonsqueezy: 'lemonsqueezy-provider.ts',
+      solana: 'solana-provider.ts',
+      solana_subs: 'solana-subscriptions-provider.ts',
+      manual: 'manual-provider.ts',
+      binance: 'binance-provider.ts',
+      binance_personal: 'binance-personal-provider.ts',
+    }
+    expect(Object.keys(files).sort()).toEqual(Object.keys(PROVIDER_CAPABILITIES).sort())
+
+    for (const [slug, file] of Object.entries(files)) {
+      const source = readFileSync(join(process.cwd(), 'lib/payments', file), 'utf8')
+      const expected =
+        PROVIDER_CAPABILITIES[slug as keyof typeof PROVIDER_CAPABILITIES]
+          .requiresConnectedAccount
+      expect(source, `${file} declares requiresConnectedAccount`).toMatch(
+        new RegExp(`requiresConnectedAccount:\\s*${expected}\\b`),
+      )
+    }
+  })
+})
+
+describe('the gated call sites', () => {
+  /**
+   * Acceptance criterion: the gate is capability-driven. A resurrected
+   * `payment_provider === 'stripe'` (or a bare `providerType === 'stripe'`) in
+   * one of these files would be the exact regression the capability exists to
+   * prevent — the rule would silently stop applying to the next rail.
+   */
+  const GATED_FILES = [
+    'app/api/stripe/create-payment-intent/route.ts',
+    'app/api/payments/checkout/route.ts',
+    'lib/payments/tenant-payment-readiness.ts',
+    'lib/payments/payment-readiness-codes.ts',
+  ]
+
+  /**
+   * One pre-existing comparison stays, and is pinned here rather than waved
+   * through: `/api/stripe/create-payment-intent` is the Stripe-only route, and
+   * this line asks "is the plan I was handed actually on this route's rail"
+   * before taking the native-subscription path. It predates #606 and is not
+   * what the capability replaces. Pinning it exactly means a NEW comparison
+   * still fails the test.
+   */
+  const KNOWN_LEGACY = new Set([
+    "if (planId && planPaymentProvider === 'stripe' && planProviderPriceId) {",
+  ])
+
+  it.each(GATED_FILES)('%s branches on capability, not on the provider name', (file) => {
+    const source = readFileSync(join(process.cwd(), file), 'utf8')
+    const comparisons = source
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => !line.startsWith('*') && !line.startsWith('//'))
+      .filter((line) => /(===|!==)\s*['"]stripe['"]|['"]stripe['"]\s*(===|!==)/.test(line))
+      .filter((line) => !KNOWN_LEGACY.has(line))
+    expect(comparisons).toEqual([])
+  })
+})

--- a/tests/unit/stripe-product-description.test.ts
+++ b/tests/unit/stripe-product-description.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+/**
+ * Stripe rejects `description: ''`.
+ *
+ * It reads an empty string as "unset this parameter" and answers
+ * "You passed an empty string for 'description'. … however 'description' cannot
+ * be unset." Both product-create paths pass `description ?? ''`
+ * (`createProduct` and `saveProductCreationWizard` in
+ * `app/actions/admin/products.ts`), so publishing a paid Stripe offering whose
+ * course had no description yet failed outright — with a raw Stripe error shown
+ * to the admin, and nothing written.
+ *
+ * Surfaced while verifying #606: it is exactly the step the acceptance criteria
+ * ask a reviewer to walk once Connect onboarding is complete. The mapper omits
+ * the field when blank rather than forcing every caller to remember.
+ */
+
+const { productsCreate } = vi.hoisted(() => ({
+  productsCreate: vi.fn(async (params: Record<string, unknown> = {}) => ({
+    id: 'prod_test',
+    name: params.name,
+    description: params.description ?? null,
+    metadata: params.metadata ?? {},
+  })),
+}))
+
+vi.mock('stripe', () => ({
+  default: class {
+    products = { create: productsCreate }
+  },
+}))
+
+const { StripePaymentProvider } = await import('@/lib/payments/stripe-provider')
+
+function provider() {
+  return new StripePaymentProvider('sk_test_fake')
+}
+
+beforeEach(() => productsCreate.mockClear())
+
+describe('StripePaymentProvider.createProduct — description mapping', () => {
+  it('omits description entirely when it is an empty string', async () => {
+    await provider().createProduct({ name: 'Course', description: '' })
+    expect(productsCreate).toHaveBeenCalledTimes(1)
+    expect(productsCreate.mock.calls[0][0]).not.toHaveProperty('description')
+  })
+
+  it('omits description when it is only whitespace', async () => {
+    await provider().createProduct({ name: 'Course', description: '   ' })
+    expect(productsCreate.mock.calls[0][0]).not.toHaveProperty('description')
+  })
+
+  it('sends a real description through, trimmed', async () => {
+    await provider().createProduct({ name: 'Course', description: '  Learn testing  ' })
+    expect(productsCreate.mock.calls[0][0]).toMatchObject({
+      name: 'Course',
+      description: 'Learn testing',
+    })
+  })
+})


### PR DESCRIPTION
## What

Student checkout and the paid-offering publish path now gate on whether a school's Stripe Connect account can actually **charge**, not on whether an account id happens to be set. The check is a new `requiresConnectedAccount` capability read through one `isReadyToAcceptPayments()` helper, and Settings → Payments now says what an incomplete setup blocks and always offers a way to finish it.

Closes #606

## Why

`tenants.stripe_account_id` is persisted the instant `stripe.accounts.create` returns — `app/api/stripe/connect/route.ts` saves it *before* the admin is even handed the hosted onboarding link. So the column answers "did an Express account object get minted", not "can this school charge a card".

Student checkout gated on that column's presence (`if (!tenant.stripe_account_id)`), so an admin who opened onboarding and closed the tab left a tenant that **looked payment-ready and was not**. The student reached the card form, submitted, and Stripe rejected the PaymentIntent because `transfer_data.destination` pointed at an account with `charges_enabled: false`. The result was a generic payment failure on the school's storefront, with nothing in the product telling either party why.

Worse, the check sat *after* `stripe.customers.create` and just before the pending `transactions` insert, so every doomed request left real side effects behind. Verified on the local stack before the fix: one such request created a Stripe customer and a pending `transactions` row, then 500'd with `{"error":"Internal server error"}`. After the fix the same request is refused with a specific message and creates nothing.

The readiness signal already existed and was already synced — `tenants.stripe_charges_enabled` / `stripe_payouts_enabled` / `stripe_details_submitted` (migration `20260717160000`), written by the `account.updated` webhook and by `syncConnectAccountStatus()`, which the Settings page force-runs whenever charges are still disabled. Settings → Payments read all three. Checkout was the one place that didn't. This is a wiring gap, not a data gap — **no migration**.

### The shape of the fix

**The ability is named, not the provider.** `ProviderCapabilities` gains `requiresConnectedAccount`: money on this rail lands in a per-tenant account the school must onboard with the provider, so the account object exists long before it can charge. True only for `stripe`.

It is deliberately *not* derived from `settlesToPlatformAccount: false`, which is also true of both Solana rails — there the school's "account" is a wallet address pasted into Settings, live the moment it is saved, with no onboarding session to abandon. The distinction is whether there is a multi-step approval a school can walk away from half-finished.

**One helper reads it,** so checkout and publish can never drift on what "ready" means:

```ts
isReadyToAcceptPayments(tenantId, provider)
  → { ready: true }
  → { ready: false, reason: 'not_connected' | 'onboarding_incomplete' }
```

Rails with nothing to onboard short-circuit to ready **without a database read at all**. A tenant row that cannot be read fails closed.

**Three call sites:**

- **Student checkout** (`/api/stripe/create-payment-intent`) refuses with two distinct codes (`SCHOOL_PAYMENTS_NOT_CONNECTED` / `SCHOOL_PAYMENTS_INCOMPLETE`), and the gate moved **above** `stripe.customers.create` and the pending transaction — an unready school now costs zero side effects. It stays *below* the parallel-subscription guard, which still owns its 409. `/api/payments/checkout` gets the same call; a no-op for every rail it handles today, which is the point — the rule belongs to "starting a payment", not to whichever route remembered it.
- **The publish path** — `createProduct`, `createPlan`, and the creation wizard's `publish` intent — refuses a paid offering on an unready rail, sitting beside the Solana-wallet guard those actions already carry. Drafts are untouched: a draft is not on sale, so a school can keep building while Stripe reviews. Provider is immutable on update (both update actions read `payment_provider` off the existing row), so the create paths are the whole surface.
- **Settings → Payments** states the consequence and always offers the action. Previously the incomplete card showed **no button at all** once `details_submitted` was true — stranding exactly the admins whose account is blocked on outstanding requirements. `/api/stripe/connect` mints a *fresh* account link for an existing account id, so the button is correct in both sub-states.

`checkout.stripe.schoolNotConnected` / `schoolSetupIncomplete` (en + es) let the storefront translate the refusal instead of echoing an English server string — same `code`-based contract as `PARALLEL_SUBSCRIPTION_CODE` (#459).

### One incidental fix, and why it's in this PR

Stripe reads `description: ''` as "unset this parameter" and rejects it outright (`"'description' cannot be unset"`). Both product-create paths pass `description ?? ''`, so publishing a paid Stripe offering whose course had no description yet **failed with a raw Stripe error**. This is pre-existing and unrelated to the gate — but it is the exact step the acceptance criteria ask a reviewer to walk once onboarding is complete, and it was hit during verification of this PR. `StripePaymentProvider.createProduct` now omits the field when blank (one line in the mapper, plus `tests/unit/stripe-product-description.test.ts`). Deliberately kept in this PR rather than split out: without it the acceptance path does not run end to end.

### Acceptance criteria

| Criterion | Where |
|---|---|
| `charges_enabled: false` refused before any Stripe call, distinct error | gate moved above `customers.create`; two exported codes |
| `charges_enabled: true` unchanged | readiness short-circuit; Playwright case 3 |
| Publishing a paid Stripe offering blocked with an actionable message | `createProduct` / `createPlan` / wizard `publish` |
| `payment-flows.spec.ts` covers the abandoned-onboarding tenant | 3 new cases |
| No `payment_provider === 'stripe'` comparison introduced | `requiresConnectedAccount` + one helper, pinned by a source-scanning test |

## How to QA

Local stack on `default.lvh.me:3000`, signed in as `owner@e2etest.com` / `password123` (admin of Default School). `npm run db:reset` first; `npm run dev` in another terminal.

**A — the abandoned onboarding (the bug)**

1. Put the tenant in the state an abandoned onboarding leaves behind — an account id with charges still disabled:
   ```sql
   update tenants set stripe_account_id = 'acct_1QaBcDeFgH606QA',
                      stripe_charges_enabled = false,
                      stripe_details_submitted = true
   where id = '00000000-0000-0000-0000-000000000001';
   ```
2. Go to **Settings → Payments** (`/en/dashboard/admin/settings?tab=payment`). The Stripe card says setup is incomplete, carries an amber notice — *"Until Stripe enables charges, students can't complete a card checkout and you can't publish a paid Stripe offering"* — and shows a **Check setup status** button. On `master` this state renders no button at all.
3. Go to `/en/checkout?courseId=1001` (the $29 "Introduction to Testing" product). Instead of a card form you get **"Card payments unavailable — This school is still finishing its payment setup…"**. Switch the URL to `/es/checkout?courseId=1001` to confirm the Spanish string.
4. Confirm nothing was created: `select * from transactions where product_id = 1001 and status = 'pending';` returns no rows, and no new Stripe customer was made. (On `master` this request creates both, then 500s.)
5. Try to publish a paid Stripe offering: **Monetization → Products → Create Product → More options → Pricing → Paid**, price `39`, Payment Method **Stripe (Credit Card, Online)**, then **Publish**. It is refused inline and by toast with *"Finish your Stripe setup in Settings → Payments before publishing a paid Stripe offering…"*. Nothing is written and nothing is created on Stripe.

**B — the gate lifts**

6. `update tenants set stripe_charges_enabled = true where id = '00000000-0000-0000-0000-000000000001';`
7. Settings → Payments now shows the green **Stripe Connected** card.
8. Publish the same paid Stripe product again — it succeeds ("Offering published") and appears in the products list tagged `STRIPE`. This step is also what exercises the `description: ''` fix; the course has no description, and on `master` it fails with a raw Stripe error.
9. Reload `/en/checkout?courseId=1001` — the readiness gate no longer fires. **Note:** the account id above is synthetic, so Stripe still rejects the PaymentIntent downstream; what step 9 shows is that the refusal is no longer ours. A genuinely successful card payment needs a real onboarded Connect account, which cannot be created against this repo's Stripe test key (Connect is not enabled on it). The `charges_enabled: true` path is asserted in Playwright instead — see below.

**C — other rails are untouched**

10. With the tenant still unready (`stripe_charges_enabled = false`), create a paid **Manual/Offline** product. It publishes normally — the gate is capability-driven and `manual` has no connected account to onboard.

**Cleanup:** `update tenants set stripe_account_id = null, stripe_charges_enabled = false, stripe_details_submitted = false where id = '00000000-0000-0000-0000-000000000001';`

## Screenshots / GIF

Before/after screenshots and a verification GIF follow as a comment on this PR.

## Checklist

- [x] `npm run typecheck` and `npm run test:unit` pass — typecheck clean; **832 tests / 63 files passed**, including 18 new in `tests/unit/connected-account-readiness.test.ts`, 4 new publish-gate cases in `tests/unit/admin-provider-actions.test.ts`, and 3 in `tests/unit/stripe-product-description.test.ts`
- [x] `npm run build` passes — `✓ Compiled successfully in 32.3s`
- [x] Every new tenant-scoped query filters by `tenant_id` (or the table genuinely has no such column) — the one new query is `tenants … .eq('id', tenantId)`
- [x] Tested with every relevant role (student / teacher / admin) — admin (Settings + publish, browser) and student (checkout refusal, Playwright as `alice@student.com` and browser)
- [x] Loading and error states handled — the storefront panel already had the error branch; it now shows a specific, translated message and keeps the "Pay another way" fallback
- [x] New UI strings added to both `messages/en.json` and `messages/es.json` — `…payment.connect.blockedNotice`, `…connect.checkStatusButton`, `checkout.stripe.schoolNotConnected`, `checkout.stripe.schoolSetupIncomplete`
- [ ] Migration — **none**; `20260717160000` already added the columns and both writers already keep them in sync

### E2E

`npx playwright test tests/playwright/payment-flows.spec.ts --workers=1` → **36 passed** (9 tests × 4 projects), including three new cases that drive the real route with a real student session while flipping the tenant's Connect columns around it:

- account id set + `charges_enabled: false` → 400 `SCHOOL_PAYMENTS_INCOMPLETE`, no pending `transactions` row
- no account id → 400 `SCHOOL_PAYMENTS_NOT_CONNECTED`, no pending row
- `charges_enabled: true` → neither readiness code fires

The spec saves and restores the tenant's original Connect columns in `beforeAll`/`afterAll`.

### Notes for the reviewer

- **No backfill needed.** `stripe_charges_enabled` defaults to `false`, so in a deployment with existing schools this gate would need a one-off re-sync before shipping. This platform has no production tenants charging today, so there is nothing to backfill — and going forward both writers keep the column current (the `account.updated` webhook, and the Settings page's forced sync, which runs precisely when charges are still disabled).
- **One pre-existing `payment_provider === 'stripe'` comparison stays**, in the native-subscription branch of `/api/stripe/create-payment-intent`. That route is Stripe-only and the line asks "is this plan on this route's rail" — it predates #606 and is not what the capability replaces. It is pinned by name in the guard test, so a *new* comparison still fails.
- Repo-wide lint has a large pre-existing error baseline; `npm run lint` reports no new errors on any file in this diff.


