### PR TITLE
fix(billing): make provider switching safe (#621)

### DIFF
--- a/app/actions/admin/billing.ts
+++ b/app/actions/admin/billing.ts
@@ -16,6 +16,13 @@ import {
   requestExpiresAt,
 } from '@/lib/billing/payment-request-ttl'
 import { revalidatePath } from 'next/cache'
+import {
+  SwitchAlreadyPendingError,
+  beginPlatformSubscriptionSwitch,
+  failPlatformSubscriptionSwitch,
+  promotePlatformSubscriptionSwitch,
+  reconcilePlatformSubscriptionSwitch,
+} from '@/lib/billing/platform-subscription-switch'
 
 async function verifyAdminAccess() {
   const supabase = await createClient()
@@ -246,6 +253,23 @@ export async function requestManualPlanUpgrade(
     throw new Error('You already have a pending plan change request. Please wait for it to be processed.')
   }
 
+  const expiresAt = requestExpiresAt()
+  let switchId: string | null
+  try {
+    switchId = await beginPlatformSubscriptionSwitch({
+      admin: adminClient,
+      tenantId,
+      targetPlanId: planId,
+      targetProvider: paymentProvider as PaymentProvider,
+      targetInterval: interval,
+      initiatedBy: userId,
+      expiresAt,
+    })
+  } catch (switchError) {
+    if (switchError instanceof SwitchAlreadyPendingError) throw switchError
+    throw new Error('Failed to prepare payment-method switch')
+  }
+
   const { data: request, error } = await adminClient
     .from('platform_payment_requests')
     .insert({
@@ -260,12 +284,14 @@ export async function requestManualPlanUpgrade(
       payment_provider: paymentProvider,
       bank_reference: bankReference || null,
       notes: notes || null,
-      expires_at: requestExpiresAt(),
+      expires_at: expiresAt,
+      switch_id: switchId,
     })
     .select('request_id')
     .single()
 
   if (error) {
+    await failPlatformSubscriptionSwitch(adminClient, switchId, error)
     console.error('Failed to create payment request:', error)
     throw new Error('Failed to create upgrade request')
   }
@@ -329,7 +355,7 @@ export async function confirmManualPayment(requestId: string) {
     .single()
 
   if (!request) throw new Error('Request not found')
-  if (request.status === 'confirmed') throw new Error('Already confirmed')
+  if (request.status === 'confirmed' && !request.switch_id) throw new Error('Already confirmed')
 
   const plan = request.platform_plans as { slug: string; transaction_fee_percent: number }
 
@@ -369,67 +395,91 @@ export async function confirmManualPayment(requestId: string) {
 
   const periodEnd = new Date(periodStart)
   if (request.interval === 'yearly') {
-    periodEnd.setFullYear(periodEnd.getFullYear() + 1)
+    periodEnd.setUTCFullYear(periodEnd.getUTCFullYear() + 1)
   } else {
-    periodEnd.setMonth(periodEnd.getMonth() + 1)
+    periodEnd.setUTCMonth(periodEnd.getUTCMonth() + 1)
   }
 
-  // Upsert subscription
-  await adminClient
-    .from('platform_subscriptions')
-    .upsert({
-      tenant_id: request.tenant_id,
-      plan_id: request.plan_id,
-      status: 'active',
-      // The rail the school actually settled on (#603). Hardcoding 'manual'
-      // here made every out-of-band payment look like a bank wire on the
-      // billing screens, whatever the school had really used.
-      payment_provider: request.payment_provider || 'manual',
-      interval: request.interval,
-      current_period_start: periodStart.toISOString(),
-      current_period_end: periodEnd.toISOString(),
-      grace_period_end: null,
-      // Reset the reminder stamp so the next cycle can remind again.
-      renewal_reminder_sent_at: null,
-      // A confirmed payment is an un-cancel (#546 §1). PostgREST's ON CONFLICT
-      // DO UPDATE only touches the columns supplied here, so omitting these two
-      // left a stale `cancel_at_period_end = true` on the row: the school paid
-      // for a full period and was then silently dropped to free at the end of
-      // it by the cron's cancel phase, with no reminder and no grace window
-      // (phases 1 and 2 both filter on `cancel_at_period_end = false`).
-      cancel_at_period_end: false,
-      canceled_at: null,
-      // A real payment supersedes any super-admin comp (#546 §3) — this is one
-      // of the override's exits, so portal changes start syncing again.
-      plan_override_by: null,
-      plan_override_at: null,
-      updated_at: now.toISOString(),
-    }, { onConflict: 'tenant_id' })
+  const subscriptionValues = {
+    tenant_id: request.tenant_id,
+    plan_id: request.plan_id,
+    status: 'active',
+    // The rail the school actually settled on (#603). Hardcoding 'manual'
+    // here made every out-of-band payment look like a bank wire on the
+    // billing screens, whatever the school had really used.
+    payment_provider: request.payment_provider || 'manual',
+    interval: request.interval,
+    current_period_start: periodStart.toISOString(),
+    current_period_end: periodEnd.toISOString(),
+    grace_period_end: null,
+    // Reset the reminder stamp so the next cycle can remind again.
+    renewal_reminder_sent_at: null,
+    // A confirmed payment is an un-cancel (#546 §1). PostgREST's ON CONFLICT
+    // DO UPDATE only touches the columns supplied here, so omitting these two
+    // left a stale `cancel_at_period_end = true` on the row: the school paid
+    // for a full period and was then silently dropped to free at the end of
+    // it by the cron's cancel phase, with no reminder and no grace window
+    // (phases 1 and 2 both filter on `cancel_at_period_end = false`).
+    cancel_at_period_end: false,
+    canceled_at: null,
+    // A real payment supersedes any super-admin comp (#546 §3) — this is one
+    // of the override's exits, so portal changes start syncing again.
+    plan_override_by: null,
+    plan_override_at: null,
+    updated_at: now.toISOString(),
+  }
 
-  // Update tenant plan
-  await adminClient
-    .from('tenants')
-    .update({
-      plan: plan.slug,
-      billing_status: 'active',
-      billing_period_end: periodEnd.toISOString(),
-      updated_at: now.toISOString(),
+  if (request.switch_id) {
+    const promoted = await promotePlatformSubscriptionSwitch({
+      admin: adminClient,
+      switchId: request.switch_id,
+      tenantId: request.tenant_id,
+      targetProvider: (request.payment_provider || 'manual') as PaymentProvider,
+      targetProviderSubscriptionId: null,
+      targetProviderCustomerId: null,
+      targetPlanId: request.plan_id,
+      targetStatus: 'active',
+      targetInterval: request.interval,
+      targetPeriodStart: periodStart.toISOString(),
+      targetPeriodEnd: periodEnd.toISOString(),
     })
-    .eq('id', request.tenant_id)
+    if (!promoted) throw new Error('Subscription switch no longer matches the current subscription')
+  } else {
+    await adminClient
+      .from('platform_subscriptions')
+      .upsert(subscriptionValues, { onConflict: 'tenant_id' })
+  }
 
-  // Update revenue splits
-  await adminClient
-    .from('revenue_splits')
-    .upsert({
-      tenant_id: request.tenant_id,
-      platform_percentage: plan.transaction_fee_percent,
-      school_percentage: 100 - plan.transaction_fee_percent,
-      updated_at: now.toISOString(),
-    }, { onConflict: 'tenant_id' })
+  if (!request.switch_id) {
+    // Update tenant plan
+    await adminClient
+      .from('tenants')
+      .update({
+        plan: plan.slug,
+        billing_status: 'active',
+        billing_period_end: periodEnd.toISOString(),
+        updated_at: now.toISOString(),
+      })
+      .eq('id', request.tenant_id)
+
+    // Update revenue splits
+    await adminClient
+      .from('revenue_splits')
+      .upsert({
+        tenant_id: request.tenant_id,
+        platform_percentage: plan.transaction_fee_percent,
+        school_percentage: 100 - plan.transaction_fee_percent,
+        updated_at: now.toISOString(),
+      }, { onConflict: 'tenant_id' })
+  }
 
   // Activation already passed the pre-flight limit check above, so this
   // clears any cutoff scheduled from a prior over-limit period.
   await reconcileAccessCutoff(adminClient, request.tenant_id)
+
+  if (request.switch_id) {
+    await reconcilePlatformSubscriptionSwitch(adminClient, request.switch_id)
+  }
 
   return { success: true }
 }

--- a/app/actions/admin/billing.ts
+++ b/app/actions/admin/billing.ts
@@ -355,6 +355,7 @@ export async function confirmManualPayment(requestId: string) {
     .single()
 
   if (!request) throw new Error('Request not found')
+  if (request.status === 'rejected') throw new Error('Rejected payments cannot be confirmed')
   if (request.status === 'confirmed' && !request.switch_id) throw new Error('Already confirmed')
 
   const plan = request.platform_plans as { slug: string; transaction_fee_percent: number }
@@ -400,35 +401,6 @@ export async function confirmManualPayment(requestId: string) {
     periodEnd.setUTCMonth(periodEnd.getUTCMonth() + 1)
   }
 
-  const subscriptionValues = {
-    tenant_id: request.tenant_id,
-    plan_id: request.plan_id,
-    status: 'active',
-    // The rail the school actually settled on (#603). Hardcoding 'manual'
-    // here made every out-of-band payment look like a bank wire on the
-    // billing screens, whatever the school had really used.
-    payment_provider: request.payment_provider || 'manual',
-    interval: request.interval,
-    current_period_start: periodStart.toISOString(),
-    current_period_end: periodEnd.toISOString(),
-    grace_period_end: null,
-    // Reset the reminder stamp so the next cycle can remind again.
-    renewal_reminder_sent_at: null,
-    // A confirmed payment is an un-cancel (#546 §1). PostgREST's ON CONFLICT
-    // DO UPDATE only touches the columns supplied here, so omitting these two
-    // left a stale `cancel_at_period_end = true` on the row: the school paid
-    // for a full period and was then silently dropped to free at the end of
-    // it by the cron's cancel phase, with no reminder and no grace window
-    // (phases 1 and 2 both filter on `cancel_at_period_end = false`).
-    cancel_at_period_end: false,
-    canceled_at: null,
-    // A real payment supersedes any super-admin comp (#546 §3) — this is one
-    // of the override's exits, so portal changes start syncing again.
-    plan_override_by: null,
-    plan_override_at: null,
-    updated_at: now.toISOString(),
-  }
-
   if (request.switch_id) {
     const promoted = await promotePlatformSubscriptionSwitch({
       admin: adminClient,
@@ -445,12 +417,39 @@ export async function confirmManualPayment(requestId: string) {
     })
     if (!promoted) throw new Error('Subscription switch no longer matches the current subscription')
   } else {
+    const subscriptionValues = {
+      tenant_id: request.tenant_id,
+      plan_id: request.plan_id,
+      status: 'active',
+      // The rail the school actually settled on (#603). Hardcoding 'manual'
+      // here made every out-of-band payment look like a bank wire on the
+      // billing screens, whatever the school had really used.
+      payment_provider: request.payment_provider || 'manual',
+      interval: request.interval,
+      current_period_start: periodStart.toISOString(),
+      current_period_end: periodEnd.toISOString(),
+      grace_period_end: null,
+      // Reset the reminder stamp so the next cycle can remind again.
+      renewal_reminder_sent_at: null,
+      // A confirmed payment is an un-cancel (#546 §1). PostgREST's ON CONFLICT
+      // DO UPDATE only touches the columns supplied here, so omitting these two
+      // left a stale `cancel_at_period_end = true` on the row: the school paid
+      // for a full period and was then silently dropped to free at the end of
+      // it by the cron's cancel phase, with no reminder and no grace window
+      // (phases 1 and 2 both filter on `cancel_at_period_end = false`).
+      cancel_at_period_end: false,
+      canceled_at: null,
+      // A real payment supersedes any super-admin comp (#546 §3) — this is one
+      // of the override's exits, so portal changes start syncing again.
+      plan_override_by: null,
+      plan_override_at: null,
+      updated_at: now.toISOString(),
+    }
+
     await adminClient
       .from('platform_subscriptions')
       .upsert(subscriptionValues, { onConflict: 'tenant_id' })
-  }
 
-  if (!request.switch_id) {
     // Update tenant plan
     await adminClient
       .from('tenants')

--- a/app/actions/platform/plans.ts
+++ b/app/actions/platform/plans.ts
@@ -13,6 +13,7 @@ import {
   type PlanPriceProvider,
 } from '@/lib/billing/plan-prices'
 import { PROVIDER_CAPABILITIES, type PaymentProvider } from '@/lib/payments/types'
+import { failPlatformSubscriptionSwitch } from '@/lib/billing/platform-subscription-switch'
 
 async function verifySuperAdmin() {
   const userId = await getCurrentUserId()
@@ -258,7 +259,7 @@ export async function rejectManualPayment(requestId: string, reason: string) {
 
   const { data: request } = await adminClient
     .from('platform_payment_requests')
-    .select('request_id, status')
+    .select('request_id, status, switch_id')
     .eq('request_id', requestId)
     .maybeSingle()
 
@@ -291,6 +292,12 @@ export async function rejectManualPayment(requestId: string, reason: string) {
   if (!updated || updated.length === 0) {
     throw new Error('This request was decided by someone else just now — reload the page.')
   }
+
+  await failPlatformSubscriptionSwitch(
+    adminClient,
+    request.switch_id,
+    `Manual payment request rejected: ${reason}`,
+  )
 
   revalidatePath('/platform/billing')
   return { success: true }

--- a/app/api/billing/checkout/route.ts
+++ b/app/api/billing/checkout/route.ts
@@ -19,7 +19,6 @@ import { createAdminClient } from '@/lib/supabase/admin'
 import { getCurrentTenantId } from '@/lib/supabase/tenant'
 import { resolveRequestLocale } from '@/lib/i18n/request-locale'
 import { PROVIDER_CAPABILITIES } from '@/lib/payments/types'
-import type { PaymentProvider } from '@/lib/payments/types'
 import {
   describeResolutionError,
   getActivePlanPrices,
@@ -27,13 +26,20 @@ import {
   resolveCheckoutProvider,
 } from '@/lib/billing/platform-billing'
 import { checkPlanLimits, formatPlanLimitError } from '@/lib/billing/plan-limits'
-import { hasOpenPaymentRequest } from '@/lib/billing/payment-request-ttl'
+import { hasOpenPaymentRequest, requestExpiresAt } from '@/lib/billing/payment-request-ttl'
 import {
   getPlatformSolanaConfig,
   quotePlatformSettlement,
   recordSolanaPlatformRequest,
   type PlatformSettlement,
 } from '@/lib/billing/solana-platform-payment'
+import {
+  SWITCH_METADATA_KEY,
+  SwitchAlreadyPendingError,
+  attachSwitchCheckoutReference,
+  beginPlatformSubscriptionSwitch,
+  failPlatformSubscriptionSwitch,
+} from '@/lib/billing/platform-subscription-switch'
 
 export const runtime = 'nodejs'
 
@@ -200,46 +206,6 @@ export async function POST(req: NextRequest) {
       )
     }
 
-    // Provider switch: supersede the live subscription before starting the new
-    // one, so the school is never billed on two rails at once. Cancelling
-    // immediately (rather than at period end) is the safe direction — the new
-    // checkout starts a fresh paid period, and a lingering old subscription
-    // would auto-renew into a double charge. Mirrors the student supersession
-    // model from #463.
-    //
-    // Only when the rail actually changes: a renewal on the SAME self-managed
-    // rail reaches this far (see the guard above), and cancelling the row the
-    // school is in the middle of paying to extend would take away the period it
-    // has already bought.
-    if (liveSub && liveSub.payment_provider !== provider) {
-      const oldCaps = PROVIDER_CAPABILITIES[liveSub.payment_provider as PaymentProvider]
-      if (oldCaps?.supportsNativeSubscriptions) {
-        try {
-          const oldProvider = getPlatformBillingProvider(liveSub.payment_provider as PaymentProvider)
-          if (oldProvider.cancelSubscription) {
-            await oldProvider.cancelSubscription(liveSub.provider_subscription_id!, true)
-          }
-        } catch (err) {
-          // Fail the request rather than the school: if we cannot stop the old
-          // subscription, starting a second one is how double-billing happens.
-          console.error('[billing/checkout] failed to cancel superseded subscription:', err)
-          return NextResponse.json(
-            { error: 'Could not cancel your current subscription. Contact support before switching payment methods.' },
-            { status: 502 },
-          )
-        }
-      }
-
-      await adminClient
-        .from('platform_subscriptions')
-        .update({
-          status: 'canceled',
-          canceled_at: new Date().toISOString(),
-          updated_at: new Date().toISOString(),
-        })
-        .eq('tenant_id', tenantId)
-    }
-
     // Get or create the tenant's customer with this provider. Since #601 the id
     // lives per (tenant, provider) in tenant_billing_customers.
     const { data: tenant } = await adminClient
@@ -294,32 +260,66 @@ export async function POST(req: NextRequest) {
     const successUrl = `${origin}/${locale}/dashboard/admin/billing?session_id={CHECKOUT_SESSION_ID}`
     const cancelUrl = `${origin}/${locale}/dashboard/admin/billing/upgrade`
 
-    const session = await paymentProvider.createCheckoutSession({
-      mode: 'subscription',
-      hosted: true,
-      providerPriceId: price.providerPriceId ?? '',
-      // The provider charges what its own price row says; this is carried for
-      // adapters that need an explicit amount (hosted pages that do not read it
-      // off the price object, and every catalog-less rail).
-      amount: amountUsd,
-      currency: price.currency,
-      reference: `platform:${tenantId}:${plan.plan_id}`,
-      providerCustomerId,
-      successUrl,
-      cancelUrl,
-      baseUrl: origin || undefined,
-      metadata: {
-        tenant_id: tenantId,
-        plan_id: plan.plan_id,
-        plan_slug: plan.slug,
-        interval,
-      },
-    })
+    const replacementExpiresAt = provider === 'solana' ? requestExpiresAt() : undefined
+    let switchId: string | null
+    try {
+      switchId = await beginPlatformSubscriptionSwitch({
+        admin: adminClient,
+        tenantId,
+        targetPlanId: plan.plan_id,
+        targetProvider: provider,
+        targetInterval: interval,
+        initiatedBy: user.id,
+        expiresAt: replacementExpiresAt,
+      })
+    } catch (switchError) {
+      if (switchError instanceof SwitchAlreadyPendingError) {
+        return NextResponse.json({ error: switchError.message }, { status: 409 })
+      }
+      throw switchError
+    }
+
+    let session
+    try {
+      session = await paymentProvider.createCheckoutSession({
+        mode: 'subscription',
+        hosted: true,
+        providerPriceId: price.providerPriceId ?? '',
+        // The provider charges what its own price row says; this is carried for
+        // adapters that need an explicit amount (hosted pages that do not read it
+        // off the price object, and every catalog-less rail).
+        amount: amountUsd,
+        currency: price.currency,
+        reference: `platform:${tenantId}:${plan.plan_id}`,
+        providerCustomerId,
+        successUrl,
+        cancelUrl,
+        baseUrl: origin || undefined,
+        metadata: {
+          tenant_id: tenantId,
+          plan_id: plan.plan_id,
+          plan_slug: plan.slug,
+          interval,
+          ...(switchId ? { [SWITCH_METADATA_KEY]: switchId } : {}),
+        },
+      })
+    } catch (checkoutError) {
+      await failPlatformSubscriptionSwitch(adminClient, switchId, checkoutError)
+      throw checkoutError
+    }
 
     if (!session.url) {
       console.error(`[billing/checkout] ${provider} returned a ${session.kind} session with no URL`)
+      await failPlatformSubscriptionSwitch(adminClient, switchId, 'Provider returned no checkout URL')
       return NextResponse.json({ error: 'Could not start checkout' }, { status: 502 })
     }
+
+    await attachSwitchCheckoutReference(
+      adminClient,
+      switchId,
+      session.providerRef ?? session.reference,
+      session.expiresAt,
+    )
 
     // The QR's on-chain reference is minted by the provider, so the row is
     // written now that we have it. A failure here must fail the request: a
@@ -327,18 +327,28 @@ export async function POST(req: NextRequest) {
     if (solanaSettlement) {
       if (!session.providerRef) {
         console.error('[billing/checkout] solana session carried no on-chain reference')
+        await failPlatformSubscriptionSwitch(adminClient, switchId, 'Solana session carried no reference')
         return NextResponse.json({ error: 'Could not start checkout' }, { status: 502 })
       }
-      const { requestId } = await recordSolanaPlatformRequest({
-        admin: adminClient,
-        tenantId,
-        userId: user.id,
-        planId: plan.plan_id,
-        amountUsd,
-        interval,
-        reference: session.providerRef,
-        settlement: solanaSettlement,
-      })
+      let requestId: string
+      try {
+        const recorded = await recordSolanaPlatformRequest({
+          admin: adminClient,
+          tenantId,
+          userId: user.id,
+          planId: plan.plan_id,
+          amountUsd,
+          interval,
+          reference: session.providerRef,
+          settlement: solanaSettlement,
+          switchId,
+          expiresAt: replacementExpiresAt,
+        })
+        requestId = recorded.requestId
+      } catch (recordError) {
+        await failPlatformSubscriptionSwitch(adminClient, switchId, recordError)
+        throw recordError
+      }
       return NextResponse.json({ kind: session.kind, url: session.url, provider, requestId })
     }
 

--- a/app/api/billing/solana/verify/route.ts
+++ b/app/api/billing/solana/verify/route.ts
@@ -84,7 +84,7 @@ export async function POST(req: NextRequest) {
     const { data: request } = await admin
       .from('platform_payment_requests')
       .select(
-        'request_id, tenant_id, plan_id, interval, status, payment_provider, provider_reference, settlement_currency, settlement_base, settlement_mint, platform_plans(slug)',
+        'request_id, tenant_id, plan_id, interval, status, payment_provider, provider_reference, settlement_currency, settlement_base, settlement_mint, switch_id, platform_plans(slug)',
       )
       .eq('request_id', requestId)
       .eq('tenant_id', tenantId)
@@ -187,6 +187,7 @@ export async function POST(req: NextRequest) {
           plan_id: request.plan_id,
           ...(planSlug ? { plan_slug: planSlug } : {}),
           interval: request.interval,
+          ...(request.switch_id ? { billing_switch_id: request.switch_id } : {}),
         },
         raw: { requestId, signature },
       },

--- a/app/api/cron/expire-platform-subscriptions/route.ts
+++ b/app/api/cron/expire-platform-subscriptions/route.ts
@@ -12,7 +12,10 @@ import {
   isRequestOpen,
 } from '@/lib/billing/payment-request-ttl'
 import { PLATFORM_SELF_MANAGED_PROVIDERS } from '@/lib/billing/platform-billing'
-import { reconcilePlatformSubscriptionSwitch } from '@/lib/billing/platform-subscription-switch'
+import {
+  abandonPlatformSubscriptionSwitch,
+  reconcilePlatformSubscriptionSwitch,
+} from '@/lib/billing/platform-subscription-switch'
 
 export const runtime = 'nodejs'
 
@@ -44,6 +47,7 @@ export const runtime = 'nodejs'
  *   3. Downgrade   — past_due sub, grace window passed → downgrade to free + email,
  *                    UNLESS an OPEN renewal payment request pauses it.
  *   4. Cancel      — cancel_at_period_end sub, period end passed → downgrade to free + email (no renewal pause).
+ *   5. Cleanup     — retry a small bounded batch of superseded-provider cancels.
  *
  * Secured by CRON_SECRET env var (set the same value in the cron scheduler).
  */
@@ -85,6 +89,7 @@ type LapsedRequestRow = {
   currency: string | null
   expires_at: string | null
   status: string
+  switch_id: string | null
   tenants: { name: string | null } | null
   platform_plans: { name: string | null } | null
 }
@@ -122,10 +127,10 @@ export async function GET(req: NextRequest) {
     switchCancellationRetries: 0,
   }
 
-  // ---- Switch recovery (#621) ----
+  // ---- Switch abandonment (#621) ----
   // A replacement checkout that never activates expires without touching the
-  // source entitlement. Activated replacements whose source cancellation
-  // failed are retried with bounded exponential backoff.
+  // source entitlement. Validated late payments may revive these rows through
+  // the source-snapshot-guarded promotion RPC.
   const { data: abandonedSwitches } = await supabase
     .from('platform_subscription_switches')
     .update({ state: 'abandoned', updated_at: nowIso })
@@ -135,21 +140,6 @@ export async function GET(req: NextRequest) {
     .limit(100)
   result.switchesAbandoned = abandonedSwitches?.length ?? 0
 
-  const { data: cleanupSwitches } = await supabase
-    .from('platform_subscription_switches')
-    .select('switch_id')
-    .in('state', ['cancellation_pending', 'cancellation_retry'])
-    .lte('next_retry_at', nowIso)
-    .order('next_retry_at', { ascending: true })
-    .limit(100)
-
-  for (const row of cleanupSwitches || []) {
-    const outcome = await reconcilePlatformSubscriptionSwitch(supabase, row.switch_id)
-    if (outcome === 'completed') result.switchCancellationsCompleted++
-    else if (outcome === 'scheduled') result.switchCancellationsScheduled++
-    else if (outcome === 'retry') result.switchCancellationRetries++
-  }
-
   // ---- Phase 0: expire lapsed payment requests (#546 §2) ----
   // Nothing else in the codebase ever moved a request out of an open state, so
   // an unpaid renewal paused the downgrade forever: click "request renewal",
@@ -157,23 +147,32 @@ export async function GET(req: NextRequest) {
   // Closing them here first means phase 3 below sees the swept state.
   const { data: lapsedRequests } = await supabase
     .from('platform_payment_requests')
-    .select('request_id, tenant_id, amount, currency, expires_at, status, tenants(name), platform_plans(name)')
+    .select('request_id, tenant_id, amount, currency, expires_at, status, switch_id, tenants(name), platform_plans(name)')
     .in('status', OPEN_REQUEST_STATUSES as unknown as string[])
     .not('expires_at', 'is', null)
     .lt('expires_at', nowIso)
 
   for (const req of (lapsedRequests as LapsedRequestRow[] | null) || []) {
-    const { error } = await supabase
+    const { data: expiredRequest, error } = await supabase
       .from('platform_payment_requests')
       .update({ status: 'expired', updated_at: nowIso })
       .eq('request_id', req.request_id)
       // Status-gated so a super admin confirming in the same instant wins.
       .in('status', OPEN_REQUEST_STATUSES as unknown as string[])
+      .select('request_id')
+      .maybeSingle()
 
     if (error) {
       console.error('expire-platform-subscriptions: failed to expire request', req.request_id, error)
       continue
     }
+    if (!expiredRequest) continue
+
+    await abandonPlatformSubscriptionSwitch(
+      supabase,
+      req.switch_id,
+      'Linked payment request expired',
+    )
 
     const emails = await getTenantAdminEmails(supabase, req.tenant_id)
     await safeEmail(emails, paymentRequestExpiredTemplate({
@@ -321,6 +320,25 @@ export async function GET(req: NextRequest) {
       billingUrl,
     }))
     result.canceled++
+  }
+
+  // ---- Phase 5: bounded source-provider cleanup (#621) ----
+  // External provider calls run last so a degraded API cannot starve request
+  // expiry, reminders, grace transitions, or tenant downgrades. Ten per daily
+  // run is enough to drain normal volume without consuming the route budget.
+  const { data: cleanupSwitches } = await supabase
+    .from('platform_subscription_switches')
+    .select('switch_id')
+    .in('state', ['cancellation_pending', 'cancellation_retry'])
+    .lte('next_retry_at', nowIso)
+    .order('next_retry_at', { ascending: true })
+    .limit(10)
+
+  for (const row of cleanupSwitches || []) {
+    const outcome = await reconcilePlatformSubscriptionSwitch(supabase, row.switch_id)
+    if (outcome === 'completed') result.switchCancellationsCompleted++
+    else if (outcome === 'scheduled') result.switchCancellationsScheduled++
+    else if (outcome === 'retry') result.switchCancellationRetries++
   }
 
   return NextResponse.json({ success: true, ...result })

--- a/app/api/cron/expire-platform-subscriptions/route.ts
+++ b/app/api/cron/expire-platform-subscriptions/route.ts
@@ -12,6 +12,7 @@ import {
   isRequestOpen,
 } from '@/lib/billing/payment-request-ttl'
 import { PLATFORM_SELF_MANAGED_PROVIDERS } from '@/lib/billing/platform-billing'
+import { reconcilePlatformSubscriptionSwitch } from '@/lib/billing/platform-subscription-switch'
 
 export const runtime = 'nodejs'
 
@@ -115,6 +116,38 @@ export async function GET(req: NextRequest) {
     downgraded: 0,
     canceled: 0,
     skippedPendingRenewal: 0,
+    switchesAbandoned: 0,
+    switchCancellationsCompleted: 0,
+    switchCancellationsScheduled: 0,
+    switchCancellationRetries: 0,
+  }
+
+  // ---- Switch recovery (#621) ----
+  // A replacement checkout that never activates expires without touching the
+  // source entitlement. Activated replacements whose source cancellation
+  // failed are retried with bounded exponential backoff.
+  const { data: abandonedSwitches } = await supabase
+    .from('platform_subscription_switches')
+    .update({ state: 'abandoned', updated_at: nowIso })
+    .eq('state', 'pending_activation')
+    .lt('expires_at', nowIso)
+    .select('switch_id')
+    .limit(100)
+  result.switchesAbandoned = abandonedSwitches?.length ?? 0
+
+  const { data: cleanupSwitches } = await supabase
+    .from('platform_subscription_switches')
+    .select('switch_id')
+    .in('state', ['cancellation_pending', 'cancellation_retry'])
+    .lte('next_retry_at', nowIso)
+    .order('next_retry_at', { ascending: true })
+    .limit(100)
+
+  for (const row of cleanupSwitches || []) {
+    const outcome = await reconcilePlatformSubscriptionSwitch(supabase, row.switch_id)
+    if (outcome === 'completed') result.switchCancellationsCompleted++
+    else if (outcome === 'scheduled') result.switchCancellationsScheduled++
+    else if (outcome === 'retry') result.switchCancellationRetries++
   }
 
   // ---- Phase 0: expire lapsed payment requests (#546 §2) ----

--- a/docs/superpowers/specs/2026-08-08-provider-switch-review-repairs-design.md
+++ b/docs/superpowers/specs/2026-08-08-provider-switch-review-repairs-design.md
@@ -1,0 +1,78 @@
+# Provider Switch Review Repairs
+
+## Context
+
+PR #627 introduces a durable ledger for switching a tenant's platform subscription between payment providers. Review found correctness gaps around same-rail crypto renewals, expired replacement intents, manual-payment lifecycle cleanup, cancellation idempotency, and cron ordering.
+
+The repair must preserve the core invariant: the current paid entitlement remains active until a validated replacement payment is promoted atomically. Delayed events for a superseded provider must never mutate the current entitlement.
+
+## Scope
+
+Address review findings 1–9. Partially address finding 10 by removing dead duplicated activation construction and correcting stale ownership comments. A full migration of every activation and downgrade path into database RPCs is outside this PR because it would broaden the concurrency model beyond issue #621.
+
+## Identity and Activation Rules
+
+The dispatcher will classify activation events into three explicit cases:
+
+1. **Switch activation:** metadata carries a switch ID. Promotion uses the switch RPC and must match tenant, target provider, target plan, interval, and the locked source snapshot.
+2. **Same-rail self-managed renewal:** the provider is the current provider and its capabilities declare a self-managed period. A signed or independently verified activation may rotate the synthetic external subscription ID and extend the period. Cross-provider events cannot use this exception.
+3. **First or terminal-state activation:** there is no stored external identity, or the stored row belongs to the same provider and is in a terminal state. A different provider requires a switch ID even when the current row is inactive.
+
+All other nonterminal events must match the current provider and external subscription identity exactly. Terminal events retain the existing exact-match downgrade rule; superseded terminal events may only close cleanup ledger state.
+
+## Switch State Lifecycle
+
+`cancellation_scheduled` records that the source provider accepted period-end cancellation. It is a closed cleanup outcome for concurrency purposes, so it will no longer participate in the one-open-switch-per-tenant unique index. Its eventual terminal webhook can still set `completed_at`.
+
+Validated payment activation may revive an `abandoned` switch only when the source snapshot still exactly matches the current subscription. This covers provider-webhook, on-chain verification, and confirmed manual-payment races after an expiry sweep. It does not permit revival after a newer switch has promoted because the source snapshot will no longer match.
+
+Hosted checkout abandonment will use a shorter durable timeout. Provider session expiry may shorten the pending window, but late validated payment remains recoverable through the guarded promotion rule. Manual and Solana requests retain their request-specific expiry.
+
+Rejecting or expiring a payment request will transition its linked pending switch to `failed` or `abandoned`, releasing the unique slot immediately. Terminal or already-promoted switches are untouched.
+
+## Cancellation Idempotency
+
+Generic error-message regex classification will be removed. Each provider adapter will classify its own structured response:
+
+- Stripe treats only its structured missing-resource code/status as already canceled.
+- Lemon Squeezy treats only an HTTP 404 response as already canceled; authentication, store, and validation failures remain retryable failures.
+- PayPal treats only an HTTP 404 response as already canceled.
+
+Adapters return a successful immediate cancellation result for the already-absent case. The coordinator treats every thrown error as retryable and records it in the ledger.
+
+## Cron Behavior
+
+Critical subscription phases—payment-request expiry, reminders, grace handling, and downgrades—will run before external provider cancellation calls. Switch cleanup will process a small bounded batch after those phases. This prevents a slow or degraded provider from starving entitlement and notification work.
+
+Expired payment requests and their linked switches will be reconciled together. Switch cleanup counters remain in the cron response for observability.
+
+## Maintainability
+
+Manual activation values will be constructed only inside the non-switch branch where they are used. Comments in downgrade helpers will describe the split ownership accurately: legacy expiry uses the TypeScript transition, while webhook exact-match downgrade uses the atomic RPC.
+
+The SQL RPC remains the canonical atomic writer for switch promotion. Non-switch activation behavior is unchanged.
+
+## Error Handling and Recovery
+
+- A late validated payment promotes if and only if the original source snapshot is still current.
+- A late payment whose source no longer matches fails safely and remains visible for manual reconciliation; it cannot overwrite a newer entitlement.
+- Provider cancellation failure never rolls back a paid target. It records a retry with bounded exponential backoff.
+- Rejection and expiry release only pending switches linked to that request.
+- Stale or uncorrelated cross-provider events are audited by the webhook ledger and otherwise ignored.
+
+## Verification
+
+Add or extend regression coverage for:
+
+- Binance and Solana same-rail renewal identity rotation and period extension.
+- Cross-provider stale activation while the current row is past due.
+- A scheduled Lemon Squeezy cancellation not blocking a later switch.
+- Revival of an abandoned switch after a validated hosted, Solana, or manual payment.
+- Refusal to revive after the source snapshot changes.
+- Manual rejection and cron expiry releasing the linked pending switch.
+- Provider-specific already-canceled classification, including Lemon Squeezy 422 remaining retryable and Stripe missing-resource convergence.
+- Critical cron phases running independently of a bounded cleanup batch.
+- Existing exact terminal identity, duplicate activation, cancellation retry, RLS, and atomic RPC behavior.
+
+Run the targeted billing suites, the full unit suite, `npm run typecheck`, changed-file lint, a fresh `npm run db:reset`, migration/RPC SQL checks, and `npm run build`.
+

--- a/lib/billing/downgrade-tenant.ts
+++ b/lib/billing/downgrade-tenant.ts
@@ -65,3 +65,26 @@ export async function downgradeTenantToFree(
 
   return platformFee
 }
+
+/**
+ * Webhook-only exact identity downgrade. The database function locks the
+ * current row and changes tenant/subscription/split atomically only when the
+ * provider tuple still matches, so a delayed superseded event is a no-op.
+ */
+export async function downgradeTenantToFreeIfCurrent(
+  adminClient: AdminClient,
+  tenantId: string,
+  paymentProvider: string,
+  providerSubscriptionId: string,
+): Promise<number | null> {
+  const { data, error } = await adminClient.rpc('downgrade_platform_subscription_if_current', {
+    _tenant_id: tenantId,
+    _payment_provider: paymentProvider,
+    _provider_subscription_id: providerSubscriptionId,
+  })
+  if (error) throw new Error(`Exact subscription downgrade failed: ${error.message}`)
+  if (data == null) return null
+
+  await reconcileAccessCutoff(adminClient, tenantId)
+  return Number(data)
+}

--- a/lib/billing/downgrade-tenant.ts
+++ b/lib/billing/downgrade-tenant.ts
@@ -9,9 +9,9 @@ type AdminClient = ReturnType<typeof createAdminClient>
  *
  * The split is read from the free plan's `transaction_fee_percent` in
  * `platform_plans` rather than hardcoded (the seed value is 10%, but reading
- * the row keeps this correct if the free-plan fee ever changes). Shared by the
- * expiry cron and the Stripe platform webhook's `customer.subscription.deleted`
- * handler so both agree on how a downgrade is written.
+ * the row keeps this correct if the free-plan fee ever changes). This writer is
+ * used by the self-managed expiry cron. Provider webhooks use the exact-match
+ * RPC wrapper below so a delayed superseded event cannot race a replacement.
  *
  * Requires a service-role client — `revenue_splits` is super-admin-only under RLS.
  * Returns the platform fee percent that was applied.

--- a/lib/billing/platform-subscription-switch.ts
+++ b/lib/billing/platform-subscription-switch.ts
@@ -85,21 +85,39 @@ export async function attachSwitchCheckoutReference(
   if (error) throw new Error(`Failed to attach replacement checkout: ${error.message}`)
 }
 
-export async function failPlatformSubscriptionSwitch(
+async function closePendingPlatformSubscriptionSwitch(
   admin: SupabaseClient,
   switchId: string | null,
+  state: 'failed' | 'abandoned',
   reason: unknown,
 ): Promise<void> {
   if (!switchId) return
-  await admin
+  const { error } = await admin
     .from('platform_subscription_switches')
     .update({
-      state: 'failed',
+      state,
       last_error: reason instanceof Error ? reason.message : String(reason),
       updated_at: new Date().toISOString(),
     })
     .eq('switch_id', switchId)
     .eq('state', 'pending_activation')
+  if (error) throw new Error(`Failed to close subscription switch: ${error.message}`)
+}
+
+export function failPlatformSubscriptionSwitch(
+  admin: SupabaseClient,
+  switchId: string | null,
+  reason: unknown,
+): Promise<void> {
+  return closePendingPlatformSubscriptionSwitch(admin, switchId, 'failed', reason)
+}
+
+export function abandonPlatformSubscriptionSwitch(
+  admin: SupabaseClient,
+  switchId: string | null,
+  reason: unknown,
+): Promise<void> {
+  return closePendingPlatformSubscriptionSwitch(admin, switchId, 'abandoned', reason)
 }
 
 export interface PromoteSwitchParams {
@@ -160,11 +178,6 @@ async function updateCleanupFailure(admin: SupabaseClient, row: SwitchCleanupRow
   if (writeError) throw new Error(`Failed to persist cancellation retry: ${writeError.message}`)
 }
 
-function alreadyCanceled(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error)
-  return /already (?:been )?cancel|resource_missing|not found|HTTP 404/i.test(message)
-}
-
 /**
  * Cancel source only after replacement promotion. Failure never rolls back the
  * paid target; it leaves a durable retry record for the reconciler.
@@ -207,13 +220,10 @@ export async function reconcilePlatformSubscriptionSwitch(
     if (!paymentProvider.cancelSubscription) {
       throw new Error(`${provider} does not expose subscription cancellation`)
     }
-    let result: CancellationResult
-    try {
-      result = await paymentProvider.cancelSubscription(row.source_provider_subscription_id, true)
-    } catch (cancelError) {
-      if (!alreadyCanceled(cancelError)) throw cancelError
-      result = { mode: 'immediate' as const }
-    }
+    const result: CancellationResult = await paymentProvider.cancelSubscription(
+      row.source_provider_subscription_id,
+      true,
+    )
     const scheduled = result.mode === 'period_end'
     const { error: resultError } = await admin
       .from('platform_subscription_switches')

--- a/lib/billing/platform-subscription-switch.ts
+++ b/lib/billing/platform-subscription-switch.ts
@@ -1,0 +1,287 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { getPlatformBillingProvider } from '@/lib/billing/platform-billing'
+import { PROVIDER_CAPABILITIES } from '@/lib/payments/types'
+import type { CancellationResult, PaymentProvider } from '@/lib/payments/types'
+
+export const SWITCH_METADATA_KEY = 'billing_switch_id'
+
+export class SwitchAlreadyPendingError extends Error {
+  constructor() {
+    super('A payment-method switch is already pending for this school.')
+  }
+}
+
+interface BeginSwitchParams {
+  admin: SupabaseClient
+  tenantId: string
+  targetPlanId: string
+  targetProvider: PaymentProvider
+  targetInterval: 'monthly' | 'yearly'
+  initiatedBy: string
+  expiresAt?: string
+}
+
+/**
+ * Snapshot the current entitlement without mutating it. The partial unique
+ * index is the concurrency guard: two checkout requests cannot mint two open
+ * replacement subscriptions for one tenant.
+ */
+export async function beginPlatformSubscriptionSwitch(
+  params: BeginSwitchParams,
+): Promise<string | null> {
+  const { admin, tenantId, targetPlanId, targetProvider, targetInterval, initiatedBy } = params
+  const { data: source, error: sourceError } = await admin
+    .from('platform_subscriptions')
+    .select('subscription_id, plan_id, payment_provider, provider_subscription_id, current_period_end, status')
+    .eq('tenant_id', tenantId)
+    .maybeSingle()
+
+  if (sourceError) throw new Error(`Failed to read current subscription: ${sourceError.message}`)
+  if (!source || source.status !== 'active' || source.payment_provider === targetProvider) return null
+
+  const switchId = crypto.randomUUID()
+  const { data, error } = await admin
+    .from('platform_subscription_switches')
+    .insert({
+      switch_id: switchId,
+      tenant_id: tenantId,
+      source_subscription_id: source.subscription_id,
+      source_plan_id: source.plan_id,
+      source_payment_provider: source.payment_provider,
+      source_provider_subscription_id: source.provider_subscription_id,
+      source_period_end: source.current_period_end,
+      target_plan_id: targetPlanId,
+      target_payment_provider: targetProvider,
+      target_interval: targetInterval,
+      initiated_by: initiatedBy,
+      ...(params.expiresAt ? { expires_at: params.expiresAt } : {}),
+    })
+    .select('switch_id')
+    .single()
+
+  if (error) {
+    if ((error as { code?: string }).code === '23505') throw new SwitchAlreadyPendingError()
+    throw new Error(`Failed to record subscription switch: ${error.message}`)
+  }
+  return data.switch_id ?? switchId
+}
+
+export async function attachSwitchCheckoutReference(
+  admin: SupabaseClient,
+  switchId: string | null,
+  reference: string | undefined,
+  expiresAt?: Date,
+): Promise<void> {
+  if (!switchId || !reference) return
+  const { error } = await admin
+    .from('platform_subscription_switches')
+    .update({
+      target_checkout_reference: reference,
+      ...(expiresAt ? { expires_at: expiresAt.toISOString() } : {}),
+      updated_at: new Date().toISOString(),
+    })
+    .eq('switch_id', switchId)
+    .eq('state', 'pending_activation')
+  if (error) throw new Error(`Failed to attach replacement checkout: ${error.message}`)
+}
+
+export async function failPlatformSubscriptionSwitch(
+  admin: SupabaseClient,
+  switchId: string | null,
+  reason: unknown,
+): Promise<void> {
+  if (!switchId) return
+  await admin
+    .from('platform_subscription_switches')
+    .update({
+      state: 'failed',
+      last_error: reason instanceof Error ? reason.message : String(reason),
+      updated_at: new Date().toISOString(),
+    })
+    .eq('switch_id', switchId)
+    .eq('state', 'pending_activation')
+}
+
+export interface PromoteSwitchParams {
+  admin: SupabaseClient
+  switchId: string
+  tenantId: string
+  targetProvider: PaymentProvider
+  targetProviderSubscriptionId: string | null
+  targetProviderCustomerId: string | null
+  targetPlanId: string
+  targetStatus: string
+  targetInterval: 'monthly' | 'yearly'
+  targetPeriodStart: string | null
+  targetPeriodEnd: string | null
+}
+
+/** Atomically replace current entitlement and move source cleanup to retryable state. */
+export async function promotePlatformSubscriptionSwitch(params: PromoteSwitchParams): Promise<boolean> {
+  const { data, error } = await params.admin.rpc('promote_platform_subscription_switch', {
+    _switch_id: params.switchId,
+    _tenant_id: params.tenantId,
+    _target_payment_provider: params.targetProvider,
+    _target_provider_subscription_id: params.targetProviderSubscriptionId,
+    _target_provider_customer_id: params.targetProviderCustomerId,
+    _target_plan_id: params.targetPlanId,
+    _target_status: params.targetStatus,
+    _target_interval: params.targetInterval,
+    _target_period_start: params.targetPeriodStart,
+    _target_period_end: params.targetPeriodEnd,
+  })
+  if (error) throw new Error(`Failed to promote subscription switch: ${error.message}`)
+  return data === true
+}
+
+type SwitchCleanupRow = {
+  switch_id: string
+  source_payment_provider: string
+  source_provider_subscription_id: string | null
+  source_period_end: string | null
+  state: string
+  cancel_attempts: number
+}
+
+async function updateCleanupFailure(admin: SupabaseClient, row: SwitchCleanupRow, error: unknown) {
+  const attempt = row.cancel_attempts + 1
+  const delayMinutes = Math.min(2 ** Math.min(attempt, 8), 240)
+  const nextRetry = new Date(Date.now() + delayMinutes * 60_000).toISOString()
+  const { error: writeError } = await admin
+    .from('platform_subscription_switches')
+    .update({
+      state: 'cancellation_retry',
+      cancel_attempts: attempt,
+      last_error: error instanceof Error ? error.message : String(error),
+      next_retry_at: nextRetry,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('switch_id', row.switch_id)
+  if (writeError) throw new Error(`Failed to persist cancellation retry: ${writeError.message}`)
+}
+
+function alreadyCanceled(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+  return /already (?:been )?cancel|resource_missing|not found|HTTP 404/i.test(message)
+}
+
+/**
+ * Cancel source only after replacement promotion. Failure never rolls back the
+ * paid target; it leaves a durable retry record for the reconciler.
+ */
+export async function reconcilePlatformSubscriptionSwitch(
+  admin: SupabaseClient,
+  switchId: string,
+): Promise<'completed' | 'scheduled' | 'retry' | 'ignored'> {
+  const { data, error } = await admin
+    .from('platform_subscription_switches')
+    .select('switch_id, source_payment_provider, source_provider_subscription_id, source_period_end, state, cancel_attempts')
+    .eq('switch_id', switchId)
+    .maybeSingle()
+  if (error) throw new Error(`Failed to load subscription switch: ${error.message}`)
+  const row = data as SwitchCleanupRow | null
+  if (!row || !['cancellation_pending', 'cancellation_retry'].includes(row.state)) return 'ignored'
+
+  const provider = row.source_payment_provider as PaymentProvider
+  const caps = PROVIDER_CAPABILITIES[provider]
+  const now = new Date().toISOString()
+
+  if (!caps?.supportsNativeSubscriptions || !row.source_provider_subscription_id) {
+    const { error: completeError } = await admin
+      .from('platform_subscription_switches')
+      .update({
+        state: 'completed',
+        source_cancel_mode: 'none',
+        completed_at: now,
+        next_retry_at: null,
+        last_error: null,
+        updated_at: now,
+      })
+      .eq('switch_id', switchId)
+    if (completeError) throw new Error(`Failed to complete local-only switch: ${completeError.message}`)
+    return 'completed'
+  }
+
+  try {
+    const paymentProvider = getPlatformBillingProvider(provider)
+    if (!paymentProvider.cancelSubscription) {
+      throw new Error(`${provider} does not expose subscription cancellation`)
+    }
+    let result: CancellationResult
+    try {
+      result = await paymentProvider.cancelSubscription(row.source_provider_subscription_id, true)
+    } catch (cancelError) {
+      if (!alreadyCanceled(cancelError)) throw cancelError
+      result = { mode: 'immediate' as const }
+    }
+    const scheduled = result.mode === 'period_end'
+    const { error: resultError } = await admin
+      .from('platform_subscription_switches')
+      .update({
+        state: scheduled ? 'cancellation_scheduled' : 'completed',
+        source_cancel_mode: result.mode,
+        source_cancel_effective_at:
+          result.effectiveAt?.toISOString() ?? (scheduled ? row.source_period_end : now),
+        cancel_attempts: row.cancel_attempts + 1,
+        completed_at: scheduled ? null : now,
+        next_retry_at: null,
+        last_error: null,
+        updated_at: now,
+      })
+      .eq('switch_id', switchId)
+    if (resultError) throw new Error(`Failed to persist source cancellation result: ${resultError.message}`)
+    return scheduled ? 'scheduled' : 'completed'
+  } catch (cleanupError) {
+    await updateCleanupFailure(admin, row, cleanupError)
+    console.error(`[billing/switch] source cancellation failed for ${switchId}:`, cleanupError)
+    return 'retry'
+  }
+}
+
+/** A delayed source terminal event completes cleanup but never touches entitlement. */
+export async function recordSupersededTerminalEvent(
+  admin: SupabaseClient,
+  provider: string,
+  providerSubscriptionId: string,
+): Promise<boolean> {
+  const now = new Date().toISOString()
+  const { data, error } = await admin
+    .from('platform_subscription_switches')
+    .update({
+      state: 'completed',
+      source_cancel_effective_at: now,
+      completed_at: now,
+      next_retry_at: null,
+      last_error: null,
+      updated_at: now,
+    })
+    .eq('source_payment_provider', provider)
+    .eq('source_provider_subscription_id', providerSubscriptionId)
+    .in('state', ['cancellation_pending', 'cancellation_retry', 'cancellation_scheduled'])
+    .select('switch_id')
+    .maybeSingle()
+  if (error) throw new Error(`Failed to record superseded terminal event: ${error.message}`)
+  return !!data
+}
+
+export function switchIdFromMetadata(metadata: Record<string, string> | undefined): string | null {
+  return metadata?.[SWITCH_METADATA_KEY] ?? null
+}
+
+export async function isCurrentPlatformSubscriptionIdentity(
+  admin: SupabaseClient,
+  tenantId: string,
+  provider: string,
+  providerSubscriptionId: string | undefined,
+): Promise<boolean> {
+  if (!providerSubscriptionId) return false
+  const { data, error } = await admin
+    .from('platform_subscriptions')
+    .select('subscription_id')
+    .eq('tenant_id', tenantId)
+    .eq('payment_provider', provider)
+    .eq('provider_subscription_id', providerSubscriptionId)
+    .maybeSingle()
+  if (error) throw new Error(`Failed to check current subscription identity: ${error.message}`)
+  return !!data
+}

--- a/lib/billing/platform-webhook-dispatch.ts
+++ b/lib/billing/platform-webhook-dispatch.ts
@@ -58,6 +58,8 @@ const ALLOWED_SUB_STATUS = new Set<string>([
   'unpaid',
 ])
 
+const TERMINAL_STORED_STATUS = new Set<string>(['canceled', 'incomplete_expired'])
+
 function storedStatus(status: SubscriptionLifecycleStatus | undefined, fallback: string): string {
   if (!status) return fallback
   if (ALLOWED_SUB_STATUS.has(status)) return status
@@ -361,11 +363,23 @@ export async function dispatchPlatformBillingEvent(
 
   const switchId = switchIdFromMetadata(event.metadata)
   const isSwitchActivation = event.type === 'subscription.activated' && !!switchId
+  const selfManaged = !!PROVIDER_CAPABILITIES[provider as PaymentProvider]?.selfManagedPeriod
+  const isSameRailSelfManagedRenewal =
+    event.type === 'subscription.activated' &&
+    selfManaged &&
+    stored?.payment_provider === provider &&
+    !!event.providerSubscriptionId
   const isFreshActivation =
     event.type === 'subscription.activated' &&
-    stored?.status !== 'active' &&
+    (!stored?.provider_subscription_id ||
+      (stored.payment_provider === provider && TERMINAL_STORED_STATUS.has(stored.status ?? ''))) &&
     !!(event.metadata?.plan_id ?? event.metadata?.planId)
-  if (!isSwitchActivation && !isFreshActivation && stored?.provider_subscription_id) {
+  if (
+    !isSwitchActivation &&
+    !isSameRailSelfManagedRenewal &&
+    !isFreshActivation &&
+    stored?.provider_subscription_id
+  ) {
     const currentIdentity =
       stored.payment_provider === provider &&
       !!event.providerSubscriptionId &&
@@ -423,7 +437,6 @@ export async function dispatchPlatformBillingEvent(
   // is minted for one specific purchase and carries that purchase's plan, so a
   // school moving from Starter to Pro would otherwise have its Pro payment
   // extend its Starter period.
-  const selfManaged = !!PROVIDER_CAPABILITIES[provider as PaymentProvider]?.selfManagedPeriod
   const isFirstActivation = !stored?.plan_id
   const trustMetadataPlan = isFirstActivation || selfManaged || isSwitchActivation
   const planId = trustMetadataPlan ? (event.metadata?.plan_id ?? event.metadata?.planId) : undefined

--- a/lib/billing/platform-webhook-dispatch.ts
+++ b/lib/billing/platform-webhook-dispatch.ts
@@ -22,7 +22,7 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 import { sendEmail } from '@/lib/email/send'
 import { paymentFailedTemplate } from '@/lib/email/templates/payment-failed'
-import { downgradeTenantToFree } from '@/lib/billing/downgrade-tenant'
+import { downgradeTenantToFreeIfCurrent } from '@/lib/billing/downgrade-tenant'
 import { reconcileAccessCutoffSafely } from '@/lib/billing/access-cutoff'
 import { applyPortalPlanChange } from '@/lib/payments/platform-plan-change'
 import { PROVIDER_CAPABILITIES } from '@/lib/payments/types'
@@ -31,6 +31,13 @@ import type {
   PaymentProvider,
   SubscriptionLifecycleStatus,
 } from '@/lib/payments/types'
+import {
+  isCurrentPlatformSubscriptionIdentity,
+  promotePlatformSubscriptionSwitch,
+  reconcilePlatformSubscriptionSwitch,
+  recordSupersededTerminalEvent,
+  switchIdFromMetadata,
+} from '@/lib/billing/platform-subscription-switch'
 
 /**
  * `platform_subscriptions.status` is CHECK-constrained
@@ -117,13 +124,29 @@ async function resolveTenantId(
       .eq('provider_subscription_id', event.providerSubscriptionId)
       .maybeSingle(),
   )
-  return (row as { tenant_id: string } | null)?.tenant_id ?? null
+  const currentTenant = (row as { tenant_id: string } | null)?.tenant_id
+  if (currentTenant) return currentTenant
+
+  const sourceSwitch = await unwrap(
+    'platform_subscription_switches lookup by source identity',
+    admin
+      .from('platform_subscription_switches')
+      .select('tenant_id')
+      .eq('source_payment_provider', provider)
+      .eq('source_provider_subscription_id', event.providerSubscriptionId)
+      .in('state', ['cancellation_pending', 'cancellation_retry', 'cancellation_scheduled'])
+      .limit(1)
+      .maybeSingle(),
+  )
+  return (sourceSwitch as { tenant_id: string } | null)?.tenant_id ?? null
 }
 
 interface StoredSubscription {
   plan_id: string | null
   status: string | null
   current_period_end: string | null
+  payment_provider: string | null
+  provider_subscription_id: string | null
 }
 
 /**
@@ -292,7 +315,35 @@ export async function dispatchPlatformBillingEvent(
   // canceled + tenant reset + free-plan split + access-cutoff reconcile), and
   // duplicating any of it here is how the two paths drift.
   if (event.type === 'subscription.canceled' || event.type === 'subscription.expired') {
-    const platformFee = await downgradeTenantToFree(admin, tenantId)
+    if (!event.providerSubscriptionId) {
+      console.warn(`[platform-webhook] ${event.type} on ${provider} has no subscription identity — ignoring`)
+      return
+    }
+    const current = await isCurrentPlatformSubscriptionIdentity(
+      admin,
+      tenantId,
+      provider,
+      event.providerSubscriptionId,
+    )
+    if (!current) {
+      const superseded = await recordSupersededTerminalEvent(
+        admin,
+        provider,
+        event.providerSubscriptionId,
+      )
+      console.log(
+        `[platform-webhook] ${event.type} for non-current ${provider}/${event.providerSubscriptionId} ` +
+          (superseded ? 'completed switch cleanup' : 'was ignored'),
+      )
+      return
+    }
+    const platformFee = await downgradeTenantToFreeIfCurrent(
+      admin,
+      tenantId,
+      provider,
+      event.providerSubscriptionId,
+    )
+    if (platformFee == null) return
     console.log(
       `[platform-webhook] subscription ${event.type} on ${provider}, tenant ${tenantId} downgraded to free (fee=${platformFee}%)`,
     )
@@ -303,12 +354,31 @@ export async function dispatchPlatformBillingEvent(
     'platform_subscriptions lookup',
     admin
       .from('platform_subscriptions')
-      .select('plan_id, status, current_period_end')
+      .select('plan_id, status, current_period_end, payment_provider, provider_subscription_id')
       .eq('tenant_id', tenantId)
       .maybeSingle(),
   )) as StoredSubscription | null
 
-  if (isStalePeriod(stored, tenantId, event.periodEnd)) return
+  const switchId = switchIdFromMetadata(event.metadata)
+  const isSwitchActivation = event.type === 'subscription.activated' && !!switchId
+  const isFreshActivation =
+    event.type === 'subscription.activated' &&
+    stored?.status !== 'active' &&
+    !!(event.metadata?.plan_id ?? event.metadata?.planId)
+  if (!isSwitchActivation && !isFreshActivation && stored?.provider_subscription_id) {
+    const currentIdentity =
+      stored.payment_provider === provider &&
+      !!event.providerSubscriptionId &&
+      stored.provider_subscription_id === event.providerSubscriptionId
+    if (!currentIdentity) {
+      console.log(
+        `[platform-webhook] ${event.type} for non-current ${provider}/${event.providerSubscriptionId ?? 'missing'} ignored`,
+      )
+      return
+    }
+  }
+
+  if (!isSwitchActivation && isStalePeriod(stored, tenantId, event.periodEnd)) return
 
   const status = storedStatus(event.subscriptionStatus, STATUS_BY_TYPE[event.type] ?? 'active')
   const periodStart = event.periodStart?.toISOString()
@@ -355,7 +425,7 @@ export async function dispatchPlatformBillingEvent(
   // extend its Starter period.
   const selfManaged = !!PROVIDER_CAPABILITIES[provider as PaymentProvider]?.selfManagedPeriod
   const isFirstActivation = !stored?.plan_id
-  const trustMetadataPlan = isFirstActivation || selfManaged
+  const trustMetadataPlan = isFirstActivation || selfManaged || isSwitchActivation
   const planId = trustMetadataPlan ? (event.metadata?.plan_id ?? event.metadata?.planId) : undefined
   const planSlug = trustMetadataPlan
     ? (event.metadata?.plan_slug ?? event.metadata?.planSlug)
@@ -368,7 +438,7 @@ export async function dispatchPlatformBillingEvent(
   // date — it is the whole difference between a paid month and a free one.
   const derived =
     selfManaged && !event.periodEnd && status === 'active'
-      ? selfManagedPeriod(stored?.current_period_end, interval, new Date(now))
+      ? selfManagedPeriod(isSwitchActivation ? null : stored?.current_period_end, interval, new Date(now))
       : null
 
   const effectiveStart = periodStart ?? derived?.start.toISOString()
@@ -430,6 +500,48 @@ export async function dispatchPlatformBillingEvent(
     // A paid period resets the reminder stamp so the next cycle can remind
     // again — the same un-cancel semantics confirmManualPayment applies (#546).
     ...(status === 'active' ? { renewal_reminder_sent_at: null } : {}),
+  }
+
+  if (isSwitchActivation) {
+    if (
+      PROVIDER_CAPABILITIES[provider as PaymentProvider]?.supportsNativeSubscriptions &&
+      !event.providerSubscriptionId
+    ) {
+      throw new Error(`Replacement activation on ${provider} has no subscription identity`)
+    }
+    const promoted = await promotePlatformSubscriptionSwitch({
+      admin,
+      switchId: switchId!,
+      tenantId,
+      targetProvider: provider as PaymentProvider,
+      targetProviderSubscriptionId: event.providerSubscriptionId ?? null,
+      targetProviderCustomerId: event.providerCustomerId ?? null,
+      targetPlanId: rowPlanId,
+      targetStatus: status,
+      targetInterval: interval ?? 'monthly',
+      targetPeriodStart: effectiveStart ?? null,
+      targetPeriodEnd: effectiveEnd ?? null,
+    })
+    if (!promoted) {
+      throw new Error(`Subscription switch ${switchId} no longer matches current billing state`)
+    }
+
+    if (event.providerCustomerId) {
+      await unwrap(
+        'tenant_billing_customers upsert',
+        admin.from('tenant_billing_customers').upsert(
+          {
+            tenant_id: tenantId,
+            payment_provider: provider,
+            provider_customer_id: event.providerCustomerId,
+          },
+          { onConflict: 'tenant_id,payment_provider' },
+        ),
+      )
+    }
+    if (status === 'active') await reconcileAccessCutoffSafely(admin, tenantId)
+    await reconcilePlatformSubscriptionSwitch(admin, switchId!)
+    return
   }
 
   // upsert, not update: a hosted-checkout activation is the first time this

--- a/lib/billing/solana-platform-payment.ts
+++ b/lib/billing/solana-platform-payment.ts
@@ -192,6 +192,9 @@ export interface RecordRequestParams {
   /** The on-chain reference the QR carries, from the provider's session. */
   reference: string
   settlement: PlatformSettlement
+  /** Correlates a cross-provider replacement without touching source entitlement. */
+  switchId?: string | null
+  expiresAt?: string
 }
 
 /**
@@ -205,7 +208,18 @@ export interface RecordRequestParams {
 export async function recordSolanaPlatformRequest(
   params: RecordRequestParams,
 ): Promise<{ requestId: string }> {
-  const { admin, tenantId, userId, planId, amountUsd, interval, reference, settlement } = params
+  const {
+    admin,
+    tenantId,
+    userId,
+    planId,
+    amountUsd,
+    interval,
+    reference,
+    settlement,
+    switchId,
+    expiresAt,
+  } = params
 
   const [{ data: target }, { data: tenant }] = await Promise.all([
     admin.from('platform_plans').select('sort_order').eq('plan_id', planId).maybeSingle(),
@@ -249,7 +263,8 @@ export async function recordSolanaPlatformRequest(
       settlement_base: settlement.base,
       settlement_mint: settlement.mint,
       settlement_sol_usd: settlement.solUsd,
-      expires_at: requestExpiresAt(),
+      expires_at: expiresAt ?? requestExpiresAt(),
+      switch_id: switchId ?? null,
     })
     .select('request_id')
     .single()

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -4612,6 +4612,7 @@ export type Database = {
           settlement_mint: string | null
           settlement_sol_usd: number | null
           status: string
+          switch_id: string | null
           tenant_id: string
           updated_at: string | null
         }
@@ -4639,6 +4640,7 @@ export type Database = {
           settlement_mint?: string | null
           settlement_sol_usd?: number | null
           status?: string
+          switch_id?: string | null
           tenant_id: string
           updated_at?: string | null
         }
@@ -4666,6 +4668,7 @@ export type Database = {
           settlement_mint?: string | null
           settlement_sol_usd?: number | null
           status?: string
+          switch_id?: string | null
           tenant_id?: string
           updated_at?: string | null
         }
@@ -4676,6 +4679,13 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "platform_plans"
             referencedColumns: ["plan_id"]
+          },
+          {
+            foreignKeyName: "platform_payment_requests_switch_id_fkey"
+            columns: ["switch_id"]
+            isOneToOne: false
+            referencedRelation: "platform_subscription_switches"
+            referencedColumns: ["switch_id"]
           },
           {
             foreignKeyName: "platform_payment_requests_tenant_id_fkey"
@@ -4780,6 +4790,116 @@ export type Database = {
           updated_at?: string | null
         }
         Relationships: []
+      }
+      platform_subscription_switches: {
+        Row: {
+          activated_at: string | null
+          cancel_attempts: number
+          completed_at: string | null
+          created_at: string
+          expires_at: string
+          initiated_by: string | null
+          last_error: string | null
+          next_retry_at: string | null
+          source_cancel_effective_at: string | null
+          source_cancel_mode: string | null
+          source_payment_provider: string
+          source_period_end: string | null
+          source_plan_id: string
+          source_provider_subscription_id: string | null
+          source_subscription_id: string
+          state: string
+          switch_id: string
+          target_checkout_reference: string | null
+          target_interval: string
+          target_payment_provider: string
+          target_plan_id: string
+          target_provider_subscription_id: string | null
+          tenant_id: string
+          updated_at: string
+        }
+        Insert: {
+          activated_at?: string | null
+          cancel_attempts?: number
+          completed_at?: string | null
+          created_at?: string
+          expires_at?: string
+          initiated_by?: string | null
+          last_error?: string | null
+          next_retry_at?: string | null
+          source_cancel_effective_at?: string | null
+          source_cancel_mode?: string | null
+          source_payment_provider: string
+          source_period_end?: string | null
+          source_plan_id: string
+          source_provider_subscription_id?: string | null
+          source_subscription_id: string
+          state?: string
+          switch_id?: string
+          target_checkout_reference?: string | null
+          target_interval: string
+          target_payment_provider: string
+          target_plan_id: string
+          target_provider_subscription_id?: string | null
+          tenant_id: string
+          updated_at?: string
+        }
+        Update: {
+          activated_at?: string | null
+          cancel_attempts?: number
+          completed_at?: string | null
+          created_at?: string
+          expires_at?: string
+          initiated_by?: string | null
+          last_error?: string | null
+          next_retry_at?: string | null
+          source_cancel_effective_at?: string | null
+          source_cancel_mode?: string | null
+          source_payment_provider?: string
+          source_period_end?: string | null
+          source_plan_id?: string
+          source_provider_subscription_id?: string | null
+          source_subscription_id?: string
+          state?: string
+          switch_id?: string
+          target_checkout_reference?: string | null
+          target_interval?: string
+          target_payment_provider?: string
+          target_plan_id?: string
+          target_provider_subscription_id?: string | null
+          tenant_id?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "platform_subscription_switches_source_plan_id_fkey"
+            columns: ["source_plan_id"]
+            isOneToOne: false
+            referencedRelation: "platform_plans"
+            referencedColumns: ["plan_id"]
+          },
+          {
+            foreignKeyName: "platform_subscription_switches_source_subscription_id_fkey"
+            columns: ["source_subscription_id"]
+            isOneToOne: false
+            referencedRelation: "platform_subscriptions"
+            referencedColumns: ["subscription_id"]
+          },
+          {
+            foreignKeyName: "platform_subscription_switches_target_plan_id_fkey"
+            columns: ["target_plan_id"]
+            isOneToOne: false
+            referencedRelation: "platform_plans"
+            referencedColumns: ["plan_id"]
+          },
+          {
+            foreignKeyName: "platform_subscription_switches_tenant_id_fkey"
+            columns: ["tenant_id"]
+            isOneToOne: false
+            referencedRelation: "tenants"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       platform_subscriptions: {
         Row: {
@@ -6395,6 +6515,29 @@ export type Database = {
       }
     }
     Functions: {
+      downgrade_platform_subscription_if_current: {
+        Args: {
+          _payment_provider: string
+          _provider_subscription_id: string
+          _tenant_id: string
+        }
+        Returns: number
+      }
+      promote_platform_subscription_switch: {
+        Args: {
+          _switch_id: string
+          _target_interval: string
+          _target_payment_provider: string
+          _target_period_end: string | null
+          _target_period_start: string | null
+          _target_plan_id: string
+          _target_provider_customer_id: string | null
+          _target_provider_subscription_id: string | null
+          _target_status: string
+          _tenant_id: string
+        }
+        Returns: boolean
+      }
       award_xp:
         | {
             Args: {

--- a/lib/payments/binance-provider.ts
+++ b/lib/payments/binance-provider.ts
@@ -61,6 +61,7 @@ interface BinancePassThrough {
   plan_id?: string
   plan_slug?: string
   interval?: string
+  billing_switch_id?: string
   /** Our own reference, when it did not fit `merchantTradeNo`. See below. */
   ref?: string
 }
@@ -75,6 +76,7 @@ const PASS_THROUGH_KEYS: (keyof BinancePassThrough)[] = [
   'plan_id',
   'plan_slug',
   'interval',
+  'billing_switch_id',
   'ref',
 ]
 

--- a/lib/payments/lemonsqueezy-provider.ts
+++ b/lib/payments/lemonsqueezy-provider.ts
@@ -355,6 +355,8 @@ export class LemonSqueezyProvider implements IPaymentProvider {
       headers: this.headers,
     })
 
+    if (response.status === 404) return { mode: 'immediate' }
+
     if (!response.ok) {
       const text = await response.text()
       throw new Error(

--- a/lib/payments/lemonsqueezy-provider.ts
+++ b/lib/payments/lemonsqueezy-provider.ts
@@ -27,6 +27,7 @@ import {
   CreateCheckoutParams,
   CheckoutSession,
   RefundParams,
+  CancellationResult,
 } from './types'
 
 const LS_BASE_URL = 'https://api.lemonsqueezy.com'
@@ -347,7 +348,7 @@ export class LemonSqueezyProvider implements IPaymentProvider {
    * endpoint. The `immediate` flag is accepted for interface compatibility but
    * has no effect; the subscription remains accessible until `renews_at`.
    */
-  async cancelSubscription(providerSubId: string, _immediate: boolean): Promise<void> {
+  async cancelSubscription(providerSubId: string, _immediate: boolean): Promise<CancellationResult> {
     // NOTE: `immediate` is ignored — LS only supports cancel-at-period-end via API.
     const response = await fetch(`${LS_BASE_URL}/v1/subscriptions/${providerSubId}`, {
       method: 'DELETE',
@@ -359,6 +360,12 @@ export class LemonSqueezyProvider implements IPaymentProvider {
       throw new Error(
         `LemonSqueezy cancelSubscription failed: HTTP ${response.status} — ${text}`,
       )
+    }
+    const payload = await response.json().catch(() => null)
+    const endsAt = payload?.data?.attributes?.ends_at ?? payload?.data?.attributes?.renews_at
+    return {
+      mode: 'period_end',
+      ...(endsAt ? { effectiveAt: new Date(endsAt) } : {}),
     }
   }
 

--- a/lib/payments/manual-provider.ts
+++ b/lib/payments/manual-provider.ts
@@ -15,6 +15,7 @@ import {
   CreateSubscriptionParams,
   ProviderSubscription,
   ProviderCapabilities,
+  CancellationResult,
 } from './types'
 
 export class ManualPaymentProvider implements IPaymentProvider {
@@ -139,8 +140,9 @@ export class ManualPaymentProvider implements IPaymentProvider {
     }
   }
 
-  async cancelSubscription(providerSubId: string, immediate: boolean): Promise<void> {
+  async cancelSubscription(_providerSubId: string, _immediate: boolean): Promise<CancellationResult> {
     // Nothing to cancel externally — the DB row carries the real state.
+    return { mode: 'none' }
   }
 
   async reactivateSubscription(providerSubId: string): Promise<void> {

--- a/lib/payments/paypal-provider.ts
+++ b/lib/payments/paypal-provider.ts
@@ -37,6 +37,7 @@ import {
   CreateCheckoutParams,
   CheckoutSession,
   RefundParams,
+  CancellationResult,
 } from './types'
 
 /**
@@ -722,7 +723,7 @@ export class PayPalPaymentProvider implements IPaymentProvider {
    * (Same access semantics as Lemon Squeezy: the CANCELLED webhook drives the
    * app-side status change.)
    */
-  async cancelSubscription(providerSubId: string, immediate: boolean): Promise<void> {
+  async cancelSubscription(providerSubId: string, immediate: boolean): Promise<CancellationResult> {
     await this.api(`/v1/billing/subscriptions/${providerSubId}/cancel`, {
       method: 'POST',
       label: 'cancelSubscription',
@@ -730,6 +731,7 @@ export class PayPalPaymentProvider implements IPaymentProvider {
         reason: immediate ? 'Canceled immediately by school admin' : 'Canceled by subscriber',
       }),
     })
+    return { mode: 'immediate' }
   }
 
   async getSubscription(providerSubId: string): Promise<ProviderSubscription> {

--- a/lib/payments/paypal-provider.ts
+++ b/lib/payments/paypal-provider.ts
@@ -40,6 +40,15 @@ import {
   CancellationResult,
 } from './types'
 
+class PayPalApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+  ) {
+    super(message)
+  }
+}
+
 /**
  * One-time prices have no PayPal catalog object (Orders v2 charges a raw
  * amount), so createPrice synthesises a deterministic id with this prefix.
@@ -167,8 +176,9 @@ export class PayPalPaymentProvider implements IPaymentProvider {
 
     if (!response.ok) {
       const text = await response.text()
-      throw new Error(
+      throw new PayPalApiError(
         `PayPal ${init?.label ?? path} failed: HTTP ${response.status} — ${text}`,
+        response.status,
       )
     }
 
@@ -724,13 +734,17 @@ export class PayPalPaymentProvider implements IPaymentProvider {
    * app-side status change.)
    */
   async cancelSubscription(providerSubId: string, immediate: boolean): Promise<CancellationResult> {
-    await this.api(`/v1/billing/subscriptions/${providerSubId}/cancel`, {
-      method: 'POST',
-      label: 'cancelSubscription',
-      body: JSON.stringify({
-        reason: immediate ? 'Canceled immediately by school admin' : 'Canceled by subscriber',
-      }),
-    })
+    try {
+      await this.api(`/v1/billing/subscriptions/${providerSubId}/cancel`, {
+        method: 'POST',
+        label: 'cancelSubscription',
+        body: JSON.stringify({
+          reason: immediate ? 'Canceled immediately by school admin' : 'Canceled by subscriber',
+        }),
+      })
+    } catch (error) {
+      if (!(error instanceof PayPalApiError) || error.status !== 404) throw error
+    }
     return { mode: 'immediate' }
   }
 

--- a/lib/payments/solana-subscriptions-provider.ts
+++ b/lib/payments/solana-subscriptions-provider.ts
@@ -32,6 +32,7 @@ import {
   CreateCheckoutParams,
   CheckoutSession,
   NormalizedBillingEvent,
+  CancellationResult,
 } from './types'
 import { generateReference } from './solana-split'
 
@@ -145,7 +146,7 @@ export class SolanaSubscriptionsProvider implements IPaymentProvider {
    * revokes the delegation itself from the billing page (`/api/payments/solana/
    * cancel-tx` → wallet sign → `/api/payments/solana/cancel-verify`).
    */
-  async cancelSubscription(_providerSubId: string, _immediate: boolean): Promise<void> {
+  async cancelSubscription(_providerSubId: string, _immediate: boolean): Promise<CancellationResult> {
     throw new Error(
       'solana_subs: the on-chain auto-pull delegation cannot be revoked server-side — it requires the subscriber\'s wallet signature. The subscription has been canceled in our records (the crank will not charge it), but the student must revoke the delegation from their wallet on the billing page.',
     )

--- a/lib/payments/stripe-provider.ts
+++ b/lib/payments/stripe-provider.ts
@@ -25,6 +25,7 @@ import {
   PreviewSubscriptionChangeParams,
   ProrationPreview,
   CustomerPortalSessionParams,
+  CancellationResult,
 } from './types'
 import { SUBSCRIPTION_LIFECYCLE_STATUSES } from './types'
 
@@ -287,14 +288,20 @@ export class StripePaymentProvider implements IPaymentProvider {
   /**
    * Cancel a Stripe subscription — immediately or at the end of the period.
    */
-  async cancelSubscription(providerSubId: string, immediate: boolean): Promise<void> {
+  async cancelSubscription(providerSubId: string, immediate: boolean): Promise<CancellationResult> {
     try {
       if (immediate) {
         await this.stripe.subscriptions.cancel(providerSubId)
+        return { mode: 'immediate' }
       } else {
-        await this.stripe.subscriptions.update(providerSubId, {
+        const subscription = await this.stripe.subscriptions.update(providerSubId, {
           cancel_at_period_end: true,
         })
+        const periodEnd = subscription.items.data[0]?.current_period_end
+        return {
+          mode: 'period_end',
+          ...(periodEnd ? { effectiveAt: new Date(periodEnd * 1000) } : {}),
+        }
       }
     } catch (error) {
       throw new Error(`Stripe cancelSubscription failed: ${error instanceof Error ? error.message : 'Unknown error'}`)

--- a/lib/payments/stripe-provider.ts
+++ b/lib/payments/stripe-provider.ts
@@ -304,6 +304,18 @@ export class StripePaymentProvider implements IPaymentProvider {
         }
       }
     } catch (error) {
+      const stripeError = error as {
+        code?: string
+        statusCode?: number
+        raw?: { code?: string }
+      }
+      if (
+        stripeError.code === 'resource_missing' ||
+        stripeError.raw?.code === 'resource_missing' ||
+        stripeError.statusCode === 404
+      ) {
+        return { mode: 'immediate' }
+      }
       throw new Error(`Stripe cancelSubscription failed: ${error instanceof Error ? error.message : 'Unknown error'}`)
     }
   }

--- a/lib/payments/types.ts
+++ b/lib/payments/types.ts
@@ -620,6 +620,12 @@ export interface NormalizedBillingEvent {
   raw: unknown
 }
 
+/** Provider-reported effect of a cancellation request. */
+export interface CancellationResult {
+  mode: 'none' | 'immediate' | 'period_end'
+  effectiveAt?: Date
+}
+
 export interface RefundParams {
   providerPaymentId: string
   amount?: number // omit for full refund
@@ -662,7 +668,7 @@ export interface IPaymentProvider {
   // Subscription operations (optional — providers without recurring billing,
   // e.g. manual/offline, implement these as no-ops)
   createSubscription?(params: CreateSubscriptionParams): Promise<ProviderSubscription>
-  cancelSubscription?(providerSubId: string, immediate: boolean): Promise<void>
+  cancelSubscription?(providerSubId: string, immediate: boolean): Promise<CancellationResult>
   // Reverse a scheduled cancel-at-period-end before the period ends. Providers
   // that scheduled the cancel on their side (Stripe, Lemon Squeezy) must clear it
   // here — a DB-only "reactivate" would leave the provider still set to cancel and

--- a/supabase/migrations/20260808154118_safe_platform_subscription_switches.sql
+++ b/supabase/migrations/20260808154118_safe_platform_subscription_switches.sql
@@ -1,0 +1,268 @@
+-- Safe provider switching for school -> platform subscriptions (issue #621).
+--
+-- `platform_subscriptions` intentionally remains the one CURRENT entitlement
+-- row per tenant. This ledger retains the source identity while a replacement
+-- is pending and until source-provider cancellation has converged.
+
+CREATE TABLE public.platform_subscription_switches (
+  switch_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id UUID NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  source_subscription_id UUID NOT NULL REFERENCES public.platform_subscriptions(subscription_id),
+  source_plan_id UUID NOT NULL REFERENCES public.platform_plans(plan_id),
+  source_payment_provider TEXT NOT NULL CHECK (source_payment_provider IN (
+    'stripe', 'paypal', 'binance', 'binance_personal',
+    'manual', 'lemonsqueezy', 'solana', 'solana_subs'
+  )),
+  source_provider_subscription_id TEXT,
+  source_period_end TIMESTAMPTZ,
+  target_plan_id UUID NOT NULL REFERENCES public.platform_plans(plan_id),
+  target_payment_provider TEXT NOT NULL CHECK (target_payment_provider IN (
+    'stripe', 'paypal', 'binance', 'binance_personal',
+    'manual', 'lemonsqueezy', 'solana', 'solana_subs'
+  )),
+  target_interval TEXT NOT NULL CHECK (target_interval IN ('monthly', 'yearly')),
+  target_provider_subscription_id TEXT,
+  target_checkout_reference TEXT,
+  state TEXT NOT NULL DEFAULT 'pending_activation'
+    CHECK (state IN (
+      'pending_activation', 'cancellation_pending', 'cancellation_retry',
+      'cancellation_scheduled', 'completed', 'failed', 'abandoned'
+    )),
+  source_cancel_mode TEXT CHECK (source_cancel_mode IN ('none', 'immediate', 'period_end')),
+  source_cancel_effective_at TIMESTAMPTZ,
+  cancel_attempts INTEGER NOT NULL DEFAULT 0 CHECK (cancel_attempts >= 0),
+  last_error TEXT,
+  next_retry_at TIMESTAMPTZ,
+  expires_at TIMESTAMPTZ NOT NULL DEFAULT (now() + interval '7 days'),
+  initiated_by UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  activated_at TIMESTAMPTZ,
+  completed_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CHECK (source_payment_provider <> target_payment_provider)
+);
+
+CREATE UNIQUE INDEX platform_subscription_switches_one_open_per_tenant
+  ON public.platform_subscription_switches(tenant_id)
+  WHERE state IN (
+    'pending_activation', 'cancellation_pending', 'cancellation_retry',
+    'cancellation_scheduled'
+  );
+
+CREATE UNIQUE INDEX platform_subscription_switches_target_identity
+  ON public.platform_subscription_switches(target_payment_provider, target_provider_subscription_id)
+  WHERE target_provider_subscription_id IS NOT NULL;
+
+CREATE INDEX platform_subscription_switches_source_identity
+  ON public.platform_subscription_switches(source_payment_provider, source_provider_subscription_id)
+  WHERE source_provider_subscription_id IS NOT NULL;
+
+CREATE INDEX platform_subscription_switches_retry
+  ON public.platform_subscription_switches(next_retry_at)
+  WHERE state IN ('cancellation_pending', 'cancellation_retry');
+
+CREATE UNIQUE INDEX IF NOT EXISTS platform_subscriptions_provider_identity_unique
+  ON public.platform_subscriptions(payment_provider, provider_subscription_id)
+  WHERE provider_subscription_id IS NOT NULL;
+
+ALTER TABLE public.platform_subscription_switches ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Tenant admins can view own subscription switches"
+  ON public.platform_subscription_switches FOR SELECT TO authenticated
+  USING (
+    tenant_id IN (
+      SELECT tenant_id
+      FROM public.tenant_users
+      WHERE user_id = auth.uid() AND role = 'admin' AND status = 'active'
+    )
+  );
+
+GRANT SELECT ON public.platform_subscription_switches TO authenticated;
+GRANT ALL ON public.platform_subscription_switches TO service_role;
+REVOKE ALL ON public.platform_subscription_switches FROM anon;
+REVOKE INSERT, UPDATE, DELETE ON public.platform_subscription_switches FROM authenticated;
+
+ALTER TABLE public.platform_payment_requests
+  ADD COLUMN switch_id UUID REFERENCES public.platform_subscription_switches(switch_id) ON DELETE SET NULL;
+
+CREATE INDEX platform_payment_requests_switch_id
+  ON public.platform_payment_requests(switch_id)
+  WHERE switch_id IS NOT NULL;
+
+-- Promote only while the ledger's source snapshot still matches the tenant's
+-- current row. The row locks serialize replacement activation against an exact
+-- terminal downgrade. Replays after promotion return true without extending a
+-- period or replacing the source snapshot again.
+CREATE OR REPLACE FUNCTION public.promote_platform_subscription_switch(
+  _switch_id UUID,
+  _tenant_id UUID,
+  _target_payment_provider TEXT,
+  _target_provider_subscription_id TEXT,
+  _target_provider_customer_id TEXT,
+  _target_plan_id UUID,
+  _target_status TEXT,
+  _target_interval TEXT,
+  _target_period_start TIMESTAMPTZ,
+  _target_period_end TIMESTAMPTZ
+) RETURNS BOOLEAN
+LANGUAGE plpgsql
+SET search_path = public
+AS $$
+DECLARE
+  _switch public.platform_subscription_switches%ROWTYPE;
+  _current public.platform_subscriptions%ROWTYPE;
+  _plan_slug TEXT;
+  _platform_fee NUMERIC;
+  _now TIMESTAMPTZ := now();
+BEGIN
+  SELECT * INTO _switch
+  FROM public.platform_subscription_switches
+  WHERE switch_id = _switch_id AND tenant_id = _tenant_id
+  FOR UPDATE;
+
+  IF NOT FOUND
+     OR _switch.target_payment_provider <> _target_payment_provider
+     OR _switch.target_plan_id <> _target_plan_id
+     OR _switch.target_interval <> _target_interval THEN
+    RETURN FALSE;
+  END IF;
+
+  IF _switch.state IN ('cancellation_pending', 'cancellation_retry', 'cancellation_scheduled', 'completed') THEN
+    RETURN _switch.target_provider_subscription_id IS NOT DISTINCT FROM _target_provider_subscription_id;
+  END IF;
+  IF _switch.state <> 'pending_activation' THEN
+    RETURN FALSE;
+  END IF;
+
+  SELECT * INTO _current
+  FROM public.platform_subscriptions
+  WHERE tenant_id = _tenant_id
+  FOR UPDATE;
+
+  IF NOT FOUND
+     OR _current.subscription_id <> _switch.source_subscription_id
+     OR _current.payment_provider <> _switch.source_payment_provider
+     OR _current.provider_subscription_id IS DISTINCT FROM _switch.source_provider_subscription_id THEN
+    RETURN FALSE;
+  END IF;
+
+  SELECT slug, transaction_fee_percent INTO _plan_slug, _platform_fee
+  FROM public.platform_plans
+  WHERE plan_id = _target_plan_id;
+  IF NOT FOUND THEN RETURN FALSE; END IF;
+
+  UPDATE public.platform_subscriptions
+  SET plan_id = _target_plan_id,
+      payment_provider = _target_payment_provider,
+      provider_subscription_id = _target_provider_subscription_id,
+      provider_customer_id = _target_provider_customer_id,
+      status = _target_status,
+      interval = _target_interval,
+      current_period_start = _target_period_start,
+      current_period_end = _target_period_end,
+      cancel_at_period_end = FALSE,
+      canceled_at = NULL,
+      grace_period_end = NULL,
+      renewal_reminder_sent_at = NULL,
+      plan_override_at = NULL,
+      plan_override_by = NULL,
+      updated_at = _now
+  WHERE subscription_id = _current.subscription_id;
+
+  UPDATE public.tenants
+  SET plan = _plan_slug,
+      billing_status = _target_status,
+      billing_period_end = _target_period_end,
+      updated_at = _now
+  WHERE id = _tenant_id;
+
+  INSERT INTO public.revenue_splits (
+    tenant_id, platform_percentage, school_percentage, updated_at
+  ) VALUES (
+    _tenant_id, _platform_fee, 100 - _platform_fee, _now
+  )
+  ON CONFLICT (tenant_id) DO UPDATE
+  SET platform_percentage = EXCLUDED.platform_percentage,
+      school_percentage = EXCLUDED.school_percentage,
+      updated_at = EXCLUDED.updated_at;
+
+  UPDATE public.platform_subscription_switches
+  SET target_provider_subscription_id = _target_provider_subscription_id,
+      state = 'cancellation_pending',
+      activated_at = COALESCE(activated_at, _now),
+      next_retry_at = _now,
+      last_error = NULL,
+      updated_at = _now
+  WHERE switch_id = _switch_id;
+
+  RETURN TRUE;
+END;
+$$;
+
+-- Terminal webhooks may downgrade only the exact provider subscription that is
+-- current while this function holds the row lock. A delayed source event
+-- returns NULL and cannot touch tenant or revenue-split state.
+CREATE OR REPLACE FUNCTION public.downgrade_platform_subscription_if_current(
+  _tenant_id UUID,
+  _payment_provider TEXT,
+  _provider_subscription_id TEXT
+) RETURNS NUMERIC
+LANGUAGE plpgsql
+SET search_path = public
+AS $$
+DECLARE
+  _current public.platform_subscriptions%ROWTYPE;
+  _platform_fee NUMERIC;
+  _now TIMESTAMPTZ := now();
+BEGIN
+  IF _provider_subscription_id IS NULL THEN RETURN NULL; END IF;
+
+  SELECT * INTO _current
+  FROM public.platform_subscriptions
+  WHERE tenant_id = _tenant_id
+  FOR UPDATE;
+
+  IF NOT FOUND
+     OR _current.payment_provider <> _payment_provider
+     OR _current.provider_subscription_id IS DISTINCT FROM _provider_subscription_id THEN
+    RETURN NULL;
+  END IF;
+
+  SELECT transaction_fee_percent INTO _platform_fee
+  FROM public.platform_plans
+  WHERE slug = 'free';
+  _platform_fee := COALESCE(_platform_fee, 10);
+
+  UPDATE public.platform_subscriptions
+  SET status = 'canceled', canceled_at = _now, updated_at = _now
+  WHERE subscription_id = _current.subscription_id;
+
+  UPDATE public.tenants
+  SET plan = 'free', billing_status = 'free', billing_period_end = NULL, updated_at = _now
+  WHERE id = _tenant_id;
+
+  INSERT INTO public.revenue_splits (
+    tenant_id, platform_percentage, school_percentage, updated_at
+  ) VALUES (
+    _tenant_id, _platform_fee, 100 - _platform_fee, _now
+  )
+  ON CONFLICT (tenant_id) DO UPDATE
+  SET platform_percentage = EXCLUDED.platform_percentage,
+      school_percentage = EXCLUDED.school_percentage,
+      updated_at = EXCLUDED.updated_at;
+
+  RETURN _platform_fee;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.promote_platform_subscription_switch(
+  UUID, UUID, TEXT, TEXT, TEXT, UUID, TEXT, TEXT, TIMESTAMPTZ, TIMESTAMPTZ
+) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.promote_platform_subscription_switch(
+  UUID, UUID, TEXT, TEXT, TEXT, UUID, TEXT, TEXT, TIMESTAMPTZ, TIMESTAMPTZ
+) TO service_role;
+
+REVOKE ALL ON FUNCTION public.downgrade_platform_subscription_if_current(UUID, TEXT, TEXT)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.downgrade_platform_subscription_if_current(UUID, TEXT, TEXT)
+  TO service_role;

--- a/supabase/migrations/20260808154118_safe_platform_subscription_switches.sql
+++ b/supabase/migrations/20260808154118_safe_platform_subscription_switches.sql
@@ -33,7 +33,7 @@ CREATE TABLE public.platform_subscription_switches (
   cancel_attempts INTEGER NOT NULL DEFAULT 0 CHECK (cancel_attempts >= 0),
   last_error TEXT,
   next_retry_at TIMESTAMPTZ,
-  expires_at TIMESTAMPTZ NOT NULL DEFAULT (now() + interval '7 days'),
+  expires_at TIMESTAMPTZ NOT NULL DEFAULT (now() + interval '1 hour'),
   initiated_by UUID REFERENCES auth.users(id) ON DELETE SET NULL,
   activated_at TIMESTAMPTZ,
   completed_at TIMESTAMPTZ,
@@ -45,8 +45,7 @@ CREATE TABLE public.platform_subscription_switches (
 CREATE UNIQUE INDEX platform_subscription_switches_one_open_per_tenant
   ON public.platform_subscription_switches(tenant_id)
   WHERE state IN (
-    'pending_activation', 'cancellation_pending', 'cancellation_retry',
-    'cancellation_scheduled'
+    'pending_activation', 'cancellation_pending', 'cancellation_retry'
   );
 
 CREATE UNIQUE INDEX platform_subscription_switches_target_identity
@@ -115,6 +114,16 @@ DECLARE
   _platform_fee NUMERIC;
   _now TIMESTAMPTZ := now();
 BEGIN
+  -- Lock the tenant's current entitlement first. Every promotion and exact
+  -- terminal downgrade uses this lock order, avoiding a revival/new-checkout
+  -- deadlock when both payments arrive together.
+  SELECT * INTO _current
+  FROM public.platform_subscriptions
+  WHERE tenant_id = _tenant_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN RETURN FALSE; END IF;
+
   SELECT * INTO _switch
   FROM public.platform_subscription_switches
   WHERE switch_id = _switch_id AND tenant_id = _tenant_id
@@ -130,20 +139,25 @@ BEGIN
   IF _switch.state IN ('cancellation_pending', 'cancellation_retry', 'cancellation_scheduled', 'completed') THEN
     RETURN _switch.target_provider_subscription_id IS NOT DISTINCT FROM _target_provider_subscription_id;
   END IF;
-  IF _switch.state <> 'pending_activation' THEN
+  IF _switch.state NOT IN ('pending_activation', 'abandoned') THEN
     RETURN FALSE;
   END IF;
 
-  SELECT * INTO _current
-  FROM public.platform_subscriptions
-  WHERE tenant_id = _tenant_id
-  FOR UPDATE;
-
-  IF NOT FOUND
-     OR _current.subscription_id <> _switch.source_subscription_id
+  IF _current.subscription_id <> _switch.source_subscription_id
      OR _current.payment_provider <> _switch.source_payment_provider
      OR _current.provider_subscription_id IS DISTINCT FROM _switch.source_provider_subscription_id THEN
     RETURN FALSE;
+  END IF;
+
+  -- A provider may settle after its checkout intent expired. The validated
+  -- payment wins while the original source is still current; release any newer
+  -- unpaid intent so reviving this switch cannot violate the open-switch index.
+  IF _switch.state = 'abandoned' THEN
+    UPDATE public.platform_subscription_switches
+    SET state = 'abandoned', updated_at = _now
+    WHERE tenant_id = _tenant_id
+      AND switch_id <> _switch_id
+      AND state = 'pending_activation';
   END IF;
 
   SELECT slug, transaction_fee_percent INTO _plan_slug, _platform_fee

--- a/tests/unit/expire-platform-subscriptions.test.ts
+++ b/tests/unit/expire-platform-subscriptions.test.ts
@@ -26,6 +26,7 @@ type Row = Record<string, unknown>
 const db: Record<string, Row[]> = {
   platform_subscriptions: [],
   platform_payment_requests: [],
+  platform_subscription_switches: [],
   platform_plans: [],
   tenants: [],
   tenant_users: [],
@@ -63,8 +64,9 @@ function makeSupabase() {
 
     function settle() {
       if (pending) {
-        for (const row of rows()) Object.assign(row, pending.values)
-        return { data: null, error: null }
+        const changed = rows()
+        for (const row of changed) Object.assign(row, pending.values)
+        return { data: embed(table, cols, changed), error: null }
       }
       return { data: embed(table, cols, rows()), error: null }
     }
@@ -113,6 +115,14 @@ function makeSupabase() {
       limit(n: number) {
         take = n
         return b
+      },
+      maybeSingle() {
+        const result = settle()
+        const resultRows = (result.data as Row[] | null) || []
+        return Promise.resolve({
+          data: resultRows.length === 1 ? resultRows[0] : null,
+          error: resultRows.length > 1 ? { message: 'more than one row' } : null,
+        })
       },
       then: (resolve: (v: unknown) => unknown) => Promise.resolve(settle()).then(resolve),
     }
@@ -279,6 +289,23 @@ describe('expire-platform-subscriptions: §2 renewal-request TTL', () => {
     )
   })
 
+  it('abandons the linked pending switch when its payment request expires', async () => {
+    db.platform_subscription_switches.push({
+      switch_id: 'switch-1',
+      tenant_id: TENANT,
+      state: 'pending_activation',
+      expires_at: daysFromNow(5),
+    })
+    seedRequest({ switch_id: 'switch-1', expires_at: daysFromNow(-1) })
+
+    await GET(req())
+
+    expect(db.platform_subscription_switches[0]).toMatchObject({
+      state: 'abandoned',
+      last_error: 'Linked payment request expired',
+    })
+  })
+
   it('leaves confirmed and rejected requests alone', async () => {
     const confirmed = seedRequest({ status: 'confirmed', expires_at: daysFromNow(-30) })
     const rejected = seedRequest({ status: 'rejected', expires_at: daysFromNow(-30) })
@@ -323,6 +350,31 @@ describe('expire-platform-subscriptions: §1 cancel-then-repay', () => {
 
     expect(body).toMatchObject({ canceled: 0, graceStarted: 1, downgraded: 0 })
     expect(downgraded).toEqual([])
+  })
+})
+
+describe('expire-platform-subscriptions: bounded switch cleanup', () => {
+  it('finishes critical downgrades and processes at most ten cleanup rows', async () => {
+    seedSub({ status: 'past_due', grace_period_end: daysFromNow(-1) })
+    for (let i = 0; i < 12; i++) {
+      db.platform_subscription_switches.push({
+        switch_id: `switch-${i}`,
+        tenant_id: TENANT,
+        source_payment_provider: 'manual',
+        source_provider_subscription_id: null,
+        source_period_end: null,
+        state: 'cancellation_pending',
+        cancel_attempts: 0,
+        next_retry_at: daysFromNow(-1),
+      })
+    }
+
+    const body = await (await GET(req())).json()
+
+    expect(body.downgraded).toBe(1)
+    expect(body.switchCancellationsCompleted).toBe(10)
+    expect(db.platform_subscription_switches.filter((row) => row.state === 'completed')).toHaveLength(10)
+    expect(db.platform_subscription_switches.filter((row) => row.state === 'cancellation_pending')).toHaveLength(2)
   })
 })
 

--- a/tests/unit/paypal-binance-providers.test.ts
+++ b/tests/unit/paypal-binance-providers.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { afterEach, describe, it, expect, vi } from 'vitest'
 import crypto from 'crypto'
 import {
   PayPalPaymentProvider,
@@ -7,6 +7,8 @@ import {
 } from '@/lib/payments/paypal-provider'
 import { BinancePayProvider } from '@/lib/payments/binance-provider'
 import { PROVIDER_CAPABILITIES } from '@/lib/payments/types'
+
+afterEach(() => vi.unstubAllGlobals())
 
 /**
  * Pins the pure/offline parts of the two new providers (issue #466): the
@@ -258,5 +260,35 @@ describe('PROVIDER_CAPABILITIES sync', () => {
   it('binance static entry matches the class capabilities', () => {
     const b = new BinancePayProvider('k', 's')
     expect(b.capabilities).toEqual(PROVIDER_CAPABILITIES.binance)
+  })
+})
+
+describe('PayPalPaymentProvider.cancelSubscription', () => {
+  function stubPayPal(cancelStatus: number) {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ access_token: 'token', expires_in: 3600 }),
+      })
+      .mockResolvedValueOnce({
+        ok: cancelStatus >= 200 && cancelStatus < 300,
+        status: cancelStatus,
+        text: async () => (cancelStatus === 404 ? 'missing' : 'provider failure'),
+      })
+    vi.stubGlobal('fetch', fetchMock)
+  }
+
+  it('treats a structured HTTP 404 as already canceled', async () => {
+    stubPayPal(404)
+    const provider = new PayPalPaymentProvider('client', 'secret')
+    await expect(provider.cancelSubscription('sub-gone', true)).resolves.toEqual({ mode: 'immediate' })
+  })
+
+  it('does not swallow other provider failures', async () => {
+    stubPayPal(422)
+    const provider = new PayPalPaymentProvider('client', 'secret')
+    await expect(provider.cancelSubscription('sub-live', true)).rejects.toThrow(/HTTP 422/)
   })
 })

--- a/tests/unit/plan-change-provider.test.ts
+++ b/tests/unit/plan-change-provider.test.ts
@@ -18,6 +18,7 @@ function makeStripe(retrieveResult: any, updateResult: any) {
     subscriptions: {
       retrieve: vi.fn().mockResolvedValue(retrieveResult),
       update: vi.fn().mockResolvedValue(updateResult),
+      cancel: vi.fn(),
     },
   }
   const provider = new StripePaymentProvider('sk_test_x')
@@ -79,6 +80,20 @@ describe('StripePaymentProvider.updateSubscription', () => {
   })
 })
 
+describe('StripePaymentProvider.cancelSubscription', () => {
+  it('converges only a structured missing-resource error', async () => {
+    const { provider, stripe } = makeStripe({}, {})
+    stripe.subscriptions.cancel.mockRejectedValue({ code: 'resource_missing' })
+    await expect(provider.cancelSubscription('sub-gone', true)).resolves.toEqual({ mode: 'immediate' })
+  })
+
+  it('does not classify message text as already canceled', async () => {
+    const { provider, stripe } = makeStripe({}, {})
+    stripe.subscriptions.cancel.mockRejectedValue(new Error('No such subscription: sub-gone'))
+    await expect(provider.cancelSubscription('sub-gone', true)).rejects.toThrow(/No such subscription/)
+  })
+})
+
 describe('LemonSqueezyProvider.updateSubscription', () => {
   afterEach(() => vi.unstubAllGlobals())
 
@@ -127,6 +142,18 @@ describe('LemonSqueezyProvider.updateSubscription', () => {
     await expect(
       provider.updateSubscription('99', { newProviderPriceId: '424242' }),
     ).rejects.toThrow(/HTTP 422/)
+  })
+
+  it('treats only a 404 cancellation response as already absent', async () => {
+    stubFetch({ ok: false, status: 404, text: 'subscription missing' })
+    const provider = new LemonSqueezyProvider('key', 'store', 'secret')
+    await expect(provider.cancelSubscription('99', true)).resolves.toEqual({ mode: 'immediate' })
+  })
+
+  it('keeps a 422 cancellation response retryable even when its text says not found', async () => {
+    stubFetch({ ok: false, status: 422, text: 'Store not found for this API key' })
+    const provider = new LemonSqueezyProvider('key', 'store', 'secret')
+    await expect(provider.cancelSubscription('99', true)).rejects.toThrow(/HTTP 422/)
   })
 })
 

--- a/tests/unit/platform-billing-checkout.test.ts
+++ b/tests/unit/platform-billing-checkout.test.ts
@@ -158,7 +158,7 @@ describe('platform billing capability', () => {
 
 interface Write {
   table: string
-  op: 'update' | 'upsert'
+  op: 'insert' | 'update' | 'upsert'
   values: Record<string, unknown>
 }
 
@@ -173,6 +173,7 @@ const state: {
   checkoutCalls: Record<string, unknown>[]
   cancelCalls: { id: string; immediate: boolean }[]
   cancelThrows: boolean
+  checkoutThrows: boolean
   overLimit: boolean
   openRequest: boolean
   recordedRequests: Record<string, unknown>[]
@@ -187,6 +188,7 @@ const state: {
   checkoutCalls: [],
   cancelCalls: [],
   cancelThrows: false,
+  checkoutThrows: false,
   overLimit: false,
   openRequest: false,
   recordedRequests: [],
@@ -200,6 +202,11 @@ function makeBuilder(table: string, writes: Write[]) {
   const b: Record<string, unknown> = {
     select: () => b,
     eq: () => b,
+    insert(values: Record<string, unknown>) {
+      pending = { table, op: 'insert', values }
+      writes.push(pending)
+      return b
+    },
     update(values: Record<string, unknown>) {
       pending = { table, op: 'update', values }
       writes.push(pending)
@@ -215,7 +222,12 @@ function makeBuilder(table: string, writes: Write[]) {
     then: (resolve: (v: unknown) => unknown) => Promise.resolve(settle()).then(resolve),
   }
   function settle() {
-    if (pending) return { data: null, error: null }
+    if (pending) {
+      if (pending.table === 'platform_subscription_switches' && pending.op === 'insert') {
+        return { data: { switch_id: 'switch-1' }, error: null }
+      }
+      return { data: null, error: null }
+    }
     if (table === 'tenant_users') return { data: state.role ? { role: state.role } : null, error: null }
     if (table === 'platform_plans') {
       return state.plan ? { data: state.plan, error: null } : { data: null, error: { message: 'not found' } }
@@ -257,9 +269,10 @@ vi.mock('@/lib/billing/platform-billing', async (importOriginal) => {
       cancelSubscription: (id: string, immediate: boolean) => {
         if (state.cancelThrows) return Promise.reject(new Error('provider down'))
         state.cancelCalls.push({ id, immediate })
-        return Promise.resolve()
+        return Promise.resolve({ mode: 'immediate' as const })
       },
       createCheckoutSession: (params: Record<string, unknown>) => {
+        if (state.checkoutThrows) return Promise.reject(new Error('checkout down'))
         state.checkoutCalls.push(params)
         // Solana hands back a QR and an on-chain reference, not a redirect.
         return Promise.resolve(
@@ -317,6 +330,7 @@ beforeEach(() => {
   state.checkoutCalls = []
   state.cancelCalls = []
   state.cancelThrows = false
+  state.checkoutThrows = false
   state.overLimit = false
   state.openRequest = false
   state.recordedRequests = []
@@ -392,7 +406,7 @@ describe('POST /api/billing/checkout — happy path', () => {
 })
 
 describe('POST /api/billing/checkout — switching payment method', () => {
-  it('supersedes a live subscription on ANOTHER provider instead of double-billing', async () => {
+  it('keeps source active while a replacement checkout is pending', async () => {
     state.existingSub = {
       subscription_id: 'ps-1',
       provider_subscription_id: 'sub_old',
@@ -403,27 +417,33 @@ describe('POST /api/billing/checkout — switching payment method', () => {
 
     const res = await POST(makeReq({ planId: PLAN_ID, provider: 'stripe' }))
     expect(res.status).toBe(200)
-    // Cancelled at the old provider, immediately — a lingering subscription
-    // would auto-renew into a second charge.
-    expect(state.cancelCalls).toEqual([{ id: 'sub_old', immediate: true }])
-    expect(state.writes.find((w) => w.table === 'platform_subscriptions')?.values).toMatchObject({
-      status: 'canceled',
+    expect(state.cancelCalls).toHaveLength(0)
+    expect(state.writes.some((w) => w.table === 'platform_subscriptions')).toBe(false)
+    expect(state.writes.find((w) => w.table === 'platform_subscription_switches' && w.op === 'insert')?.values).toMatchObject({
+      source_payment_provider: 'lemonsqueezy',
+      source_provider_subscription_id: 'sub_old',
+      target_payment_provider: 'stripe',
     })
+    expect(state.checkoutCalls[0].metadata).toMatchObject({ billing_switch_id: 'switch-1' })
     expect(state.checkoutCalls).toHaveLength(1)
   })
 
-  it('refuses to start the new subscription if the old one cannot be cancelled', async () => {
+  it('a failed replacement checkout leaves source untouched and closes the switch intent', async () => {
     state.existingSub = {
       subscription_id: 'ps-1',
       provider_subscription_id: 'sub_old',
       status: 'active',
       payment_provider: 'lemonsqueezy',
     }
-    state.cancelThrows = true
+    state.checkoutThrows = true
 
     const res = await POST(makeReq({ planId: PLAN_ID, provider: 'stripe' }))
-    expect(res.status).toBe(502)
-    expect(state.checkoutCalls).toHaveLength(0)
+    expect(res.status).toBe(500)
+    expect(state.cancelCalls).toHaveLength(0)
+    expect(state.writes.some((w) => w.table === 'platform_subscriptions')).toBe(false)
+    expect(state.writes.find((w) => w.table === 'platform_subscription_switches' && w.op === 'update')?.values).toMatchObject({
+      state: 'failed',
+    })
   })
 
   it('sends a same-provider plan change back to the in-app flow', async () => {
@@ -553,6 +573,24 @@ describe('POST /api/billing/checkout — crypto rails (#610)', () => {
     }
     const res = await POST(makeReq({ planId: PLAN_ID, provider: 'binance' }))
     expect(res.status).toBe(200)
-    expect(state.cancelCalls).toEqual([{ id: 'sub_live', immediate: true }])
+    expect(state.cancelCalls).toHaveLength(0)
+    expect(state.checkoutCalls[0].metadata).toMatchObject({ billing_switch_id: 'switch-1' })
+  })
+
+  it('links a Stripe → Solana payment request to the pending switch', async () => {
+    state.prices = solanaPrice()
+    state.existingSub = {
+      subscription_id: 'ps-1',
+      plan_id: 'plan-old',
+      current_period_end: '2026-09-01T00:00:00.000Z',
+      provider_subscription_id: 'sub-live',
+      status: 'active',
+      payment_provider: 'stripe',
+    }
+
+    const res = await POST(makeReq({ planId: PLAN_ID, provider: 'solana' }))
+    expect(res.status).toBe(200)
+    expect(state.recordedRequests[0]).toMatchObject({ switchId: 'switch-1' })
+    expect(state.cancelCalls).toHaveLength(0)
   })
 })

--- a/tests/unit/platform-billing-crypto-rails.test.ts
+++ b/tests/unit/platform-billing-crypto-rails.test.ts
@@ -254,6 +254,7 @@ describe('dispatchPlatformBillingEvent on a self-managed rail', () => {
       plan_id: PLAN_PRO,
       status: 'active',
       payment_provider: 'binance',
+      provider_subscription_id: 'order_previous',
       interval: 'monthly',
       current_period_end: end,
     })
@@ -265,6 +266,7 @@ describe('dispatchPlatformBillingEvent on a self-managed rail', () => {
 
     const extended = new Date(sub().current_period_end as string).getTime()
     expect(extended).toBeGreaterThan(new Date(end).getTime() + 27 * DAY)
+    expect(sub().provider_subscription_id).toBe('order_9001')
   })
 
   it('moves the school to the plan it just paid for', async () => {

--- a/tests/unit/platform-billing-lifecycle.test.ts
+++ b/tests/unit/platform-billing-lifecycle.test.ts
@@ -35,7 +35,7 @@ let db: Db
 const providerCalls: { method: string; id: string; params?: Record<string, unknown> }[] = []
 
 function makeClient() {
-  return createFakeSupabase(db, {
+  const fake = createFakeSupabase(db, {
     embeds: {
       platform_plans: { table: 'platform_plans', localKey: 'plan_id', foreignKey: 'plan_id' },
       tenants: { table: 'tenants', localKey: 'tenant_id', foreignKey: 'id' },
@@ -44,7 +44,38 @@ function makeClient() {
       platform_subscriptions: 'tenant_id',
       revenue_splits: 'tenant_id',
     },
-  }).client
+  })
+  return {
+    ...fake.client,
+    rpc: (name: string, args: Record<string, unknown>) => {
+      if (name !== 'promote_platform_subscription_switch') {
+        return Promise.resolve({ data: null, error: { message: `unexpected rpc ${name}` } })
+      }
+      const row = db.platform_subscription_switches.find((s) => s.switch_id === args._switch_id)
+      const sub = db.platform_subscriptions.find((s) => s.tenant_id === args._tenant_id)
+      if (!row || !sub) return Promise.resolve({ data: false, error: null })
+      if (['cancellation_pending', 'cancellation_retry', 'cancellation_scheduled', 'completed'].includes(String(row.state))) {
+        return Promise.resolve({ data: true, error: null })
+      }
+      Object.assign(sub, {
+        plan_id: args._target_plan_id,
+        payment_provider: args._target_payment_provider,
+        provider_subscription_id: args._target_provider_subscription_id,
+        status: args._target_status,
+        interval: args._target_interval,
+        current_period_start: args._target_period_start,
+        current_period_end: args._target_period_end,
+        cancel_at_period_end: false,
+        canceled_at: null,
+      })
+      Object.assign(row, {
+        state: 'cancellation_pending',
+        target_provider_subscription_id: args._target_provider_subscription_id,
+        cancel_attempts: row.cancel_attempts ?? 0,
+      })
+      return Promise.resolve({ data: true, error: null })
+    },
+  }
 }
 
 vi.mock('@/lib/supabase/server', () => ({ createClient: () => Promise.resolve(makeClient()) }))
@@ -72,11 +103,23 @@ vi.mock('@/lib/payments', async (importActual) => {
       },
       cancelSubscription: (id: string, immediate: boolean) => {
         providerCalls.push({ method: 'cancelSubscription', id, params: { immediate } })
-        return Promise.resolve()
+        return Promise.resolve({ mode: 'immediate' as const })
       },
       reactivateSubscription: (id: string) => {
         providerCalls.push({ method: 'reactivateSubscription', id })
         return Promise.resolve()
+      },
+    }),
+  }
+})
+vi.mock('@/lib/billing/platform-billing', async (importActual) => {
+  const actual = await importActual<typeof import('@/lib/billing/platform-billing')>()
+  return {
+    ...actual,
+    getPlatformBillingProvider: () => ({
+      cancelSubscription: (id: string, immediate: boolean) => {
+        providerCalls.push({ method: 'cancelSourceSubscription', id, params: { immediate } })
+        return Promise.resolve({ mode: 'immediate' as const })
       },
     }),
   }
@@ -173,9 +216,73 @@ beforeEach(() => {
     tenant_billing_customers: [],
     platform_subscriptions: [],
     platform_payment_requests: [],
+    platform_subscription_switches: [],
     revenue_splits: [],
     courses: [],
   }
+})
+
+describe('#621 — manual provider switches', () => {
+  it('links the pending manual request to a source snapshot without canceling source', async () => {
+    const source = seedSub({
+      payment_provider: 'stripe',
+      provider_subscription_id: 'sub-stripe-live',
+      plan_id: PLAN_PRO,
+    })
+
+    await requestManualPlanUpgrade(PLAN_BUSINESS, 'yearly')
+    const request = db.platform_payment_requests[0]
+    const ledger = db.platform_subscription_switches[0]
+
+    expect(source).toMatchObject({ status: 'active', provider_subscription_id: 'sub-stripe-live' })
+    expect(providerCalls).toHaveLength(0)
+    expect(ledger).toMatchObject({
+      source_payment_provider: 'stripe',
+      source_provider_subscription_id: 'sub-stripe-live',
+      target_payment_provider: 'manual',
+      target_plan_id: PLAN_BUSINESS,
+    })
+    expect(request.switch_id).toBe(ledger.switch_id)
+  })
+
+  it('promotes confirmed manual payment before canceling the old provider', async () => {
+    seedSub({ payment_provider: 'stripe', provider_subscription_id: 'sub-stripe-live' })
+    await requestManualPlanUpgrade(PLAN_BUSINESS, 'yearly')
+    const request = db.platform_payment_requests[0]
+    request.request_id = 'req-switch-manual'
+
+    await confirmManualPayment(request.request_id as string)
+
+    expect(db.platform_subscriptions[0]).toMatchObject({
+      status: 'active',
+      payment_provider: 'manual',
+      provider_subscription_id: null,
+      plan_id: PLAN_BUSINESS,
+    })
+    expect(providerCalls).toEqual([
+      { method: 'cancelSourceSubscription', id: 'sub-stripe-live', params: { immediate: true } },
+    ])
+    expect(db.platform_subscription_switches[0]).toMatchObject({
+      state: 'completed',
+      source_cancel_mode: 'immediate',
+    })
+  })
+
+  it('replaying confirmed switch activation does not extend the period or cancel twice', async () => {
+    seedSub({ payment_provider: 'stripe', provider_subscription_id: 'sub-stripe-live' })
+    await requestManualPlanUpgrade(PLAN_BUSINESS, 'yearly')
+    const request = db.platform_payment_requests[0]
+    request.request_id = 'req-switch-replay'
+
+    await confirmManualPayment(request.request_id as string)
+    const periodEnd = db.platform_subscriptions[0].current_period_end
+    await confirmManualPayment(request.request_id as string)
+
+    expect(db.platform_subscriptions[0].current_period_end).toBe(periodEnd)
+    expect(providerCalls).toEqual([
+      { method: 'cancelSourceSubscription', id: 'sub-stripe-live', params: { immediate: true } },
+    ])
+  })
 })
 
 describe('#546 §1 — confirming a payment un-cancels', () => {

--- a/tests/unit/platform-billing-lifecycle.test.ts
+++ b/tests/unit/platform-billing-lifecycle.test.ts
@@ -54,8 +54,12 @@ function makeClient() {
       const row = db.platform_subscription_switches.find((s) => s.switch_id === args._switch_id)
       const sub = db.platform_subscriptions.find((s) => s.tenant_id === args._tenant_id)
       if (!row || !sub) return Promise.resolve({ data: false, error: null })
-      if (['cancellation_pending', 'cancellation_retry', 'cancellation_scheduled', 'completed'].includes(String(row.state))) {
+      const state = String(row.state ?? 'pending_activation')
+      if (['cancellation_pending', 'cancellation_retry', 'cancellation_scheduled', 'completed'].includes(state)) {
         return Promise.resolve({ data: true, error: null })
+      }
+      if (!['pending_activation', 'abandoned'].includes(state)) {
+        return Promise.resolve({ data: false, error: null })
       }
       Object.assign(sub, {
         plan_id: args._target_plan_id,
@@ -223,6 +227,13 @@ beforeEach(() => {
 })
 
 describe('#621 — manual provider switches', () => {
+  it('does not revive a payment request that was explicitly rejected', async () => {
+    const request = seedRequest({ status: 'rejected' })
+    await expect(confirmManualPayment(request.request_id as string)).rejects.toThrow(
+      /Rejected payments cannot be confirmed/,
+    )
+  })
+
   it('links the pending manual request to a source snapshot without canceling source', async () => {
     const source = seedSub({
       payment_provider: 'stripe',
@@ -282,6 +293,25 @@ describe('#621 — manual provider switches', () => {
     expect(providerCalls).toEqual([
       { method: 'cancelSourceSubscription', id: 'sub-stripe-live', params: { immediate: true } },
     ])
+  })
+
+  it('credits a validated late manual payment after its switch was abandoned', async () => {
+    seedSub({ payment_provider: 'stripe', provider_subscription_id: 'sub-stripe-live' })
+    await requestManualPlanUpgrade(PLAN_BUSINESS, 'yearly')
+    const request = db.platform_payment_requests[0]
+    request.request_id = 'req-switch-late'
+    request.status = 'expired'
+    db.platform_subscription_switches[0].state = 'abandoned'
+
+    await confirmManualPayment(request.request_id as string)
+
+    expect(request.status).toBe('confirmed')
+    expect(db.platform_subscriptions[0]).toMatchObject({
+      payment_provider: 'manual',
+      plan_id: PLAN_BUSINESS,
+      status: 'active',
+    })
+    expect(db.platform_subscription_switches[0].state).toBe('completed')
   })
 })
 

--- a/tests/unit/platform-billing-webhook-route.test.ts
+++ b/tests/unit/platform-billing-webhook-route.test.ts
@@ -130,7 +130,7 @@ vi.mock('@/lib/email/send', () => ({
 }))
 
 vi.mock('@/lib/billing/downgrade-tenant', () => ({
-  downgradeTenantToFree: vi.fn(() => Promise.resolve(10)),
+  downgradeTenantToFreeIfCurrent: vi.fn(() => Promise.resolve(10)),
 }))
 
 // The reconciler has its own suite (platform-plan-change.test.ts). What matters
@@ -160,7 +160,7 @@ vi.mock('@/lib/billing/platform-billing', async (importOriginal) => {
 
 import { POST } from '@/app/api/billing/webhook/[provider]/route'
 import { applyPortalPlanChange } from '@/lib/payments/platform-plan-change'
-import { downgradeTenantToFree } from '@/lib/billing/downgrade-tenant'
+import { downgradeTenantToFreeIfCurrent } from '@/lib/billing/downgrade-tenant'
 
 const TENANT = '00000000-0000-0000-0000-000000000001'
 const PLAN_ID = 'f9318c3a-815d-448d-802e-cf356c2791a4'
@@ -229,7 +229,7 @@ beforeEach(() => {
   state.writes = []
   state.emails = []
   vi.mocked(applyPortalPlanChange).mockClear()
-  vi.mocked(downgradeTenantToFree).mockClear()
+  vi.mocked(downgradeTenantToFreeIfCurrent).mockClear()
 })
 
 describe('platform billing webhook — route gates', () => {
@@ -549,13 +549,25 @@ describe('platform billing webhook — subscription updates', () => {
 
 describe('platform billing webhook — cancellation', () => {
   it('downgrades the tenant to free on subscription deletion', async () => {
+    state.storedSub = {
+      tenant_id: TENANT,
+      plan_id: PLAN_ID,
+      status: 'active',
+      current_period_end: END_ISO,
+      payment_provider: 'stripe',
+      provider_subscription_id: 'sub_123',
+    }
     const res = await POST(
       makeReq(makeEvent('customer.subscription.deleted', cloverSubscription())),
       params(),
     )
     expect(res.status).toBe(200)
-    expect(downgradeTenantToFree).toHaveBeenCalledTimes(1)
-    expect(vi.mocked(downgradeTenantToFree).mock.calls[0][1]).toBe(TENANT)
+    expect(downgradeTenantToFreeIfCurrent).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(downgradeTenantToFreeIfCurrent).mock.calls[0].slice(1)).toEqual([
+      TENANT,
+      'stripe',
+      'sub_123',
+    ])
     // The whole transition belongs to that helper — duplicating any of it here
     // is how the cron path and the webhook path drift.
     expect(writesTo('platform_subscriptions', 'upsert')).toHaveLength(0)

--- a/tests/unit/platform-subscription-switch.test.ts
+++ b/tests/unit/platform-subscription-switch.test.ts
@@ -113,6 +113,17 @@ describe('source cancellation reconciliation', () => {
       last_error: 'provider unavailable',
     })
   })
+
+  it('does not infer already-canceled from provider error message text', async () => {
+    providerState.error = new Error('HTTP 422 — Store not found for this API key')
+    const { db, admin } = setup({ switch: switchRow({ source_payment_provider: 'lemonsqueezy' }) })
+
+    await expect(reconcilePlatformSubscriptionSwitch(admin, 'switch-1')).resolves.toBe('retry')
+    expect(db.platform_subscription_switches[0]).toMatchObject({
+      state: 'cancellation_retry',
+      last_error: 'HTTP 422 — Store not found for this API key',
+    })
+  })
 })
 
 describe('webhook identity scoping', () => {
@@ -179,6 +190,28 @@ describe('webhook identity scoping', () => {
         type: 'subscription.past_due',
         providerSubscriptionId: 'sub-old',
         metadata: { tenant_id: TENANT },
+        raw: {},
+      },
+      { provider: 'stripe', admin },
+    )
+    expect(db.platform_subscriptions[0]).toEqual(current)
+  })
+
+  it('does not treat a stale cross-provider activation as fresh while current is past due', async () => {
+    const current = {
+      tenant_id: TENANT,
+      plan_id: 'plan-new',
+      payment_provider: 'lemonsqueezy',
+      provider_subscription_id: 'sub-new',
+      current_period_end: '2026-10-01T00:00:00.000Z',
+      status: 'past_due',
+    }
+    const { db, admin } = setup({ current })
+    await dispatchPlatformBillingEvent(
+      {
+        type: 'subscription.activated',
+        providerSubscriptionId: 'sub-old',
+        metadata: { tenant_id: TENANT, plan_id: 'plan-old', interval: 'monthly' },
         raw: {},
       },
       { provider: 'stripe', admin },

--- a/tests/unit/platform-subscription-switch.test.ts
+++ b/tests/unit/platform-subscription-switch.test.ts
@@ -1,0 +1,209 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { createFakeSupabase, type Db } from './support/fake-supabase'
+
+const providerState: {
+  result: { mode: 'none' | 'immediate' | 'period_end'; effectiveAt?: Date }
+  error: Error | null
+  calls: { id: string; immediate: boolean }[]
+} = {
+  result: { mode: 'immediate' },
+  error: null,
+  calls: [],
+}
+
+vi.mock('@/lib/billing/platform-billing', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/billing/platform-billing')>()
+  return {
+    ...actual,
+    getPlatformBillingProvider: () => ({
+      cancelSubscription: (id: string, immediate: boolean) => {
+        providerState.calls.push({ id, immediate })
+        if (providerState.error) return Promise.reject(providerState.error)
+        return Promise.resolve(providerState.result)
+      },
+    }),
+  }
+})
+
+vi.mock('@/lib/billing/downgrade-tenant', () => ({
+  downgradeTenantToFreeIfCurrent: vi.fn(() => Promise.resolve(10)),
+}))
+
+import {
+  reconcilePlatformSubscriptionSwitch,
+} from '@/lib/billing/platform-subscription-switch'
+import { dispatchPlatformBillingEvent } from '@/lib/billing/platform-webhook-dispatch'
+import { downgradeTenantToFreeIfCurrent } from '@/lib/billing/downgrade-tenant'
+
+const TENANT = '00000000-0000-0000-0000-000000000001'
+
+function switchRow(over: Record<string, unknown> = {}) {
+  return {
+    switch_id: 'switch-1',
+    tenant_id: TENANT,
+    source_payment_provider: 'stripe',
+    source_provider_subscription_id: 'sub-old',
+    source_period_end: '2026-09-01T00:00:00.000Z',
+    target_payment_provider: 'lemonsqueezy',
+    target_provider_subscription_id: 'sub-new',
+    state: 'cancellation_pending',
+    cancel_attempts: 0,
+    next_retry_at: '2026-08-08T00:00:00.000Z',
+    ...over,
+  }
+}
+
+function setup(over: { current?: Record<string, unknown>; switch?: Record<string, unknown> } = {}) {
+  const db: Db = {
+    platform_subscriptions: over.current ? [over.current] : [],
+    platform_subscription_switches: over.switch ? [over.switch] : [],
+  }
+  const fake = createFakeSupabase(db)
+  return { db, admin: fake.client as unknown as SupabaseClient, writes: fake.writes }
+}
+
+beforeEach(() => {
+  providerState.result = { mode: 'immediate' }
+  providerState.error = null
+  providerState.calls = []
+  vi.mocked(downgradeTenantToFreeIfCurrent).mockClear()
+})
+
+describe('source cancellation reconciliation', () => {
+  it('marks an immediate source cancellation completed after target activation', async () => {
+    const { db, admin } = setup({ switch: switchRow() })
+    await expect(reconcilePlatformSubscriptionSwitch(admin, 'switch-1')).resolves.toBe('completed')
+    expect(providerState.calls).toEqual([{ id: 'sub-old', immediate: true }])
+    expect(db.platform_subscription_switches[0]).toMatchObject({
+      state: 'completed',
+      source_cancel_mode: 'immediate',
+      cancel_attempts: 1,
+      last_error: null,
+    })
+  })
+
+  it('records Lemon Squeezy period-end semantics instead of claiming immediate cancellation', async () => {
+    providerState.result = { mode: 'period_end', effectiveAt: new Date('2026-09-01T00:00:00.000Z') }
+    const { db, admin } = setup({
+      switch: switchRow({ source_payment_provider: 'lemonsqueezy' }),
+    })
+    await expect(reconcilePlatformSubscriptionSwitch(admin, 'switch-1')).resolves.toBe('scheduled')
+    expect(db.platform_subscription_switches[0]).toMatchObject({
+      state: 'cancellation_scheduled',
+      source_cancel_mode: 'period_end',
+      source_cancel_effective_at: '2026-09-01T00:00:00.000Z',
+    })
+  })
+
+  it('keeps replacement entitlement and schedules retry when source cancellation fails', async () => {
+    providerState.error = new Error('provider unavailable')
+    const current = {
+      tenant_id: TENANT,
+      payment_provider: 'lemonsqueezy',
+      provider_subscription_id: 'sub-new',
+      status: 'active',
+    }
+    const { db, admin } = setup({ current, switch: switchRow() })
+    await expect(reconcilePlatformSubscriptionSwitch(admin, 'switch-1')).resolves.toBe('retry')
+    expect(db.platform_subscriptions[0]).toEqual(current)
+    expect(db.platform_subscription_switches[0]).toMatchObject({
+      state: 'cancellation_retry',
+      cancel_attempts: 1,
+      last_error: 'provider unavailable',
+    })
+  })
+})
+
+describe('webhook identity scoping', () => {
+  it('downgrades only an exact current provider/subscription identity', async () => {
+    const { admin } = setup({
+      current: {
+        tenant_id: TENANT,
+        payment_provider: 'stripe',
+        provider_subscription_id: 'sub-current',
+        status: 'active',
+      },
+    })
+    await dispatchPlatformBillingEvent(
+      {
+        type: 'subscription.canceled',
+        providerSubscriptionId: 'sub-current',
+        metadata: { tenant_id: TENANT },
+        raw: {},
+      },
+      { provider: 'stripe', admin },
+    )
+    expect(downgradeTenantToFreeIfCurrent).toHaveBeenCalledWith(
+      admin,
+      TENANT,
+      'stripe',
+      'sub-current',
+    )
+  })
+
+  it('records a delayed source terminal event without downgrading the replacement', async () => {
+    const current = {
+      tenant_id: TENANT,
+      payment_provider: 'lemonsqueezy',
+      provider_subscription_id: 'sub-new',
+      status: 'active',
+    }
+    const { db, admin } = setup({ current, switch: switchRow({ state: 'cancellation_scheduled' }) })
+    await dispatchPlatformBillingEvent(
+      {
+        type: 'subscription.expired',
+        providerSubscriptionId: 'sub-old',
+        metadata: { tenant_id: TENANT },
+        raw: {},
+      },
+      { provider: 'stripe', admin },
+    )
+    expect(downgradeTenantToFreeIfCurrent).not.toHaveBeenCalled()
+    expect(db.platform_subscriptions[0]).toEqual(current)
+    expect(db.platform_subscription_switches[0].state).toBe('completed')
+  })
+
+  it('ignores a late nonterminal event from the superseded source', async () => {
+    const current = {
+      tenant_id: TENANT,
+      plan_id: 'plan-new',
+      payment_provider: 'lemonsqueezy',
+      provider_subscription_id: 'sub-new',
+      current_period_end: '2026-10-01T00:00:00.000Z',
+      status: 'active',
+    }
+    const { db, admin } = setup({ current, switch: switchRow() })
+    await dispatchPlatformBillingEvent(
+      {
+        type: 'subscription.past_due',
+        providerSubscriptionId: 'sub-old',
+        metadata: { tenant_id: TENANT },
+        raw: {},
+      },
+      { provider: 'stripe', admin },
+    )
+    expect(db.platform_subscriptions[0]).toEqual(current)
+  })
+
+  it('unknown old terminal identity is an audited no-op', async () => {
+    const current = {
+      tenant_id: TENANT,
+      payment_provider: 'lemonsqueezy',
+      provider_subscription_id: 'sub-new',
+      status: 'active',
+    }
+    const { db, admin } = setup({ current })
+    await dispatchPlatformBillingEvent(
+      {
+        type: 'subscription.canceled',
+        providerSubscriptionId: 'sub-unknown',
+        metadata: { tenant_id: TENANT },
+        raw: {},
+      },
+      { provider: 'stripe', admin },
+    )
+    expect(downgradeTenantToFreeIfCurrent).not.toHaveBeenCalled()
+    expect(db.platform_subscriptions[0]).toEqual(current)
+  })
+})

--- a/tests/unit/reject-manual-payment.test.ts
+++ b/tests/unit/reject-manual-payment.test.ts
@@ -22,24 +22,39 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
  */
 
 const state: {
-  row: { request_id: string; status: string } | null
+  row: { request_id: string; status: string; switch_id?: string | null } | null
   /** Rows the conditional UPDATE matched — [] means the status filter excluded it. */
   updateMatches: { request_id: string }[]
   updateError: { message: string } | null
   /** What the action actually sent, and what it filtered on. */
   lastUpdate: Record<string, unknown> | null
   lastNotFilter: { column: string; operator: string; value: unknown } | null
+  lastSwitchUpdate: Record<string, unknown> | null
 } = {
   row: null,
   updateMatches: [],
   updateError: null,
   lastUpdate: null,
   lastNotFilter: null,
+  lastSwitchUpdate: null,
 }
 
 function makeFakeAdmin() {
   return {
-    from() {
+    from(table: string) {
+      if (table === 'platform_subscription_switches') {
+        const switchBuilder: Record<string, unknown> = {
+          update(values: Record<string, unknown>) {
+            state.lastSwitchUpdate = values
+            return switchBuilder
+          },
+          eq() { return switchBuilder },
+          then(resolve: (value: unknown) => unknown) {
+            return Promise.resolve({ data: [], error: null }).then(resolve)
+          },
+        }
+        return switchBuilder
+      }
       const b: Record<string, unknown> = {
         select() { return b },
         eq() { return b },
@@ -96,6 +111,7 @@ beforeEach(() => {
   state.updateError = null
   state.lastUpdate = null
   state.lastNotFilter = null
+  state.lastSwitchUpdate = null
 })
 
 describe('rejectManualPayment — terminal statuses are refused', () => {
@@ -133,6 +149,18 @@ describe('rejectManualPayment — open statuses still reject', () => {
       success: true,
     })
     expect(state.lastUpdate?.status).toBe('rejected')
+  })
+
+  it('fails the linked pending switch so the school can submit again', async () => {
+    state.row = { request_id: REQUEST_ID, status: 'pending', switch_id: 'switch-1' }
+    state.updateMatches = [{ request_id: REQUEST_ID }]
+
+    await rejectManualPayment(REQUEST_ID, 'No transfer received')
+
+    expect(state.lastSwitchUpdate).toMatchObject({
+      state: 'failed',
+      last_error: 'Manual payment request rejected: No transfer received',
+    })
   })
 })
 


### PR DESCRIPTION
## What

Closes #621

Makes cross-provider platform subscription switching safe and recoverable:

- keeps the current paid entitlement active while replacement checkout/payment is pending
- promotes a paid replacement atomically through a service-role-only database RPC
- retains the superseded provider identity in a durable switch ledger and retries cancellation failures
- scopes terminal and nonterminal webhook mutations to the exact current provider/subscription identity
- threads switch correlation through hosted checkout, manual payment, Solana, and Binance metadata

## Why

The previous flow canceled the current provider before replacement checkout existed. Failed or abandoned checkout could therefore remove a school's paid entitlement, and a delayed terminal webhook from the old provider could later downgrade a successfully activated replacement.

This change separates the pending replacement from the one current entitlement row. The source stays active until payment activation wins an atomic database transition; source-provider cancellation happens afterward and is recoverable.

This branch should be rebased after prerequisite #625 before merge so its webhook claim/concurrency changes are preserved.

## How to QA

1. Run `npm run db:reset` and confirm migration `20260808154118_safe_platform_subscription_switches.sql` applies.
2. Run `npm run test:unit` and confirm all platform billing switch, checkout, lifecycle, crypto, and webhook regressions pass.
3. Start with an active Stripe platform subscription, begin a Lemon Squeezy checkout, then abandon it. Confirm the Stripe subscription and tenant plan remain active and the switch expires to `abandoned`.
4. Complete a Stripe → Lemon Squeezy switch. Confirm the target becomes current first, the source identity remains in `platform_subscription_switches`, and Lemon Squeezy/Stripe cancellation state reflects the provider's actual immediate or period-end result.
5. Replay target activation and send a delayed terminal webhook for the source. Confirm the target period is not extended, the tenant is not downgraded, and source cleanup converges idempotently.
6. Send a terminal webhook matching the exact current provider/subscription identity. Confirm the tenant downgrades to free.

## Screenshots / GIF

Not applicable — backend billing lifecycle, database, and webhook behavior only; no UI changed.

## Checklist

- [x] `npm run typecheck`, `npm run test:unit` (65 files / 853 tests), and `npm run build` pass
- [x] Changed-file lint passes with no errors
- [x] Tenant-scoped reads and mutations are identity-gated; switch writes/RPCs are service-role-only
- [x] Admin-only billing entry points preserve their existing authorization checks
- [x] Failed and abandoned replacement checkouts preserve the current entitlement; cancellation failures are retryable
- [x] No new user-facing strings or translation keys
- [x] Migration applies on a fresh `npm run db:reset`; generated database types are updated

