### PR TITLE
fix(billing): safely replay Solana plan activation (#622)

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,12 +1,12 @@
 # Scheduled invocation of the app's /api/cron/* routes (issue #513).
 #
-# Production runs on Dokploy, which does not read `vercel.json` — so the seven
+# Production runs on Dokploy, which does not read `vercel.json` — so these
 # cron routes declared there had no scheduler at all and every non-payment
 # lifecycle job (access-cutoff enforcement, platform-subscription expiry, daily
 # digest, league rollover, payment reconciliation) was inert in production.
 #
 # Each route authenticates with the same `Authorization: Bearer $CRON_SECRET`
-# header it already implements, so no application code changed to support this.
+# header, including newly added reconciliation workers.
 #
 # Required repository settings (Settings → Secrets and variables → Actions):
 #   secret   CRON_SECRET    — must match the CRON_SECRET env var on the Dokploy app
@@ -28,7 +28,7 @@ name: Scheduled cron routes
 on:
   schedule:
     # Keep these in sync with vercel.json and with the case block below.
-    - cron: '*/10 * * * *' # solana-reconcile + binance-personal-reconcile
+    - cron: '*/10 * * * *' # payment + webhook + activation reconcilers
     - cron: '0 * * * *' # daily-digest — hourly by design (each tenant sends at its own local hour)
     - cron: '0 0 * * *' # expire-subscriptions
     - cron: '0 1 * * 1' # league-rollover (pg_cron also runs it Mondays 00:05; this is the fallback)
@@ -48,6 +48,8 @@ on:
           - league-rollover
           - solana-reconcile
           - binance-personal-reconcile
+          - redeliver-webhook-events
+          - reconcile-solana-platform-activations
           # Never scheduled: solana-pull submits on-chain USDC transfers and has
           # never had a scheduler in vercel.json either. Available here for
           # manual runs only — putting it on a timer needs its own review.
@@ -78,7 +80,7 @@ jobs:
             routes="$DISPATCH_ROUTE"
           else
             case "${SCHEDULE:-}" in
-              '*/10 * * * *') routes='solana-reconcile binance-personal-reconcile' ;;
+              '*/10 * * * *') routes='solana-reconcile binance-personal-reconcile redeliver-webhook-events reconcile-solana-platform-activations' ;;
               '0 * * * *')    routes='daily-digest' ;;
               '0 0 * * *')    routes='expire-subscriptions' ;;
               '0 1 * * 1')    routes='league-rollover' ;;

