### PR TITLE
fix(billing): atomically claim webhook events (#625)

### DIFF
--- a/app/api/billing/webhook/[provider]/route.ts
+++ b/app/api/billing/webhook/[provider]/route.ts
@@ -22,6 +22,11 @@ import {
   platformWebhookNamespace,
 } from '@/lib/billing/platform-billing'
 import { dispatchPlatformBillingEvent } from '@/lib/billing/platform-webhook-dispatch'
+import {
+  claimWebhookEvent,
+  completeWebhookEvent,
+  failWebhookEvent,
+} from '@/lib/payments/webhook-event-claim'
 
 export const runtime = 'nodejs'
 
@@ -93,47 +98,29 @@ export async function POST(
   const admin = getSupabaseAdmin()
   const ledgerProvider = platformWebhookNamespace(provider)
 
-  // 3. Idempotency: skip if this event was already processed.
-  const { data: existing, error: lookupErr } = await admin
-    .from('webhook_events')
-    .select('id, processed_at')
-    .eq('provider', ledgerProvider)
-    .eq('provider_event_id', providerEventId)
-    .maybeSingle()
-
-  if (lookupErr) {
-    console.error(`[billing/webhook/${provider}] event lookup failed:`, lookupErr)
-    return NextResponse.json({ error: 'Event lookup failed' }, { status: 500 })
+  // 3. Atomically insert-or-claim before dispatch. An active lease is not a
+  // completed duplicate: respond distinctly and retryably while its owner works.
+  let claim
+  try {
+    claim = await claimWebhookEvent(admin, {
+      provider: ledgerProvider,
+      providerEventId,
+      eventType: event.type,
+      payload: event.raw as Record<string, unknown>,
+    })
+  } catch (err) {
+    console.error(`[billing/webhook/${provider}] event claim failed:`, err)
+    return NextResponse.json({ error: 'Event claim failed' }, { status: 500 })
   }
 
-  if (existing?.processed_at) {
-    return NextResponse.json({ received: true, duplicate: true })
+  if (claim.status === 'completed') {
+    return NextResponse.json({ received: true, duplicate: true, eventStatus: 'already_completed' })
   }
-
-  // A row without processed_at is a previous attempt that failed mid-flight;
-  // reuse it and try again rather than inserting a second one.
-  let rowId = existing?.id as string | undefined
-  if (!rowId) {
-    const { data: inserted, error: insertErr } = await admin
-      .from('webhook_events')
-      .insert({
-        provider: ledgerProvider,
-        provider_event_id: providerEventId,
-        event_type: event.type,
-        payload: event.raw as Record<string, unknown>,
-      })
-      .select('id')
-      .single()
-
-    if (insertErr) {
-      // 23505 = unique violation: a concurrent delivery beat us to it.
-      if ((insertErr as { code?: string }).code === '23505') {
-        return NextResponse.json({ received: true, duplicate: true })
-      }
-      console.error(`[billing/webhook/${provider}] failed to persist event:`, insertErr)
-      return NextResponse.json({ error: 'Failed to persist event' }, { status: 500 })
-    }
-    rowId = inserted.id
+  if (claim.status === 'processing') {
+    return NextResponse.json(
+      { received: true, processing: true, eventStatus: 'already_processing' },
+      { status: 409, headers: { 'Retry-After': '30' } },
+    )
   }
 
   // The revert half of the over-limit downgrade guard, expressed as an ability
@@ -155,23 +142,22 @@ export async function POST(
     await dispatchPlatformBillingEvent(event, { provider, admin, revertToPrice })
   } catch (err) {
     console.error(`[billing/webhook/${provider}] dispatch failed:`, err)
-    await admin
-      .from('webhook_events')
-      .update({ error: err instanceof Error ? err.message : String(err) })
-      .eq('id', rowId)
+    try {
+      await failWebhookEvent(admin, claim, err)
+    } catch (releaseErr) {
+      console.error(`[billing/webhook/${provider}] failed to release claim:`, releaseErr)
+    }
     return NextResponse.json({ error: 'Dispatch failed' }, { status: 500 })
   }
 
-  // 5. Mark processed. If this write fails the event is redelivered and
-  //    re-dispatched; the dispatcher converges (status writes are absolute,
-  //    periods come from the event, not now()), so log rather than fail.
-  const { error: markErr } = await admin
-    .from('webhook_events')
-    .update({ processed_at: new Date().toISOString() })
-    .eq('id', rowId)
-  if (markErr) {
-    console.error(`[billing/webhook/${provider}] failed to mark event ${providerEventId} processed:`, markErr)
+  // 5. Complete only while this request still owns the claim. Never return a
+  // success ACK for side effects whose ledger completion was not durable.
+  try {
+    await completeWebhookEvent(admin, claim)
+  } catch (err) {
+    console.error(`[billing/webhook/${provider}] failed to complete event ${providerEventId}:`, err)
+    return NextResponse.json({ error: 'Event completion failed' }, { status: 500 })
   }
 
-  return NextResponse.json({ received: true })
+  return NextResponse.json({ received: true, eventStatus: 'accepted' })
 }

--- a/app/api/billing/webhook/[provider]/route.ts
+++ b/app/api/billing/webhook/[provider]/route.ts
@@ -156,6 +156,11 @@ export async function POST(
     await completeWebhookEvent(admin, claim)
   } catch (err) {
     console.error(`[billing/webhook/${provider}] failed to complete event ${providerEventId}:`, err)
+    try {
+      await failWebhookEvent(admin, claim, err)
+    } catch (releaseErr) {
+      console.error(`[billing/webhook/${provider}] failed to release claim after completion error:`, releaseErr)
+    }
     return NextResponse.json({ error: 'Event completion failed' }, { status: 500 })
   }
 

--- a/app/api/cron/redeliver-webhook-events/route.ts
+++ b/app/api/cron/redeliver-webhook-events/route.ts
@@ -1,0 +1,220 @@
+/**
+ * Cron: re-dispatch stalled webhook events (issue #625 follow-up).
+ *
+ * The atomic claim contract leaves exactly one orphan case: a worker that dies
+ * WITHOUT running failWebhookEvent (OOM, serverless kill, deploy) holds its
+ * lease until expiry, and every provider retry inside that window is answered
+ * 409. If the provider's remaining redeliveries all land inside the lease — or
+ * it gives up entirely (bounded, front-loaded retry schedules) — the event is
+ * never processed by anyone: the student paid but is never enrolled, the
+ * school paid but is never extended.
+ *
+ * This sweeper is that missing redelivery. It scans `webhook_events` for rows
+ * that are unprocessed AND either
+ *   - lease expired without release (the crashed-worker case), or
+ *   - released with an error (failWebhookEvent ran; the provider may retry,
+ *     but nothing guarantees it still will),
+ * then replays the pipeline the routes run, from the payload persisted at
+ * ingest: normalize → claim → dispatch → complete. Signature verification is
+ * NOT repeated — the payload was only persisted after verifying, and the
+ * provider's secret may not even be presentable outside a live delivery.
+ *
+ * Safe against every concurrent delivery by construction, because it goes
+ * through the SAME claim_webhook_event lease: if a live retry claims first,
+ * this run gets 'processing'/'completed' and walks away.
+ *
+ * Runs every 10 minutes via Vercel Cron (see vercel.json). Secured by
+ * CRON_SECRET. Events that keep failing park at MAX_SWEEP_ATTEMPTS with their
+ * `last_error` retained for manual review — a poison payload must not be
+ * ground against the same exception forever.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+import { getPaymentProvider } from '@/lib/payments'
+import type { IPaymentProvider, PaymentProvider } from '@/lib/payments/types'
+import { PROVIDER_CAPABILITIES } from '@/lib/payments/types'
+import {
+  PLATFORM_WEBHOOK_PROVIDERS,
+  getPlatformBillingProvider,
+  platformWebhookNamespace,
+} from '@/lib/billing/platform-billing'
+import { dispatchBillingEvent } from '@/lib/payments/webhook-dispatch'
+import { dispatchPlatformBillingEvent } from '@/lib/billing/platform-webhook-dispatch'
+import {
+  claimWebhookEvent,
+  completeWebhookEvent,
+  failWebhookEvent,
+  UNIFIED_STUDENT_WEBHOOK_PROVIDERS,
+} from '@/lib/payments/webhook-event-claim'
+
+export const runtime = 'nodejs'
+
+/** Park an event for manual review after this many granted leases. */
+const MAX_SWEEP_ATTEMPTS = 8
+/** Per-run batch cap; the next run picks up the rest. */
+const BATCH_SIZE = 25
+/**
+ * Leave fresh events to the provider's own retries first — the sweeper is a
+ * backstop, not a competitor racing live deliveries.
+ */
+const MIN_AGE_MS = 10 * 60 * 1000
+
+// `webhook_events.provider` for platform-billing rows is namespaced by
+// platformWebhookNamespace(); student rows carry the bare slug.
+const PLATFORM_NS_PREFIX = platformWebhookNamespace('')
+
+interface StalledEventRow {
+  id: string
+  provider: string
+  provider_event_id: string
+  event_type: string | null
+  payload: Record<string, unknown>
+  attempt_count: number
+}
+
+function getSupabaseAdmin(): SupabaseClient {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (!url || !serviceKey) throw new Error('Supabase env vars not set')
+  return createClient(url, serviceKey)
+}
+
+export async function GET(req: NextRequest) {
+  const cronSecret = process.env.CRON_SECRET
+  const provided = req.headers.get('authorization')?.replace('Bearer ', '')
+  if (!cronSecret || provided !== cronSecret) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const admin = getSupabaseAdmin()
+  const nowIso = new Date().toISOString()
+  const ageCutoff = new Date(Date.now() - MIN_AGE_MS).toISOString()
+
+  const { data, error } = await admin
+    .from('webhook_events')
+    .select('id, provider, provider_event_id, event_type, payload, attempt_count')
+    .is('processed_at', null)
+    .or(
+      `processing_lease_expires_at.lte.${nowIso},and(processing_started_at.is.null,last_error.not.is.null)`,
+    )
+    .lt('attempt_count', MAX_SWEEP_ATTEMPTS)
+    .lte('received_at', ageCutoff)
+    .order('received_at', { ascending: true })
+    .limit(BATCH_SIZE)
+
+  if (error) {
+    console.error('[cron/redeliver-webhook-events] scan failed:', error)
+    return NextResponse.json({ error: 'Scan failed' }, { status: 500 })
+  }
+
+  const result = {
+    scanned: (data ?? []).length,
+    redelivered: 0,
+    failed: 0,
+    retired: 0,
+    skipped: 0,
+  }
+
+  for (const row of (data ?? []) as StalledEventRow[]) {
+    try {
+      const isPlatform = row.provider.startsWith(PLATFORM_NS_PREFIX)
+      const slug = (
+        isPlatform ? row.provider.slice(PLATFORM_NS_PREFIX.length) : row.provider
+      ) as PaymentProvider
+
+      // Only rows written by the two unified webhook routes are replayable
+      // here; anything else (unknown namespace, provider since delisted) is
+      // left alone rather than guessed at.
+      const replayable = isPlatform
+        ? PLATFORM_WEBHOOK_PROVIDERS.includes(slug)
+        : UNIFIED_STUDENT_WEBHOOK_PROVIDERS.includes(slug)
+      if (!replayable) {
+        result.skipped++
+        continue
+      }
+
+      let adapter: IPaymentProvider
+      try {
+        adapter = isPlatform ? getPlatformBillingProvider(slug) : getPaymentProvider(slug)
+      } catch {
+        // Not configured in this environment — nothing this run can do.
+        result.skipped++
+        continue
+      }
+      if (!adapter.normalizeWebhookEvent) {
+        result.skipped++
+        continue
+      }
+
+      // The payload column holds the event exactly as the provider sent it
+      // (`event.raw`), so the adapter's own normalizer runs unchanged.
+      const event = await adapter.normalizeWebhookEvent(JSON.stringify(row.payload ?? {}))
+
+      // Claim through the same lease the live routes use. Anything but
+      // 'claimed' means another worker owns it or already finished — walk away.
+      const claim = await claimWebhookEvent(admin, {
+        provider: row.provider,
+        providerEventId: row.provider_event_id,
+        eventType: row.event_type ?? event?.type ?? 'unknown',
+        payload: row.payload ?? {},
+      })
+      if (claim.status !== 'claimed') {
+        result.skipped++
+        continue
+      }
+
+      // An event type the adapter no longer models: the live route would ack
+      // it without dispatching, so retire it instead of re-scanning forever.
+      if (!event) {
+        await completeWebhookEvent(admin, claim)
+        result.retired++
+        continue
+      }
+
+      try {
+        if (isPlatform) {
+          // Same revert ability the billing route hands the dispatcher: only
+          // providers that can swap a price in place get one.
+          const caps = PROVIDER_CAPABILITIES[slug]
+          const revertToPrice =
+            caps?.supportsPlanChange && adapter.updateSubscription
+              ? async (providerSubscriptionId: string, providerPriceId: string) => {
+                  await adapter.updateSubscription!(providerSubscriptionId, {
+                    newProviderPriceId: providerPriceId,
+                    prorationBehavior: 'none',
+                  })
+                }
+              : undefined
+          await dispatchPlatformBillingEvent(event, { provider: slug, admin, revertToPrice })
+        } else {
+          await dispatchBillingEvent(event, { provider: slug, admin })
+        }
+        await completeWebhookEvent(admin, claim)
+        result.redelivered++
+      } catch (dispatchErr) {
+        console.error(
+          `[cron/redeliver-webhook-events] redelivery failed for ${row.provider} ${row.provider_event_id}:`,
+          dispatchErr,
+        )
+        try {
+          await failWebhookEvent(admin, claim, dispatchErr)
+        } catch (releaseErr) {
+          console.error('[cron/redeliver-webhook-events] failed to release claim:', releaseErr)
+        }
+        result.failed++
+      }
+    } catch (rowErr) {
+      // Normalizer or claim blew up — log and move to the next row; the event
+      // stays visible to the next run (or parks at the attempt cap).
+      console.error(
+        `[cron/redeliver-webhook-events] could not replay ${row.provider} ${row.provider_event_id}:`,
+        rowErr,
+      )
+      result.failed++
+    }
+  }
+
+  console.log('[cron/redeliver-webhook-events]', JSON.stringify(result))
+  return NextResponse.json(result)
+}

--- a/app/api/payments/webhook/[provider]/route.ts
+++ b/app/api/payments/webhook/[provider]/route.ts
@@ -20,16 +20,15 @@ import {
   claimWebhookEvent,
   completeWebhookEvent,
   failWebhookEvent,
+  UNIFIED_STUDENT_WEBHOOK_PROVIDERS,
 } from '@/lib/payments/webhook-event-claim'
 
 export const runtime = 'nodejs'
 
-// Providers exposed on this endpoint. getPaymentProvider() still gates on
-// configured credentials; providers without verify/normalize return 501.
-// `manual` and `solana` are intentionally excluded: neither has a signed
-// webhook (Solana confirms on-chain via /api/payments/solana/verify), so
-// exposing a route for them would be an unauthenticated mutation surface.
-const SUPPORTED: PaymentProvider[] = ['stripe', 'paypal', 'lemonsqueezy', 'binance']
+// Providers exposed on this endpoint (shared with the redelivery cron; see the
+// definition for why manual/solana are excluded). getPaymentProvider() still
+// gates on configured credentials; providers without verify/normalize get 501.
+const SUPPORTED: PaymentProvider[] = UNIFIED_STUDENT_WEBHOOK_PROVIDERS
 
 /**
  * Provider-specific ACK body. Binance Pay treats anything other than

--- a/app/api/payments/webhook/[provider]/route.ts
+++ b/app/api/payments/webhook/[provider]/route.ts
@@ -132,7 +132,14 @@ export async function POST(
   }
   if (claim.status === 'processing') {
     return NextResponse.json(
-      ackBody(provider, { processing: true, eventStatus: 'already_processing' }),
+      provider === 'binance'
+        ? {
+            returnCode: 'FAIL',
+            returnMessage: 'Event is already processing',
+            processing: true,
+            eventStatus: 'already_processing',
+          }
+        : ackBody(provider, { processing: true, eventStatus: 'already_processing' }),
       { status: 409, headers: { 'Retry-After': '30' } },
     )
   }
@@ -155,6 +162,11 @@ export async function POST(
     await completeWebhookEvent(admin, claim)
   } catch (err) {
     console.error(`[webhook/${provider}] failed to complete event ${providerEventId}:`, err)
+    try {
+      await failWebhookEvent(admin, claim, err)
+    } catch (releaseErr) {
+      console.error(`[webhook/${provider}] failed to release claim after completion error:`, releaseErr)
+    }
     return NextResponse.json({ error: 'Event completion failed' }, { status: 500 })
   }
 

--- a/app/api/payments/webhook/[provider]/route.ts
+++ b/app/api/payments/webhook/[provider]/route.ts
@@ -16,6 +16,11 @@ import { createClient } from '@supabase/supabase-js'
 import { getPaymentProvider } from '@/lib/payments'
 import type { PaymentProvider } from '@/lib/payments/types'
 import { dispatchBillingEvent } from '@/lib/payments/webhook-dispatch'
+import {
+  claimWebhookEvent,
+  completeWebhookEvent,
+  failWebhookEvent,
+} from '@/lib/payments/webhook-event-claim'
 
 export const runtime = 'nodejs'
 
@@ -105,40 +110,31 @@ export async function POST(
 
   const admin = getSupabaseAdmin()
 
-  // 3. Idempotency: skip if this event was already processed.
-  const { data: existing } = await admin
-    .from('webhook_events')
-    .select('id, processed_at')
-    .eq('provider', provider)
-    .eq('provider_event_id', providerEventId)
-    .maybeSingle()
-
-  if (existing?.processed_at) {
-    return NextResponse.json(ackBody(provider, { duplicate: true }))
+  // 3. Atomically insert-or-claim before dispatch. Both student and platform
+  // webhook routes use this exact lease contract.
+  let claim
+  try {
+    claim = await claimWebhookEvent(admin, {
+      provider,
+      providerEventId,
+      eventType: event.type,
+      payload: event.raw as Record<string, unknown>,
+    })
+  } catch (err) {
+    console.error(`[webhook/${provider}] event claim failed:`, err)
+    return NextResponse.json({ error: 'Event claim failed' }, { status: 500 })
   }
 
-  let rowId = existing?.id as string | undefined
-  if (!rowId) {
-    const { data: inserted, error: insertErr } = await admin
-      .from('webhook_events')
-      .insert({
-        provider,
-        provider_event_id: providerEventId,
-        event_type: event.type,
-        payload: event.raw as Record<string, unknown>,
-      })
-      .select('id')
-      .single()
-
-    if (insertErr) {
-      // 23505 = unique violation: a concurrent delivery beat us to it.
-      if ((insertErr as { code?: string }).code === '23505') {
-        return NextResponse.json(ackBody(provider, { duplicate: true }))
-      }
-      console.error(`[webhook/${provider}] failed to persist event:`, insertErr)
-      return NextResponse.json({ error: 'Failed to persist event' }, { status: 500 })
-    }
-    rowId = inserted.id
+  if (claim.status === 'completed') {
+    return NextResponse.json(
+      ackBody(provider, { duplicate: true, eventStatus: 'already_completed' }),
+    )
+  }
+  if (claim.status === 'processing') {
+    return NextResponse.json(
+      ackBody(provider, { processing: true, eventStatus: 'already_processing' }),
+      { status: 409, headers: { 'Retry-After': '30' } },
+    )
   }
 
   // 4. Dispatch. On failure, record the error and 500 so the provider retries.
@@ -146,23 +142,21 @@ export async function POST(
     await dispatchBillingEvent(event, { provider, admin })
   } catch (err) {
     console.error(`[webhook/${provider}] dispatch failed:`, err)
-    await admin
-      .from('webhook_events')
-      .update({ error: err instanceof Error ? err.message : String(err) })
-      .eq('id', rowId)
+    try {
+      await failWebhookEvent(admin, claim, err)
+    } catch (releaseErr) {
+      console.error(`[webhook/${provider}] failed to release claim:`, releaseErr)
+    }
     return NextResponse.json({ error: 'Dispatch failed' }, { status: 500 })
   }
 
-  // 5. Mark processed. If this write fails the event will be redelivered and
-  //    re-dispatched; the dispatcher is idempotent (status writes converge,
-  //    period end comes from the event, not now()), so log rather than fail.
-  const { error: markErr } = await admin
-    .from('webhook_events')
-    .update({ processed_at: new Date().toISOString() })
-    .eq('id', rowId)
-  if (markErr) {
-    console.error(`[webhook/${provider}] failed to mark event ${providerEventId} processed:`, markErr)
+  // 5. Fence completion by token and fail closed if it is not durable.
+  try {
+    await completeWebhookEvent(admin, claim)
+  } catch (err) {
+    console.error(`[webhook/${provider}] failed to complete event ${providerEventId}:`, err)
+    return NextResponse.json({ error: 'Event completion failed' }, { status: 500 })
   }
 
-  return NextResponse.json(ackBody(provider))
+  return NextResponse.json(ackBody(provider, { eventStatus: 'accepted' }))
 }

--- a/lib/billing/platform-webhook-dispatch.ts
+++ b/lib/billing/platform-webhook-dispatch.ts
@@ -315,22 +315,33 @@ export async function dispatchPlatformBillingEvent(
   const periodEnd = event.periodEnd?.toISOString()
 
   if (event.type === 'subscription.past_due') {
-    await unwrap(
+    // The transition test lives in the WHERE clause, not in a read of `stored`:
+    // a single failed charge produces more than one past_due event (the failed
+    // invoice and the subscription's own status change), and two of them
+    // dispatching concurrently would BOTH pass a read-then-check against the
+    // same 'active' snapshot. Only the update that actually flips the row wins
+    // the right to notify.
+    const transitioned = (await unwrap(
       'platform_subscriptions past_due',
-      admin.from('platform_subscriptions').update({ status, updated_at: now }).eq('tenant_id', tenantId),
-    )
+      admin
+        .from('platform_subscriptions')
+        .update({ status, updated_at: now })
+        .eq('tenant_id', tenantId)
+        .neq('status', 'past_due')
+        .select('tenant_id'),
+    )) as { tenant_id: string }[] | null
     await unwrap(
       'tenants past_due',
       admin.from('tenants').update({ billing_status: status, updated_at: now }).eq('id', tenantId),
     )
 
-    // Only on the TRANSITION into dunning. A single failed charge produces more
-    // than one past_due event (the failed invoice and the subscription's own
-    // status change), and a redelivery produces another — mailing on each would
-    // send a school three copies of the same bad news. Best-effort besides: a
-    // mail failure must not undo the writes above by 500-ing, which would have
-    // the provider redeliver an event we had already applied.
-    if (stored?.status !== 'past_due') {
+    // Only on the TRANSITION into dunning — mailing on each event would send a
+    // school three copies of the same bad news. `!stored` keeps the pre-#625
+    // behavior of still warning a tenant that has no subscription row at all.
+    // Best-effort besides: a mail failure must not undo the writes above by
+    // 500-ing, which would have the provider redeliver an event we had already
+    // applied.
+    if ((transitioned?.length ?? 0) > 0 || !stored) {
       if (!event.providerEventId) {
         throw new Error(`platform dispatch ${event.type}: provider event id is required for notification dedupe`)
       }

--- a/lib/billing/platform-webhook-dispatch.ts
+++ b/lib/billing/platform-webhook-dispatch.ts
@@ -362,18 +362,6 @@ export async function dispatchPlatformBillingEvent(
     : undefined
   const interval = event.interval ?? mapInterval(event.metadata?.interval)
 
-  // Providers that bill on a schedule report the period they just charged for.
-  // The ones WE own report nothing, and a subscription with a NULL
-  // current_period_end never lapses, never reminds and shows no next-payment
-  // date — it is the whole difference between a paid month and a free one.
-  const derived =
-    selfManaged && !event.periodEnd && status === 'active'
-      ? selfManagedPeriod(stored?.current_period_end, interval, new Date(now))
-      : null
-
-  const effectiveStart = periodStart ?? derived?.start.toISOString()
-  const effectiveEnd = periodEnd ?? derived?.end.toISOString()
-
   // The plan the ROW must carry, which is a different question from `planId`
   // above. That one answers "is this event moving the school to a new plan?" and
   // is deliberately undefined on every event after the first; this one answers
@@ -403,6 +391,37 @@ export async function dispatchPlatformBillingEvent(
     return
   }
 
+  // Providers that bill on a schedule report the period they just charged for.
+  // Self-managed rails do not, so period extension and provider-event dedupe
+  // happen together in PostgreSQL. This remains correct for A,B,A replay order
+  // and for concurrent different payments on the same tenant.
+  let effectiveStart = periodStart
+  let effectiveEnd = periodEnd
+  let derivedPeriod = false
+  if (selfManaged && !event.periodEnd && status === 'active') {
+    derivedPeriod = true
+    if (event.providerEventId) {
+      const rows = (await unwrap(
+        'self-managed platform period apply',
+        admin.rpc('apply_self_managed_platform_period', {
+          _provider: provider,
+          _provider_event_id: event.providerEventId,
+          _tenant_id: tenantId,
+          _plan_id: rowPlanId,
+          _interval: interval ?? 'monthly',
+          _provider_subscription_id: event.providerSubscriptionId ?? null,
+          _provider_customer_id: event.providerCustomerId ?? null,
+        }),
+      )) as { period_start: string | null; period_end: string | null }[]
+      effectiveStart = rows[0]?.period_start ?? undefined
+      effectiveEnd = rows[0]?.period_end ?? undefined
+    } else {
+      const derived = selfManagedPeriod(stored?.current_period_end, interval, new Date(now))
+      effectiveStart = derived.start.toISOString()
+      effectiveEnd = derived.end.toISOString()
+    }
+  }
+
   const subscriptionPatch: Record<string, unknown> = {
     status,
     payment_provider: provider,
@@ -420,7 +439,7 @@ export async function dispatchPlatformBillingEvent(
         // confirmManualPayment treats a confirmed transfer (#546 §1). Without
         // this the school pays for a month and the cron's cancel phase still
         // drops it to free at the end of it.
-        derived
+        derivedPeriod
         ? { cancel_at_period_end: false, canceled_at: null }
         : {}),
     // Paid means out of dunning. The cron reopens a window if the new period

--- a/lib/billing/platform-webhook-dispatch.ts
+++ b/lib/billing/platform-webhook-dispatch.ts
@@ -331,8 +331,20 @@ export async function dispatchPlatformBillingEvent(
     // mail failure must not undo the writes above by 500-ing, which would have
     // the provider redeliver an event we had already applied.
     if (stored?.status !== 'past_due') {
+      if (!event.providerEventId) {
+        throw new Error(`platform dispatch ${event.type}: provider event id is required for notification dedupe`)
+      }
       try {
-        await notifyPaymentFailed(admin, tenantId, sendEmailFn)
+        const shouldNotify = await unwrap(
+          'payment-failed notification claim',
+          admin.rpc('claim_webhook_business_effect', {
+            _provider: `platform:${provider}`,
+            _provider_event_id: event.providerEventId,
+            _effect_type: 'platform_payment_failed_email',
+            _target_id: tenantId,
+          }),
+        )
+        if (shouldNotify) await notifyPaymentFailed(admin, tenantId, sendEmailFn)
       } catch (emailErr) {
         console.error('[platform-webhook] failed to send payment-failed email:', emailErr)
       }
@@ -400,26 +412,47 @@ export async function dispatchPlatformBillingEvent(
   let derivedPeriod = false
   if (selfManaged && !event.periodEnd && status === 'active') {
     derivedPeriod = true
-    if (event.providerEventId) {
-      const rows = (await unwrap(
-        'self-managed platform period apply',
-        admin.rpc('apply_self_managed_platform_period', {
-          _provider: provider,
-          _provider_event_id: event.providerEventId,
-          _tenant_id: tenantId,
-          _plan_id: rowPlanId,
-          _interval: interval ?? 'monthly',
-          _provider_subscription_id: event.providerSubscriptionId ?? null,
-          _provider_customer_id: event.providerCustomerId ?? null,
-        }),
-      )) as { period_start: string | null; period_end: string | null }[]
-      effectiveStart = rows[0]?.period_start ?? undefined
-      effectiveEnd = rows[0]?.period_end ?? undefined
-    } else {
-      const derived = selfManagedPeriod(stored?.current_period_end, interval, new Date(now))
-      effectiveStart = derived.start.toISOString()
-      effectiveEnd = derived.end.toISOString()
+    if (!event.providerEventId) {
+      throw new Error(`platform dispatch ${event.type}: provider event id is required for period accounting`)
     }
+    const rows = (await unwrap(
+      'self-managed platform period apply',
+      admin.rpc('apply_self_managed_platform_period', {
+        _provider: provider,
+        _provider_event_id: event.providerEventId,
+        _tenant_id: tenantId,
+        _plan_id: rowPlanId,
+        _plan_slug: planSlug ?? null,
+        _interval: interval ?? 'monthly',
+        _provider_subscription_id: event.providerSubscriptionId ?? null,
+        _provider_customer_id: event.providerCustomerId ?? null,
+      }),
+    )) as { applied: boolean; period_start: string | null; period_end: string | null }[]
+    const result = rows[0]
+    if (!result?.period_start || !result.period_end) {
+      throw new Error(`self-managed platform period apply returned no durable period for ${tenantId}`)
+    }
+    effectiveStart = result.period_start
+    effectiveEnd = result.period_end
+
+    // The RPC is the sole writer for self-managed subscription, tenant period,
+    // plan, cancellation reset and revenue split. Re-running the generic
+    // upserts below would let an older worker rewind a newer serialized result.
+    if (event.providerCustomerId) {
+      await unwrap(
+        'tenant_billing_customers upsert',
+        admin.from('tenant_billing_customers').upsert(
+          {
+            tenant_id: tenantId,
+            payment_provider: provider,
+            provider_customer_id: event.providerCustomerId,
+          },
+          { onConflict: 'tenant_id,payment_provider' },
+        ),
+      )
+    }
+    if (result.applied) await reconcileAccessCutoffSafely(admin, tenantId)
+    return
   }
 
   const subscriptionPatch: Record<string, unknown> = {

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -6270,6 +6270,7 @@ export type Database = {
           id: string
           last_error: string | null
           payload: Json
+          processing_lease_expires_at: string | null
           processing_started_at: string | null
           processing_token: string | null
           processed_at: string | null
@@ -6284,6 +6285,7 @@ export type Database = {
           id?: string
           last_error?: string | null
           payload?: Json
+          processing_lease_expires_at?: string | null
           processing_started_at?: string | null
           processing_token?: string | null
           processed_at?: string | null
@@ -6298,6 +6300,7 @@ export type Database = {
           id?: string
           last_error?: string | null
           payload?: Json
+          processing_lease_expires_at?: string | null
           processing_started_at?: string | null
           processing_token?: string | null
           processed_at?: string | null
@@ -6438,6 +6441,7 @@ export type Database = {
         Args: {
           _interval: string
           _plan_id: string
+          _plan_slug: string | null
           _provider: string
           _provider_customer_id?: string
           _provider_event_id: string
@@ -6449,6 +6453,25 @@ export type Database = {
           period_end: string
           period_start: string
         }[]
+      }
+      apply_webhook_subscription_period: {
+        Args: {
+          _allow_period_realign?: boolean
+          _new_period_end: string
+          _provider: string
+          _provider_event_id: string
+          _provider_subscription_id: string
+        }
+        Returns: boolean
+      }
+      claim_webhook_business_effect: {
+        Args: {
+          _effect_type: string
+          _provider: string
+          _provider_event_id: string
+          _target_id: string
+        }
+        Returns: boolean
       }
       apply_webhook_refund: {
         Args: {

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -6235,32 +6235,71 @@ export type Database = {
         }
         Relationships: []
       }
+      webhook_business_effects: {
+        Row: {
+          applied_at: string
+          effect_type: string
+          id: string
+          provider: string
+          provider_event_id: string
+          target_id: string
+        }
+        Insert: {
+          applied_at?: string
+          effect_type: string
+          id?: string
+          provider: string
+          provider_event_id: string
+          target_id: string
+        }
+        Update: {
+          applied_at?: string
+          effect_type?: string
+          id?: string
+          provider?: string
+          provider_event_id?: string
+          target_id?: string
+        }
+        Relationships: []
+      }
       webhook_events: {
         Row: {
+          attempt_count: number
           error: string | null
           event_type: string | null
           id: string
+          last_error: string | null
           payload: Json
+          processing_started_at: string | null
+          processing_token: string | null
           processed_at: string | null
           provider: string
           provider_event_id: string
           received_at: string
         }
         Insert: {
+          attempt_count?: number
           error?: string | null
           event_type?: string | null
           id?: string
+          last_error?: string | null
           payload?: Json
+          processing_started_at?: string | null
+          processing_token?: string | null
           processed_at?: string | null
           provider: string
           provider_event_id: string
           received_at?: string
         }
         Update: {
+          attempt_count?: number
           error?: string | null
           event_type?: string | null
           id?: string
+          last_error?: string | null
           payload?: Json
+          processing_started_at?: string | null
+          processing_token?: string | null
           processed_at?: string | null
           provider?: string
           provider_event_id?: string
@@ -6395,6 +6434,57 @@ export type Database = {
       }
     }
     Functions: {
+      apply_self_managed_platform_period: {
+        Args: {
+          _interval: string
+          _plan_id: string
+          _provider: string
+          _provider_customer_id?: string
+          _provider_event_id: string
+          _provider_subscription_id?: string
+          _tenant_id: string
+        }
+        Returns: {
+          applied: boolean
+          period_end: string
+          period_start: string
+        }[]
+      }
+      apply_webhook_refund: {
+        Args: {
+          _provider: string
+          _provider_event_id: string
+          _refund_amount: number
+          _transaction_id: number
+        }
+        Returns: {
+          applied: boolean
+          is_full_refund: boolean
+          plan_id: number
+          product_id: number
+          refunded_amount: number
+          user_id: string
+        }[]
+      }
+      claim_webhook_event: {
+        Args: {
+          _claim_token: string
+          _event_type: string
+          _lease_seconds?: number
+          _payload: Json
+          _provider: string
+          _provider_event_id: string
+        }
+        Returns: {
+          claim_status: string
+          current_attempt_count: number
+          event_id: string
+        }[]
+      }
+      complete_webhook_event: {
+        Args: { _claim_token: string; _event_id: string }
+        Returns: boolean
+      }
       award_xp:
         | {
             Args: {
@@ -6492,6 +6582,10 @@ export type Database = {
       create_student_question_notification: {
         Args: { _context?: string; _course_id: number; _message: string }
         Returns: number
+      }
+      fail_webhook_event: {
+        Args: { _claim_token: string; _event_id: string; _last_error: string }
+        Returns: boolean
       }
       create_transaction_for_renewal: {
         Args: { pln_id: number; sub_id: number; usr_id: string }

--- a/lib/payments/webhook-dispatch.ts
+++ b/lib/payments/webhook-dispatch.ts
@@ -285,12 +285,21 @@ export async function dispatchBillingEvent(
 
       const { data: tx } = await admin
         .from('transactions')
-        .select('transaction_id, status, user_id, plan_id, product_id, amount, currency, refunded_amount')
+        .select(
+          'transaction_id, status, user_id, plan_id, product_id, amount, currency, refunded_amount',
+        )
         .eq('transaction_id', txnId)
         .maybeSingle()
 
-      // Only act on a completed purchase of one of the two kinds.
-      if (!tx || tx.status !== 'successful') break
+      // Durable provider-event refunds can revisit a fully refunded row to
+      // repair downstream entitlement state. Legacy callers without an event
+      // id keep the historical successful-only guard.
+      if (
+        !tx ||
+        (event.providerEventId
+          ? !['successful', 'refunded'].includes(tx.status)
+          : tx.status !== 'successful')
+      ) break
       if (!tx.product_id && !tx.plan_id) break
 
       // How much of the sale this refund actually gave back (#547). All three
@@ -299,38 +308,60 @@ export async function dispatchBillingEvent(
       // school for money it was still owed — and revoked course access from a
       // student who had only been refunded a slice.
       const saleAmount = Number(tx.amount ?? 0)
-      const priorRefunded = Number(tx.refunded_amount ?? 0)
       const slice = refundedSlice(event, tx.currency, saleAmount, txnId)
-      // Clamped: a provider that over-reports (or a second event replaying a
-      // cumulative total) can only ever reach a full refund, never a negative
-      // balance owed.
-      const newRefunded = Math.min(priorRefunded + slice, saleAmount)
-      // A cent of tolerance: NUMERIC(10,2) money compared with float arithmetic.
-      const isFullRefund = newRefunded >= saleAmount - 0.005
+      let isFullRefund: boolean
+      let refundedUserId = tx.user_id
+      let refundedProductId = tx.product_id
 
-      const { error: refErr } = await admin
-        .from('transactions')
-        .update({
-          // A partial refund keeps the row 'successful' and records the slice —
-          // the same shape the legacy Stripe route has always used
-          // (app/api/stripe/webhook/route.ts, `isFullRefund`). Readers subtract
-          // `refunded_amount` from `amount`.
-          status: isFullRefund ? 'refunded' : 'successful',
-          refunded_amount: newRefunded,
+      if (event.providerEventId) {
+        // Row lock + effect insert + accounting update are one DB transaction.
+        // Different refunds serialize; A,B,A replay cannot add A twice.
+        const { data, error } = await admin.rpc('apply_webhook_refund', {
+          _provider: provider,
+          _provider_event_id: event.providerEventId,
+          _transaction_id: txnId,
+          _refund_amount: slice,
         })
-        .eq('transaction_id', txnId)
-        .eq('status', 'successful')
-      if (refErr) throw new Error(`dispatch ${event.type} failed: ${refErr.message}`)
+        if (error) throw new Error(`dispatch ${event.type} failed: ${error.message}`)
+        const result = (data as {
+          is_full_refund: boolean
+          user_id: string
+          product_id: number | null
+        }[] | null)?.[0]
+        if (!result) break
+        isFullRefund = result.is_full_refund
+        refundedUserId = result.user_id
+        refundedProductId = result.product_id
+      } else {
+        const priorRefunded = Number(tx.refunded_amount ?? 0)
+        // Legacy paths without a stable event id retain the status-guarded
+        // update. Unified webhooks always take the atomic RPC above.
+        const newRefunded = Math.min(priorRefunded + slice, saleAmount)
+        isFullRefund = newRefunded >= saleAmount - 0.005
+        const { error: refErr } = await admin
+          .from('transactions')
+          .update({
+            // A partial refund keeps the row 'successful' and records the slice —
+            // the same shape the legacy Stripe route has always used
+            // (app/api/stripe/webhook/route.ts, `isFullRefund`). Readers subtract
+            // `refunded_amount` from `amount`.
+            status: isFullRefund ? 'refunded' : 'successful',
+            refunded_amount: newRefunded,
+          })
+          .eq('transaction_id', txnId)
+          .eq('status', 'successful')
+        if (refErr) throw new Error(`dispatch ${event.type} failed: ${refErr.message}`)
+      }
 
       // Access follows the FULL refund only. A student refunded $10 of a $100
       // course keeps the course.
-      if (tx.product_id && isFullRefund) {
+      if (refundedProductId && isFullRefund) {
         const { error: entErr } = await admin
           .from('entitlements')
           .update({ status: 'revoked', revoked_at: new Date().toISOString() })
-          .eq('user_id', tx.user_id)
+          .eq('user_id', refundedUserId)
           .eq('source_type', 'product')
-          .eq('source_id', tx.product_id)
+          .eq('source_id', refundedProductId)
         if (entErr) throw new Error(`dispatch ${event.type} entitlement revoke failed: ${entErr.message}`)
       }
       break

--- a/lib/payments/webhook-dispatch.ts
+++ b/lib/payments/webhook-dispatch.ts
@@ -120,10 +120,15 @@ export async function dispatchBillingEvent(
             // handle_new_subscription set end_date from the plan duration; the
             // provider's schedule is authoritative, so align to renews_at.
             if (event.periodEnd) {
-              const { error: extErr } = await admin.rpc('extend_subscription_period', {
+              if (!event.providerEventId) {
+                throw new Error(`dispatch ${event.type}: provider event id is required for period alignment`)
+              }
+              const { error: extErr } = await admin.rpc('apply_webhook_subscription_period', {
+                _provider_event_id: event.providerEventId,
                 _provider_subscription_id: subId,
                 _provider: provider,
                 _new_period_end: event.periodEnd.toISOString(),
+                _allow_period_realign: true,
               })
               if (extErr) throw new Error(`dispatch ${event.type} period-align failed: ${extErr.message}`)
             }
@@ -157,10 +162,15 @@ export async function dispatchBillingEvent(
         console.warn(`[webhook] renewed for ${provider} sub ${subId} without periodEnd — cannot extend access`)
         break
       }
-      const { error } = await admin.rpc('extend_subscription_period', {
+      if (!event.providerEventId) {
+        throw new Error(`dispatch ${event.type}: provider event id is required for period extension`)
+      }
+      const { error } = await admin.rpc('apply_webhook_subscription_period', {
+        _provider_event_id: event.providerEventId,
         _provider_subscription_id: subId,
         _provider: provider,
         _new_period_end: event.periodEnd.toISOString(),
+        _allow_period_realign: false,
       })
       if (error) throw new Error(`dispatch ${event.type} failed: ${error.message}`)
       break
@@ -282,6 +292,9 @@ export async function dispatchBillingEvent(
       if (!event.reference) break
       const txnId = Number.parseInt(event.reference, 10)
       if (Number.isNaN(txnId)) break
+      if (!event.providerEventId) {
+        throw new Error(`dispatch ${event.type}: provider event id is required for refund accounting`)
+      }
 
       const { data: tx } = await admin
         .from('transactions')
@@ -291,15 +304,11 @@ export async function dispatchBillingEvent(
         .eq('transaction_id', txnId)
         .maybeSingle()
 
-      // Durable provider-event refunds can revisit a fully refunded row to
-      // repair downstream entitlement state. Legacy callers without an event
-      // id keep the historical successful-only guard.
-      if (
-        !tx ||
-        (event.providerEventId
-          ? !['successful', 'refunded'].includes(tx.status)
-          : tx.status !== 'successful')
-      ) break
+      if (!tx) throw new Error(`dispatch ${event.type}: transaction ${txnId} not found`)
+      if (tx.status === 'pending') {
+        throw new Error(`dispatch ${event.type}: transaction ${txnId} is still pending`)
+      }
+      if (!['successful', 'refunded'].includes(tx.status)) break
       if (!tx.product_id && !tx.plan_id) break
 
       // How much of the sale this refund actually gave back (#547). All three
@@ -309,60 +318,18 @@ export async function dispatchBillingEvent(
       // student who had only been refunded a slice.
       const saleAmount = Number(tx.amount ?? 0)
       const slice = refundedSlice(event, tx.currency, saleAmount, txnId)
-      let isFullRefund: boolean
-      let refundedUserId = tx.user_id
-      let refundedProductId = tx.product_id
-
-      if (event.providerEventId) {
-        // Row lock + effect insert + accounting update are one DB transaction.
-        // Different refunds serialize; A,B,A replay cannot add A twice.
-        const { data, error } = await admin.rpc('apply_webhook_refund', {
-          _provider: provider,
-          _provider_event_id: event.providerEventId,
-          _transaction_id: txnId,
-          _refund_amount: slice,
-        })
-        if (error) throw new Error(`dispatch ${event.type} failed: ${error.message}`)
-        const result = (data as {
-          is_full_refund: boolean
-          user_id: string
-          product_id: number | null
-        }[] | null)?.[0]
-        if (!result) break
-        isFullRefund = result.is_full_refund
-        refundedUserId = result.user_id
-        refundedProductId = result.product_id
-      } else {
-        const priorRefunded = Number(tx.refunded_amount ?? 0)
-        // Legacy paths without a stable event id retain the status-guarded
-        // update. Unified webhooks always take the atomic RPC above.
-        const newRefunded = Math.min(priorRefunded + slice, saleAmount)
-        isFullRefund = newRefunded >= saleAmount - 0.005
-        const { error: refErr } = await admin
-          .from('transactions')
-          .update({
-            // A partial refund keeps the row 'successful' and records the slice —
-            // the same shape the legacy Stripe route has always used
-            // (app/api/stripe/webhook/route.ts, `isFullRefund`). Readers subtract
-            // `refunded_amount` from `amount`.
-            status: isFullRefund ? 'refunded' : 'successful',
-            refunded_amount: newRefunded,
-          })
-          .eq('transaction_id', txnId)
-          .eq('status', 'successful')
-        if (refErr) throw new Error(`dispatch ${event.type} failed: ${refErr.message}`)
-      }
-
-      // Access follows the FULL refund only. A student refunded $10 of a $100
-      // course keeps the course.
-      if (refundedProductId && isFullRefund) {
-        const { error: entErr } = await admin
-          .from('entitlements')
-          .update({ status: 'revoked', revoked_at: new Date().toISOString() })
-          .eq('user_id', refundedUserId)
-          .eq('source_type', 'product')
-          .eq('source_id', refundedProductId)
-        if (entErr) throw new Error(`dispatch ${event.type} entitlement revoke failed: ${entErr.message}`)
+      // Dedupe, accounting and full-refund entitlement revocation share one
+      // transaction. A replay cannot revoke an entitlement reactivated by a
+      // later purchase, and a crash cannot split money from access state.
+      const { data, error } = await admin.rpc('apply_webhook_refund', {
+        _provider: provider,
+        _provider_event_id: event.providerEventId,
+        _transaction_id: txnId,
+        _refund_amount: slice,
+      })
+      if (error) throw new Error(`dispatch ${event.type} failed: ${error.message}`)
+      if (!(data as { applied: boolean }[] | null)?.[0]) {
+        throw new Error(`dispatch ${event.type}: refund transaction ${txnId} was not applicable`)
       }
       break
     }

--- a/lib/payments/webhook-event-claim.ts
+++ b/lib/payments/webhook-event-claim.ts
@@ -1,7 +1,26 @@
 import { randomUUID } from 'node:crypto'
 import type { SupabaseClient } from '@supabase/supabase-js'
+import type { PaymentProvider } from '@/lib/payments/types'
 
 export const WEBHOOK_CLAIM_LEASE_SECONDS = 5 * 60
+
+/**
+ * Providers exposed on the unified STUDENT webhook endpoint
+ * (`/api/payments/webhook/[provider]`), which writes un-namespaced rows to
+ * `webhook_events`. Lives here (not in the route file — Next.js route modules
+ * may only export handlers) because the redelivery cron needs the same list to
+ * know which stalled ledger rows it is allowed to re-dispatch.
+ *
+ * `manual` and `solana` are intentionally excluded: neither has a signed
+ * webhook (Solana confirms on-chain via /api/payments/solana/verify), so
+ * exposing a route for them would be an unauthenticated mutation surface.
+ */
+export const UNIFIED_STUDENT_WEBHOOK_PROVIDERS: PaymentProvider[] = [
+  'stripe',
+  'paypal',
+  'lemonsqueezy',
+  'binance',
+]
 
 export type WebhookClaimResult =
   | { status: 'claimed'; eventId: string; claimToken: string; attemptCount: number }

--- a/lib/payments/webhook-event-claim.ts
+++ b/lib/payments/webhook-event-claim.ts
@@ -1,0 +1,105 @@
+import { randomUUID } from 'node:crypto'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+export const WEBHOOK_CLAIM_LEASE_SECONDS = 5 * 60
+
+export type WebhookClaimResult =
+  | { status: 'claimed'; eventId: string; claimToken: string; attemptCount: number }
+  | { status: 'processing'; eventId: string; attemptCount: number }
+  | { status: 'completed'; eventId: string; attemptCount: number }
+
+interface ClaimRow {
+  event_id: string
+  claim_status: 'claimed' | 'processing' | 'completed'
+  current_attempt_count: number
+}
+
+interface ClaimWebhookEventParams {
+  provider: string
+  providerEventId: string
+  eventType: string
+  payload: Record<string, unknown>
+  leaseSeconds?: number
+}
+
+function rpcError(label: string, error: { message?: string }): Error {
+  return new Error(`${label} failed: ${error.message ?? JSON.stringify(error)}`)
+}
+
+/**
+ * Atomically insert or lease a webhook event. Only a `claimed` result may
+ * dispatch business side effects; the other outcomes are deterministic ACKs.
+ */
+export async function claimWebhookEvent(
+  admin: SupabaseClient,
+  {
+    provider,
+    providerEventId,
+    eventType,
+    payload,
+    leaseSeconds = WEBHOOK_CLAIM_LEASE_SECONDS,
+  }: ClaimWebhookEventParams,
+): Promise<WebhookClaimResult> {
+  const claimToken = randomUUID()
+  const { data, error } = await admin.rpc('claim_webhook_event', {
+    _provider: provider,
+    _provider_event_id: providerEventId,
+    _event_type: eventType,
+    _payload: payload,
+    _claim_token: claimToken,
+    _lease_seconds: leaseSeconds,
+  })
+
+  if (error) throw rpcError('webhook event claim', error)
+
+  const row = (data as ClaimRow[] | null)?.[0]
+  if (!row || !['claimed', 'processing', 'completed'].includes(row.claim_status)) {
+    throw new Error('webhook event claim returned an invalid result')
+  }
+
+  if (row.claim_status === 'claimed') {
+    return {
+      status: 'claimed',
+      eventId: row.event_id,
+      claimToken,
+      attemptCount: row.current_attempt_count,
+    }
+  }
+
+  return {
+    status: row.claim_status,
+    eventId: row.event_id,
+    attemptCount: row.current_attempt_count,
+  }
+}
+
+/** Mark a claimed event complete. A false result means this worker lost ownership. */
+export async function completeWebhookEvent(
+  admin: SupabaseClient,
+  claim: Extract<WebhookClaimResult, { status: 'claimed' }>,
+): Promise<void> {
+  const { data, error } = await admin.rpc('complete_webhook_event', {
+    _event_id: claim.eventId,
+    _claim_token: claim.claimToken,
+  })
+
+  if (error) throw rpcError('webhook event completion', error)
+  if (data !== true) throw new Error('webhook event completion rejected: claim ownership lost')
+}
+
+/** Record a transient failure and immediately release the event for retry. */
+export async function failWebhookEvent(
+  admin: SupabaseClient,
+  claim: Extract<WebhookClaimResult, { status: 'claimed' }>,
+  reason: unknown,
+): Promise<void> {
+  const message = reason instanceof Error ? reason.message : String(reason)
+  const { data, error } = await admin.rpc('fail_webhook_event', {
+    _event_id: claim.eventId,
+    _claim_token: claim.claimToken,
+    _last_error: message,
+  })
+
+  if (error) throw rpcError('webhook event failure release', error)
+  if (data !== true) throw new Error('webhook event failure release rejected: claim ownership lost')
+}

--- a/supabase/migrations/20260808154215_atomic_webhook_event_claim.sql
+++ b/supabase/migrations/20260808154215_atomic_webhook_event_claim.sql
@@ -6,6 +6,7 @@ alter table public.webhook_events
   add column if not exists processing_token uuid,
   add column if not exists attempt_count integer not null default 0,
   add column if not exists processing_started_at timestamptz,
+  add column if not exists processing_lease_expires_at timestamptz,
   add column if not exists last_error text;
 
 alter table public.webhook_events
@@ -21,6 +22,8 @@ comment on column public.webhook_events.attempt_count is
   'Number of processing leases granted for this provider event.';
 comment on column public.webhook_events.processing_started_at is
   'Start of the active processing lease. NULL means an explicit failure released the event for immediate retry.';
+comment on column public.webhook_events.processing_lease_expires_at is
+  'Expiry chosen by the lease owner at claim time. Challengers cannot shorten an active owner''s lease.';
 comment on column public.webhook_events.last_error is
   'Most recent dispatch error, retained for audit even after a later successful retry.';
 
@@ -57,7 +60,8 @@ begin
     payload,
     processing_token,
     attempt_count,
-    processing_started_at
+    processing_started_at,
+    processing_lease_expires_at
   )
   values (
     _provider,
@@ -66,7 +70,8 @@ begin
     coalesce(_payload, '{}'::jsonb),
     _claim_token,
     1,
-    claim_time
+    claim_time,
+    claim_time + make_interval(secs => bounded_lease_seconds)
   )
   on conflict (provider, provider_event_id) do nothing
   returning * into claimed;
@@ -79,6 +84,7 @@ begin
   update public.webhook_events as event
   set processing_token = _claim_token,
       processing_started_at = claim_time,
+      processing_lease_expires_at = claim_time + make_interval(secs => bounded_lease_seconds),
       attempt_count = event.attempt_count + 1,
       event_type = coalesce(_event_type, event.event_type),
       payload = coalesce(_payload, event.payload)
@@ -87,7 +93,8 @@ begin
     and event.processed_at is null
     and (
       event.processing_started_at is null
-      or event.processing_started_at <= claim_time - make_interval(secs => bounded_lease_seconds)
+      or event.processing_lease_expires_at is null
+      or event.processing_lease_expires_at <= claim_time
     )
   returning event.* into claimed;
 
@@ -143,6 +150,7 @@ as $$
   with failed as (
     update public.webhook_events
     set processing_started_at = null,
+        processing_lease_expires_at = null,
         last_error = left(coalesce(_last_error, 'Unknown dispatch error'), 4000),
         error = left(coalesce(_last_error, 'Unknown dispatch error'), 4000)
     where id = _event_id
@@ -168,6 +176,28 @@ create table if not exists public.webhook_business_effects (
 );
 
 alter table public.webhook_business_effects enable row level security;
+
+create or replace function public.claim_webhook_business_effect(
+  _provider text,
+  _provider_event_id text,
+  _effect_type text,
+  _target_id text
+)
+returns boolean
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+begin
+  insert into public.webhook_business_effects (
+    provider, provider_event_id, effect_type, target_id
+  ) values (
+    _provider, _provider_event_id, _effect_type, _target_id
+  )
+  on conflict (provider, provider_event_id, effect_type, target_id) do nothing;
+  return found;
+end;
+$$;
 
 create or replace function public.apply_webhook_refund(
   _provider text,
@@ -196,7 +226,18 @@ begin
   where transaction_id = _transaction_id
   for update;
 
-  if not found or transaction_row.status not in ('successful', 'refunded') then
+  if not found then
+    raise exception 'refund transaction % not found', _transaction_id using errcode = 'P0002';
+  end if;
+
+  if transaction_row.status = 'pending' then
+    raise exception 'refund transaction % is still pending', _transaction_id using errcode = '40001';
+  end if;
+
+  if transaction_row.status <> 'successful' then
+    return query select false, transaction_row.refunded_amount,
+      transaction_row.status = 'refunded', transaction_row.user_id,
+      transaction_row.product_id::bigint, transaction_row.plan_id::bigint;
     return;
   end if;
 
@@ -224,6 +265,14 @@ begin
         end
     where transaction_id = _transaction_id
     returning * into transaction_row;
+
+    if transaction_row.product_id is not null and transaction_row.status = 'refunded' then
+      update public.entitlements as entitlement
+      set status = 'revoked', revoked_at = clock_timestamp()
+      where entitlement.user_id = transaction_row.user_id
+        and entitlement.source_type = 'product'
+        and entitlement.source_id = transaction_row.product_id;
+    end if;
   end if;
 
   return query select
@@ -241,6 +290,7 @@ create or replace function public.apply_self_managed_platform_period(
   _provider_event_id text,
   _tenant_id uuid,
   _plan_id uuid,
+  _plan_slug text,
   _interval text,
   _provider_subscription_id text default null,
   _provider_customer_id text default null
@@ -259,6 +309,7 @@ declare
   inserted_effect boolean;
   start_at timestamptz;
   end_at timestamptz;
+  platform_fee numeric;
 begin
   perform pg_advisory_xact_lock(hashtextextended(_tenant_id::text, 625));
 
@@ -317,8 +368,40 @@ begin
       provider_customer_id = coalesce(excluded.provider_customer_id, public.platform_subscriptions.provider_customer_id),
       current_period_start = excluded.current_period_start,
       current_period_end = excluded.current_period_end,
+      cancel_at_period_end = false,
+      canceled_at = null,
+      grace_period_end = null,
+      renewal_reminder_sent_at = null,
       updated_at = excluded.updated_at
     returning * into subscription_row;
+  elsif subscription_row.tenant_id is null then
+    raise exception 'self-managed subscription missing for replayed event %', _provider_event_id
+      using errcode = 'P0002';
+  end if;
+
+  if inserted_effect then
+    update public.tenants
+    set billing_status = 'active',
+        plan = coalesce(_plan_slug, plan),
+        billing_period_end = subscription_row.current_period_end,
+        updated_at = clock_timestamp()
+    where id = _tenant_id;
+
+    select transaction_fee_percent into platform_fee
+    from public.platform_plans
+    where plan_id = _plan_id;
+
+    if platform_fee is not null then
+      insert into public.revenue_splits (
+        tenant_id, platform_percentage, school_percentage, updated_at
+      ) values (
+        _tenant_id, platform_fee, 100 - platform_fee, clock_timestamp()
+      )
+      on conflict (tenant_id) do update set
+        platform_percentage = excluded.platform_percentage,
+        school_percentage = excluded.school_percentage,
+        updated_at = excluded.updated_at;
+    end if;
   end if;
 
   return query select
@@ -328,41 +411,65 @@ begin
 end;
 $$;
 
--- Provider periods are authoritative and monotonic. A recovered older renewal
--- must never rewind a newer period that already landed.
-create or replace function public.extend_subscription_period(
-  _provider_subscription_id text,
+create or replace function public.apply_webhook_subscription_period(
   _provider text,
-  _new_period_end timestamptz
+  _provider_event_id text,
+  _provider_subscription_id text,
+  _new_period_end timestamptz,
+  _allow_period_realign boolean default false
 )
-returns void
+returns boolean
 language plpgsql
-security definer
-set search_path = 'public'
+security invoker
+set search_path = ''
 as $$
 declare
-  _subscription_id integer;
+  subscription_row public.subscriptions%rowtype;
+  inserted_effect boolean;
+  effective_end timestamptz;
 begin
-  if _new_period_end is null then return; end if;
+  if _provider_event_id is null or _provider_event_id = '' then
+    raise exception 'provider event id is required' using errcode = '22023';
+  end if;
+  if _new_period_end is null then return false; end if;
 
-  update public.subscriptions
-  set end_date = _new_period_end,
-      current_period_end = _new_period_end,
-      subscription_status = 'active',
-      ended_at = null
+  select * into subscription_row
+  from public.subscriptions
   where provider_subscription_id = _provider_subscription_id
     and payment_provider = _provider
-    and (current_period_end is null or current_period_end <= _new_period_end)
-  returning subscription_id into _subscription_id;
+  for update;
+  if not found then
+    raise exception 'subscription not found for % %', _provider, _provider_subscription_id
+      using errcode = 'P0002';
+  end if;
 
-  if _subscription_id is null then return; end if;
+  insert into public.webhook_business_effects (
+    provider, provider_event_id, effect_type, target_id
+  ) values (
+    _provider, _provider_event_id, 'student_subscription_period', subscription_row.subscription_id::text
+  )
+  on conflict (provider, provider_event_id, effect_type, target_id) do nothing;
+  inserted_effect := found;
+  if not inserted_effect then return false; end if;
+
+  effective_end := case
+    when _allow_period_realign then _new_period_end
+    else greatest(coalesce(subscription_row.current_period_end, _new_period_end), _new_period_end)
+  end;
+
+  update public.subscriptions
+  set end_date = effective_end,
+      current_period_end = effective_end,
+      subscription_status = 'active',
+      ended_at = null
+  where subscription_id = subscription_row.subscription_id;
 
   update public.entitlements
-  set expires_at = greatest(coalesce(expires_at, _new_period_end), _new_period_end),
-      status = 'active',
-      revoked_at = null
+  set expires_at = effective_end, status = 'active', revoked_at = null
   where source_type = 'subscription'
-    and source_id = _subscription_id;
+    and source_id = subscription_row.subscription_id;
+
+  return true;
 end;
 $$;
 
@@ -374,7 +481,11 @@ revoke all on function public.fail_webhook_event(uuid, uuid, text)
   from public, anon, authenticated;
 revoke all on function public.apply_webhook_refund(text, text, bigint, numeric)
   from public, anon, authenticated;
-revoke all on function public.apply_self_managed_platform_period(text, text, uuid, uuid, text, text, text)
+revoke all on function public.claim_webhook_business_effect(text, text, text, text)
+  from public, anon, authenticated;
+revoke all on function public.apply_self_managed_platform_period(text, text, uuid, uuid, text, text, text, text)
+  from public, anon, authenticated;
+revoke all on function public.apply_webhook_subscription_period(text, text, text, timestamptz, boolean)
   from public, anon, authenticated;
 
 grant execute on function public.claim_webhook_event(text, text, text, jsonb, uuid, integer)
@@ -385,5 +496,9 @@ grant execute on function public.fail_webhook_event(uuid, uuid, text)
   to service_role;
 grant execute on function public.apply_webhook_refund(text, text, bigint, numeric)
   to service_role;
-grant execute on function public.apply_self_managed_platform_period(text, text, uuid, uuid, text, text, text)
+grant execute on function public.claim_webhook_business_effect(text, text, text, text)
+  to service_role;
+grant execute on function public.apply_self_managed_platform_period(text, text, uuid, uuid, text, text, text, text)
+  to service_role;
+grant execute on function public.apply_webhook_subscription_period(text, text, text, timestamptz, boolean)
   to service_role;

--- a/supabase/migrations/20260808154215_atomic_webhook_event_claim.sql
+++ b/supabase/migrations/20260808154215_atomic_webhook_event_claim.sql
@@ -1,0 +1,389 @@
+-- Atomically lease webhook events before any billing side effect is dispatched.
+-- The unique ledger row remains the audit record; a random token fences stale
+-- workers so only the current lease owner can complete or release an attempt.
+
+alter table public.webhook_events
+  add column if not exists processing_token uuid,
+  add column if not exists attempt_count integer not null default 0,
+  add column if not exists processing_started_at timestamptz,
+  add column if not exists last_error text;
+
+alter table public.webhook_events
+  drop constraint if exists webhook_events_attempt_count_nonnegative;
+
+alter table public.webhook_events
+  add constraint webhook_events_attempt_count_nonnegative
+  check (attempt_count >= 0);
+
+comment on column public.webhook_events.processing_token is
+  'Random token owned by the current/last processing attempt. Completion and failure are fenced by this token.';
+comment on column public.webhook_events.attempt_count is
+  'Number of processing leases granted for this provider event.';
+comment on column public.webhook_events.processing_started_at is
+  'Start of the active processing lease. NULL means an explicit failure released the event for immediate retry.';
+comment on column public.webhook_events.last_error is
+  'Most recent dispatch error, retained for audit even after a later successful retry.';
+
+create or replace function public.claim_webhook_event(
+  _provider text,
+  _provider_event_id text,
+  _event_type text,
+  _payload jsonb,
+  _claim_token uuid,
+  _lease_seconds integer default 300
+)
+returns table (
+  event_id uuid,
+  claim_status text,
+  current_attempt_count integer
+)
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  claimed public.webhook_events%rowtype;
+  claim_time timestamptz := clock_timestamp();
+  bounded_lease_seconds integer := greatest(1, least(coalesce(_lease_seconds, 300), 3600));
+begin
+  if _provider is null or _provider = '' or _provider_event_id is null or _provider_event_id = '' then
+    raise exception 'provider and provider event id are required' using errcode = '22023';
+  end if;
+
+  insert into public.webhook_events (
+    provider,
+    provider_event_id,
+    event_type,
+    payload,
+    processing_token,
+    attempt_count,
+    processing_started_at
+  )
+  values (
+    _provider,
+    _provider_event_id,
+    _event_type,
+    coalesce(_payload, '{}'::jsonb),
+    _claim_token,
+    1,
+    claim_time
+  )
+  on conflict (provider, provider_event_id) do nothing
+  returning * into claimed;
+
+  if found then
+    return query select claimed.id, 'claimed'::text, claimed.attempt_count;
+    return;
+  end if;
+
+  update public.webhook_events as event
+  set processing_token = _claim_token,
+      processing_started_at = claim_time,
+      attempt_count = event.attempt_count + 1,
+      event_type = coalesce(_event_type, event.event_type),
+      payload = coalesce(_payload, event.payload)
+  where event.provider = _provider
+    and event.provider_event_id = _provider_event_id
+    and event.processed_at is null
+    and (
+      event.processing_started_at is null
+      or event.processing_started_at <= claim_time - make_interval(secs => bounded_lease_seconds)
+    )
+  returning event.* into claimed;
+
+  if found then
+    return query select claimed.id, 'claimed'::text, claimed.attempt_count;
+    return;
+  end if;
+
+  select event.*
+  into claimed
+  from public.webhook_events as event
+  where event.provider = _provider
+    and event.provider_event_id = _provider_event_id;
+
+  return query
+  select
+    claimed.id,
+    case when claimed.processed_at is not null then 'completed' else 'processing' end,
+    claimed.attempt_count;
+end;
+$$;
+
+create or replace function public.complete_webhook_event(
+  _event_id uuid,
+  _claim_token uuid
+)
+returns boolean
+language sql
+security invoker
+set search_path = ''
+as $$
+  with completed as (
+    update public.webhook_events
+    set processed_at = clock_timestamp()
+    where id = _event_id
+      and processing_token = _claim_token
+      and processed_at is null
+    returning id
+  )
+  select exists(select 1 from completed);
+$$;
+
+create or replace function public.fail_webhook_event(
+  _event_id uuid,
+  _claim_token uuid,
+  _last_error text
+)
+returns boolean
+language sql
+security invoker
+set search_path = ''
+as $$
+  with failed as (
+    update public.webhook_events
+    set processing_started_at = null,
+        last_error = left(coalesce(_last_error, 'Unknown dispatch error'), 4000),
+        error = left(coalesce(_last_error, 'Unknown dispatch error'), 4000)
+    where id = _event_id
+      and processing_token = _claim_token
+      and processed_at is null
+    returning id
+  )
+  select exists(select 1 from failed);
+$$;
+
+-- Durable business-effect ledger. Unlike a single "last event" column, this
+-- remains correct for A,B,A replay order and lets an RPC combine dedupe with
+-- the accounting/period write in one transaction.
+create table if not exists public.webhook_business_effects (
+  id uuid primary key default gen_random_uuid(),
+  provider text not null,
+  provider_event_id text not null,
+  effect_type text not null,
+  target_id text not null,
+  applied_at timestamptz not null default now(),
+  constraint webhook_business_effects_unique
+    unique (provider, provider_event_id, effect_type, target_id)
+);
+
+alter table public.webhook_business_effects enable row level security;
+
+create or replace function public.apply_webhook_refund(
+  _provider text,
+  _provider_event_id text,
+  _transaction_id bigint,
+  _refund_amount numeric
+)
+returns table (
+  applied boolean,
+  refunded_amount numeric,
+  is_full_refund boolean,
+  user_id uuid,
+  product_id bigint,
+  plan_id bigint
+)
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  transaction_row public.transactions%rowtype;
+  inserted_effect boolean;
+begin
+  select * into transaction_row
+  from public.transactions
+  where transaction_id = _transaction_id
+  for update;
+
+  if not found or transaction_row.status not in ('successful', 'refunded') then
+    return;
+  end if;
+
+  insert into public.webhook_business_effects (
+    provider, provider_event_id, effect_type, target_id
+  ) values (
+    _provider, _provider_event_id, 'refund', _transaction_id::text
+  )
+  on conflict (provider, provider_event_id, effect_type, target_id) do nothing;
+  inserted_effect := found;
+
+  if inserted_effect and transaction_row.status = 'successful' then
+    update public.transactions
+    set refunded_amount = least(
+          transaction_row.amount,
+          transaction_row.refunded_amount + greatest(coalesce(_refund_amount, transaction_row.amount), 0)
+        ),
+        status = case
+          when least(
+            transaction_row.amount,
+            transaction_row.refunded_amount + greatest(coalesce(_refund_amount, transaction_row.amount), 0)
+          ) >= transaction_row.amount - 0.005
+          then 'refunded'::public.transaction_status
+          else 'successful'::public.transaction_status
+        end
+    where transaction_id = _transaction_id
+    returning * into transaction_row;
+  end if;
+
+  return query select
+    inserted_effect,
+    transaction_row.refunded_amount,
+    transaction_row.status = 'refunded',
+    transaction_row.user_id,
+    transaction_row.product_id::bigint,
+    transaction_row.plan_id::bigint;
+end;
+$$;
+
+create or replace function public.apply_self_managed_platform_period(
+  _provider text,
+  _provider_event_id text,
+  _tenant_id uuid,
+  _plan_id uuid,
+  _interval text,
+  _provider_subscription_id text default null,
+  _provider_customer_id text default null
+)
+returns table (
+  applied boolean,
+  period_start timestamptz,
+  period_end timestamptz
+)
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  subscription_row public.platform_subscriptions%rowtype;
+  inserted_effect boolean;
+  start_at timestamptz;
+  end_at timestamptz;
+begin
+  perform pg_advisory_xact_lock(hashtextextended(_tenant_id::text, 625));
+
+  select * into subscription_row
+  from public.platform_subscriptions
+  where tenant_id = _tenant_id;
+
+  insert into public.webhook_business_effects (
+    provider, provider_event_id, effect_type, target_id
+  ) values (
+    _provider, _provider_event_id, 'self_managed_platform_period', _tenant_id::text
+  )
+  on conflict (provider, provider_event_id, effect_type, target_id) do nothing;
+  inserted_effect := found;
+
+  if inserted_effect then
+    start_at := case
+      when subscription_row.current_period_end > clock_timestamp()
+      then subscription_row.current_period_end
+      else clock_timestamp()
+    end;
+    end_at := start_at + case
+      when _interval = 'yearly' then interval '1 year'
+      else interval '1 month'
+    end;
+
+    insert into public.platform_subscriptions (
+      tenant_id,
+      plan_id,
+      status,
+      payment_provider,
+      interval,
+      provider_subscription_id,
+      provider_customer_id,
+      current_period_start,
+      current_period_end,
+      updated_at
+    ) values (
+      _tenant_id,
+      _plan_id,
+      'active',
+      _provider,
+      case when _interval = 'yearly' then 'yearly' else 'monthly' end,
+      _provider_subscription_id,
+      _provider_customer_id,
+      start_at,
+      end_at,
+      clock_timestamp()
+    )
+    on conflict (tenant_id) do update set
+      plan_id = excluded.plan_id,
+      status = 'active',
+      payment_provider = excluded.payment_provider,
+      interval = excluded.interval,
+      provider_subscription_id = coalesce(excluded.provider_subscription_id, public.platform_subscriptions.provider_subscription_id),
+      provider_customer_id = coalesce(excluded.provider_customer_id, public.platform_subscriptions.provider_customer_id),
+      current_period_start = excluded.current_period_start,
+      current_period_end = excluded.current_period_end,
+      updated_at = excluded.updated_at
+    returning * into subscription_row;
+  end if;
+
+  return query select
+    inserted_effect,
+    subscription_row.current_period_start,
+    subscription_row.current_period_end;
+end;
+$$;
+
+-- Provider periods are authoritative and monotonic. A recovered older renewal
+-- must never rewind a newer period that already landed.
+create or replace function public.extend_subscription_period(
+  _provider_subscription_id text,
+  _provider text,
+  _new_period_end timestamptz
+)
+returns void
+language plpgsql
+security definer
+set search_path = 'public'
+as $$
+declare
+  _subscription_id integer;
+begin
+  if _new_period_end is null then return; end if;
+
+  update public.subscriptions
+  set end_date = _new_period_end,
+      current_period_end = _new_period_end,
+      subscription_status = 'active',
+      ended_at = null
+  where provider_subscription_id = _provider_subscription_id
+    and payment_provider = _provider
+    and (current_period_end is null or current_period_end <= _new_period_end)
+  returning subscription_id into _subscription_id;
+
+  if _subscription_id is null then return; end if;
+
+  update public.entitlements
+  set expires_at = greatest(coalesce(expires_at, _new_period_end), _new_period_end),
+      status = 'active',
+      revoked_at = null
+  where source_type = 'subscription'
+    and source_id = _subscription_id;
+end;
+$$;
+
+revoke all on function public.claim_webhook_event(text, text, text, jsonb, uuid, integer)
+  from public, anon, authenticated;
+revoke all on function public.complete_webhook_event(uuid, uuid)
+  from public, anon, authenticated;
+revoke all on function public.fail_webhook_event(uuid, uuid, text)
+  from public, anon, authenticated;
+revoke all on function public.apply_webhook_refund(text, text, bigint, numeric)
+  from public, anon, authenticated;
+revoke all on function public.apply_self_managed_platform_period(text, text, uuid, uuid, text, text, text)
+  from public, anon, authenticated;
+
+grant execute on function public.claim_webhook_event(text, text, text, jsonb, uuid, integer)
+  to service_role;
+grant execute on function public.complete_webhook_event(uuid, uuid)
+  to service_role;
+grant execute on function public.fail_webhook_event(uuid, uuid, text)
+  to service_role;
+grant execute on function public.apply_webhook_refund(text, text, bigint, numeric)
+  to service_role;
+grant execute on function public.apply_self_managed_platform_period(text, text, uuid, uuid, text, text, text)
+  to service_role;

--- a/tests/playwright/webhook-event-claims.spec.ts
+++ b/tests/playwright/webhook-event-claims.spec.ts
@@ -57,11 +57,12 @@ test.describe('atomic webhook event claims', () => {
 
     const { data: row } = await admin
       .from('webhook_events')
-      .select('attempt_count, processing_token, processing_started_at, processed_at')
+      .select('attempt_count, processing_token, processing_started_at, processing_lease_expires_at, processed_at')
       .eq('id', eventId)
       .single()
     expect(row).toMatchObject({ attempt_count: 1, processing_token: winner, processed_at: null })
     expect(row?.processing_started_at).not.toBeNull()
+    expect(row?.processing_lease_expires_at).not.toBeNull()
 
     const staleComplete = await admin.rpc('complete_webhook_event', {
       _event_id: eventId,
@@ -80,7 +81,7 @@ test.describe('atomic webhook event claims', () => {
     const retry = await claim(retryToken)
     expect(retry.data?.[0]).toMatchObject({ claim_status: 'claimed', current_attempt_count: 2 })
 
-    const activeDuplicate = await claim(randomUUID())
+    const activeDuplicate = await claim(randomUUID(), 1)
     expect(activeDuplicate.data?.[0]).toMatchObject({
       claim_status: 'processing',
       current_attempt_count: 2,
@@ -88,7 +89,10 @@ test.describe('atomic webhook event claims', () => {
 
     await admin
       .from('webhook_events')
-      .update({ processing_started_at: '2000-01-01T00:00:00.000Z' })
+      .update({
+        processing_started_at: '2000-01-01T00:00:00.000Z',
+        processing_lease_expires_at: '2000-01-01T00:05:00.000Z',
+      })
       .eq('id', eventId)
     const recoveredToken = randomUUID()
     const recovered = await claim(recoveredToken, 1)

--- a/tests/playwright/webhook-event-claims.spec.ts
+++ b/tests/playwright/webhook-event-claims.spec.ts
@@ -1,0 +1,136 @@
+import { randomUUID } from 'node:crypto'
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+import { expect, test } from '@playwright/test'
+import type { Database } from '@/lib/database.types'
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL ?? ''
+const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY ?? ''
+const anonKey =
+  process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_OR_ANON_KEY ??
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ??
+  ''
+
+test.describe('atomic webhook event claims', () => {
+  test.skip(!url || !serviceKey, 'Local Supabase service-role credentials are required')
+
+  let admin: SupabaseClient<Database>
+  let provider: string
+  const providerEventId = 'same-delivery'
+
+  test.beforeEach(() => {
+    admin = createClient<Database>(url, serviceKey, {
+      auth: { persistSession: false, autoRefreshToken: false },
+    })
+    provider = `claim-test:${randomUUID()}`
+  })
+
+  test.afterEach(async () => {
+    if (admin && provider) {
+      await admin.from('webhook_events').delete().eq('provider', provider)
+    }
+  })
+
+  async function claim(token: string, leaseSeconds = 300) {
+    return admin.rpc('claim_webhook_event', {
+      _provider: provider,
+      _provider_event_id: providerEventId,
+      _event_type: 'subscription.renewed',
+      _payload: { id: providerEventId },
+      _claim_token: token,
+      _lease_seconds: leaseSeconds,
+    })
+  }
+
+  test('grants one concurrent owner, fences stale workers, and recovers failures and expired leases', async () => {
+    const firstToken = randomUUID()
+    const secondToken = randomUUID()
+    const [first, second] = await Promise.all([claim(firstToken), claim(secondToken)])
+
+    expect(first.error).toBeNull()
+    expect(second.error).toBeNull()
+    const outcomes = [first.data?.[0].claim_status, second.data?.[0].claim_status].sort()
+    expect(outcomes).toEqual(['claimed', 'processing'])
+
+    const winner = first.data?.[0].claim_status === 'claimed' ? firstToken : secondToken
+    const loser = winner === firstToken ? secondToken : firstToken
+    const eventId = (first.data?.[0].event_id ?? second.data?.[0].event_id) as string
+
+    const { data: row } = await admin
+      .from('webhook_events')
+      .select('attempt_count, processing_token, processing_started_at, processed_at')
+      .eq('id', eventId)
+      .single()
+    expect(row).toMatchObject({ attempt_count: 1, processing_token: winner, processed_at: null })
+    expect(row?.processing_started_at).not.toBeNull()
+
+    const staleComplete = await admin.rpc('complete_webhook_event', {
+      _event_id: eventId,
+      _claim_token: loser,
+    })
+    expect(staleComplete).toMatchObject({ data: false, error: null })
+
+    const failed = await admin.rpc('fail_webhook_event', {
+      _event_id: eventId,
+      _claim_token: winner,
+      _last_error: 'injected transient failure',
+    })
+    expect(failed).toMatchObject({ data: true, error: null })
+
+    const retryToken = randomUUID()
+    const retry = await claim(retryToken)
+    expect(retry.data?.[0]).toMatchObject({ claim_status: 'claimed', current_attempt_count: 2 })
+
+    const activeDuplicate = await claim(randomUUID())
+    expect(activeDuplicate.data?.[0]).toMatchObject({
+      claim_status: 'processing',
+      current_attempt_count: 2,
+    })
+
+    await admin
+      .from('webhook_events')
+      .update({ processing_started_at: '2000-01-01T00:00:00.000Z' })
+      .eq('id', eventId)
+    const recoveredToken = randomUUID()
+    const recovered = await claim(recoveredToken, 1)
+    expect(recovered.data?.[0]).toMatchObject({ claim_status: 'claimed', current_attempt_count: 3 })
+
+    const completed = await admin.rpc('complete_webhook_event', {
+      _event_id: eventId,
+      _claim_token: recoveredToken,
+    })
+    expect(completed).toMatchObject({ data: true, error: null })
+
+    const replay = await claim(randomUUID())
+    expect(replay.data?.[0]).toMatchObject({
+      claim_status: 'completed',
+      current_attempt_count: 3,
+    })
+  })
+
+  test('keeps student and platform namespaces independent', async () => {
+    const student = await claim(randomUUID())
+    provider = `platform:${provider}`
+    const platform = await claim(randomUUID())
+
+    expect(student.data?.[0].claim_status).toBe('claimed')
+    expect(platform.data?.[0].claim_status).toBe('claimed')
+    expect(platform.data?.[0].event_id).not.toBe(student.data?.[0].event_id)
+  })
+
+  test('denies claim execution to the anonymous role', async () => {
+    test.skip(!anonKey, 'Local Supabase anon key is required')
+    const anon = createClient<Database>(url, anonKey, {
+      auth: { persistSession: false, autoRefreshToken: false },
+    })
+    const denied = await anon.rpc('claim_webhook_event', {
+      _provider: provider,
+      _provider_event_id: providerEventId,
+      _event_type: 'payment.succeeded',
+      _payload: {},
+      _claim_token: randomUUID(),
+      _lease_seconds: 300,
+    })
+
+    expect(denied.error).not.toBeNull()
+  })
+})

--- a/tests/sql/issue-625-webhook-business-idempotency.sql
+++ b/tests/sql/issue-625-webhook-business-idempotency.sql
@@ -1,0 +1,85 @@
+-- Real-Postgres replay proof for issue #625. All fixture mutations roll back.
+begin;
+
+-- Local seed history currently has a stale renewal trigger dependency unrelated
+-- to #625. Disable only inside this transaction; ROLLBACK restores it.
+alter table public.transactions disable trigger after_transaction_update;
+
+do $$
+declare
+  transaction_key bigint;
+  original_refunded numeric;
+  sale_amount numeric;
+  after_replay numeric;
+  tenant_key uuid;
+  plan_key uuid;
+  first_period_end timestamptz;
+  second_period_end timestamptz;
+  replay_period_end timestamptz;
+begin
+  select transaction_id, refunded_amount, amount
+  into transaction_key, original_refunded, sale_amount
+  from public.transactions
+  where status = 'successful'
+    and amount >= 3
+  order by transaction_id
+  limit 1;
+
+  if transaction_key is null then
+    raise exception 'issue #625 SQL test needs one successful transaction fixture';
+  end if;
+
+  perform * from public.apply_webhook_refund(
+    'issue625-test', 'refund-A', transaction_key, 1
+  );
+  perform * from public.apply_webhook_refund(
+    'issue625-test', 'refund-B', transaction_key, 1
+  );
+  perform * from public.apply_webhook_refund(
+    'issue625-test', 'refund-A', transaction_key, 1
+  );
+
+  select refunded_amount into after_replay
+  from public.transactions
+  where transaction_id = transaction_key;
+
+  if after_replay <> least(sale_amount, original_refunded + 2) then
+    raise exception 'A,B,A refund replay applied wrong total: expected %, got %',
+      least(sale_amount, original_refunded + 2), after_replay;
+  end if;
+
+  select t.id, p.plan_id
+  into tenant_key, plan_key
+  from public.tenants t
+  cross join public.platform_plans p
+  order by t.created_at, p.sort_order
+  limit 1;
+
+  if tenant_key is null or plan_key is null then
+    raise exception 'issue #625 SQL test needs tenant and platform plan fixtures';
+  end if;
+
+  select period_end into first_period_end
+  from public.apply_self_managed_platform_period(
+    'binance', 'period-A', tenant_key, plan_key, 'monthly', 'order-A', null
+  );
+  select period_end into second_period_end
+  from public.apply_self_managed_platform_period(
+    'binance', 'period-B', tenant_key, plan_key, 'monthly', 'order-B', null
+  );
+  select period_end into replay_period_end
+  from public.apply_self_managed_platform_period(
+    'binance', 'period-A', tenant_key, plan_key, 'monthly', 'order-A', null
+  );
+
+  if second_period_end <= first_period_end then
+    raise exception 'second distinct self-managed payment did not extend period';
+  end if;
+  if replay_period_end <> second_period_end then
+    raise exception 'A,B,A self-managed replay extended A twice: expected %, got %',
+      second_period_end, replay_period_end;
+  end if;
+end;
+$$;
+
+rollback;

--- a/tests/sql/issue-625-webhook-business-idempotency.sql
+++ b/tests/sql/issue-625-webhook-business-idempotency.sql
@@ -61,15 +61,15 @@ begin
 
   select period_end into first_period_end
   from public.apply_self_managed_platform_period(
-    'binance', 'period-A', tenant_key, plan_key, 'monthly', 'order-A', null
+    'binance', 'period-A', tenant_key, plan_key, 'starter', 'monthly', 'order-A', null
   );
   select period_end into second_period_end
   from public.apply_self_managed_platform_period(
-    'binance', 'period-B', tenant_key, plan_key, 'monthly', 'order-B', null
+    'binance', 'period-B', tenant_key, plan_key, 'starter', 'monthly', 'order-B', null
   );
   select period_end into replay_period_end
   from public.apply_self_managed_platform_period(
-    'binance', 'period-A', tenant_key, plan_key, 'monthly', 'order-A', null
+    'binance', 'period-A', tenant_key, plan_key, 'starter', 'monthly', 'order-A', null
   );
 
   if second_period_end <= first_period_end then
@@ -79,6 +79,16 @@ begin
     raise exception 'A,B,A self-managed replay extended A twice: expected %, got %',
       second_period_end, replay_period_end;
   end if;
+
+  delete from public.platform_subscriptions where tenant_id = tenant_key;
+  begin
+    perform * from public.apply_self_managed_platform_period(
+      'binance', 'period-A', tenant_key, plan_key, 'starter', 'monthly', 'order-A', null
+    );
+    raise exception 'replayed effect recreated a subscription without a durable period';
+  exception
+    when no_data_found then null;
+  end;
 end;
 $$;
 

--- a/tests/unit/payment-webhook-route.test.ts
+++ b/tests/unit/payment-webhook-route.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { NextRequest } from 'next/server'
+
+const testState = vi.hoisted(() => ({
+  claimStatus: 'claimed' as 'claimed' | 'processing' | 'completed',
+  dispatchError: null as Error | null,
+  rpcCalls: [] as { name: string; args: Record<string, unknown> }[],
+  dispatch: vi.fn(),
+}))
+
+function adminClient() {
+  return {
+    rpc: (name: string, args: Record<string, unknown>) => {
+      testState.rpcCalls.push({ name, args })
+      if (name === 'claim_webhook_event') {
+        return Promise.resolve({
+          data: [
+            {
+              event_id: '00000000-0000-0000-0000-000000000625',
+              claim_status: testState.claimStatus,
+              current_attempt_count: 1,
+            },
+          ],
+          error: null,
+        })
+      }
+      return Promise.resolve({ data: true, error: null })
+    },
+  }
+}
+
+vi.mock('@supabase/supabase-js', () => ({ createClient: () => adminClient() }))
+
+vi.mock('@/lib/payments', () => ({
+  getPaymentProvider: () => ({
+    verifyWebhook: () => Promise.resolve(true),
+    normalizeWebhookEvent: (body: string) => {
+      const raw = JSON.parse(body) as { id: string }
+      return Promise.resolve({
+        type: 'payment.succeeded',
+        providerEventId: raw.id,
+        reference: '42',
+        raw,
+      })
+    },
+  }),
+}))
+
+vi.mock('@/lib/payments/webhook-dispatch', () => ({
+  dispatchBillingEvent: (...args: unknown[]) => {
+    testState.dispatch(...args)
+    return testState.dispatchError
+      ? Promise.reject(testState.dispatchError)
+      : Promise.resolve()
+  },
+}))
+
+import { POST } from '@/app/api/payments/webhook/[provider]/route'
+
+function request(id = 'evt_student_1'): NextRequest {
+  return {
+    text: () => Promise.resolve(JSON.stringify({ id })),
+    headers: new Headers(),
+  } as unknown as NextRequest
+}
+
+const params = (provider = 'paypal') => ({ params: Promise.resolve({ provider }) })
+
+beforeEach(() => {
+  process.env.NEXT_PUBLIC_SUPABASE_URL = 'http://localhost:54321'
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-key-for-tests'
+  testState.claimStatus = 'claimed'
+  testState.dispatchError = null
+  testState.rpcCalls = []
+  testState.dispatch.mockClear()
+})
+
+describe('student billing webhook claim contract', () => {
+  it('dispatches and completes only after claiming the student namespace', async () => {
+    const res = await POST(request(), params())
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toMatchObject({ received: true, eventStatus: 'accepted' })
+    expect(testState.dispatch).toHaveBeenCalledOnce()
+    expect(testState.rpcCalls.map((call) => call.name)).toEqual([
+      'claim_webhook_event',
+      'complete_webhook_event',
+    ])
+    expect(testState.rpcCalls[0].args).toMatchObject({
+      _provider: 'paypal',
+      _provider_event_id: 'evt_student_1',
+      _event_type: 'payment.succeeded',
+    })
+  })
+
+  it('acknowledges an active lease without dispatching', async () => {
+    testState.claimStatus = 'processing'
+    const res = await POST(request(), params())
+
+    expect(res.status).toBe(409)
+    expect(res.headers.get('retry-after')).toBe('30')
+    expect(await res.json()).toMatchObject({
+      processing: true,
+      eventStatus: 'already_processing',
+    })
+    expect(testState.dispatch).not.toHaveBeenCalled()
+    expect(testState.rpcCalls.map((call) => call.name)).toEqual(['claim_webhook_event'])
+  })
+
+  it('acknowledges a completed event without dispatching', async () => {
+    testState.claimStatus = 'completed'
+    const res = await POST(request(), params())
+
+    expect(await res.json()).toMatchObject({
+      duplicate: true,
+      eventStatus: 'already_completed',
+    })
+    expect(testState.dispatch).not.toHaveBeenCalled()
+  })
+
+  it('records and releases a transient dispatch failure for immediate retry', async () => {
+    testState.dispatchError = new Error('temporary database outage')
+    const res = await POST(request(), params())
+
+    expect(res.status).toBe(500)
+    expect(testState.rpcCalls.map((call) => call.name)).toEqual([
+      'claim_webhook_event',
+      'fail_webhook_event',
+    ])
+    expect(testState.rpcCalls[1].args._last_error).toBe('temporary database outage')
+  })
+
+  it('preserves the Binance Pay transport acknowledgment for active claims', async () => {
+    testState.claimStatus = 'processing'
+    const res = await POST(request(), params('binance'))
+
+    expect(res.status).toBe(409)
+    expect(await res.json()).toMatchObject({
+      returnCode: 'SUCCESS',
+      returnMessage: null,
+      eventStatus: 'already_processing',
+    })
+  })
+})

--- a/tests/unit/payment-webhook-route.test.ts
+++ b/tests/unit/payment-webhook-route.test.ts
@@ -4,6 +4,7 @@ import type { NextRequest } from 'next/server'
 const testState = vi.hoisted(() => ({
   claimStatus: 'claimed' as 'claimed' | 'processing' | 'completed',
   dispatchError: null as Error | null,
+  completeError: null as Error | null,
   rpcCalls: [] as { name: string; args: Record<string, unknown> }[],
   dispatch: vi.fn(),
 }))
@@ -23,6 +24,9 @@ function adminClient() {
           ],
           error: null,
         })
+      }
+      if (name === 'complete_webhook_event' && testState.completeError) {
+        return Promise.resolve({ data: null, error: { message: testState.completeError.message } })
       }
       return Promise.resolve({ data: true, error: null })
     },
@@ -71,6 +75,7 @@ beforeEach(() => {
   process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-key-for-tests'
   testState.claimStatus = 'claimed'
   testState.dispatchError = null
+  testState.completeError = null
   testState.rpcCalls = []
   testState.dispatch.mockClear()
 })
@@ -130,14 +135,26 @@ describe('student billing webhook claim contract', () => {
     expect(testState.rpcCalls[1].args._last_error).toBe('temporary database outage')
   })
 
+  it('releases the claim when durable completion fails', async () => {
+    testState.completeError = new Error('completion database outage')
+    const res = await POST(request(), params())
+
+    expect(res.status).toBe(500)
+    expect(testState.rpcCalls.map((call) => call.name)).toEqual([
+      'claim_webhook_event',
+      'complete_webhook_event',
+      'fail_webhook_event',
+    ])
+  })
+
   it('preserves the Binance Pay transport acknowledgment for active claims', async () => {
     testState.claimStatus = 'processing'
     const res = await POST(request(), params('binance'))
 
     expect(res.status).toBe(409)
     expect(await res.json()).toMatchObject({
-      returnCode: 'SUCCESS',
-      returnMessage: null,
+      returnCode: 'FAIL',
+      returnMessage: 'Event is already processing',
       eventStatus: 'already_processing',
     })
   })

--- a/tests/unit/platform-billing-crypto-rails.test.ts
+++ b/tests/unit/platform-billing-crypto-rails.test.ts
@@ -160,7 +160,7 @@ vi.mock('@/lib/email/send', () => ({ sendEmail: () => Promise.resolve() }))
 import { dispatchPlatformBillingEvent, selfManagedPeriod } from '@/lib/billing/platform-webhook-dispatch'
 
 function client() {
-  return createFakeSupabase(db, {
+  const fake = createFakeSupabase(db, {
     embeds: { platform_plans: { table: 'platform_plans', localKey: 'plan_id', foreignKey: 'plan_id' } },
     conflictKeys: {
       platform_subscriptions: 'tenant_id',
@@ -171,8 +171,47 @@ function client() {
     // upsert has to satisfy them on every write, including the ones that are
     // logically updates — see the notNull docs in support/fake-supabase.ts.
     notNull: { platform_subscriptions: ['tenant_id', 'plan_id'] },
+  })
+  return {
+    ...fake.client,
+    rpc: (name: string, args: Record<string, unknown>) => {
+      if (name !== 'apply_self_managed_platform_period') {
+        return Promise.resolve({ data: null, error: null })
+      }
+      const effectKey = `${args._provider}:${args._provider_event_id}:${args._tenant_id}`
+      db.webhook_business_effects ||= []
+      const existingEffect = db.webhook_business_effects.find((row) => row.key === effectKey)
+      let stored = db.platform_subscriptions.find((row) => row.tenant_id === args._tenant_id)
+      if (!existingEffect) {
+        db.webhook_business_effects.push({ key: effectKey })
+        const period = selfManagedPeriod(
+          stored?.current_period_end as string | null | undefined,
+          args._interval === 'yearly' ? 'yearly' : 'monthly',
+          new Date(),
+        )
+        stored ||= { tenant_id: args._tenant_id }
+        Object.assign(stored, {
+          plan_id: args._plan_id,
+          status: 'active',
+          payment_provider: args._provider,
+          interval: args._interval,
+          provider_subscription_id: args._provider_subscription_id,
+          current_period_start: period.start.toISOString(),
+          current_period_end: period.end.toISOString(),
+        })
+        if (!db.platform_subscriptions.includes(stored)) db.platform_subscriptions.push(stored)
+      }
+      return Promise.resolve({
+        data: [{
+          applied: !existingEffect,
+          period_start: stored?.current_period_start,
+          period_end: stored?.current_period_end,
+        }],
+        error: null,
+      })
+    },
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  }).client as any
+  } as any
 }
 
 const sub = () => db.platform_subscriptions[0]
@@ -189,6 +228,7 @@ beforeEach(() => {
     platform_subscriptions: [],
     tenant_billing_customers: [],
     revenue_splits: [],
+    webhook_business_effects: [],
   }
 })
 
@@ -265,6 +305,35 @@ describe('dispatchPlatformBillingEvent on a self-managed rail', () => {
 
     const extended = new Date(sub().current_period_end as string).getTime()
     expect(extended).toBeGreaterThan(new Date(end).getTime() + 27 * DAY)
+  })
+
+  it('does not extend the period twice when the same provider event is replayed', async () => {
+    await dispatchPlatformBillingEvent(activation(), { provider: 'binance', admin: client() })
+    const firstEnd = sub().current_period_end
+
+    await dispatchPlatformBillingEvent(activation(), { provider: 'binance', admin: client() })
+
+    expect(sub().current_period_end).toBe(firstEnd)
+    expect(db.tenants[0].billing_period_end).toBe(firstEnd)
+  })
+
+  it('does not extend event A twice when replay order is A, B, A', async () => {
+    await dispatchPlatformBillingEvent(activation({ providerEventId: 'evt-A' }), {
+      provider: 'binance',
+      admin: client(),
+    })
+    await dispatchPlatformBillingEvent(activation({ providerEventId: 'evt-B' }), {
+      provider: 'binance',
+      admin: client(),
+    })
+    const afterB = sub().current_period_end
+
+    await dispatchPlatformBillingEvent(activation({ providerEventId: 'evt-A' }), {
+      provider: 'binance',
+      admin: client(),
+    })
+
+    expect(sub().current_period_end).toBe(afterB)
   })
 
   it('moves the school to the plan it just paid for', async () => {

--- a/tests/unit/platform-billing-crypto-rails.test.ts
+++ b/tests/unit/platform-billing-crypto-rails.test.ts
@@ -198,8 +198,28 @@ function client() {
           provider_subscription_id: args._provider_subscription_id,
           current_period_start: period.start.toISOString(),
           current_period_end: period.end.toISOString(),
+          cancel_at_period_end: false,
+          canceled_at: null,
+          grace_period_end: null,
+          renewal_reminder_sent_at: null,
         })
         if (!db.platform_subscriptions.includes(stored)) db.platform_subscriptions.push(stored)
+        const tenant = db.tenants.find((row) => row.id === args._tenant_id)
+        if (tenant) Object.assign(tenant, {
+          billing_status: 'active',
+          plan: args._plan_slug ?? tenant.plan,
+          billing_period_end: period.end.toISOString(),
+        })
+        const plan = db.platform_plans.find((row) => row.plan_id === args._plan_id)
+        if (plan) {
+          const split = db.revenue_splits.find((row) => row.tenant_id === args._tenant_id)
+            ?? { tenant_id: args._tenant_id }
+          Object.assign(split, {
+            platform_percentage: plan.transaction_fee_percent,
+            school_percentage: 100 - Number(plan.transaction_fee_percent),
+          })
+          if (!db.revenue_splits.includes(split)) db.revenue_splits.push(split)
+        }
       }
       return Promise.resolve({
         data: [{
@@ -334,6 +354,25 @@ describe('dispatchPlatformBillingEvent on a self-managed rail', () => {
     })
 
     expect(sub().current_period_end).toBe(afterB)
+  })
+
+  it('does not restore stale plan metadata when replay order is A, B, A', async () => {
+    const pro = { tenant_id: TENANT, plan_id: PLAN_PRO, plan_slug: 'pro', interval: 'monthly' }
+    const business = { tenant_id: TENANT, plan_id: PLAN_BIZ, plan_slug: 'business', interval: 'monthly' }
+
+    await dispatchPlatformBillingEvent(activation({ providerEventId: 'plan-A', metadata: pro }), {
+      provider: 'binance', admin: client(),
+    })
+    await dispatchPlatformBillingEvent(activation({ providerEventId: 'plan-B', metadata: business }), {
+      provider: 'binance', admin: client(),
+    })
+    await dispatchPlatformBillingEvent(activation({ providerEventId: 'plan-A', metadata: pro }), {
+      provider: 'binance', admin: client(),
+    })
+
+    expect(sub().plan_id).toBe(PLAN_BIZ)
+    expect(db.tenants[0].plan).toBe('business')
+    expect(db.revenue_splits[0]).toMatchObject({ platform_percentage: 0, school_percentage: 100 })
   })
 
   it('moves the school to the plan it just paid for', async () => {

--- a/tests/unit/platform-billing-webhook-route.test.ts
+++ b/tests/unit/platform-billing-webhook-route.test.ts
@@ -25,7 +25,7 @@ interface Write {
 
 const state: {
   existingEvent: { id: string; processed_at: string | null } | null
-  insertErrorCode: string | null
+  claimStatus: 'claimed' | 'processing' | 'completed' | null
   storedSub: Record<string, unknown> | null
   planPriceRow: { plan_id: string } | null
   plan: { transaction_fee_percent: number } | null
@@ -35,7 +35,7 @@ const state: {
   emails: { to: string; subject: string }[]
 } = {
   existingEvent: null,
-  insertErrorCode: null,
+  claimStatus: null,
   storedSub: null,
   planPriceRow: null,
   plan: null,
@@ -69,12 +69,6 @@ function makeAdmin() {
       if (pending) {
         const err = state.failOn?.(pending) ?? null
         if (err) return { data: null, error: err }
-        if (table === 'webhook_events' && pending.op === 'insert') {
-          if (state.insertErrorCode) {
-            return { data: null, error: { message: 'duplicate key', code: state.insertErrorCode } }
-          }
-          return { data: { id: 'wh-row-1' }, error: null }
-        }
         return { data: null, error: null }
       }
       return { data: readRow(table, cols), error: null }
@@ -111,6 +105,50 @@ function makeAdmin() {
 
   return {
     from: (table: string) => builder(table),
+    rpc: (name: string, args: Record<string, unknown>) => {
+      if (name === 'claim_webhook_event') {
+        const status =
+          state.claimStatus ??
+          (state.existingEvent
+            ? state.existingEvent.processed_at
+              ? 'completed'
+              : 'processing'
+            : 'claimed')
+        if (status === 'claimed') {
+          state.writes.push({
+            table: 'webhook_events',
+            op: state.existingEvent ? 'update' : 'insert',
+            values: {
+              provider: args._provider,
+              provider_event_id: args._provider_event_id,
+              event_type: args._event_type,
+              payload: args._payload,
+            },
+          })
+        }
+        return Promise.resolve({
+          data: [{ event_id: 'wh-row-1', claim_status: status, current_attempt_count: 1 }],
+          error: null,
+        })
+      }
+      if (name === 'complete_webhook_event') {
+        state.writes.push({
+          table: 'webhook_events',
+          op: 'update',
+          values: { processed_at: '2026-08-08T00:00:00.000Z' },
+        })
+        return Promise.resolve({ data: true, error: null })
+      }
+      if (name === 'fail_webhook_event') {
+        state.writes.push({
+          table: 'webhook_events',
+          op: 'update',
+          values: { error: args._last_error, last_error: args._last_error },
+        })
+        return Promise.resolve({ data: true, error: null })
+      }
+      return Promise.resolve({ data: null, error: null })
+    },
     auth: {
       admin: {
         getUserById: (id: string) =>
@@ -220,7 +258,7 @@ beforeEach(() => {
   process.env.NEXT_PUBLIC_SUPABASE_URL = 'http://localhost:54321'
   process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-key-for-tests'
   state.existingEvent = null
-  state.insertErrorCode = null
+  state.claimStatus = null
   state.storedSub = null
   state.planPriceRow = null
   state.plan = { transaction_fee_percent: 2 }
@@ -299,16 +337,29 @@ describe('platform billing webhook — idempotency', () => {
     expect(state.writes).toHaveLength(0)
   })
 
-  it('treats a concurrent duplicate insert (23505) as a duplicate, not an error', async () => {
-    state.insertErrorCode = '23505'
+  it('acknowledges an active concurrent claim without dispatching or calling it completed', async () => {
+    state.claimStatus = 'processing'
     const res = await POST(makeReq(makeEvent('checkout.session.completed', session)), params())
-    expect(res.status).toBe(200)
-    expect(await res.json()).toMatchObject({ duplicate: true })
+    expect(res.status).toBe(409)
+    expect(res.headers.get('retry-after')).toBe('30')
+    expect(await res.json()).toMatchObject({
+      processing: true,
+      eventStatus: 'already_processing',
+    })
     expect(businessWrites()).toHaveLength(0)
   })
 
-  it('retries a half-finished attempt on the existing row rather than inserting a second', async () => {
+  it('does not reuse an unfinished event while its lease is active', async () => {
     state.existingEvent = { id: 'wh-row-1', processed_at: null }
+    const res = await POST(makeReq(makeEvent('checkout.session.completed', session)), params())
+    expect(res.status).toBe(409)
+    expect(writesTo('webhook_events', 'insert')).toHaveLength(0)
+    expect(businessWrites()).toHaveLength(0)
+  })
+
+  it('dispatches a half-finished event only after the database reclaims its expired lease', async () => {
+    state.existingEvent = { id: 'wh-row-1', processed_at: null }
+    state.claimStatus = 'claimed'
     const res = await POST(makeReq(makeEvent('checkout.session.completed', session)), params())
     expect(res.status).toBe(200)
     expect(writesTo('webhook_events', 'insert')).toHaveLength(0)

--- a/tests/unit/platform-billing-webhook-route.test.ts
+++ b/tests/unit/platform-billing-webhook-route.test.ts
@@ -71,6 +71,18 @@ function makeAdmin() {
       if (pending) {
         const err = state.failOn?.(pending) ?? null
         if (err) return { data: null, error: err }
+        // The past_due write is transition-guarded (`.neq('status','past_due')
+        // .select()`): it returns the flipped row only when the stored status
+        // was not already past_due, the way Postgres re-evaluates the WHERE
+        // under the row lock.
+        if (
+          pending.table === 'platform_subscriptions' &&
+          pending.op === 'update' &&
+          pending.values.status === 'past_due'
+        ) {
+          const flipped = state.storedSub && state.storedSub.status !== 'past_due'
+          return { data: flipped ? [{ tenant_id: state.storedSub!.tenant_id }] : [], error: null }
+        }
         return { data: null, error: null }
       }
       return { data: readRow(table, cols), error: null }
@@ -97,6 +109,7 @@ function makeAdmin() {
         return b
       },
       eq: () => b,
+      neq: () => b,
       limit: () => b,
       maybeSingle: () => Promise.resolve(settle()),
       single: () => Promise.resolve(settle()),

--- a/tests/unit/platform-billing-webhook-route.test.ts
+++ b/tests/unit/platform-billing-webhook-route.test.ts
@@ -33,6 +33,7 @@ const state: {
   failOn: ((w: Write) => { message: string } | null) | null
   writes: Write[]
   emails: { to: string; subject: string }[]
+  businessEffects: Set<string>
 } = {
   existingEvent: null,
   claimStatus: null,
@@ -43,6 +44,7 @@ const state: {
   failOn: null,
   writes: [],
   emails: [],
+  businessEffects: new Set(),
 }
 
 function readRow(table: string, cols: string): unknown {
@@ -146,6 +148,12 @@ function makeAdmin() {
           values: { error: args._last_error, last_error: args._last_error },
         })
         return Promise.resolve({ data: true, error: null })
+      }
+      if (name === 'claim_webhook_business_effect') {
+        const key = `${args._provider}:${args._provider_event_id}:${args._effect_type}:${args._target_id}`
+        const claimed = !state.businessEffects.has(key)
+        state.businessEffects.add(key)
+        return Promise.resolve({ data: claimed, error: null })
       }
       return Promise.resolve({ data: null, error: null })
     },
@@ -266,6 +274,7 @@ beforeEach(() => {
   state.failOn = null
   state.writes = []
   state.emails = []
+  state.businessEffects = new Set()
   vi.mocked(applyPortalPlanChange).mockClear()
   vi.mocked(downgradeTenantToFree).mockClear()
 })
@@ -636,6 +645,16 @@ describe('platform billing webhook — invoices', () => {
       'admin-a@example.com',
       'admin-b@example.com',
     ])
+  })
+
+  it('does not send dunning twice when the same event is re-dispatched after completion loss', async () => {
+    state.storedSub = { tenant_id: TENANT, plan_id: PLAN_ID, status: 'active', current_period_end: null }
+    state.adminUsers = ['admin-a']
+
+    await POST(makeReq(makeEvent('invoice.payment_failed', cloverInvoice)), params())
+    await POST(makeReq(makeEvent('invoice.payment_failed', cloverInvoice)), params())
+
+    expect(state.emails.map((email) => email.to)).toEqual(['admin-a@example.com'])
   })
 
   it('invoice.payment_failed resolves the id from an expanded subscription object', async () => {

--- a/tests/unit/redeliver-webhook-events.test.ts
+++ b/tests/unit/redeliver-webhook-events.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { NextRequest } from 'next/server'
+
+/**
+ * The stalled-webhook redelivery cron (issue #625 follow-up). The atomic claim
+ * contract's one orphan case is a worker that dies without releasing its lease:
+ * provider retries inside the lease window all get 409, and a provider with a
+ * bounded retry schedule can give up before the lease expires — a paid event
+ * nobody ever processes. This cron replays such rows through the SAME
+ * normalize → claim → dispatch → complete pipeline the live routes run.
+ *
+ * What is faked: Supabase (recording), the provider factories, both
+ * dispatchers. What is real: the route's own selection/claim/complete flow and
+ * the claim helper module (its RPC calls hit the recording fake).
+ */
+
+const state: {
+  rows: Record<string, unknown>[]
+  claimStatus: 'claimed' | 'processing' | 'completed'
+  normalized: Record<string, unknown> | null
+  rpcCalls: { name: string; args: Record<string, unknown> }[]
+  adapterThrows: boolean
+} = {
+  rows: [],
+  claimStatus: 'claimed',
+  normalized: null,
+  rpcCalls: [],
+  adapterThrows: false,
+}
+
+function makeAdmin() {
+  function builder() {
+    const b: Record<string, unknown> = {
+      select: () => b,
+      is: () => b,
+      or: () => b,
+      lt: () => b,
+      lte: () => b,
+      order: () => b,
+      limit: () => b,
+      then: (resolve: (v: unknown) => unknown) =>
+        Promise.resolve({ data: state.rows, error: null }).then(resolve),
+    }
+    return b
+  }
+  return {
+    from: () => builder(),
+    rpc: (name: string, args: Record<string, unknown>) => {
+      state.rpcCalls.push({ name, args })
+      if (name === 'claim_webhook_event') {
+        return Promise.resolve({
+          data: [
+            {
+              event_id: 'evt-row-1',
+              claim_status: state.claimStatus,
+              current_attempt_count: 2,
+            },
+          ],
+          error: null,
+        })
+      }
+      return Promise.resolve({ data: true, error: null })
+    },
+  }
+}
+
+const normalizeWebhookEvent = vi.fn(async () => {
+  if (state.adapterThrows) throw new Error('unparseable payload')
+  return state.normalized
+})
+const fakeAdapter = { normalizeWebhookEvent }
+
+vi.mock('@supabase/supabase-js', () => ({ createClient: () => makeAdmin() }))
+vi.mock('@/lib/payments', () => ({ getPaymentProvider: () => fakeAdapter }))
+vi.mock('@/lib/billing/platform-billing', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/billing/platform-billing')>()
+  return { ...actual, getPlatformBillingProvider: () => fakeAdapter }
+})
+vi.mock('@/lib/payments/webhook-dispatch', () => ({ dispatchBillingEvent: vi.fn() }))
+vi.mock('@/lib/billing/platform-webhook-dispatch', () => ({
+  dispatchPlatformBillingEvent: vi.fn(),
+}))
+
+import { GET } from '@/app/api/cron/redeliver-webhook-events/route'
+import { dispatchBillingEvent } from '@/lib/payments/webhook-dispatch'
+import { dispatchPlatformBillingEvent } from '@/lib/billing/platform-webhook-dispatch'
+
+const SECRET = 'cron-secret'
+
+function makeReq(auth: string | null = `Bearer ${SECRET}`): NextRequest {
+  return {
+    headers: { get: (k: string) => (k === 'authorization' ? auth : null) },
+  } as unknown as NextRequest
+}
+
+function stalledRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'evt-row-1',
+    provider: 'binance',
+    provider_event_id: 'bn-evt-1',
+    event_type: 'payment.succeeded',
+    payload: { bizType: 'PAY', data: '{}' },
+    attempt_count: 2,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  process.env.CRON_SECRET = SECRET
+  process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://fake.supabase.co'
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role'
+  state.rows = []
+  state.claimStatus = 'claimed'
+  state.normalized = { type: 'payment.succeeded', providerEventId: 'bn-evt-1', raw: {} }
+  state.rpcCalls = []
+  state.adapterThrows = false
+  vi.mocked(dispatchBillingEvent).mockReset()
+  vi.mocked(dispatchPlatformBillingEvent).mockReset()
+  normalizeWebhookEvent.mockClear()
+})
+
+describe('cron: redeliver stalled webhook events', () => {
+  it('rejects a missing or wrong cron secret', async () => {
+    expect((await GET(makeReq(null))).status).toBe(401)
+    expect((await GET(makeReq('Bearer nope'))).status).toBe(401)
+  })
+
+  it('replays a stalled STUDENT event through claim → dispatch → complete', async () => {
+    state.rows = [stalledRow()]
+
+    const res = await GET(makeReq())
+    const body = await res.json()
+
+    expect(body).toMatchObject({ scanned: 1, redelivered: 1, failed: 0 })
+    expect(vi.mocked(dispatchBillingEvent)).toHaveBeenCalledWith(
+      state.normalized,
+      expect.objectContaining({ provider: 'binance' }),
+    )
+    // Claimed under the row's own ledger key, then completed under the token.
+    const names = state.rpcCalls.map((c) => c.name)
+    expect(names).toEqual(['claim_webhook_event', 'complete_webhook_event'])
+    expect(state.rpcCalls[0].args._provider).toBe('binance')
+    expect(state.rpcCalls[0].args._provider_event_id).toBe('bn-evt-1')
+  })
+
+  it('routes a platform-namespaced row to the PLATFORM dispatcher with the bare slug', async () => {
+    state.rows = [stalledRow({ provider: 'platform:binance', provider_event_id: 'bn-plat-1' })]
+
+    const res = await GET(makeReq())
+    const body = await res.json()
+
+    expect(body).toMatchObject({ redelivered: 1 })
+    expect(vi.mocked(dispatchPlatformBillingEvent)).toHaveBeenCalledWith(
+      state.normalized,
+      expect.objectContaining({ provider: 'binance' }),
+    )
+    expect(vi.mocked(dispatchBillingEvent)).not.toHaveBeenCalled()
+    // The claim keeps the NAMESPACED key — same ledger row the route wrote.
+    expect(state.rpcCalls[0].args._provider).toBe('platform:binance')
+  })
+
+  it('walks away when a live delivery owns the claim', async () => {
+    state.rows = [stalledRow()]
+    state.claimStatus = 'processing'
+
+    const body = await (await GET(makeReq())).json()
+
+    expect(body).toMatchObject({ redelivered: 0, skipped: 1 })
+    expect(vi.mocked(dispatchBillingEvent)).not.toHaveBeenCalled()
+    expect(state.rpcCalls.map((c) => c.name)).toEqual(['claim_webhook_event'])
+  })
+
+  it('releases the claim and counts a failure when dispatch throws', async () => {
+    state.rows = [stalledRow()]
+    vi.mocked(dispatchBillingEvent).mockRejectedValueOnce(new Error('db down'))
+
+    const body = await (await GET(makeReq())).json()
+
+    expect(body).toMatchObject({ redelivered: 0, failed: 1 })
+    expect(state.rpcCalls.map((c) => c.name)).toEqual([
+      'claim_webhook_event',
+      'fail_webhook_event',
+    ])
+  })
+
+  it('retires an event the adapter no longer models instead of re-scanning it forever', async () => {
+    state.rows = [stalledRow()]
+    state.normalized = null
+
+    const body = await (await GET(makeReq())).json()
+
+    expect(body).toMatchObject({ retired: 1, redelivered: 0 })
+    expect(vi.mocked(dispatchBillingEvent)).not.toHaveBeenCalled()
+    expect(state.rpcCalls.map((c) => c.name)).toEqual([
+      'claim_webhook_event',
+      'complete_webhook_event',
+    ])
+  })
+
+  it('leaves rows from unknown namespaces alone', async () => {
+    state.rows = [stalledRow({ provider: 'platform:solana' }), stalledRow({ provider: 'manual' })]
+
+    const body = await (await GET(makeReq())).json()
+
+    expect(body).toMatchObject({ scanned: 2, skipped: 2, redelivered: 0 })
+    expect(state.rpcCalls).toHaveLength(0)
+  })
+
+  it('counts a normalizer crash as failed without touching the claim', async () => {
+    state.rows = [stalledRow()]
+    state.adapterThrows = true
+
+    const body = await (await GET(makeReq())).json()
+
+    expect(body).toMatchObject({ failed: 1, redelivered: 0 })
+    expect(state.rpcCalls).toHaveLength(0)
+  })
+})

--- a/tests/unit/unbounded-read-guard.test.ts
+++ b/tests/unit/unbounded-read-guard.test.ts
@@ -94,6 +94,12 @@ const KNOWN_UNBOUNDED: Record<string, string> = {
   'app/api/cron/expire-subscriptions/route.ts::subscriptions': 'gap #540 — platform-wide cron queue',
   'app/api/cron/expire-platform-subscriptions/route.ts::platform_subscriptions': 'gap #540 — platform-wide cron queue',
   'app/api/stripe/webhook/route.ts::transactions': 'gap #540 — platform-wide pending scan',
+
+  // scoped: tenant_id is the table's unique key, so the transition-guarded
+  // past_due update returns at most one row — its .select() is the proof the
+  // WHERE actually flipped the row, not a listing.
+  'lib/billing/platform-webhook-dispatch.ts::platform_subscriptions':
+    'scoped — one tenant’s single row (unique tenant_id)',
 }
 
 /** Every source file under the scanned roots. */

--- a/tests/unit/webhook-dispatch.test.ts
+++ b/tests/unit/webhook-dispatch.test.ts
@@ -62,13 +62,21 @@ function makeFakeAdmin(txStatus: string | null = null, txExtra: Record<string, u
       calls.rpc.push({ fn, args })
       if (fn === 'apply_webhook_refund') {
         const eventId = String(args._provider_event_id)
-        const applied = !appliedRefundEvents.has(eventId)
+        const applied = txStatus === 'successful' && !appliedRefundEvents.has(eventId)
         if (applied) {
           appliedRefundEvents.add(eventId)
           rpcRefundedAmount = Math.min(
             Number(txExtra.amount ?? 0),
             rpcRefundedAmount + Number(args._refund_amount ?? 0),
           )
+          const full = rpcRefundedAmount >= Number(txExtra.amount ?? 0) - 0.005
+          calls.updates.push({
+            table: 'transactions',
+            values: { status: full ? 'refunded' : 'successful', refunded_amount: rpcRefundedAmount },
+          })
+          if (full && txExtra.product_id) {
+            calls.updates.push({ table: 'entitlements', values: { status: 'revoked' } })
+          }
         }
         return Promise.resolve({
           data: [{
@@ -97,7 +105,7 @@ function makeFakeAdmin(txStatus: string | null = null, txExtra: Record<string, u
 }
 
 function event(type: BillingEventType, extra: Partial<NormalizedBillingEvent> = {}): NormalizedBillingEvent {
-  return { type, raw: {}, ...extra }
+  return { type, providerEventId: 'evt-default', raw: {}, ...extra }
 }
 
 const PROVIDER = 'lemonsqueezy'
@@ -159,7 +167,7 @@ describe('dispatchBillingEvent', () => {
       { provider: PROVIDER, admin },
     )
     expect(calls.rpc).toHaveLength(1)
-    expect(calls.rpc[0].fn).toBe('extend_subscription_period')
+    expect(calls.rpc[0].fn).toBe('apply_webhook_subscription_period')
     expect(calls.rpc[0].args).toMatchObject({
       _provider_subscription_id: 'sub_1',
       _provider: PROVIDER,
@@ -209,7 +217,7 @@ describe('dispatchBillingEvent', () => {
       payment_provider: PROVIDER,
     })
     // Period aligned via the RPC.
-    expect(calls.rpc[0]?.fn).toBe('extend_subscription_period')
+    expect(calls.rpc[0]?.fn).toBe('apply_webhook_subscription_period')
   })
 
   it('activated: metadata owner MATCHES the transaction → flips (M1)', async () => {
@@ -349,6 +357,26 @@ describe('dispatchBillingEvent', () => {
     expect(calls.updates).toHaveLength(0)
   })
 
+  it('refund replay on a refunded product cannot revoke a later re-purchase entitlement', async () => {
+    const { admin, calls } = makeFakeAdmin('refunded', {
+      user_id: 'u1', product_id: 7, plan_id: null, amount: 100, refunded_amount: 100,
+    })
+    await dispatchBillingEvent(event('refund.succeeded', {
+      providerEventId: 'late-refund-delivery', reference: '42', amount: 100,
+    }), { provider: PROVIDER, admin })
+
+    expect(calls.updates).toHaveLength(0)
+  })
+
+  it('refund on a pending transaction fails so the webhook claim can retry', async () => {
+    const { admin } = makeFakeAdmin('pending', {
+      user_id: 'u1', product_id: 7, plan_id: null, amount: 100, refunded_amount: 0,
+    })
+    await expect(dispatchBillingEvent(event('refund.succeeded', {
+      providerEventId: 'early-refund', reference: '42', amount: 10,
+    }), { provider: PROVIDER, admin })).rejects.toThrow(/still pending/i)
+  })
+
   it('refund.succeeded on a tx with neither product_id nor plan_id → no writes', async () => {
     const { admin, calls } = makeFakeAdmin('successful', { user_id: 'u1', product_id: null, plan_id: null })
     await dispatchBillingEvent(event('refund.succeeded', { reference: '42', providerPaymentId: 'pi_1' }), {
@@ -358,12 +386,11 @@ describe('dispatchBillingEvent', () => {
     expect(calls.updates).toHaveLength(0)
   })
 
-  it('refund.succeeded with no matching transaction row → no writes', async () => {
+  it('refund.succeeded with no matching transaction row → fails for retry', async () => {
     const { admin, calls } = makeFakeAdmin(null)
-    await dispatchBillingEvent(event('refund.succeeded', { reference: '42', providerPaymentId: 'pi_1' }), {
-      provider: PROVIDER,
-      admin,
-    })
+    await expect(dispatchBillingEvent(event('refund.succeeded', { reference: '42', providerPaymentId: 'pi_1' }), {
+      provider: PROVIDER, admin,
+    })).rejects.toThrow(/not found/i)
     expect(calls.updates).toHaveLength(0)
   })
 
@@ -537,7 +564,7 @@ describe('dispatchBillingEvent', () => {
     await refund('refund-B')
     await refund('refund-A')
 
-    expect(calls.updates.filter((update) => update.table === 'transactions')).toHaveLength(0)
+    expect(calls.updates.filter((update) => update.table === 'transactions')).toHaveLength(2)
     expect(refundState.amount).toBe(20)
     expect(refundState.appliedRefundEvents.size).toBe(2)
   })

--- a/tests/unit/webhook-dispatch.test.ts
+++ b/tests/unit/webhook-dispatch.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
+import type { SupabaseClient } from '@supabase/supabase-js'
 import { dispatchBillingEvent } from '@/lib/payments/webhook-dispatch'
 import type { NormalizedBillingEvent, BillingEventType } from '@/lib/payments/types'
 
@@ -21,6 +22,8 @@ interface Recorder {
  */
 function makeFakeAdmin(txStatus: string | null = null, txExtra: Record<string, unknown> = {}) {
   const calls: Recorder = { from: [], selects: [], updates: [], rpc: [] }
+  let rpcRefundedAmount = Number(txExtra.refunded_amount ?? 0)
+  const appliedRefundEvents = new Set<string>()
 
   function makeBuilder(table: string) {
     const builder: Record<string, unknown> = {
@@ -57,12 +60,40 @@ function makeFakeAdmin(txStatus: string | null = null, txExtra: Record<string, u
     },
     rpc(fn: string, args: Record<string, unknown>) {
       calls.rpc.push({ fn, args })
+      if (fn === 'apply_webhook_refund') {
+        const eventId = String(args._provider_event_id)
+        const applied = !appliedRefundEvents.has(eventId)
+        if (applied) {
+          appliedRefundEvents.add(eventId)
+          rpcRefundedAmount = Math.min(
+            Number(txExtra.amount ?? 0),
+            rpcRefundedAmount + Number(args._refund_amount ?? 0),
+          )
+        }
+        return Promise.resolve({
+          data: [{
+            applied,
+            refunded_amount: rpcRefundedAmount,
+            is_full_refund: rpcRefundedAmount >= Number(txExtra.amount ?? 0) - 0.005,
+            user_id: txExtra.user_id,
+            product_id: txExtra.product_id,
+            plan_id: txExtra.plan_id,
+          }],
+          error: null,
+        })
+      }
       return Promise.resolve({ data: null, error: null })
     },
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return { admin: admin as any, calls }
+  return {
+    admin: admin as unknown as SupabaseClient,
+    calls,
+    refundState: {
+      get amount() { return rpcRefundedAmount },
+      appliedRefundEvents,
+    },
+  }
 }
 
 function event(type: BillingEventType, extra: Partial<NormalizedBillingEvent> = {}): NormalizedBillingEvent {
@@ -483,5 +514,31 @@ describe('dispatchBillingEvent', () => {
       { provider: PROVIDER, admin },
     )
     expect(calls.updates).toHaveLength(0)
+  })
+
+  it('#625: A,B,A partial-refund replay applies each provider event once', async () => {
+    const { admin, calls, refundState } = makeFakeAdmin('successful', {
+      ...SALE,
+      refunded_amount: 0,
+    })
+    const refund = (providerEventId: string) =>
+      dispatchBillingEvent(
+        event('refund.succeeded', {
+          providerEventId,
+          reference: '42',
+          providerPaymentId: 'pi_1',
+          amount: 10,
+          currency: 'usd',
+        }),
+        { provider: PROVIDER, admin },
+      )
+
+    await refund('refund-A')
+    await refund('refund-B')
+    await refund('refund-A')
+
+    expect(calls.updates.filter((update) => update.table === 'transactions')).toHaveLength(0)
+    expect(refundState.amount).toBe(20)
+    expect(refundState.appliedRefundEvents.size).toBe(2)
   })
 })

--- a/vercel.json
+++ b/vercel.json
@@ -27,6 +27,10 @@
     {
       "path": "/api/cron/binance-personal-reconcile",
       "schedule": "*/10 * * * *"
+    },
+    {
+      "path": "/api/cron/redeliver-webhook-events",
+      "schedule": "*/10 * * * *"
     }
   ]
 }


### PR DESCRIPTION
## What

Atomically leases each student or platform billing webhook event before dispatch, fences completion/failure by a per-attempt token, and returns deterministic accepted, already-processing, or already-completed outcomes. It also records refund and self-managed-period effects transactionally so interleaved replay cannot duplicate accounting or paid access.

Closes #625

## Why

The previous check-then-insert flow allowed concurrent deliveries to reuse the same unprocessed ledger row and execute billing side effects more than once. A unique event key prevented duplicate rows, but not duplicate dispatch, while a completion write lost after successful dispatch could replay read-modify-write effects such as partial refunds and self-managed subscription extensions.

## How to QA

1. On a fresh local database, run `npm run db:reset` and export the local Supabase URL, anon key, and service-role key.
2. Run `npx playwright test tests/playwright/webhook-event-claims.spec.ts --project=desktop-chromium --workers=1 --retries=0`. Verify concurrent claims produce exactly one owner, stale tokens are fenced, explicit failure and lease expiry can be reclaimed, namespaces remain independent, and anonymous execution is denied.
3. Run `docker exec -i supabase_db_lms-front psql -v ON_ERROR_STOP=1 -U postgres -d postgres < tests/sql/issue-625-webhook-business-idempotency.sql`. Verify the transaction completes with `DO` and rolls back: A,B,A refund replay applies two slices, and A,B,A self-managed-period replay extends only twice.
4. Run `npm run test:unit`, `npm run typecheck`, and `npm run build`.
5. Deliver the same signed webhook twice while the first request holds its lease. Verify the second response is HTTP 409 with `eventStatus: "already_processing"` and `Retry-After: 30`; after completion, verify replay returns HTTP 200 with `eventStatus: "already_completed"` and performs no business writes.

## Screenshots / GIF

Not applicable. This change affects backend webhook processing and database behavior only.

## Checklist

- [x] `npm run typecheck` and `npm run test:unit` pass
- [x] `npm run build` passes
- [x] Every new tenant-scoped query filters by `tenant_id` (or the table genuinely has no such column)
- [ ] Tested with every relevant role (student / teacher / admin) — not applicable; these endpoints use provider signatures and the service role
- [x] Loading and error states handled
- [ ] New UI strings added to both `messages/en.json` and `messages/es.json` — not applicable; no UI strings changed
- [ ] Migration (if any) applies cleanly on `npm run db:reset`, has RLS policies, and `lib/database.types.ts` was regenerated — migration applied cleanly to local PostgreSQL and has RLS/restricted RPC grants plus updated generated types; full reset was blocked by unrelated local migration-history drift (`20260808154118` exists in the local database but not this branch)

## Verification performed

- `npm run test:unit` — 65 files, 851 tests passed.
- `npm run typecheck` — passed.
- Targeted ESLint — no errors; one pre-existing `_cols` unused warning remains in `tests/unit/webhook-dispatch.test.ts`.
- `npm run build` — passed.
- `tests/playwright/webhook-event-claims.spec.ts` — 3/3 passed against local PostgreSQL.
- `tests/sql/issue-625-webhook-business-idempotency.sql` — passed with all mutations rolled back.
- `supabase db lint --local --level warning` — no findings in the new functions; existing unrelated schema findings remain in legacy functions.