--- a/app/[locale]/dashboard/admin/billing/checkout/[requestId]/page.tsx
+++ b/app/[locale]/dashboard/admin/billing/checkout/[requestId]/page.tsx
@@ -37,7 +37,7 @@ export default async function PlatformSolanaCheckoutPage({
   const { data: request } = await supabase
     .from('platform_payment_requests')
     .select(
-      'request_id, status, amount, interval, expires_at, payment_provider, provider_reference, settlement_currency, settlement_base, settlement_mint, platform_plans(name)',
+      'request_id, status, activation_state, amount, interval, expires_at, payment_provider, provider_reference, settlement_currency, settlement_base, settlement_mint, platform_plans(name)',
     )
     .eq('request_id', requestId)
     .maybeSingle()
@@ -47,7 +47,7 @@ export default async function PlatformSolanaCheckoutPage({
   }
 
   // Already paid — there is nothing to show but the billing page it activated.
-  if (request.status === 'confirmed') {
+  if (request.status === 'confirmed' || request.activation_state === 'activated') {
     redirect(`/${locale}/dashboard/admin/billing`)
   }
 

--- a/app/api/billing/solana/tx/route.ts
+++ b/app/api/billing/solana/tx/route.ts
@@ -78,13 +78,18 @@ export async function POST(req: NextRequest) {
     const { data: request } = await admin
       .from('platform_payment_requests')
       .select(
-        'request_id, tenant_id, status, expires_at, payment_provider, settlement_currency, settlement_base, settlement_mint',
+        'request_id, tenant_id, status, expires_at, payment_provider, provider_charge_id, activation_state, settlement_currency, settlement_base, settlement_mint',
       )
       .eq('provider_reference', reference)
       .maybeSingle()
 
     if (!request || request.payment_provider !== 'solana') {
       return NextResponse.json({ error: 'Payment request not found' }, { status: 404 })
+    }
+    // Once a transfer is observed, the durable activation worker owns recovery.
+    // Never build a second wallet transaction for the same request/reference.
+    if (request.provider_charge_id || request.activation_state) {
+      return NextResponse.json({ error: 'This payment has already been observed' }, { status: 409 })
     }
     // A lapsed request stops being payable the moment its TTL passes, whether
     // or not the expiry cron has swept it yet (#546) — otherwise a stale QR

--- a/app/api/billing/solana/verify/route.ts
+++ b/app/api/billing/solana/verify/route.ts
@@ -8,13 +8,11 @@
  * a real transfer of the LOCKED amount to the platform wallet carrying this
  * request's unguessable reference.
  *
- * Confirmation is a two-step claim:
- *   1. write the signature onto the request (UNIQUE), which is what stops one
- *      settled transfer from buying two plan periods;
- *   2. hand a `subscription.activated` event to `dispatchPlatformBillingEvent`,
- *      the same function the Stripe/Binance webhooks dispatch through, so the
- *      subscription row, the tenant mirror, the revenue split and the period all
- *      come from one implementation.
+ * Confirmation is a durable two-stage workflow:
+ *   1. atomically observe the signature (UNIQUE), which stops one settled
+ *      transfer from buying two plan periods;
+ *   2. lease replay-safe entitlement activation. A failed or crashed worker is
+ *      retried here or by the reconciliation cron until the request is activated.
  *
  * Deliberately NOT re-checking plan limits here, unlike `confirmManualPayment`:
  * by this point the school's money is on chain and irreversible, and refusing to
@@ -27,7 +25,10 @@ import { createClient } from '@/lib/supabase/server'
 import { createClient as createAdminSupabase } from '@supabase/supabase-js'
 import { PublicKey } from '@solana/web3.js'
 import { getCurrentTenantId } from '@/lib/supabase/tenant'
-import { dispatchPlatformBillingEvent } from '@/lib/billing/platform-webhook-dispatch'
+import {
+  observeSolanaPlatformPayment,
+  processSolanaPlatformActivation,
+} from '@/lib/billing/solana-platform-activation'
 import {
   getPlatformSolanaConfig,
   resolveStoredSettlement,
@@ -84,7 +85,7 @@ export async function POST(req: NextRequest) {
     const { data: request } = await admin
       .from('platform_payment_requests')
       .select(
-        'request_id, tenant_id, plan_id, interval, status, payment_provider, provider_reference, settlement_currency, settlement_base, settlement_mint, switch_id, platform_plans(slug)',
+        'request_id, tenant_id, plan_id, interval, status, payment_provider, provider_reference, provider_charge_id, settlement_currency, settlement_base, settlement_mint, switch_id, activation_state, activation_attempt_count, platform_plans(slug)',
       )
       .eq('request_id', requestId)
       .eq('tenant_id', tenantId)
@@ -93,10 +94,36 @@ export async function POST(req: NextRequest) {
     if (!request || request.payment_provider !== 'solana') {
       return NextResponse.json({ error: 'Payment request not found' }, { status: 404 })
     }
-    // Idempotent under the page's own polling: the first poll to land the claim
-    // activates, every later one reports the same answer.
-    if (request.status === 'confirmed') {
-      return NextResponse.json({ confirmed: true, alreadyProcessed: true })
+    if (request.activation_state === 'activated' || request.status === 'confirmed') {
+      return NextResponse.json({
+        confirmed: true,
+        state: 'activated',
+        signature: request.provider_charge_id,
+        alreadyProcessed: true,
+      })
+    }
+    if (
+      request.activation_state === 'terminal_invalid' ||
+      request.status === 'rejected' ||
+      request.status === 'expired'
+    ) {
+      return NextResponse.json({ confirmed: false, state: 'terminal_invalid' })
+    }
+
+    // Once a signature is durable, never depend on the chain lookup again.
+    // Retry the leased, idempotent activation directly.
+    if (request.provider_charge_id) {
+      const activation = await processSolanaPlatformActivation(admin, requestId)
+      return NextResponse.json({
+        confirmed: activation.state === 'activated',
+        state: activation.state,
+        signature: request.provider_charge_id,
+        attemptCount: activation.attemptCount,
+        ...(activation.state === 'activated' && !activation.claimed
+          ? { alreadyProcessed: true }
+          : {}),
+        ...(activation.alertRequired ? { alertRequired: true } : {}),
+      })
     }
     if (!(OPEN_REQUEST_STATUSES as readonly string[]).includes(request.status)) {
       return NextResponse.json({ confirmed: false, status: request.status })
@@ -130,72 +157,59 @@ export async function POST(req: NextRequest) {
       // A transaction WAS found and it did not pay what was owed. Never a
       // confirmation, and never silent.
       console.error(`[billing/solana/verify] on-chain validation failed for ${requestId}:`, err)
-      return NextResponse.json({ error: 'On-chain validation failed' }, { status: 422 })
+      return NextResponse.json(
+        { error: 'On-chain validation failed', confirmed: false, state: 'terminal_invalid' },
+        { status: 422 },
+      )
     }
 
     if (!signature) {
       return NextResponse.json({ error: 'On-chain validation failed' }, { status: 422 })
     }
 
-    // Claim the payment. Status-gated so two concurrent polls cannot both
-    // activate; UNIQUE on provider_charge_id so one signature cannot settle two
-    // requests even if a reference were reused.
-    const nowIso = new Date().toISOString()
-    const { data: claimed, error: claimErr } = await admin
-      .from('platform_payment_requests')
-      .update({
-        status: 'confirmed',
-        provider_charge_id: signature,
-        confirmed_at: nowIso,
-        updated_at: nowIso,
-      })
-      .eq('request_id', requestId)
-      .in('status', OPEN_REQUEST_STATUSES as unknown as string[])
-      .select('request_id')
-      .maybeSingle()
-
-    if (claimErr) {
-      if ((claimErr as { code?: string }).code === '23505') {
-        return NextResponse.json(
-          { error: 'This on-chain payment was already used for another request' },
-          { status: 409 },
-        )
-      }
-      console.error(`[billing/solana/verify] failed to claim ${requestId}:`, claimErr)
-      return NextResponse.json({ error: 'Failed to record payment' }, { status: 500 })
-    }
-    if (!claimed) {
-      // A concurrent poll won the claim and is activating; report its outcome.
-      return NextResponse.json({ confirmed: true, alreadyProcessed: true })
-    }
-
-    // PostgREST types an embedded one-to-one as an array; the FK makes it a
-    // single row.
-    const plan = request.platform_plans as unknown as { slug: string } | { slug: string }[] | null
-    const planSlug = (Array.isArray(plan) ? plan[0] : plan)?.slug
-
-    await dispatchPlatformBillingEvent(
-      {
-        type: 'subscription.activated',
-        providerEventId: signature,
-        providerPaymentId: signature,
-        // Solana has no subscription object; the settling signature stands in
-        // as the provider-side id, exactly as the Binance order id does.
-        providerSubscriptionId: signature,
-        metadata: {
-          tenant_id: request.tenant_id,
-          plan_id: request.plan_id,
-          ...(planSlug ? { plan_slug: planSlug } : {}),
-          interval: request.interval,
-          ...(request.switch_id ? { billing_switch_id: request.switch_id } : {}),
+    const observed = await observeSolanaPlatformPayment(admin, requestId, tenantId, signature)
+    if (observed.status === 'signature_conflict') {
+      return NextResponse.json(
+        {
+          error: 'This on-chain payment was already used for another request',
+          confirmed: false,
+          state: 'terminal_invalid',
         },
-        raw: { requestId, signature },
-      },
-      { provider: 'solana', admin },
-    )
+        { status: 409 },
+      )
+    }
+    if (observed.status === 'signature_mismatch') {
+      return NextResponse.json(
+        { error: 'Payment request has a different signature', confirmed: false, state: 'terminal_invalid' },
+        { status: 409 },
+      )
+    }
+    if (observed.status === 'not_found') {
+      return NextResponse.json({ error: 'Payment request not found' }, { status: 404 })
+    }
+    if (observed.status === 'terminal_invalid') {
+      return NextResponse.json({ confirmed: false, state: 'terminal_invalid' })
+    }
+    if (observed.status === 'activated') {
+      return NextResponse.json({
+        confirmed: true,
+        state: 'activated',
+        signature: observed.signature,
+        alreadyProcessed: true,
+      })
+    }
 
-    console.log(`[billing/solana/verify] confirmed request ${requestId} (signature ${signature})`)
-    return NextResponse.json({ confirmed: true, signature })
+    const activation = await processSolanaPlatformActivation(admin, requestId)
+    if (activation.state === 'activated') {
+      console.log(`[billing/solana/verify] activated request ${requestId} (signature ${signature})`)
+    }
+    return NextResponse.json({
+      confirmed: activation.state === 'activated',
+      state: activation.state,
+      signature,
+      attemptCount: activation.attemptCount,
+      ...(activation.alertRequired ? { alertRequired: true } : {}),
+    })
   } catch (error) {
     console.error('[billing/solana/verify] error:', error)
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })

--- a/app/api/cron/expire-platform-subscriptions/route.ts
+++ b/app/api/cron/expire-platform-subscriptions/route.ts
@@ -7,6 +7,7 @@ import { downgradeTenantToFree } from '@/lib/billing/downgrade-tenant'
 import { getTenantAdminEmails } from '@/lib/billing/tenant-admins'
 import { paymentRequestExpiredTemplate } from '@/lib/email/templates/payment-request-expired'
 import {
+  EXPIRABLE_REQUEST_STATUSES,
   OPEN_REQUEST_STATUSES,
   REQUEST_TTL_DAYS,
   isRequestOpen,
@@ -148,7 +149,7 @@ export async function GET(req: NextRequest) {
   const { data: lapsedRequests } = await supabase
     .from('platform_payment_requests')
     .select('request_id, tenant_id, amount, currency, expires_at, status, switch_id, tenants(name), platform_plans(name)')
-    .in('status', OPEN_REQUEST_STATUSES as unknown as string[])
+    .in('status', EXPIRABLE_REQUEST_STATUSES as unknown as string[])
     .not('expires_at', 'is', null)
     .lt('expires_at', nowIso)
 
@@ -158,7 +159,7 @@ export async function GET(req: NextRequest) {
       .update({ status: 'expired', updated_at: nowIso })
       .eq('request_id', req.request_id)
       // Status-gated so a super admin confirming in the same instant wins.
-      .in('status', OPEN_REQUEST_STATUSES as unknown as string[])
+      .in('status', EXPIRABLE_REQUEST_STATUSES as unknown as string[])
       .select('request_id')
       .maybeSingle()
 

--- a/app/api/cron/reconcile-solana-platform-activations/route.ts
+++ b/app/api/cron/reconcile-solana-platform-activations/route.ts
@@ -1,0 +1,151 @@
+/**
+ * Retry observed Solana platform payments whose entitlement activation did not
+ * complete in the verification request (#622).
+ *
+ * Every row is leased through the same token-fenced RPC as the live poll. The
+ * downstream dispatcher deduplicates the on-chain signature, so reclaiming a
+ * crashed worker cannot extend the paid period twice.
+ */
+
+import { timingSafeEqual } from 'node:crypto'
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+import {
+  processSolanaPlatformActivation,
+  SOLANA_ACTIVATION_MAX_ATTEMPTS,
+} from '@/lib/billing/solana-platform-activation'
+
+export const runtime = 'nodejs'
+
+const BATCH_SIZE = 25
+
+interface ActivationQueueRow {
+  request_id: string
+}
+
+interface ParkedActivationRow {
+  request_id: string
+  tenant_id: string
+  provider_charge_id: string | null
+  activation_attempt_count: number
+  activation_last_error: string | null
+}
+
+function safeEqual(a: string, b: string): boolean {
+  const left = Buffer.from(a)
+  const right = Buffer.from(b)
+  return left.length === right.length && timingSafeEqual(left, right)
+}
+
+function getSupabaseAdmin(): SupabaseClient {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (!url || !serviceKey) throw new Error('Supabase env vars not set')
+  return createClient(url, serviceKey)
+}
+
+export async function GET(req: NextRequest) {
+  const cronSecret = process.env.CRON_SECRET
+  const provided = req.headers.get('authorization')?.replace('Bearer ', '')
+  if (!cronSecret || !provided || !safeEqual(provided, cronSecret)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const admin = getSupabaseAdmin()
+  const nowIso = new Date().toISOString()
+  const { data, error } = await admin
+    .from('platform_payment_requests')
+    .select('request_id')
+    .eq('payment_provider', 'solana')
+    .in('activation_state', ['observed', 'processing', 'failed_retryable'])
+    .or(
+      `activation_state.eq.observed,and(activation_state.eq.processing,activation_lease_expires_at.lte.${nowIso}),and(activation_state.eq.failed_retryable,activation_next_retry_at.lte.${nowIso})`,
+    )
+    .lt('activation_attempt_count', SOLANA_ACTIVATION_MAX_ATTEMPTS)
+    .order('payment_observed_at', { ascending: true })
+    .limit(BATCH_SIZE)
+
+  if (error) {
+    console.error('[cron/reconcile-solana-platform-activations] scan failed:', error)
+    return NextResponse.json({ error: 'Scan failed' }, { status: 500 })
+  }
+
+  const result = {
+    scanned: data?.length ?? 0,
+    activated: 0,
+    failed: 0,
+    processing: 0,
+    alerts: 0,
+    errors: 0,
+  }
+
+  for (const row of (data ?? []) as ActivationQueueRow[]) {
+    try {
+      const activation = await processSolanaPlatformActivation(admin, row.request_id)
+      if (activation.state === 'activated') result.activated++
+      else if (activation.state === 'processing') result.processing++
+      else if (activation.state === 'failed_retryable') result.failed++
+    } catch (activationError) {
+      result.errors++
+      console.error(
+        `[cron/reconcile-solana-platform-activations] request ${row.request_id} failed:`,
+        activationError,
+      )
+    }
+  }
+
+  // Emit one durable structured alert when automatic retries park. Keeping an
+  // alert timestamp prevents every ten-minute run from paging the same row.
+  const { data: parked, error: parkedError } = await admin
+    .from('platform_payment_requests')
+    .select(
+      'request_id, tenant_id, provider_charge_id, activation_attempt_count, activation_last_error',
+    )
+    .eq('payment_provider', 'solana')
+    .eq('activation_state', 'failed_retryable')
+    .gte('activation_attempt_count', SOLANA_ACTIVATION_MAX_ATTEMPTS)
+    .is('activation_alerted_at', null)
+    .limit(BATCH_SIZE)
+
+  if (parkedError) {
+    result.errors++
+    console.error('[cron/reconcile-solana-platform-activations] alert scan failed:', parkedError)
+  } else {
+    for (const row of (parked ?? []) as ParkedActivationRow[]) {
+      const { data: alerted, error: alertError } = await admin
+        .from('platform_payment_requests')
+        .update({ activation_alerted_at: nowIso, updated_at: nowIso })
+        .eq('request_id', row.request_id)
+        .eq('activation_state', 'failed_retryable')
+        .is('activation_alerted_at', null)
+        .select('request_id')
+        .maybeSingle()
+
+      if (alertError) {
+        result.errors++
+        console.error(
+          `[cron/reconcile-solana-platform-activations] failed to mark alert ${row.request_id}:`,
+          alertError,
+        )
+        continue
+      }
+      if (!alerted) continue
+
+      result.alerts++
+      console.error(
+        '[billing-alert]',
+        JSON.stringify({
+          type: 'solana_platform_activation_exhausted',
+          requestId: row.request_id,
+          tenantId: row.tenant_id,
+          signature: row.provider_charge_id,
+          attempts: row.activation_attempt_count,
+          lastError: row.activation_last_error,
+        }),
+      )
+    }
+  }
+
+  console.log('[cron/reconcile-solana-platform-activations]', JSON.stringify(result))
+  return NextResponse.json(result)
+}

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -284,7 +284,7 @@ makes logs hard to read.
 
 #### Option A — GitHub Actions (default, and what the repo ships)
 
-`.github/workflows/cron.yml` runs all seven schedules. It needs two repository
+`.github/workflows/cron.yml` runs all declared schedules. It needs two repository
 settings under **Settings → Secrets and variables → Actions**:
 
 | Kind | Name | Value |
@@ -336,6 +336,10 @@ If you choose this, disable the schedules in `.github/workflows/cron.yml`.
 */10 * * * * curl -s -H "Authorization: Bearer YOUR_CRON_SECRET" https://lmsplatform.com/api/cron/solana-reconcile
 # Confirm Binance personal-wallet payments
 */10 * * * * curl -s -H "Authorization: Bearer YOUR_CRON_SECRET" https://lmsplatform.com/api/cron/binance-personal-reconcile
+# Replay stalled signed webhook deliveries
+*/10 * * * * curl -s -H "Authorization: Bearer YOUR_CRON_SECRET" https://lmsplatform.com/api/cron/redeliver-webhook-events
+# Retry paid Solana platform requests whose entitlement activation stalled
+*/10 * * * * curl -s -H "Authorization: Bearer YOUR_CRON_SECRET" https://lmsplatform.com/api/cron/reconcile-solana-platform-activations
 ```
 
 > `/api/cron/solana-pull` exists but is deliberately not on any schedule here or

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -296,7 +296,7 @@ Each `stripe listen` prints its own signing secret; they are different values, d
 
 ### Cron endpoints
 
-`/api/cron/*` (subscription expiry, plan-limit enforcement, daily digest, league rollover, Solana pull/reconcile) are protected by `CRON_SECRET`. Trigger one manually:
+`/api/cron/*` (subscription expiry, plan-limit enforcement, daily digest, league rollover, webhook redelivery, and payment/activation reconciliation) are protected by `CRON_SECRET`. Trigger one manually:
 
 ```bash
 curl -H "Authorization: Bearer $CRON_SECRET" http://lvh.me:3000/api/cron/expire-subscriptions

--- a/lib/billing/payment-request-ttl.ts
+++ b/lib/billing/payment-request-ttl.ts
@@ -20,8 +20,11 @@
 
 import type { SupabaseClient } from '@supabase/supabase-js'
 
-/** Statuses that mean "this request is still an open promise to pay". */
+/** Statuses that block a second request and pause entitlement downgrade. */
 export const OPEN_REQUEST_STATUSES = ['pending', 'instructions_sent', 'payment_received'] as const
+
+/** Only unpaid promises may be swept by the request TTL. */
+export const EXPIRABLE_REQUEST_STATUSES = ['pending', 'instructions_sent'] as const
 
 /**
  * Days a request stays open before the cron expires it. Mirrors the
@@ -51,6 +54,9 @@ export function isRequestOpen(
   now: Date = new Date()
 ): boolean {
   if (!(OPEN_REQUEST_STATUSES as readonly string[]).includes(request.status)) return false
+  // Money has been observed. Expiring this row would turn a recoverable
+  // activation failure back into money-without-service with no retry record.
+  if (request.status === 'payment_received') return true
   // A NULL expiry predates the column (or was written by an older client);
   // treat it as open so a legitimate in-flight request is never dropped.
   if (!request.expires_at) return true

--- a/lib/billing/solana-platform-activation.ts
+++ b/lib/billing/solana-platform-activation.ts
@@ -1,0 +1,210 @@
+import { randomUUID } from 'node:crypto'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { dispatchPlatformBillingEvent } from '@/lib/billing/platform-webhook-dispatch'
+
+export const SOLANA_ACTIVATION_MAX_ATTEMPTS = 5
+export const SOLANA_ACTIVATION_LEASE_SECONDS = 5 * 60
+export const SOLANA_ACTIVATION_RETRY_SECONDS = 60
+
+export type SolanaActivationState =
+  | 'observed'
+  | 'processing'
+  | 'activated'
+  | 'failed_retryable'
+  | 'terminal_invalid'
+
+interface ObservationRow {
+  observation_status:
+    | 'observed'
+    | 'activated'
+    | 'terminal_invalid'
+    | 'signature_conflict'
+    | 'signature_mismatch'
+    | 'not_found'
+  current_activation_state: SolanaActivationState | null
+  current_signature: string | null
+}
+
+interface ClaimRow {
+  claim_status:
+    | 'claimed'
+    | 'processing'
+    | 'activated'
+    | 'terminal_invalid'
+    | 'retry_later'
+    | 'attempts_exhausted'
+    | 'not_found'
+  current_activation_state: SolanaActivationState | null
+  current_attempt_count: number
+}
+
+interface ActivationRequestRow {
+  request_id: string
+  tenant_id: string
+  plan_id: string
+  interval: string
+  provider_charge_id: string
+  switch_id: string | null
+  platform_plans: { slug: string } | { slug: string }[] | null
+}
+
+export type ObserveSolanaPaymentResult =
+  | { status: 'observed' | 'activated'; state: SolanaActivationState; signature: string }
+  | {
+      status: 'terminal_invalid' | 'signature_conflict' | 'signature_mismatch' | 'not_found'
+      state: SolanaActivationState | null
+      signature: string | null
+    }
+
+export interface ProcessSolanaActivationResult {
+  state: SolanaActivationState
+  attemptCount: number
+  claimed: boolean
+  alertRequired?: boolean
+}
+
+function rpcError(label: string, error: { message?: string }): Error {
+  return new Error(`${label} failed: ${error.message ?? JSON.stringify(error)}`)
+}
+
+/** Atomically persist the verified signature before any entitlement work runs. */
+export async function observeSolanaPlatformPayment(
+  admin: SupabaseClient,
+  requestId: string,
+  tenantId: string,
+  signature: string,
+): Promise<ObserveSolanaPaymentResult> {
+  const { data, error } = await admin.rpc('observe_solana_platform_payment', {
+    _request_id: requestId,
+    _tenant_id: tenantId,
+    _signature: signature,
+  })
+  if (error) throw rpcError('Solana payment observation', error)
+
+  const row = (data as ObservationRow[] | null)?.[0]
+  if (!row) throw new Error('Solana payment observation returned no result')
+
+  if (row.observation_status === 'observed' || row.observation_status === 'activated') {
+    if (!row.current_activation_state || !row.current_signature) {
+      throw new Error('Solana payment observation returned an incomplete success result')
+    }
+    return {
+      status: row.observation_status,
+      state: row.current_activation_state,
+      signature: row.current_signature,
+    }
+  }
+
+  return {
+    status: row.observation_status,
+    state: row.current_activation_state,
+    signature: row.current_signature,
+  }
+}
+
+/**
+ * Lease and dispatch one observed payment.
+ *
+ * The dispatcher is replay-safe by signature. If this worker dies after the
+ * entitlement commit but before completion, the next lease repeats the same
+ * event without extending the paid period twice.
+ */
+export async function processSolanaPlatformActivation(
+  admin: SupabaseClient,
+  requestId: string,
+): Promise<ProcessSolanaActivationResult> {
+  const claimToken = randomUUID()
+  const { data, error } = await admin.rpc('claim_solana_platform_activation', {
+    _request_id: requestId,
+    _claim_token: claimToken,
+    _lease_seconds: SOLANA_ACTIVATION_LEASE_SECONDS,
+    _max_attempts: SOLANA_ACTIVATION_MAX_ATTEMPTS,
+  })
+  if (error) throw rpcError('Solana activation claim', error)
+
+  const claim = (data as ClaimRow[] | null)?.[0]
+  if (!claim) throw new Error('Solana activation claim returned no result')
+
+  if (claim.claim_status !== 'claimed') {
+    const state = claim.current_activation_state ?? 'terminal_invalid'
+    return {
+      state,
+      attemptCount: claim.current_attempt_count,
+      claimed: false,
+      ...(claim.claim_status === 'attempts_exhausted' ? { alertRequired: true } : {}),
+    }
+  }
+
+  const { data: request, error: requestError } = await admin
+    .from('platform_payment_requests')
+    .select(
+      'request_id, tenant_id, plan_id, interval, provider_charge_id, switch_id, platform_plans(slug)',
+    )
+    .eq('request_id', requestId)
+    .eq('payment_provider', 'solana')
+    .maybeSingle()
+
+  try {
+    if (requestError) throw rpcError('Solana activation request lookup', requestError)
+    if (!request?.provider_charge_id) throw new Error('Observed Solana payment has no signature')
+
+    const row = request as unknown as ActivationRequestRow
+    const embeddedPlan = row.platform_plans
+    const planSlug = (Array.isArray(embeddedPlan) ? embeddedPlan[0] : embeddedPlan)?.slug
+
+    await dispatchPlatformBillingEvent(
+      {
+        type: 'subscription.activated',
+        providerEventId: row.provider_charge_id,
+        providerPaymentId: row.provider_charge_id,
+        providerSubscriptionId: row.provider_charge_id,
+        metadata: {
+          tenant_id: row.tenant_id,
+          plan_id: row.plan_id,
+          ...(planSlug ? { plan_slug: planSlug } : {}),
+          interval: row.interval,
+          ...(row.switch_id ? { billing_switch_id: row.switch_id } : {}),
+        },
+        raw: { requestId: row.request_id, signature: row.provider_charge_id },
+      },
+      { provider: 'solana', admin },
+    )
+
+    const { data: completed, error: completeError } = await admin.rpc(
+      'complete_solana_platform_activation',
+      { _request_id: requestId, _claim_token: claimToken },
+    )
+    if (completeError) throw rpcError('Solana activation completion', completeError)
+    if (completed !== true) {
+      throw new Error('Solana activation completion rejected: claim ownership lost')
+    }
+
+    return { state: 'activated', attemptCount: claim.current_attempt_count, claimed: true }
+  } catch (activationError) {
+    const message = activationError instanceof Error ? activationError.message : String(activationError)
+    const { data: failureState, error: failError } = await admin.rpc(
+      'fail_solana_platform_activation',
+      {
+        _request_id: requestId,
+        _claim_token: claimToken,
+        _last_error: message,
+        _retry_delay_seconds: SOLANA_ACTIVATION_RETRY_SECONDS,
+        _max_attempts: SOLANA_ACTIVATION_MAX_ATTEMPTS,
+      },
+    )
+
+    if (failError) {
+      console.error('[billing/solana/activation] failed to release activation lease:', failError)
+    }
+    console.error(`[billing/solana/activation] attempt failed for ${requestId}:`, activationError)
+
+    const ownershipLost = failureState === 'ownership_lost'
+    const exhausted = failureState === 'attempts_exhausted'
+    return {
+      state: ownershipLost ? 'processing' : 'failed_retryable',
+      attemptCount: claim.current_attempt_count,
+      claimed: true,
+      ...(exhausted ? { alertRequired: true } : {}),
+    }
+  }
+}

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -4589,6 +4589,15 @@ export type Database = {
       }
       platform_payment_requests: {
         Row: {
+          activated_at: string | null
+          activation_alerted_at: string | null
+          activation_attempt_count: number
+          activation_last_error: string | null
+          activation_lease_expires_at: string | null
+          activation_next_retry_at: string | null
+          activation_started_at: string | null
+          activation_state: string | null
+          activation_token: string | null
           admin_notes: string | null
           amount: number
           bank_reference: string | null
@@ -4600,6 +4609,7 @@ export type Database = {
           interval: string
           notes: string | null
           payment_provider: string
+          payment_observed_at: string | null
           plan_id: string
           proof_url: string | null
           provider_charge_id: string | null
@@ -4617,6 +4627,15 @@ export type Database = {
           updated_at: string | null
         }
         Insert: {
+          activated_at?: string | null
+          activation_alerted_at?: string | null
+          activation_attempt_count?: number
+          activation_last_error?: string | null
+          activation_lease_expires_at?: string | null
+          activation_next_retry_at?: string | null
+          activation_started_at?: string | null
+          activation_state?: string | null
+          activation_token?: string | null
           admin_notes?: string | null
           amount: number
           bank_reference?: string | null
@@ -4628,6 +4647,7 @@ export type Database = {
           interval?: string
           notes?: string | null
           payment_provider?: string
+          payment_observed_at?: string | null
           plan_id: string
           proof_url?: string | null
           provider_charge_id?: string | null
@@ -4645,6 +4665,15 @@ export type Database = {
           updated_at?: string | null
         }
         Update: {
+          activated_at?: string | null
+          activation_alerted_at?: string | null
+          activation_attempt_count?: number
+          activation_last_error?: string | null
+          activation_lease_expires_at?: string | null
+          activation_next_retry_at?: string | null
+          activation_started_at?: string | null
+          activation_state?: string | null
+          activation_token?: string | null
           admin_notes?: string | null
           amount?: number
           bank_reference?: string | null
@@ -4656,6 +4685,7 @@ export type Database = {
           interval?: string
           notes?: string | null
           payment_provider?: string
+          payment_observed_at?: string | null
           plan_id?: string
           proof_url?: string | null
           provider_charge_id?: string | null
@@ -6624,8 +6654,25 @@ export type Database = {
           event_id: string
         }[]
       }
+      claim_solana_platform_activation: {
+        Args: {
+          _claim_token: string
+          _lease_seconds?: number
+          _max_attempts?: number
+          _request_id: string
+        }
+        Returns: {
+          claim_status: string
+          current_activation_state: string
+          current_attempt_count: number
+        }[]
+      }
       complete_webhook_event: {
         Args: { _claim_token: string; _event_id: string }
+        Returns: boolean
+      }
+      complete_solana_platform_activation: {
+        Args: { _claim_token: string; _request_id: string }
         Returns: boolean
       }
       downgrade_platform_subscription_if_current: {
@@ -6635,6 +6682,24 @@ export type Database = {
           _tenant_id: string
         }
         Returns: number
+      }
+      fail_solana_platform_activation: {
+        Args: {
+          _claim_token: string
+          _last_error: string
+          _max_attempts?: number
+          _request_id: string
+          _retry_delay_seconds?: number
+        }
+        Returns: string
+      }
+      observe_solana_platform_payment: {
+        Args: { _request_id: string; _signature: string; _tenant_id: string }
+        Returns: {
+          current_activation_state: string
+          current_signature: string
+          observation_status: string
+        }[]
       }
       promote_platform_subscription_switch: {
         Args: {

--- a/supabase/migrations/20260808182305_solana_platform_activation_recovery.sql
+++ b/supabase/migrations/20260808182305_solana_platform_activation_recovery.sql
@@ -1,0 +1,336 @@
+-- Durable Solana platform-payment activation (issue #622).
+--
+-- On-chain observation and entitlement activation cannot share one transaction:
+-- the latter runs application orchestration and may call provider APIs during a
+-- subscription switch. Persist the observed payment first, then lease the
+-- replay-safe dispatcher. A crashed worker can be reclaimed after its lease;
+-- token-fenced completion prevents that stale worker from winning later.
+
+alter table public.platform_payment_requests
+  add column payment_observed_at timestamptz,
+  add column activation_state text check (activation_state in (
+    'observed', 'processing', 'activated', 'failed_retryable', 'terminal_invalid'
+  )),
+  add column activation_attempt_count integer not null default 0
+    check (activation_attempt_count >= 0),
+  add column activation_last_error text,
+  add column activation_next_retry_at timestamptz,
+  add column activation_started_at timestamptz,
+  add column activation_lease_expires_at timestamptz,
+  add column activation_token uuid,
+  add column activation_alerted_at timestamptz,
+  add column activated_at timestamptz;
+
+comment on column public.platform_payment_requests.activation_state is
+  'Durable entitlement state for observed Solana platform payments. NULL for rails that do not use this worker.';
+comment on column public.platform_payment_requests.activation_token is
+  'Lease-fencing token. Only the worker holding this token may complete or fail an activation attempt.';
+
+create index platform_payment_requests_solana_activation_queue
+  on public.platform_payment_requests (
+    activation_state,
+    activation_next_retry_at,
+    activation_lease_expires_at,
+    payment_observed_at
+  )
+  where payment_provider = 'solana'
+    and activation_state in ('observed', 'processing', 'failed_retryable');
+
+-- Preserve genuinely completed historical payments, but put any legacy row
+-- that was marked confirmed before its replay-safe business effect landed back
+-- into the recovery queue. This repairs existing money-without-service rows
+-- instead of blessing them as activated during deployment.
+with classified as (
+  select
+    request.request_id,
+    (
+      exists (
+        select 1
+        from public.webhook_business_effects effect
+        where effect.provider = 'solana'
+          and effect.provider_event_id = request.provider_charge_id
+          and effect.effect_type = 'self_managed_platform_period'
+          and effect.target_id = request.tenant_id::text
+      )
+      or exists (
+        select 1
+        from public.platform_subscriptions subscription
+        where subscription.tenant_id = request.tenant_id
+          and subscription.payment_provider = 'solana'
+          and subscription.provider_subscription_id = request.provider_charge_id
+          and subscription.status = 'active'
+      )
+      or exists (
+        select 1
+        from public.platform_subscription_switches switch
+        where switch.switch_id = request.switch_id
+          and switch.target_payment_provider = 'solana'
+          and switch.target_provider_subscription_id = request.provider_charge_id
+          and switch.state <> 'pending_activation'
+      )
+    ) as was_activated
+  from public.platform_payment_requests request
+  where request.payment_provider = 'solana'
+    and request.status = 'confirmed'
+    and request.provider_charge_id is not null
+)
+update public.platform_payment_requests request
+set payment_observed_at = coalesce(request.confirmed_at, request.updated_at, request.created_at, clock_timestamp()),
+    activation_state = case when classified.was_activated then 'activated' else 'failed_retryable' end,
+    activated_at = case when classified.was_activated then coalesce(request.confirmed_at, request.updated_at) end,
+    status = case when classified.was_activated then 'confirmed' else 'payment_received' end,
+    confirmed_at = case when classified.was_activated then request.confirmed_at end,
+    activation_last_error = case
+      when classified.was_activated then null
+      else 'Legacy confirmed Solana payment requires entitlement reconciliation'
+    end,
+    activation_next_retry_at = case when classified.was_activated then null else clock_timestamp() end
+from classified
+where request.request_id = classified.request_id;
+
+create or replace function public.observe_solana_platform_payment(
+  _request_id uuid,
+  _tenant_id uuid,
+  _signature text
+)
+returns table (
+  observation_status text,
+  current_activation_state text,
+  current_signature text
+)
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  request_row public.platform_payment_requests%rowtype;
+begin
+  if _signature is null or btrim(_signature) = '' then
+    raise exception 'Solana signature is required' using errcode = '22023';
+  end if;
+
+  select * into request_row
+  from public.platform_payment_requests
+  where request_id = _request_id
+    and tenant_id = _tenant_id
+  for update;
+
+  if not found or request_row.payment_provider <> 'solana' then
+    return query select 'not_found'::text, null::text, null::text;
+    return;
+  end if;
+
+  if request_row.activation_state = 'activated' or request_row.status = 'confirmed' then
+    return query select
+      case when request_row.provider_charge_id = _signature then 'activated' else 'signature_mismatch' end,
+      'activated'::text,
+      request_row.provider_charge_id;
+    return;
+  end if;
+
+  if request_row.activation_state = 'terminal_invalid'
+     or request_row.status in ('rejected', 'expired') then
+    return query select 'terminal_invalid'::text, 'terminal_invalid'::text, request_row.provider_charge_id;
+    return;
+  end if;
+
+  if request_row.provider_charge_id is not null
+     and request_row.provider_charge_id <> _signature then
+    return query select 'signature_mismatch'::text, request_row.activation_state, request_row.provider_charge_id;
+    return;
+  end if;
+
+  begin
+    update public.platform_payment_requests
+    set provider_charge_id = _signature,
+        status = 'payment_received',
+        payment_observed_at = coalesce(payment_observed_at, clock_timestamp()),
+        activation_state = coalesce(activation_state, 'observed'),
+        updated_at = clock_timestamp()
+    where request_id = _request_id
+    returning * into request_row;
+  exception
+    when unique_violation then
+      update public.platform_payment_requests
+      set status = 'rejected',
+          activation_state = 'terminal_invalid',
+          activation_last_error = 'On-chain signature already settled another request',
+          activation_next_retry_at = null,
+          updated_at = clock_timestamp()
+      where request_id = _request_id
+      returning * into request_row;
+
+      return query select 'signature_conflict'::text, request_row.activation_state, request_row.provider_charge_id;
+      return;
+  end;
+
+  return query select 'observed'::text, request_row.activation_state, request_row.provider_charge_id;
+end;
+$$;
+
+create or replace function public.claim_solana_platform_activation(
+  _request_id uuid,
+  _claim_token uuid,
+  _lease_seconds integer default 300,
+  _max_attempts integer default 5
+)
+returns table (
+  claim_status text,
+  current_activation_state text,
+  current_attempt_count integer
+)
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  request_row public.platform_payment_requests%rowtype;
+begin
+  if _claim_token is null then
+    raise exception 'Activation claim token is required' using errcode = '22023';
+  end if;
+  if _lease_seconds < 1 or _max_attempts < 1 then
+    raise exception 'Lease seconds and max attempts must be positive' using errcode = '22023';
+  end if;
+
+  select * into request_row
+  from public.platform_payment_requests
+  where request_id = _request_id
+  for update;
+
+  if not found or request_row.payment_provider <> 'solana'
+     or request_row.provider_charge_id is null then
+    return query select 'not_found'::text, null::text, 0;
+    return;
+  end if;
+
+  if request_row.activation_state = 'activated' or request_row.status = 'confirmed' then
+    return query select 'activated'::text, 'activated'::text, request_row.activation_attempt_count;
+    return;
+  end if;
+
+  if request_row.activation_state = 'terminal_invalid'
+     or request_row.status in ('rejected', 'expired') then
+    return query select 'terminal_invalid'::text, 'terminal_invalid'::text, request_row.activation_attempt_count;
+    return;
+  end if;
+
+  if request_row.activation_state = 'processing'
+     and request_row.activation_lease_expires_at > clock_timestamp() then
+    return query select 'processing'::text, 'processing'::text, request_row.activation_attempt_count;
+    return;
+  end if;
+
+  if request_row.activation_state = 'failed_retryable'
+     and request_row.activation_next_retry_at > clock_timestamp() then
+    return query select 'retry_later'::text, 'failed_retryable'::text, request_row.activation_attempt_count;
+    return;
+  end if;
+
+  if request_row.activation_attempt_count >= _max_attempts then
+    return query select 'attempts_exhausted'::text, 'failed_retryable'::text, request_row.activation_attempt_count;
+    return;
+  end if;
+
+  update public.platform_payment_requests
+  set activation_state = 'processing',
+      activation_attempt_count = activation_attempt_count + 1,
+      activation_started_at = clock_timestamp(),
+      activation_lease_expires_at = clock_timestamp() + make_interval(secs => _lease_seconds),
+      activation_token = _claim_token,
+      activation_next_retry_at = null,
+      updated_at = clock_timestamp()
+  where request_id = _request_id
+  returning * into request_row;
+
+  return query select 'claimed'::text, request_row.activation_state, request_row.activation_attempt_count;
+end;
+$$;
+
+create or replace function public.complete_solana_platform_activation(
+  _request_id uuid,
+  _claim_token uuid
+)
+returns boolean
+language sql
+security invoker
+set search_path = ''
+as $$
+  with completed as (
+    update public.platform_payment_requests
+    set activation_state = 'activated',
+        status = 'confirmed',
+        confirmed_at = coalesce(confirmed_at, clock_timestamp()),
+        activated_at = coalesce(activated_at, clock_timestamp()),
+        activation_last_error = null,
+        activation_next_retry_at = null,
+        activation_started_at = null,
+        activation_lease_expires_at = null,
+        activation_token = null,
+        updated_at = clock_timestamp()
+    where request_id = _request_id
+      and activation_state = 'processing'
+      and activation_token = _claim_token
+    returning request_id
+  )
+  select exists(select 1 from completed);
+$$;
+
+create or replace function public.fail_solana_platform_activation(
+  _request_id uuid,
+  _claim_token uuid,
+  _last_error text,
+  _retry_delay_seconds integer default 60,
+  _max_attempts integer default 5
+)
+returns text
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  request_row public.platform_payment_requests%rowtype;
+begin
+  if _retry_delay_seconds < 0 or _max_attempts < 1 then
+    raise exception 'Retry delay must be non-negative and max attempts positive' using errcode = '22023';
+  end if;
+
+  update public.platform_payment_requests
+  set activation_state = 'failed_retryable',
+      activation_last_error = left(coalesce(_last_error, 'Unknown activation error'), 2000),
+      activation_next_retry_at = case
+        when activation_attempt_count >= _max_attempts then null
+        else clock_timestamp() + make_interval(secs => _retry_delay_seconds)
+      end,
+      activation_started_at = null,
+      activation_lease_expires_at = null,
+      activation_token = null,
+      updated_at = clock_timestamp()
+  where request_id = _request_id
+    and activation_state = 'processing'
+    and activation_token = _claim_token
+  returning * into request_row;
+
+  if not found then return 'ownership_lost'; end if;
+  if request_row.activation_attempt_count >= _max_attempts then return 'attempts_exhausted'; end if;
+  return 'failed_retryable';
+end;
+$$;
+
+revoke all on function public.observe_solana_platform_payment(uuid, uuid, text)
+  from public, anon, authenticated;
+revoke all on function public.claim_solana_platform_activation(uuid, uuid, integer, integer)
+  from public, anon, authenticated;
+revoke all on function public.complete_solana_platform_activation(uuid, uuid)
+  from public, anon, authenticated;
+revoke all on function public.fail_solana_platform_activation(uuid, uuid, text, integer, integer)
+  from public, anon, authenticated;
+
+grant execute on function public.observe_solana_platform_payment(uuid, uuid, text)
+  to service_role;
+grant execute on function public.claim_solana_platform_activation(uuid, uuid, integer, integer)
+  to service_role;
+grant execute on function public.complete_solana_platform_activation(uuid, uuid)
+  to service_role;
+grant execute on function public.fail_solana_platform_activation(uuid, uuid, text, integer, integer)
+  to service_role;

--- a/tests/sql/issue-622-solana-platform-activation-recovery.sql
+++ b/tests/sql/issue-622-solana-platform-activation-recovery.sql
@@ -1,0 +1,156 @@
+-- Real-Postgres failure/replay proof for issue #622. All mutations roll back.
+begin;
+
+do $$
+declare
+  tenant_key uuid;
+  plan_key uuid;
+  plan_slug text;
+  user_key uuid;
+  request_a constant uuid := '62200000-0000-0000-0000-000000000001';
+  request_b constant uuid := '62200000-0000-0000-0000-000000000002';
+  token_a constant uuid := '62200000-0000-0000-0000-000000000011';
+  token_b constant uuid := '62200000-0000-0000-0000-000000000012';
+  signature_a constant text := 'issue-622-solana-signature-A';
+  observation text;
+  claim text;
+  attempts integer;
+  failure_state text;
+  first_applied boolean;
+  replay_applied boolean;
+  first_period_end timestamptz;
+  replay_period_end timestamptz;
+begin
+  select tenant.id, plan.plan_id, plan.slug
+  into tenant_key, plan_key, plan_slug
+  from public.tenants tenant
+  cross join public.platform_plans plan
+  where plan.slug <> 'free'
+  order by tenant.created_at, plan.sort_order
+  limit 1;
+
+  select id into user_key from auth.users order by created_at limit 1;
+
+  if tenant_key is null or plan_key is null or user_key is null then
+    raise exception 'issue #622 SQL test needs a tenant, paid platform plan, and auth user fixture';
+  end if;
+
+  insert into public.platform_payment_requests (
+    request_id, tenant_id, plan_id, requested_by, interval, amount, currency,
+    status, payment_provider, provider_reference, settlement_currency,
+    settlement_base, expires_at
+  ) values
+    (
+      request_a, tenant_key, plan_key, user_key, 'monthly', 9, 'usd',
+      'pending', 'solana', 'issue-622-reference-A', 'usdc', 9000000,
+      clock_timestamp() + interval '1 hour'
+    ),
+    (
+      request_b, tenant_key, plan_key, user_key, 'monthly', 9, 'usd',
+      'pending', 'solana', 'issue-622-reference-B', 'usdc', 9000000,
+      clock_timestamp() + interval '1 hour'
+    );
+
+  select result.observation_status into observation
+  from public.observe_solana_platform_payment(request_a, tenant_key, signature_a) result;
+  if observation <> 'observed' then
+    raise exception 'first signature observation returned %, expected observed', observation;
+  end if;
+
+  select result.claim_status, result.current_attempt_count
+  into claim, attempts
+  from public.claim_solana_platform_activation(request_a, token_a, 300, 5) result;
+  if claim <> 'claimed' or attempts <> 1 then
+    raise exception 'first activation lease returned % attempt %, expected claimed/1', claim, attempts;
+  end if;
+
+  -- Entitlement commits, then the worker dies before completing its request
+  -- lease. The replay must see the same durable period and apply no second one.
+  select result.applied, result.period_end
+  into first_applied, first_period_end
+  from public.apply_self_managed_platform_period(
+    'solana', signature_a, tenant_key, plan_key, plan_slug, 'monthly', signature_a, null
+  ) result;
+  if not first_applied then
+    raise exception 'first entitlement activation did not apply';
+  end if;
+
+  update public.platform_payment_requests
+  set activation_lease_expires_at = clock_timestamp() - interval '1 second'
+  where request_id = request_a;
+
+  select result.claim_status, result.current_attempt_count
+  into claim, attempts
+  from public.claim_solana_platform_activation(request_a, token_b, 300, 5) result;
+  if claim <> 'claimed' or attempts <> 2 then
+    raise exception 'stale-lease takeover returned % attempt %, expected claimed/2', claim, attempts;
+  end if;
+
+  select result.applied, result.period_end
+  into replay_applied, replay_period_end
+  from public.apply_self_managed_platform_period(
+    'solana', signature_a, tenant_key, plan_key, plan_slug, 'monthly', signature_a, null
+  ) result;
+  if replay_applied or replay_period_end <> first_period_end then
+    raise exception 'replay duplicated period: applied %, first %, replay %',
+      replay_applied, first_period_end, replay_period_end;
+  end if;
+
+  if public.complete_solana_platform_activation(request_a, token_a) then
+    raise exception 'stale worker completed after losing its lease token';
+  end if;
+  if not public.complete_solana_platform_activation(request_a, token_b) then
+    raise exception 'current worker could not complete activation';
+  end if;
+
+  select result.claim_status into claim
+  from public.claim_solana_platform_activation(
+    request_a, '62200000-0000-0000-0000-000000000013', 300, 5
+  ) result;
+  if claim <> 'activated' then
+    raise exception 'completed replay returned %, expected activated', claim;
+  end if;
+
+  -- The same signature cannot settle a second request. The loser becomes a
+  -- durable terminal-invalid record rather than retrying a payment it does not own.
+  select result.observation_status into observation
+  from public.observe_solana_platform_payment(request_b, tenant_key, signature_a) result;
+  if observation <> 'signature_conflict' then
+    raise exception 'duplicate signature returned %, expected signature_conflict', observation;
+  end if;
+  if not exists (
+    select 1 from public.platform_payment_requests
+    where request_id = request_b
+      and status = 'rejected'
+      and activation_state = 'terminal_invalid'
+      and activation_last_error is not null
+  ) then
+    raise exception 'duplicate-signature request was not parked terminal-invalid';
+  end if;
+
+  -- Failure release is retryable and token-fenced.
+  update public.platform_payment_requests
+  set activation_state = 'processing',
+      status = 'payment_received',
+      provider_charge_id = 'issue-622-solana-signature-B',
+      activation_token = token_a,
+      activation_attempt_count = 1
+  where request_id = request_b;
+
+  failure_state := public.fail_solana_platform_activation(
+    request_b, token_b, 'stale failure', 0, 5
+  );
+  if failure_state <> 'ownership_lost' then
+    raise exception 'stale failure returned %, expected ownership_lost', failure_state;
+  end if;
+
+  failure_state := public.fail_solana_platform_activation(
+    request_b, token_a, 'injected activation failure', 0, 5
+  );
+  if failure_state <> 'failed_retryable' then
+    raise exception 'owned failure returned %, expected failed_retryable', failure_state;
+  end if;
+end;
+$$;
+
+rollback;

--- a/tests/unit/payment-request-ttl.test.ts
+++ b/tests/unit/payment-request-ttl.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import {
+  EXPIRABLE_REQUEST_STATUSES,
   OPEN_REQUEST_STATUSES,
   REQUEST_TTL_DAYS,
   isRequestOpen,
@@ -32,6 +33,11 @@ describe('payment-request TTL', () => {
     // Deliberate: tying "does it still count" to the sweep would hand the
     // downgrade-pause leak back during any cron outage.
     expect(isRequestOpen({ status: 'pending', expires_at: at(-0.001) }, NOW)).toBe(false)
+  })
+
+  it('never expires a request after money has been observed', () => {
+    expect(EXPIRABLE_REQUEST_STATUSES).not.toContain('payment_received')
+    expect(isRequestOpen({ status: 'payment_received', expires_at: at(-30) }, NOW)).toBe(true)
   })
 
   it('never counts a terminal status', () => {

--- a/tests/unit/reconcile-solana-platform-activations.test.ts
+++ b/tests/unit/reconcile-solana-platform-activations.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { NextRequest } from 'next/server'
+
+const testState = vi.hoisted(() => ({
+  queue: [] as { request_id: string }[],
+  parked: [] as Record<string, unknown>[],
+  updateSucceeds: true,
+  process: vi.fn(),
+}))
+
+function adminClient() {
+  let readNumber = 0
+
+  return {
+    from: () => {
+      const readIndex = readNumber++
+      let isUpdate = false
+      const builder: Record<string, unknown> = {}
+      for (const method of ['select', 'eq', 'in', 'or', 'lt', 'gte', 'order', 'limit', 'is']) {
+        builder[method] = () => builder
+      }
+      builder.update = () => {
+        isUpdate = true
+        return builder
+      }
+      builder.maybeSingle = () =>
+        Promise.resolve({
+          data: testState.updateSucceeds ? { request_id: 'parked-1' } : null,
+          error: null,
+        })
+      builder.then = (resolve: (value: unknown) => unknown) => {
+        const data = isUpdate ? null : readIndex === 0 ? testState.queue : testState.parked
+        return Promise.resolve({ data, error: null }).then(resolve)
+      }
+      return builder
+    },
+  }
+}
+
+vi.mock('@supabase/supabase-js', () => ({ createClient: () => adminClient() }))
+vi.mock('@/lib/billing/solana-platform-activation', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/billing/solana-platform-activation')>()
+  return {
+    ...actual,
+    processSolanaPlatformActivation: testState.process,
+  }
+})
+
+import { GET } from '@/app/api/cron/reconcile-solana-platform-activations/route'
+
+const SECRET = 'cron-secret'
+
+function request(auth: string | null = `Bearer ${SECRET}`): NextRequest {
+  return {
+    headers: { get: () => auth },
+  } as unknown as NextRequest
+}
+
+beforeEach(() => {
+  process.env.CRON_SECRET = SECRET
+  process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://fake.supabase.co'
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role'
+  testState.queue = []
+  testState.parked = []
+  testState.updateSucceeds = true
+  testState.process.mockReset()
+  vi.spyOn(console, 'error').mockImplementation(() => undefined)
+  vi.spyOn(console, 'log').mockImplementation(() => undefined)
+})
+
+describe('cron: reconcile Solana platform activations', () => {
+  it('rejects a missing or incorrect cron secret', async () => {
+    expect((await GET(request(null))).status).toBe(401)
+    expect((await GET(request('Bearer wrong'))).status).toBe(401)
+  })
+
+  it('retries each due request and emits one durable alert for parked work', async () => {
+    testState.queue = [{ request_id: 'request-a' }, { request_id: 'request-b' }]
+    testState.parked = [
+      {
+        request_id: 'parked-1',
+        tenant_id: 'tenant-1',
+        provider_charge_id: 'signature-1',
+        activation_attempt_count: 5,
+        activation_last_error: 'database unavailable',
+      },
+    ]
+    testState.process
+      .mockResolvedValueOnce({ state: 'activated', attemptCount: 2, claimed: true })
+      .mockResolvedValueOnce({ state: 'failed_retryable', attemptCount: 3, claimed: true })
+
+    const response = await GET(request())
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      scanned: 2,
+      activated: 1,
+      failed: 1,
+      processing: 0,
+      alerts: 1,
+      errors: 0,
+    })
+    expect(testState.process).toHaveBeenCalledTimes(2)
+    expect(console.error).toHaveBeenCalledWith(
+      '[billing-alert]',
+      expect.stringContaining('solana_platform_activation_exhausted'),
+    )
+  })
+
+  it('continues the batch when one activation throws', async () => {
+    testState.queue = [{ request_id: 'broken' }, { request_id: 'healthy' }]
+    testState.process
+      .mockRejectedValueOnce(new Error('claim RPC unavailable'))
+      .mockResolvedValueOnce({ state: 'processing', attemptCount: 1, claimed: false })
+
+    const body = await (await GET(request())).json()
+
+    expect(body).toMatchObject({ scanned: 2, processing: 1, errors: 1 })
+    expect(testState.process).toHaveBeenCalledTimes(2)
+  })
+})

--- a/tests/unit/solana-platform-activation.test.ts
+++ b/tests/unit/solana-platform-activation.test.ts
@@ -1,0 +1,227 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+const dispatch = vi.hoisted(() => vi.fn())
+
+vi.mock('@/lib/billing/platform-webhook-dispatch', () => ({
+  dispatchPlatformBillingEvent: dispatch,
+}))
+
+import {
+  observeSolanaPlatformPayment,
+  processSolanaPlatformActivation,
+} from '@/lib/billing/solana-platform-activation'
+
+interface FakeState {
+  claimStatus:
+    | 'claimed'
+    | 'processing'
+    | 'activated'
+    | 'terminal_invalid'
+    | 'retry_later'
+    | 'attempts_exhausted'
+    | 'not_found'
+  activationState: 'observed' | 'processing' | 'activated' | 'failed_retryable' | 'terminal_invalid'
+  attemptCount: number
+  observationStatus:
+    | 'observed'
+    | 'activated'
+    | 'terminal_invalid'
+    | 'signature_conflict'
+    | 'signature_mismatch'
+    | 'not_found'
+  complete: boolean
+  failureState: 'failed_retryable' | 'attempts_exhausted' | 'ownership_lost'
+  rpcCalls: { name: string; args: Record<string, unknown> }[]
+}
+
+const state: FakeState = {
+  claimStatus: 'claimed',
+  activationState: 'processing',
+  attemptCount: 1,
+  observationStatus: 'observed',
+  complete: true,
+  failureState: 'failed_retryable',
+  rpcCalls: [],
+}
+
+const requestRow = {
+  request_id: 'request-622',
+  tenant_id: 'tenant-622',
+  plan_id: 'plan-622',
+  interval: 'monthly',
+  provider_charge_id: 'signature-622',
+  switch_id: null,
+  platform_plans: { slug: 'starter' },
+}
+
+function adminClient(): SupabaseClient {
+  const builder: Record<string, unknown> = {}
+  builder.select = () => builder
+  builder.eq = () => builder
+  builder.maybeSingle = () => Promise.resolve({ data: requestRow, error: null })
+
+  return {
+    from: () => builder,
+    rpc: (name: string, args: Record<string, unknown>) => {
+      state.rpcCalls.push({ name, args })
+      if (name === 'observe_solana_platform_payment') {
+        return Promise.resolve({
+          data: [
+            {
+              observation_status: state.observationStatus,
+              current_activation_state:
+                state.observationStatus === 'not_found' ? null : state.activationState,
+              current_signature:
+                state.observationStatus === 'not_found' ? null : requestRow.provider_charge_id,
+            },
+          ],
+          error: null,
+        })
+      }
+      if (name === 'claim_solana_platform_activation') {
+        return Promise.resolve({
+          data: [
+            {
+              claim_status: state.claimStatus,
+              current_activation_state: state.activationState,
+              current_attempt_count: state.attemptCount,
+            },
+          ],
+          error: null,
+        })
+      }
+      if (name === 'complete_solana_platform_activation') {
+        return Promise.resolve({ data: state.complete, error: null })
+      }
+      if (name === 'fail_solana_platform_activation') {
+        return Promise.resolve({ data: state.failureState, error: null })
+      }
+      return Promise.resolve({ data: null, error: { message: `Unexpected RPC ${name}` } })
+    },
+  } as unknown as SupabaseClient
+}
+
+beforeEach(() => {
+  state.claimStatus = 'claimed'
+  state.activationState = 'processing'
+  state.attemptCount = 1
+  state.observationStatus = 'observed'
+  state.complete = true
+  state.failureState = 'failed_retryable'
+  state.rpcCalls = []
+  dispatch.mockReset()
+})
+
+describe('Solana platform payment observation', () => {
+  it('persists the verified signature through the observation RPC', async () => {
+    const result = await observeSolanaPlatformPayment(
+      adminClient(),
+      requestRow.request_id,
+      requestRow.tenant_id,
+      requestRow.provider_charge_id,
+    )
+
+    expect(result).toEqual({
+      status: 'observed',
+      state: 'processing',
+      signature: requestRow.provider_charge_id,
+    })
+    expect(state.rpcCalls[0]).toEqual({
+      name: 'observe_solana_platform_payment',
+      args: {
+        _request_id: requestRow.request_id,
+        _tenant_id: requestRow.tenant_id,
+        _signature: requestRow.provider_charge_id,
+      },
+    })
+  })
+
+  it('surfaces a signature conflict as terminal invalidity', async () => {
+    state.observationStatus = 'signature_conflict'
+    state.activationState = 'terminal_invalid'
+
+    await expect(
+      observeSolanaPlatformPayment(
+        adminClient(),
+        requestRow.request_id,
+        requestRow.tenant_id,
+        requestRow.provider_charge_id,
+      ),
+    ).resolves.toMatchObject({ status: 'signature_conflict', state: 'terminal_invalid' })
+  })
+})
+
+describe('Solana platform entitlement activation', () => {
+  it('dispatches and completes only while owning the activation lease', async () => {
+    const result = await processSolanaPlatformActivation(adminClient(), requestRow.request_id)
+
+    expect(result).toEqual({ state: 'activated', attemptCount: 1, claimed: true })
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'subscription.activated',
+        providerEventId: requestRow.provider_charge_id,
+        providerSubscriptionId: requestRow.provider_charge_id,
+        metadata: expect.objectContaining({
+          tenant_id: requestRow.tenant_id,
+          plan_id: requestRow.plan_id,
+          plan_slug: 'starter',
+        }),
+      }),
+      expect.objectContaining({ provider: 'solana' }),
+    )
+    expect(state.rpcCalls.map((call) => call.name)).toEqual([
+      'claim_solana_platform_activation',
+      'complete_solana_platform_activation',
+    ])
+    expect(state.rpcCalls[1].args._claim_token).toBe(state.rpcCalls[0].args._claim_token)
+  })
+
+  it('records a retryable failure after the payment is already observed', async () => {
+    dispatch.mockRejectedValueOnce(new Error('injected activation failure'))
+
+    const result = await processSolanaPlatformActivation(adminClient(), requestRow.request_id)
+
+    expect(result).toEqual({ state: 'failed_retryable', attemptCount: 1, claimed: true })
+    expect(state.rpcCalls.map((call) => call.name)).toEqual([
+      'claim_solana_platform_activation',
+      'fail_solana_platform_activation',
+    ])
+    expect(state.rpcCalls[1].args._last_error).toBe('injected activation failure')
+  })
+
+  it('does not dispatch when another worker owns the live lease', async () => {
+    state.claimStatus = 'processing'
+
+    const result = await processSolanaPlatformActivation(adminClient(), requestRow.request_id)
+
+    expect(result).toEqual({ state: 'processing', attemptCount: 1, claimed: false })
+    expect(dispatch).not.toHaveBeenCalled()
+    expect(state.rpcCalls.map((call) => call.name)).toEqual(['claim_solana_platform_activation'])
+  })
+
+  it('parks and alerts after the bounded attempt threshold', async () => {
+    state.claimStatus = 'attempts_exhausted'
+    state.activationState = 'failed_retryable'
+    state.attemptCount = 5
+
+    const result = await processSolanaPlatformActivation(adminClient(), requestRow.request_id)
+
+    expect(result).toEqual({
+      state: 'failed_retryable',
+      attemptCount: 5,
+      claimed: false,
+      alertRequired: true,
+    })
+    expect(dispatch).not.toHaveBeenCalled()
+  })
+
+  it('cannot release or complete work after losing the lease token', async () => {
+    dispatch.mockRejectedValueOnce(new Error('late stale worker'))
+    state.failureState = 'ownership_lost'
+
+    const result = await processSolanaPlatformActivation(adminClient(), requestRow.request_id)
+
+    expect(result).toEqual({ state: 'processing', attemptCount: 1, claimed: true })
+  })
+})

--- a/tests/unit/solana-platform-verify.test.ts
+++ b/tests/unit/solana-platform-verify.test.ts
@@ -1,0 +1,172 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { NextRequest } from 'next/server'
+
+const testState = vi.hoisted(() => ({
+  request: {} as Record<string, unknown>,
+  verifyTransfer: vi.fn(),
+  observe: vi.fn(),
+  process: vi.fn(),
+}))
+
+function chain(result: unknown) {
+  const builder: Record<string, unknown> = {}
+  builder.select = () => builder
+  builder.eq = () => builder
+  builder.in = () => builder
+  builder.single = () => Promise.resolve({ data: result, error: null })
+  builder.maybeSingle = () => Promise.resolve({ data: result, error: null })
+  return builder
+}
+
+const sessionClient = {
+  auth: { getUser: () => Promise.resolve({ data: { user: { id: 'admin-user' } }, error: null }) },
+  from: () => chain({ role: 'admin' }),
+}
+
+const adminClient = {
+  from: () => chain(testState.request),
+}
+
+vi.mock('@/lib/supabase/server', () => ({ createClient: () => sessionClient }))
+vi.mock('@supabase/supabase-js', () => ({ createClient: () => adminClient }))
+vi.mock('@/lib/supabase/tenant', () => ({ getCurrentTenantId: () => 'tenant-622' }))
+vi.mock('@/lib/rate-limit', () => ({ paymentPollLimiter: { check: () => Promise.resolve() } }))
+vi.mock('@solana/web3.js', () => ({ PublicKey: class PublicKey {} }))
+vi.mock('@/lib/billing/solana-platform-payment', () => ({
+  getPlatformSolanaConfig: () => ({ rpcUrl: 'https://rpc.example' }),
+  resolveStoredSettlement: () => ({ currency: 'usdc', base: 9000000 }),
+  verifyPlatformTransfer: testState.verifyTransfer,
+}))
+vi.mock('@/lib/billing/solana-platform-activation', () => ({
+  observeSolanaPlatformPayment: testState.observe,
+  processSolanaPlatformActivation: testState.process,
+}))
+
+import { POST } from '@/app/api/billing/solana/verify/route'
+
+function request(): NextRequest {
+  return {
+    json: () => Promise.resolve({ requestId: 'request-622' }),
+  } as unknown as NextRequest
+}
+
+function payment(overrides: Record<string, unknown> = {}) {
+  return {
+    request_id: 'request-622',
+    tenant_id: 'tenant-622',
+    plan_id: 'plan-622',
+    interval: 'monthly',
+    status: 'pending',
+    payment_provider: 'solana',
+    provider_reference: 'reference-622',
+    provider_charge_id: null,
+    settlement_currency: 'usdc',
+    settlement_base: 9000000,
+    settlement_mint: 'mint-622',
+    switch_id: null,
+    activation_state: null,
+    activation_attempt_count: 0,
+    platform_plans: { slug: 'starter' },
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://fake.supabase.co'
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role'
+  testState.request = payment()
+  testState.verifyTransfer.mockReset().mockResolvedValue({ confirmed: true, signature: 'signature-622' })
+  testState.observe.mockReset().mockResolvedValue({
+    status: 'observed',
+    state: 'observed',
+    signature: 'signature-622',
+  })
+  testState.process.mockReset().mockResolvedValue({
+    state: 'activated',
+    attemptCount: 1,
+    claimed: true,
+  })
+})
+
+describe('Solana platform verification activation states', () => {
+  it('returns activated only after entitlement processing completes', async () => {
+    const response = await POST(request())
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({
+      confirmed: true,
+      state: 'activated',
+      signature: 'signature-622',
+      attemptCount: 1,
+    })
+    expect(testState.observe).toHaveBeenCalledOnce()
+    expect(testState.process).toHaveBeenCalledOnce()
+  })
+
+  it('keeps an observed payment recoverable when activation fails', async () => {
+    testState.process.mockResolvedValueOnce({
+      state: 'failed_retryable',
+      attemptCount: 1,
+      claimed: true,
+    })
+
+    const body = await (await POST(request())).json()
+
+    expect(body).toMatchObject({
+      confirmed: false,
+      state: 'failed_retryable',
+      signature: 'signature-622',
+    })
+  })
+
+  it('retries a durable signature without querying the chain again', async () => {
+    testState.request = payment({
+      status: 'payment_received',
+      provider_charge_id: 'signature-622',
+      activation_state: 'failed_retryable',
+      activation_attempt_count: 1,
+    })
+    testState.process.mockResolvedValueOnce({
+      state: 'processing',
+      attemptCount: 2,
+      claimed: false,
+    })
+
+    const body = await (await POST(request())).json()
+
+    expect(body).toMatchObject({ confirmed: false, state: 'processing', attemptCount: 2 })
+    expect(testState.verifyTransfer).not.toHaveBeenCalled()
+    expect(testState.observe).not.toHaveBeenCalled()
+  })
+
+  it('reports signature reuse as terminal invalidity', async () => {
+    testState.observe.mockResolvedValueOnce({
+      status: 'signature_conflict',
+      state: 'terminal_invalid',
+      signature: null,
+    })
+
+    const response = await POST(request())
+
+    expect(response.status).toBe(409)
+    expect(await response.json()).toMatchObject({ confirmed: false, state: 'terminal_invalid' })
+    expect(testState.process).not.toHaveBeenCalled()
+  })
+
+  it('returns idempotent success for an already activated request', async () => {
+    testState.request = payment({
+      status: 'confirmed',
+      provider_charge_id: 'signature-622',
+      activation_state: 'activated',
+    })
+
+    const body = await (await POST(request())).json()
+
+    expect(body).toMatchObject({
+      confirmed: true,
+      state: 'activated',
+      alreadyProcessed: true,
+    })
+    expect(testState.process).not.toHaveBeenCalled()
+  })
+})

--- a/vercel.json
+++ b/vercel.json
@@ -31,6 +31,10 @@
     {
       "path": "/api/cron/redeliver-webhook-events",
       "schedule": "*/10 * * * *"
+    },
+    {
+      "path": "/api/cron/reconcile-solana-platform-activations",
+      "schedule": "*/10 * * * *"
     }
   ]
 }


### PR DESCRIPTION
## What

Make Solana platform-payment observation durable before entitlement activation, then recover failed or crashed activation attempts through token-fenced leases and scheduled reconciliation.

The change also prevents paid requests from expiring as unpaid, blocks a second wallet transaction after observation, records bounded attempts/errors, and emits a one-time structured alert when automatic retries are exhausted.

Closes #622

## Why

The verification route previously marked a request `confirmed` before dispatching plan activation. If dispatch failed, the customer had paid on-chain but received no service, and every later poll returned `alreadyProcessed` without retrying.

Downstream entitlement writers were already idempotent by signature. This PR adds the missing durable observation and recovery state around those operations, so a crash after entitlement commit can safely replay without extending the plan twice.

## How to QA

1. Apply migrations to a fresh local stack with `npm run db:reset` (or apply the new migration with `supabase migration up`).
2. Run `npm run test:unit`; the Solana activation tests inject a failure after payment observation, exercise retry/lease ownership, and verify explicit API states.
3. Run the real-Postgres crash-window proof:
   `docker exec -i supabase_db_lms-front psql -U postgres -d postgres -v ON_ERROR_STOP=1 < tests/sql/issue-622-solana-platform-activation-recovery.sql`
4. Confirm the SQL test reports `BEGIN`, `DO`, `ROLLBACK`. It commits one entitlement effect, simulates a worker dying before completion, reclaims the stale lease, and proves the replay does not add another paid period.
5. With local Solana credentials, verify one platform payment while injecting a dispatcher failure. The verify API should return `failed_retryable`; a later poll or `/api/cron/reconcile-solana-platform-activations` should return `activated` without another transfer.

Verified by the author:

- `npm run typecheck` — passed.
- `npm run test:unit` — 70 files and 904 tests passed.
- Changed-file ESLint — passed.
- `npm run build` — passed.
- Issue #622 rollback-only SQL regression — passed against local Supabase.
- `supabase db lint --local --level warning` — no findings in the new functions. Existing unrelated schema findings remain in legacy functions.
- Repository-wide `npm run lint` remains red due to 536 pre-existing errors in unrelated legacy, scripts, generated skill assets, and tests; no changed file reports an ESLint error.

## Screenshots / GIF

Not applicable. This is a database/API/reconciliation correctness change with no visual presentation change.

## Checklist

- [x] `npm run typecheck` and `npm run test:unit` pass
- [x] `npm run build` passes
- [x] Every new tenant-scoped user query filters by `tenant_id`; the service-role cron intentionally scans the cross-tenant recovery queue
- [ ] Tested with every relevant role (student / teacher / admin) — automated route coverage verifies the required tenant-admin gate; live credentialed Solana QA remains environment-dependent
- [x] Loading and error states handled
- [x] New UI strings added to both `messages/en.json` and `messages/es.json` — not applicable; no UI strings were added
- [ ] Migration applies cleanly on `npm run db:reset`, has RLS policies, and `lib/database.types.ts` was regenerated — verified with `supabase migration up`, local RPC execution, generated-type comparison, and service-role-only grants; a destructive local reset was intentionally not run
