### PR TITLE
fix(#626): make platform billing health capability-aware

### DIFF
--- a/app/[locale]/dashboard/admin/billing/upgrade/page.tsx
+++ b/app/[locale]/dashboard/admin/billing/upgrade/page.tsx
@@ -13,7 +13,6 @@ export default async function UpgradePage({
 }: {
   searchParams: Promise<{ plan?: string; interval?: string }>
 }) {
-  const t = await getTranslations('dashboard.admin')
   const tBreadcrumbs = await getTranslations('dashboard.admin.breadcrumbs')
   const [plans, status, { plan: planParam, interval: intervalParam }] = await Promise.all([
     getAvailablePlans(),
@@ -36,11 +35,13 @@ export default async function UpgradePage({
   // method a super admin has not priced (#603).
   const supabase = await createClient()
   const tenantId = await getCurrentTenantId()
-  const providerStatuses = await getTenantPlatformProviderStatuses(supabase, tenantId)
-  const { data: priceRows } = await supabase
-    .from('platform_plan_prices')
-    .select('plan_id, payment_provider, interval, provider_price_id, currency, amount')
-    .eq('is_active', true)
+  const [providerStatuses, { data: priceRows }] = await Promise.all([
+    getTenantPlatformProviderStatuses(supabase, tenantId),
+    supabase
+      .from('platform_plan_prices')
+      .select('plan_id, payment_provider, interval, provider_price_id, currency, amount')
+      .eq('is_active', true),
+  ])
 
   const planProviders: Record<string, { monthly: string[]; yearly: string[] }> = {}
   for (const row of priceRows ?? []) {

--- a/app/[locale]/dashboard/admin/billing/upgrade/page.tsx
+++ b/app/[locale]/dashboard/admin/billing/upgrade/page.tsx
@@ -2,8 +2,10 @@ import { getAvailablePlans, getSubscriptionStatus } from '@/app/actions/admin/bi
 import { getTranslations } from 'next-intl/server'
 import { AdminBreadcrumb } from '@/components/admin/admin-breadcrumb'
 import { createClient } from '@/lib/supabase/server'
+import { getCurrentTenantId } from '@/lib/supabase/tenant'
 import { PROVIDER_CAPABILITIES, type PaymentProvider } from '@/lib/payments/types'
-import { isPlatformCheckoutProvider } from '@/lib/billing/platform-billing'
+import { evaluatePlatformCheckoutAvailability } from '@/lib/billing/platform-checkout-availability'
+import { getTenantPlatformProviderStatuses } from '@/lib/billing/platform-checkout-runtime'
 import { UpgradePageClient } from './upgrade-page-client'
 
 export default async function UpgradePage({
@@ -33,19 +35,33 @@ export default async function UpgradePage({
   // the same read the pricing page does — so an admin never sees a payment
   // method a super admin has not priced (#603).
   const supabase = await createClient()
+  const tenantId = await getCurrentTenantId()
+  const providerStatuses = await getTenantPlatformProviderStatuses(supabase, tenantId)
   const { data: priceRows } = await supabase
     .from('platform_plan_prices')
-    .select('plan_id, payment_provider, interval')
+    .select('plan_id, payment_provider, interval, provider_price_id, currency, amount')
     .eq('is_active', true)
 
   const planProviders: Record<string, { monthly: string[]; yearly: string[] }> = {}
   for (const row of priceRows ?? []) {
-    // A priced row for a provider that cannot run a platform checkout would be a
-    // dead button, so it is filtered on the capability, never on the slug.
-    if (!isPlatformCheckoutProvider(row.payment_provider)) continue
+    const plan = plans.find((candidate) => candidate.plan_id === row.plan_id)
+    if (!plan) continue
+    const interval = row.interval === 'yearly' ? 'yearly' : 'monthly'
+    const availability = evaluatePlatformCheckoutAvailability({
+      provider: row.payment_provider,
+      interval,
+      price: {
+        interval: row.interval,
+        currency: row.currency,
+        providerPriceId: row.provider_price_id,
+        amount: row.amount === null ? null : Number(row.amount),
+      },
+      fallbackAmount: interval === 'yearly' ? Number(plan.price_yearly) : Number(plan.price_monthly),
+      runtime: providerStatuses[row.payment_provider],
+    })
+    if (!availability.available) continue
     const bucket = (planProviders[row.plan_id] ??= { monthly: [], yearly: [] })
-    const key = row.interval === 'yearly' ? 'yearly' : 'monthly'
-    if (!bucket[key].includes(row.payment_provider)) bucket[key].push(row.payment_provider)
+    if (!bucket[interval].includes(row.payment_provider)) bucket[interval].push(row.payment_provider)
   }
 
   const sub = status.subscription

--- a/app/[locale]/platform/billing-health/page.tsx
+++ b/app/[locale]/platform/billing-health/page.tsx
@@ -151,9 +151,9 @@ export default async function PlatformBillingHealthPage() {
                         data-testid="unpurchasable-plan-row"
                         data-plan-slug={plan.slug}
                       >
-                        <span className="font-medium text-red-800 dark:text-red-300">{plan.name}</span>
-                        <Badge variant="outline" className="font-mono text-[10px]">{plan.slug}</Badge>
-                        <span className="text-xs text-red-700/80 dark:text-red-400/80">
+                        <span className="min-w-0 font-medium text-red-800 dark:text-red-300">{plan.name}</span>
+                        <Badge variant="outline" className="shrink-0 font-mono text-[10px]">{plan.slug}</Badge>
+                        <span className="min-w-0 break-words text-xs text-red-700/80 dark:text-red-400/80">
                           {plan.providerDiagnostics.length > 0
                             ? plan.providerDiagnostics
                                 .flatMap((diagnostic) =>
@@ -222,7 +222,7 @@ export default async function PlatformBillingHealthPage() {
                   <p className="mt-1 text-[11px] text-muted-foreground/70">{card.sub}</p>
                 </div>
                 <div className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-lg ${card.bg}`}>
-                  <card.icon className={`h-[18px] w-[18px] ${card.iconColor}`} strokeWidth={1.75} />
+                  <card.icon className={`h-[18px] w-[18px] ${card.iconColor}`} strokeWidth={1.75} aria-hidden="true" />
                 </div>
               </div>
             </CardContent>

--- a/app/[locale]/platform/billing-health/page.tsx
+++ b/app/[locale]/platform/billing-health/page.tsx
@@ -4,7 +4,7 @@ import {
   getPlanConfigurationHealth,
 } from '@/app/actions/platform/billing-health'
 import type { AtRiskReason } from '@/lib/billing/billing-health'
-import { providerLabel } from '@/lib/billing/plan-prices'
+import { platformCheckoutReasonLabel, providerLabel } from '@/lib/billing/plan-prices'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { format } from 'date-fns'
@@ -126,8 +126,8 @@ export default async function PlatformBillingHealthPage() {
         <CardContent className="space-y-4">
           {planHealth.unpurchasable.length === 0 && planHealth.partiallyPriced.length === 0 ? (
             <p className="text-sm text-muted-foreground">
-              Every active paid plan has an active provider price. Card checkout can reach a
-              hosted page for all of them.
+              Every active paid plan has at least one executable automated checkout method.
+              Manual transfer is tracked separately as an offline fallback.
             </p>
           ) : (
             <>
@@ -137,12 +137,11 @@ export default async function PlatformBillingHealthPage() {
                   data-testid="unpurchasable-plans"
                 >
                   <p className="text-sm font-medium text-red-800 dark:text-red-300">
-                    Not purchasable — no active provider price
+                    Not purchasable — no executable automated provider
                   </p>
                   <p className="mt-0.5 text-xs text-red-700/80 dark:text-red-400/80">
-                    These plans are advertised with a price but every card upgrade fails with
-                    &ldquo;price not configured&rdquo;. The only way to pay for them is an offline
-                    transfer.
+                    These plans are advertised with a price, but every configured automated
+                    provider is blocked. Manual transfer remains available separately.
                   </p>
                   <ul className="mt-3 space-y-1.5 text-sm">
                     {planHealth.unpurchasable.map((plan) => (
@@ -154,6 +153,18 @@ export default async function PlatformBillingHealthPage() {
                       >
                         <span className="font-medium text-red-800 dark:text-red-300">{plan.name}</span>
                         <Badge variant="outline" className="font-mono text-[10px]">{plan.slug}</Badge>
+                        <span className="text-xs text-red-700/80 dark:text-red-400/80">
+                          {plan.providerDiagnostics.length > 0
+                            ? plan.providerDiagnostics
+                                .flatMap((diagnostic) =>
+                                  diagnostic.unavailable.map(
+                                    ({ interval, reason }) =>
+                                      `${providerLabel(diagnostic.provider)} ${interval}: ${platformCheckoutReasonLabel(reason)}`,
+                                  ),
+                                )
+                                .join(' · ')
+                            : 'No provider price configured'}
+                        </span>
                       </li>
                     ))}
                   </ul>
@@ -177,8 +188,8 @@ export default async function PlatformBillingHealthPage() {
                       >
                         <span className="font-medium text-amber-800 dark:text-amber-300">{plan.name}</span>{' '}
                         <span className="text-amber-700/80 dark:text-amber-400/80">
-                          — no price for {plan.missingIntervals.join(' or ')}; buyable via{' '}
-                          {plan.providers.map((p) => providerLabel(p.provider)).join(', ')}
+                          — no executable checkout for {plan.missingIntervals.join(' or ')}; ready via{' '}
+                          {plan.automatedProviders.map((p) => providerLabel(p.provider)).join(', ')}
                         </span>
                       </li>
                     ))}

--- a/app/[locale]/platform/plans/page.tsx
+++ b/app/[locale]/platform/plans/page.tsx
@@ -75,14 +75,15 @@ export default async function PlatformPlansPage() {
           <IconAlertTriangle
             className="mt-0.5 h-[18px] w-[18px] shrink-0 text-red-700 dark:text-red-400"
             strokeWidth={1.75}
+            aria-hidden="true"
           />
           <div className="text-sm">
             <p className="font-medium text-red-800 dark:text-red-300">
               {unpurchasableCount} active paid {unpurchasableCount === 1 ? 'plan is' : 'plans are'} not purchasable
             </p>
             <p className="mt-0.5 text-red-700/80 dark:text-red-400/80">
-              They are advertised on the pricing page but have no active provider price, so card
-              checkout fails with &ldquo;price not configured&rdquo;. Add one under <strong>Prices</strong>.
+              They are advertised on the pricing page but have no executable automated provider.
+              Check the status under <strong>Prices</strong>.
             </p>
           </div>
         </div>

--- a/app/[locale]/platform/plans/page.tsx
+++ b/app/[locale]/platform/plans/page.tsx
@@ -6,6 +6,7 @@ import {
   summarizePlanPurchasability,
   type PlatformPlanPriceInput,
 } from '@/lib/billing/plan-prices'
+import { getPlatformProviderRuntimeStatuses } from '@/lib/billing/platform-checkout-runtime'
 import { PlanEditor } from './plan-editor'
 import {
   PlanPricesEditor,
@@ -37,6 +38,7 @@ export default async function PlatformPlansPage() {
     amount: row.amount,
     isActive: row.is_active,
   }))
+  const providerStatuses = getPlatformProviderRuntimeStatuses()
 
   const purchasability = summarizePlanPurchasability(
     (plans || []).map((plan) => ({
@@ -48,6 +50,7 @@ export default async function PlatformPlansPage() {
       isActive: plan.is_active,
     })),
     prices,
+    { providerStatuses },
   )
   const purchasabilityByPlan = new Map(purchasability.map((p) => [p.planId, p]))
   const unpurchasableCount = purchasability.filter(
@@ -146,11 +149,12 @@ export default async function PlatformPlansPage() {
               <div className="border-t pt-4">
                 <p className="text-[11px] uppercase tracking-wider text-muted-foreground mb-2">Checkout</p>
                 {summary && (
-                  <PlanPurchasabilityBadge
+              <PlanPurchasabilityBadge
                     isPaid={summary.isPaid}
                     isPurchasable={summary.isPurchasable}
-                    providers={summary.providers}
+                    providers={summary.automatedProviders}
                     missingIntervals={summary.missingIntervals}
+                    diagnostics={summary.providerDiagnostics}
                   />
                 )}
               </div>
@@ -160,6 +164,8 @@ export default async function PlatformPlansPage() {
                   planId={plan.plan_id}
                   planSlug={plan.slug}
                   prices={planPrices}
+                  providerDiagnostics={summary?.providerDiagnostics}
+                  providerStatuses={providerStatuses}
                 />
               </div>
 

--- a/app/[locale]/platform/plans/plan-prices-editor.tsx
+++ b/app/[locale]/platform/plans/plan-prices-editor.tsx
@@ -202,7 +202,7 @@ export function PlanPricesEditor({
 
           <div className="space-y-5 py-2">
             <p className="text-xs text-muted-foreground">
-              A plan is only purchasable through a provider that has an active price here.
+              A plan is only purchasable through a provider with an active, executable price here.
               Paste the id the provider generated (Stripe <code className="font-mono">price_…</code>,
               Lemon Squeezy variant id); this app never creates it for you.
             </p>
@@ -294,7 +294,7 @@ export function PlanPricesEditor({
                               aria-label={`Remove ${providerLabel(price.paymentProvider)} ${price.interval} price`}
                               data-testid="plan-price-delete-btn"
                             >
-                              <IconTrash className="h-4 w-4" strokeWidth={1.75} />
+                              <IconTrash className="h-4 w-4" strokeWidth={1.75} aria-hidden="true" />
                             </Button>
                           </td>
                         </tr>
@@ -356,12 +356,15 @@ export function PlanPricesEditor({
                 </Label>
                 <Input
                   id={`price-id-${planId}`}
+                  name={`provider-price-id-${planId}`}
                   className="font-mono text-xs"
                   placeholder={catalogLess ? "No catalog — leave blank" : "price_1234…"}
                   value={form.providerPriceId}
                   onChange={(e) => setForm((p) => ({ ...p, providerPriceId: e.target.value }))}
                   disabled={catalogLess}
                   data-testid="plan-price-id-input"
+                  autoComplete="off"
+                  spellCheck={false}
                 />
                 {catalogLess && (
                   <p className="text-xs text-muted-foreground">
@@ -395,13 +398,16 @@ export function PlanPricesEditor({
                   <Label htmlFor={`amount-${planId}`}>Amount</Label>
                   <Input
                     id={`amount-${planId}`}
+                    name={`amount-${planId}`}
                     type="number"
                     step="0.01"
                     min="0"
-                    placeholder="Optional"
+                    inputMode="decimal"
+                    placeholder="Optional…"
                     value={form.amount}
                     onChange={(e) => setForm((p) => ({ ...p, amount: e.target.value }))}
                     data-testid="plan-price-amount-input"
+                    autoComplete="off"
                   />
                 </div>
 

--- a/app/[locale]/platform/plans/plan-prices-editor.tsx
+++ b/app/[locale]/platform/plans/plan-prices-editor.tsx
@@ -32,15 +32,24 @@ import {
   PLAN_PRICE_INTERVALS,
   PLATFORM_BILLING_UI_PROVIDERS,
   providerLabel,
+  platformCheckoutReasonLabel,
+  type ProviderDiagnostic,
   type PlatformPlanPriceInput,
 } from "@/lib/billing/plan-prices"
-import { PROVIDER_CAPABILITIES, type PaymentProvider } from "@/lib/payments/types"
+import {
+  PROVIDER_CAPABILITIES,
+  type PaymentProvider,
+} from "@/lib/payments/types"
+import type { PlatformProviderRuntimeStatus } from "@/lib/billing/platform-checkout-availability"
+import { evaluatePlatformCheckoutAvailability } from "@/lib/billing/platform-checkout-availability"
 
 interface Props {
   planId: string
   planSlug: string
   /** Every price row for this plan, active or not. */
   prices: PlatformPlanPriceInput[]
+  providerDiagnostics?: ProviderDiagnostic[]
+  providerStatuses?: Record<string, PlatformProviderRuntimeStatus>
 }
 
 const EMPTY_FORM = {
@@ -61,7 +70,13 @@ const EMPTY_FORM = {
  * telling a human to run SQL, which is why every plan 400s on card checkout on
  * any environment where nobody did.
  */
-export function PlanPricesEditor({ planId, planSlug, prices }: Props) {
+export function PlanPricesEditor({
+  planId,
+  planSlug,
+  prices,
+  providerDiagnostics = [],
+  providerStatuses = {},
+}: Props) {
   const router = useRouter()
   const [open, setOpen] = useState(false)
   const [saving, setSaving] = useState(false)
@@ -82,6 +97,33 @@ export function PlanPricesEditor({ planId, planSlug, prices }: Props) {
   // demands a value nobody can supply is how placeholder ids get typed in.
   const catalogLess =
     PROVIDER_CAPABILITIES[form.paymentProvider as PaymentProvider]?.createsCatalog === false
+
+  const runtime = providerStatuses[form.paymentProvider]
+  const runtimeReason = !runtime?.enabled
+    ? "disabled"
+    : !runtime?.configured
+      ? "missing_credentials"
+      : !runtime.ready
+        ? "provider_not_ready"
+        : null
+  const formAvailability = evaluatePlatformCheckoutAvailability({
+    provider: form.paymentProvider,
+    interval: form.interval,
+    price: editingExisting
+      ? {
+          interval: editingExisting.interval,
+          currency: editingExisting.currency,
+          providerPriceId: editingExisting.providerPriceId,
+          amount: editingExisting.amount,
+        }
+      : null,
+    fallbackAmount: form.amount.trim() === "" ? null : Number(form.amount),
+    runtime,
+  })
+  const formReason =
+    formAvailability.reason === "ready" || formAvailability.reason === "missing_price"
+      ? runtimeReason
+      : formAvailability.reason
 
   async function handleSave() {
     setSaving(true)
@@ -185,6 +227,7 @@ export function PlanPricesEditor({ planId, planSlug, prices }: Props) {
                         <th className="pb-2 font-medium">Interval</th>
                         <th className="pb-2 font-medium">Price ID</th>
                         <th className="pb-2 font-medium">Amount</th>
+                        <th className="pb-2 font-medium">Status</th>
                         <th className="pb-2 font-medium">Active</th>
                         <th className="pb-2" aria-label="Actions" />
                       </tr>
@@ -213,6 +256,25 @@ export function PlanPricesEditor({ planId, planSlug, prices }: Props) {
                             {price.amount === null
                               ? "—"
                               : `${price.amount} ${price.currency.toUpperCase()}`}
+                          </td>
+                          <td className="py-2.5">
+                            {(() => {
+                              const diagnostic = providerDiagnostics.find(
+                                (item) => item.provider === price.paymentProvider,
+                              )
+                              const unavailable = diagnostic?.unavailable.find(
+                                (item) => item.interval === price.interval,
+                              )
+                              return unavailable ? (
+                                <Badge variant="destructive" className="text-[10px]">
+                                  {platformCheckoutReasonLabel(unavailable.reason)}
+                                </Badge>
+                              ) : diagnostic?.availableIntervals.includes(price.interval as "monthly" | "yearly") ? (
+                                <Badge variant="secondary" className="text-[10px]">Ready</Badge>
+                              ) : (
+                                <span className="text-xs text-muted-foreground">Not evaluated</span>
+                              )
+                            })()}
                           </td>
                           <td className="py-2.5">
                             <Switch
@@ -360,6 +422,18 @@ export function PlanPricesEditor({ planId, planSlug, prices }: Props) {
                   ? `Saving overwrites the existing ${providerLabel(form.paymentProvider)} ${form.interval} price.`
                   : "Leave the amount blank when the provider charges the plan's listed price."}
               </p>
+              {runtimeReason && (
+                <p className="text-xs font-medium text-amber-700 dark:text-amber-400">
+                  {platformCheckoutReasonLabel(runtimeReason)}. This price will not make the plan
+                  purchasable until the provider is ready.
+                </p>
+              )}
+              {formReason && formReason !== runtimeReason && (
+                <p className="text-xs font-medium text-amber-700 dark:text-amber-400">
+                  {platformCheckoutReasonLabel(formReason)}. The saved row will remain visible for
+                  diagnosis but cannot satisfy platform purchasability.
+                </p>
+              )}
             </div>
           </div>
 
@@ -387,11 +461,13 @@ export function PlanPurchasabilityBadge({
   isPurchasable,
   providers,
   missingIntervals,
+  diagnostics,
 }: {
   isPaid: boolean
   isPurchasable: boolean
   providers: { provider: string; intervals: string[] }[]
   missingIntervals: string[]
+  diagnostics?: ProviderDiagnostic[]
 }) {
   if (!isPaid) {
     return (
@@ -408,7 +484,20 @@ export function PlanPurchasabilityBadge({
         data-testid="plan-purchasability"
         data-purchasable="false"
       >
-        Not purchasable — no active provider price. Card checkout will fail.
+        Not purchasable — no executable automated provider. Manual transfer remains a separate
+        fallback.
+        {diagnostics && diagnostics.length > 0 && (
+          <span className="mt-1 block font-normal">
+            {diagnostics
+              .flatMap((diagnostic) =>
+                diagnostic.unavailable.map(
+                  ({ interval, reason }) =>
+                    `${providerLabel(diagnostic.provider)} ${interval}: ${platformCheckoutReasonLabel(reason)}`,
+                ),
+              )
+              .join(" · ")}
+          </span>
+        )}
       </p>
     )
   }
@@ -433,7 +522,7 @@ export function PlanPurchasabilityBadge({
 export function PlanPurchasabilityChip({ isPurchasable }: { isPurchasable: boolean }) {
   return isPurchasable ? null : (
     <Badge variant="destructive" className="text-[10px]" data-testid="plan-unpurchasable-chip">
-      No price
+      Unavailable
     </Badge>
   )
 }

--- a/app/actions/platform/billing-health.ts
+++ b/app/actions/platform/billing-health.ts
@@ -19,6 +19,7 @@ import {
   type PlatformPlanInput,
   type PlatformPlanPriceInput,
 } from '@/lib/billing/plan-prices'
+import { getPlatformProviderRuntimeStatuses } from '@/lib/billing/platform-checkout-runtime'
 
 async function verifySuperAdmin() {
   const userId = await getCurrentUserId()
@@ -231,9 +232,10 @@ export async function getPlanConfigurationHealth(): Promise<PlanConfigurationHea
     amount: row.amount,
     isActive: row.is_active,
   }))
+  const providerStatuses = getPlatformProviderRuntimeStatuses()
 
   return {
-    unpurchasable: findUnpurchasablePlans(plans, prices),
-    partiallyPriced: findPartiallyPricedPlans(plans, prices),
+    unpurchasable: findUnpurchasablePlans(plans, prices, { providerStatuses }),
+    partiallyPriced: findPartiallyPricedPlans(plans, prices, { providerStatuses }),
   }
 }

--- a/app/api/billing/checkout/route.ts
+++ b/app/api/billing/checkout/route.ts
@@ -19,6 +19,7 @@ import { createAdminClient } from '@/lib/supabase/admin'
 import { getCurrentTenantId } from '@/lib/supabase/tenant'
 import { resolveRequestLocale } from '@/lib/i18n/request-locale'
 import { PROVIDER_CAPABILITIES } from '@/lib/payments/types'
+import { getTenantPlatformProviderStatuses } from '@/lib/billing/platform-checkout-runtime'
 import {
   describeResolutionError,
   getActivePlanPrices,
@@ -92,6 +93,9 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'Cannot subscribe to free plan via checkout' }, { status: 400 })
     }
 
+    const providerStatuses = await getTenantPlatformProviderStatuses(adminClient, tenantId)
+    const fallbackAmount = Number(interval === 'yearly' ? plan.price_yearly : plan.price_monthly) || 0
+
     const { data: existingSub } = await adminClient
       .from('platform_subscriptions')
       .select('subscription_id, provider_subscription_id, status, payment_provider')
@@ -111,6 +115,9 @@ export async function POST(req: NextRequest) {
     const resolved = resolveCheckoutProvider(prices, interval, {
       requested: typeof requestedProvider === 'string' ? requestedProvider : undefined,
       tenantProvider: existingSub?.payment_provider ?? null,
+      providerStatuses,
+      expectedCurrency: 'usd',
+      fallbackAmount,
     })
 
     if (!resolved.ok) {

--- a/lib/billing/plan-prices.ts
+++ b/lib/billing/plan-prices.ts
@@ -157,7 +157,7 @@ export interface PlanPurchasability {
   isActive: boolean
   /** True when the plan charges for at least one interval. */
   isPaid: boolean
-  /** True when at least one active price row exists, on any provider. */
+  /** True when at least one active price row can execute automated checkout. */
   isPurchasable: boolean
   /** Providers with at least one active price row. */
   providers: ProviderCoverage[]
@@ -168,8 +168,8 @@ export interface PlanPurchasability {
   /** Manual transfer is a separate fallback and never counts as automation. */
   manualAvailable: boolean
   /**
-   * Intervals the plan charges for but no provider covers with an active row.
-   * A plan with a monthly *and* a yearly price but only a monthly price row is
+   * Intervals the plan charges for but no provider can execute checkout on.
+   * A plan with a monthly *and* a yearly price but only a monthly executable method is
    * purchasable, yet half its pricing page is a dead button — that is a
    * weaker problem than "no price at all", so it is reported separately rather
    * than collapsed into `isPurchasable`.
@@ -287,7 +287,7 @@ export function summarizePlanPurchasability(
 
 /**
  * The check `/platform/billing-health` renders: active plans that charge money
- * and have no active price row on any provider. These are advertised on the
+ * and have no executable automated checkout method. These are advertised on the
  * pricing page at `$9/mo` and 400 on every card upgrade — the exact state #602
  * was filed for.
  *
@@ -310,7 +310,7 @@ export function findUnpurchasablePlans(
 
 /**
  * The softer half: plans that *are* buyable, but not on every interval they
- * quote a price for. Reported apart from `findUnpurchasablePlans` so the hard
+ * quote an executable price for. Reported apart from `findUnpurchasablePlans` so the hard
  * failure is never diluted by the partial one.
  */
 export function findPartiallyPricedPlans(

--- a/lib/billing/plan-prices.ts
+++ b/lib/billing/plan-prices.ts
@@ -22,6 +22,15 @@
  * modules and nothing tested the callers (#540).
  */
 
+import {
+  evaluatePlatformCheckoutAvailability,
+  platformCheckoutReasonLabel,
+  type PlatformCheckoutUnavailableReason,
+  type PlatformProviderRuntimeStatus,
+} from '@/lib/billing/platform-checkout-availability'
+
+export { platformCheckoutReasonLabel }
+
 export type PlanPriceInterval = 'monthly' | 'yearly'
 
 export const PLAN_PRICE_INTERVALS: readonly PlanPriceInterval[] = ['monthly', 'yearly']
@@ -135,6 +144,12 @@ export interface ProviderCoverage {
   intervals: PlanPriceInterval[]
 }
 
+export interface ProviderDiagnostic {
+  provider: string
+  availableIntervals: PlanPriceInterval[]
+  unavailable: Array<{ interval: PlanPriceInterval; reason: PlatformCheckoutUnavailableReason }>
+}
+
 export interface PlanPurchasability {
   planId: string
   slug: string
@@ -146,6 +161,12 @@ export interface PlanPurchasability {
   isPurchasable: boolean
   /** Providers with at least one active price row. */
   providers: ProviderCoverage[]
+  /** Providers with at least one executable automated checkout method. */
+  automatedProviders: ProviderCoverage[]
+  /** Per-provider reason for every charged interval that is not executable. */
+  providerDiagnostics: ProviderDiagnostic[]
+  /** Manual transfer is a separate fallback and never counts as automation. */
+  manualAvailable: boolean
   /**
    * Intervals the plan charges for but no provider covers with an active row.
    * A plan with a monthly *and* a yearly price but only a monthly price row is
@@ -172,6 +193,10 @@ function chargedIntervals(plan: PlatformPlanInput): PlanPriceInterval[] {
 export function summarizePlanPurchasability(
   plans: PlatformPlanInput[],
   prices: PlatformPlanPriceInput[],
+  options: {
+    providerStatuses?: Record<string, PlatformProviderRuntimeStatus>
+    expectedCurrency?: string
+  } = {},
 ): PlanPurchasability[] {
   const activePricesByPlan = new Map<string, PlatformPlanPriceInput[]>()
   for (const price of prices) {
@@ -198,8 +223,51 @@ export function summarizePlanPurchasability(
       }))
       .sort((a, b) => a.provider.localeCompare(b.provider))
 
-    const covered = new Set(active.map((p) => p.interval))
     const charged = chargedIntervals(plan)
+
+    const providerDiagnostics: ProviderDiagnostic[] = [...intervalsByProvider.keys()]
+      .sort((a, b) => a.localeCompare(b))
+      .map((provider) => {
+        const rows = active.filter((price) => price.paymentProvider === provider)
+        const runtime = options.providerStatuses?.[provider]
+        const availableIntervals: PlanPriceInterval[] = []
+        const unavailable: ProviderDiagnostic['unavailable'] = []
+
+        for (const interval of charged) {
+          const exact = rows.find((price) => price.interval === interval)
+          const fallback = exact ?? rows[0] ?? null
+          const availability = evaluatePlatformCheckoutAvailability({
+            provider,
+            interval,
+            price: fallback
+              ? {
+                  interval: fallback.interval,
+                  currency: fallback.currency,
+                  providerPriceId: fallback.providerPriceId,
+                  amount: fallback.amount,
+                }
+              : null,
+            expectedCurrency: options.expectedCurrency,
+            fallbackAmount: interval === 'yearly' ? plan.priceYearly : plan.priceMonthly,
+            runtime,
+          })
+
+          if (availability.available && exact) availableIntervals.push(interval)
+          else unavailable.push({ interval, reason: availability.reason })
+        }
+
+        return { provider, availableIntervals, unavailable }
+      })
+
+    const automatedProviders = providers.filter((provider) =>
+      providerDiagnostics.some(
+        (diagnostic) =>
+          diagnostic.provider === provider.provider && diagnostic.availableIntervals.length > 0,
+      ),
+    )
+    const covered = new Set(
+      providerDiagnostics.flatMap((diagnostic) => diagnostic.availableIntervals),
+    )
 
     return {
       planId: plan.planId,
@@ -207,8 +275,11 @@ export function summarizePlanPurchasability(
       name: plan.name,
       isActive: plan.isActive,
       isPaid: charged.length > 0,
-      isPurchasable: active.length > 0,
+      isPurchasable: automatedProviders.length > 0,
       providers,
+      automatedProviders,
+      providerDiagnostics,
+      manualAvailable: charged.length > 0,
       missingIntervals: charged.filter((i) => !covered.has(i)),
     }
   })
@@ -227,8 +298,12 @@ export function summarizePlanPurchasability(
 export function findUnpurchasablePlans(
   plans: PlatformPlanInput[],
   prices: PlatformPlanPriceInput[],
+  options: {
+    providerStatuses?: Record<string, PlatformProviderRuntimeStatus>
+    expectedCurrency?: string
+  } = {},
 ): PlanPurchasability[] {
-  return summarizePlanPurchasability(plans, prices).filter(
+  return summarizePlanPurchasability(plans, prices, options).filter(
     (plan) => plan.isActive && plan.isPaid && !plan.isPurchasable,
   )
 }
@@ -241,8 +316,12 @@ export function findUnpurchasablePlans(
 export function findPartiallyPricedPlans(
   plans: PlatformPlanInput[],
   prices: PlatformPlanPriceInput[],
+  options: {
+    providerStatuses?: Record<string, PlatformProviderRuntimeStatus>
+    expectedCurrency?: string
+  } = {},
 ): PlanPurchasability[] {
-  return summarizePlanPurchasability(plans, prices).filter(
+  return summarizePlanPurchasability(plans, prices, options).filter(
     (plan) =>
       plan.isActive && plan.isPaid && plan.isPurchasable && plan.missingIntervals.length > 0,
   )

--- a/lib/billing/platform-billing.ts
+++ b/lib/billing/platform-billing.ts
@@ -16,6 +16,12 @@ import {
   type PaymentProvider,
 } from '@/lib/payments/types'
 import type { PlanPriceInterval } from '@/lib/billing/plan-prices'
+import {
+  evaluatePlatformCheckoutAvailability,
+  platformCheckoutReasonLabel,
+  type PlatformCheckoutUnavailableReason,
+  type PlatformProviderRuntimeStatus,
+} from '@/lib/billing/platform-checkout-availability'
 
 /**
  * Providers exposed on `POST /api/billing/webhook/[provider]`.
@@ -128,6 +134,7 @@ export type ProviderResolutionError =
   | { kind: 'provider_unpriced'; requested: string; providers: string[] }
   | { kind: 'ambiguous'; providers: string[] }
   | { kind: 'unsupported'; requested: string }
+  | { kind: 'unavailable'; providers: string[]; reasons: Record<string, PlatformCheckoutUnavailableReason> }
 
 /**
  * Decide which provider a checkout runs through, given the plan's active price
@@ -149,10 +156,30 @@ export type ProviderResolutionError =
 export function resolveCheckoutProvider(
   prices: PlatformPriceRow[],
   interval: PlanPriceInterval,
-  opts: { requested?: string; tenantProvider?: string | null } = {},
+  opts: {
+    requested?: string
+    tenantProvider?: string | null
+    providerStatuses?: Record<string, PlatformProviderRuntimeStatus>
+    expectedCurrency?: string
+    fallbackAmount?: number | null
+  } = {},
 ): { ok: true; value: ProviderResolution } | { ok: false; error: ProviderResolutionError } {
   const forInterval = prices.filter((p) => p.interval === interval)
-  const available = [...new Set(forInterval.map((p) => p.paymentProvider))].sort()
+  const configured = [...new Set(forInterval.map((p) => p.paymentProvider))].sort()
+  const availabilityByProvider = new Map<string, PlatformCheckoutUnavailableReason>()
+  for (const provider of configured) {
+    const row = forInterval.find((price) => price.paymentProvider === provider) ?? null
+    const availability = evaluatePlatformCheckoutAvailability({
+      provider,
+      interval,
+      price: row,
+      expectedCurrency: opts.expectedCurrency,
+      fallbackAmount: opts.fallbackAmount,
+      runtime: opts.providerStatuses?.[provider],
+    })
+    availabilityByProvider.set(provider, availability.reason)
+  }
+  const available = configured.filter((provider) => availabilityByProvider.get(provider) === 'ready')
 
   if (opts.requested) {
     if (!isPlatformCheckoutProvider(opts.requested)) {
@@ -162,26 +189,46 @@ export function resolveCheckoutProvider(
     if (!match) {
       return {
         ok: false,
-        error: { kind: 'provider_unpriced', requested: opts.requested, providers: available },
+        error: { kind: 'provider_unpriced', requested: opts.requested, providers: configured },
+      }
+    }
+    const reason = availabilityByProvider.get(opts.requested)
+    if (reason !== 'ready') {
+      return {
+        ok: false,
+        error: {
+          kind: 'unavailable',
+          providers: [opts.requested],
+          reasons: { [opts.requested]: reason ?? 'missing_price' },
+        },
       }
     }
     return { ok: true, value: { provider: opts.requested as PaymentProvider, price: match } }
   }
 
-  if (available.length === 0) return { ok: false, error: { kind: 'no_prices', providers: [] } }
+  if (available.length === 0) {
+    if (configured.length === 0) return { ok: false, error: { kind: 'no_prices', providers: [] } }
+    return {
+      ok: false,
+      error: {
+        kind: 'unavailable',
+        providers: configured,
+        reasons: Object.fromEntries(
+          configured.map((provider) => [provider, availabilityByProvider.get(provider) ?? 'missing_price']),
+        ),
+      },
+    }
+  }
 
   if (opts.tenantProvider) {
     const match = forInterval.find((p) => p.paymentProvider === opts.tenantProvider)
-    if (match && isPlatformCheckoutProvider(match.paymentProvider)) {
+    if (match && available.includes(match.paymentProvider)) {
       return { ok: true, value: { provider: match.paymentProvider as PaymentProvider, price: match } }
     }
   }
 
   if (available.length === 1) {
     const match = forInterval.find((p) => p.paymentProvider === available[0])!
-    if (!isPlatformCheckoutProvider(match.paymentProvider)) {
-      return { ok: false, error: { kind: 'unsupported', requested: match.paymentProvider } }
-    }
     return { ok: true, value: { provider: match.paymentProvider as PaymentProvider, price: match } }
   }
 
@@ -212,5 +259,9 @@ export function describeResolutionError(error: ProviderResolutionError, interval
       return `Several payment providers are configured for this plan (${error.providers.join(', ')}). Choose one.`
     case 'unsupported':
       return `${error.requested} cannot be used to pay for a platform plan.`
+    case 'unavailable':
+      return `No configured provider can execute ${interval} platform checkout: ${Object.entries(error.reasons)
+        .map(([provider, reason]) => `${provider} (${platformCheckoutReasonLabel(reason)})`)
+        .join(', ')}.`
   }
 }

--- a/lib/billing/platform-checkout-availability.ts
+++ b/lib/billing/platform-checkout-availability.ts
@@ -1,0 +1,124 @@
+import { PROVIDER_CAPABILITIES, type PaymentProvider } from '@/lib/payments/types'
+
+export type PlatformCheckoutUnavailableReason =
+  | 'ready'
+  | 'capability'
+  | 'disabled'
+  | 'missing_credentials'
+  | 'provider_not_ready'
+  | 'missing_price'
+  | 'interval_mismatch'
+  | 'currency_mismatch'
+
+export interface PlatformProviderRuntimeStatus {
+  /** Tenant-level payment setting. Platform health passes this as true. */
+  enabled: boolean
+  /** Global provider credentials/configuration are present. */
+  configured: boolean
+  /** Provider-specific runtime prerequisites are valid. */
+  ready: boolean
+}
+
+export interface PlatformCheckoutPrice {
+  interval: string
+  currency: string
+  providerPriceId: string | null
+  amount: number | null
+}
+
+export interface PlatformCheckoutAvailability {
+  provider: string
+  interval: string
+  available: boolean
+  reason: PlatformCheckoutUnavailableReason
+}
+
+export interface EvaluatePlatformCheckoutAvailabilityInput {
+  provider: string
+  interval: string
+  price: PlatformCheckoutPrice | null
+  /** Platform plans are denominated in USD; callers may override for future plans. */
+  expectedCurrency?: string
+  /** Fallback list price used by catalog-less rails when row.amount is null. */
+  fallbackAmount?: number | null
+  runtime?: Partial<PlatformProviderRuntimeStatus>
+}
+
+/**
+ * One predicate for every platform billing surface.
+ *
+ * Callers may gather runtime state differently (super-admin health has no tenant
+ * setting, while an upgrade page has one), but the decision order and reason
+ * codes stay identical. Provider identity is consulted only through the static
+ * capability table.
+ */
+export function evaluatePlatformCheckoutAvailability(
+  input: EvaluatePlatformCheckoutAvailabilityInput,
+): PlatformCheckoutAvailability {
+  const capability = PROVIDER_CAPABILITIES[input.provider as PaymentProvider]
+  const runtime: PlatformProviderRuntimeStatus = {
+    enabled: true,
+    configured: true,
+    ready: true,
+    ...input.runtime,
+  }
+
+  const unavailable = (reason: PlatformCheckoutUnavailableReason): PlatformCheckoutAvailability => ({
+    provider: input.provider,
+    interval: input.interval,
+    available: false,
+    reason,
+  })
+
+  if (!capability?.supportsPlatformBillingCheckout) return unavailable('capability')
+  if (!runtime.enabled) return unavailable('disabled')
+  if (!runtime.configured) return unavailable('missing_credentials')
+  if (!runtime.ready) return unavailable('provider_not_ready')
+  if (!input.price) return unavailable('missing_price')
+  if (input.price.interval !== input.interval) return unavailable('interval_mismatch')
+
+  const expectedCurrency = (input.expectedCurrency ?? 'usd').toLowerCase()
+  if (input.price.currency.toLowerCase() !== expectedCurrency) {
+    return unavailable('currency_mismatch')
+  }
+
+  if (capability.createsCatalog && !input.price.providerPriceId) {
+    return unavailable('missing_price')
+  }
+
+  if (
+    !capability.createsCatalog &&
+    input.price.amount === null &&
+    !((input.fallbackAmount ?? 0) > 0)
+  ) {
+    return unavailable('missing_price')
+  }
+
+  return {
+    provider: input.provider,
+    interval: input.interval,
+    available: true,
+    reason: 'ready',
+  }
+}
+
+export function platformCheckoutReasonLabel(reason: PlatformCheckoutUnavailableReason): string {
+  switch (reason) {
+    case 'capability':
+      return 'Platform checkout capability disabled'
+    case 'disabled':
+      return 'Provider disabled in payment settings'
+    case 'missing_credentials':
+      return 'Provider credentials are missing'
+    case 'provider_not_ready':
+      return 'Provider runtime configuration is not ready'
+    case 'missing_price':
+      return 'Price is missing or incomplete'
+    case 'interval_mismatch':
+      return 'No price for this billing interval'
+    case 'currency_mismatch':
+      return 'Price currency does not match platform billing'
+    case 'ready':
+      return 'Ready for platform checkout'
+  }
+}

--- a/lib/billing/platform-checkout-runtime.ts
+++ b/lib/billing/platform-checkout-runtime.ts
@@ -1,0 +1,70 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { getPlatformSolanaConfig } from '@/lib/billing/solana-platform-payment'
+import { PLAN_PRICE_PROVIDERS } from '@/lib/billing/plan-prices'
+import type {
+  PaymentProvider,
+} from '@/lib/payments/types'
+import type { PlatformProviderRuntimeStatus } from '@/lib/billing/platform-checkout-availability'
+
+const REQUIRED_ENV: Partial<Record<PaymentProvider, string[]>> = {
+  stripe: ['STRIPE_SECRET_KEY'],
+  paypal: ['PAYPAL_CLIENT_ID', 'PAYPAL_CLIENT_SECRET'],
+  binance: ['BINANCE_PAY_API_KEY', 'BINANCE_PAY_API_SECRET'],
+  lemonsqueezy: ['LEMONSQUEEZY_API_KEY', 'LEMONSQUEEZY_STORE_ID', 'LEMONSQUEEZY_WEBHOOK_SECRET'],
+  solana: ['SOLANA_RPC_URL', 'SOLANA_PLATFORM_WALLET'],
+}
+
+/**
+ * Resolve global provider configuration without constructing a provider or
+ * exposing credentials. `ready` catches syntactically invalid Solana config;
+ * other providers currently have no separate readiness handshake.
+ */
+export function getPlatformProviderRuntimeStatuses(): Record<string, PlatformProviderRuntimeStatus> {
+  return Object.fromEntries(
+    PLAN_PRICE_PROVIDERS.map((provider) => {
+      const required = REQUIRED_ENV[provider as PaymentProvider] ?? []
+      const configured = required.every((key) => Boolean(process.env[key]))
+      const ready = provider === 'solana' ? configured && Boolean(getPlatformSolanaConfig()) : configured
+      return [provider, { enabled: true, configured, ready }]
+    }),
+  )
+}
+
+const TENANT_SETTING_BY_PROVIDER: Partial<Record<PaymentProvider, string>> = {
+  stripe: 'stripe_enabled',
+  paypal: 'paypal_enabled',
+  lemonsqueezy: 'lemonsqueezy_enabled',
+  binance: 'binance_enabled',
+  solana: 'solana_enabled',
+}
+
+/** Resolve tenant payment toggles used by the school upgrade surface/API. */
+export async function getTenantPlatformProviderStatuses(
+  admin: SupabaseClient,
+  tenantId: string,
+): Promise<Record<string, PlatformProviderRuntimeStatus>> {
+  const settings = new Map<string, boolean>()
+  for (const setting of Object.values(TENANT_SETTING_BY_PROVIDER)) {
+    if (!setting) continue
+    const { data } = await admin
+      .from('tenant_settings')
+      .select('setting_key, setting_value')
+      .eq('tenant_id', tenantId)
+      .eq('setting_key', setting)
+      .maybeSingle()
+    if (data) {
+      settings.set(
+        setting,
+        (data.setting_value as { enabled?: boolean } | null)?.enabled === true,
+      )
+    }
+  }
+
+  return Object.fromEntries(
+    Object.entries(getPlatformProviderRuntimeStatuses()).map(([provider, status]) => {
+      const setting = TENANT_SETTING_BY_PROVIDER[provider as PaymentProvider]
+      const enabled = setting ? (settings.has(setting) ? settings.get(setting)! : provider === 'stripe') : true
+      return [provider, { ...status, enabled }]
+    }),
+  )
+}

--- a/lib/billing/platform-checkout-runtime.ts
+++ b/lib/billing/platform-checkout-runtime.ts
@@ -7,7 +7,11 @@ import type {
 import type { PlatformProviderRuntimeStatus } from '@/lib/billing/platform-checkout-availability'
 
 const REQUIRED_ENV: Partial<Record<PaymentProvider, string[]>> = {
-  stripe: ['STRIPE_SECRET_KEY'],
+  // Platform Stripe checkout is not executable without the separate webhook
+  // secret: the hosted session can be created with STRIPE_SECRET_KEY, but the
+  // subscription would never activate when /api/billing/webhook/stripe cannot
+  // verify the completion event.
+  stripe: ['STRIPE_SECRET_KEY', 'STRIPE_PLATFORM_WEBHOOK_SECRET'],
   paypal: ['PAYPAL_CLIENT_ID', 'PAYPAL_CLIENT_SECRET'],
   binance: ['BINANCE_PAY_API_KEY', 'BINANCE_PAY_API_SECRET'],
   lemonsqueezy: ['LEMONSQUEEZY_API_KEY', 'LEMONSQUEEZY_STORE_ID', 'LEMONSQUEEZY_WEBHOOK_SECRET'],
@@ -44,20 +48,24 @@ export async function getTenantPlatformProviderStatuses(
   tenantId: string,
 ): Promise<Record<string, PlatformProviderRuntimeStatus>> {
   const settings = new Map<string, boolean>()
-  for (const setting of Object.values(TENANT_SETTING_BY_PROVIDER)) {
-    if (!setting) continue
-    const { data } = await admin
-      .from('tenant_settings')
-      .select('setting_key, setting_value')
-      .eq('tenant_id', tenantId)
-      .eq('setting_key', setting)
-      .maybeSingle()
-    if (data) {
-      settings.set(
-        setting,
-        (data.setting_value as { enabled?: boolean } | null)?.enabled === true,
-      )
-    }
+  const settingKeys = Object.values(TENANT_SETTING_BY_PROVIDER).filter(
+    (setting): setting is string => Boolean(setting),
+  )
+  const { data, error } = await admin
+    .from('tenant_settings')
+    .select('setting_key, setting_value')
+    .eq('tenant_id', tenantId)
+    .in('setting_key', settingKeys)
+
+  // A settings read failure must not silently fall back to Stripe-enabled
+  // defaults and create a checkout the tenant explicitly disabled.
+  if (error) throw new Error(`Failed to read tenant payment settings: ${error.message}`)
+
+  for (const row of data ?? []) {
+    settings.set(
+      row.setting_key,
+      (row.setting_value as { enabled?: boolean } | null)?.enabled === true,
+    )
   }
 
   return Object.fromEntries(

--- a/tests/unit/platform-billing-checkout.test.ts
+++ b/tests/unit/platform-billing-checkout.test.ts
@@ -258,6 +258,17 @@ vi.mock('@/lib/supabase/tenant', () => ({ getCurrentTenantId: () => Promise.reso
 
 vi.mock('@/lib/i18n/request-locale', () => ({ resolveRequestLocale: () => 'es' }))
 
+// Route tests mock provider sessions and database rows; keep the runtime
+// configuration truth table in platform-checkout-availability.test.ts.
+vi.mock('@/lib/billing/platform-checkout-runtime', () => ({
+  getTenantPlatformProviderStatuses: () =>
+    Promise.resolve({
+      stripe: { enabled: true, configured: true, ready: true },
+      binance: { enabled: true, configured: true, ready: true },
+      solana: { enabled: true, configured: true, ready: true },
+    }),
+}))
+
 vi.mock('@/lib/billing/platform-billing', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/lib/billing/platform-billing')>()
   return {

--- a/tests/unit/platform-billing-checkout.test.ts
+++ b/tests/unit/platform-billing-checkout.test.ts
@@ -177,6 +177,7 @@ const state: {
   overLimit: boolean
   openRequest: boolean
   recordedRequests: Record<string, unknown>[]
+  providerStatuses: Record<string, { enabled: boolean; configured: boolean; ready: boolean }>
 } = {
   user: null,
   role: null,
@@ -192,6 +193,7 @@ const state: {
   overLimit: false,
   openRequest: false,
   recordedRequests: [],
+  providerStatuses: {},
 }
 
 const TENANT = '00000000-0000-0000-0000-000000000001'
@@ -261,12 +263,7 @@ vi.mock('@/lib/i18n/request-locale', () => ({ resolveRequestLocale: () => 'es' }
 // Route tests mock provider sessions and database rows; keep the runtime
 // configuration truth table in platform-checkout-availability.test.ts.
 vi.mock('@/lib/billing/platform-checkout-runtime', () => ({
-  getTenantPlatformProviderStatuses: () =>
-    Promise.resolve({
-      stripe: { enabled: true, configured: true, ready: true },
-      binance: { enabled: true, configured: true, ready: true },
-      solana: { enabled: true, configured: true, ready: true },
-    }),
+  getTenantPlatformProviderStatuses: () => Promise.resolve(state.providerStatuses),
 }))
 
 vi.mock('@/lib/billing/platform-billing', async (importOriginal) => {
@@ -345,6 +342,11 @@ beforeEach(() => {
   state.overLimit = false
   state.openRequest = false
   state.recordedRequests = []
+  state.providerStatuses = {
+    stripe: { enabled: true, configured: true, ready: true },
+    binance: { enabled: true, configured: true, ready: true },
+    solana: { enabled: true, configured: true, ready: true },
+  }
 })
 
 describe('POST /api/billing/checkout — guards', () => {
@@ -379,6 +381,17 @@ describe('POST /api/billing/checkout — guards', () => {
     const res = await POST(makeReq({ planId: PLAN_ID, provider: 'lemonsqueezy' }))
     expect(res.status).toBe(400)
     expect((await res.json()).error).toContain('stripe')
+  })
+
+  it('rejects a disabled provider before creating a customer or checkout session', async () => {
+    state.providerStatuses.stripe.enabled = false
+
+    const res = await POST(makeReq({ planId: PLAN_ID, provider: 'stripe' }))
+
+    expect(res.status).toBe(400)
+    expect((await res.json()).error).toContain('disabled')
+    expect(state.checkoutCalls).toHaveLength(0)
+    expect(state.writes.some((write) => write.table === 'tenant_billing_customers')).toBe(false)
   })
 })
 

--- a/tests/unit/platform-checkout-availability.test.ts
+++ b/tests/unit/platform-checkout-availability.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest'
+import {
+  evaluatePlatformCheckoutAvailability,
+  type PlatformProviderRuntimeStatus,
+} from '@/lib/billing/platform-checkout-availability'
+import { summarizePlanPurchasability, type PlatformPlanInput, type PlatformPlanPriceInput } from '@/lib/billing/plan-prices'
+
+const runtime: PlatformProviderRuntimeStatus = { enabled: true, configured: true, ready: true }
+const price = (overrides: Partial<NonNullable<Parameters<typeof evaluatePlatformCheckoutAvailability>[0]['price']>> = {}) => ({
+  interval: 'monthly',
+  currency: 'usd',
+  providerPriceId: 'price_123',
+  amount: 29,
+  ...overrides,
+})
+
+const plan: PlatformPlanInput = {
+  planId: 'plan-pro',
+  slug: 'pro',
+  name: 'Pro',
+  priceMonthly: 29,
+  priceYearly: 290,
+  isActive: true,
+}
+
+const planPrice = (overrides: Partial<PlatformPlanPriceInput> = {}): PlatformPlanPriceInput => ({
+  priceId: 'row-1',
+  planId: 'plan-pro',
+  paymentProvider: 'stripe',
+  interval: 'monthly',
+  providerPriceId: 'price_123',
+  currency: 'usd',
+  amount: 29,
+  isActive: true,
+  ...overrides,
+})
+
+describe('evaluatePlatformCheckoutAvailability', () => {
+  it('rejects a provider whose platform capability is disabled', () => {
+    expect(
+      evaluatePlatformCheckoutAvailability({ provider: 'paypal', interval: 'monthly', price: price(), runtime }),
+    ).toMatchObject({ available: false, reason: 'capability' })
+  })
+
+  it.each([
+    ['disabled', { enabled: false }],
+    ['missing credentials', { configured: false }],
+    ['provider not ready', { ready: false }],
+  ] as const)('reports %s before inspecting price', (_label, override) => {
+    const expectedReason = 'enabled' in override
+      ? 'disabled'
+      : 'configured' in override
+        ? 'missing_credentials'
+        : 'provider_not_ready'
+    expect(
+      evaluatePlatformCheckoutAvailability({
+        provider: 'stripe',
+        interval: 'monthly',
+        price: null,
+        runtime: { ...runtime, ...override },
+      }),
+    ).toMatchObject({ available: false, reason: expectedReason })
+  })
+
+  it('separates missing price, interval mismatch, and currency mismatch', () => {
+    expect(evaluatePlatformCheckoutAvailability({ provider: 'stripe', interval: 'monthly', price: null, runtime }).reason).toBe('missing_price')
+    expect(evaluatePlatformCheckoutAvailability({ provider: 'stripe', interval: 'yearly', price: price(), runtime }).reason).toBe('interval_mismatch')
+    expect(evaluatePlatformCheckoutAvailability({ provider: 'stripe', interval: 'monthly', price: price({ currency: 'eur' }), runtime }).reason).toBe('currency_mismatch')
+  })
+
+  it('requires a catalog id for catalog-backed providers', () => {
+    expect(
+      evaluatePlatformCheckoutAvailability({
+        provider: 'stripe',
+        interval: 'monthly',
+        price: price({ providerPriceId: null }),
+        runtime,
+      }).reason,
+    ).toBe('missing_price')
+  })
+})
+
+describe('plan purchasability uses executable methods', () => {
+  it('does not count a PayPal-only price as purchasable', () => {
+    const [summary] = summarizePlanPurchasability([plan], [planPrice({ paymentProvider: 'paypal' })], {
+      providerStatuses: { paypal: runtime },
+    })
+
+    expect(summary.isPurchasable).toBe(false)
+    expect(summary.manualAvailable).toBe(true)
+    expect(summary.providerDiagnostics[0].unavailable[0].reason).toBe('capability')
+  })
+
+  it('keeps manual transfer separate from automated purchasability', () => {
+    const [summary] = summarizePlanPurchasability([plan], [planPrice({ paymentProvider: 'manual', providerPriceId: null })], {
+      providerStatuses: { manual: runtime },
+    })
+
+    expect(summary.isPurchasable).toBe(false)
+    expect(summary.manualAvailable).toBe(true)
+  })
+
+  it('accepts one executable automated provider and rejects a disabled one', () => {
+    const [summary] = summarizePlanPurchasability(
+      [plan],
+      [
+        planPrice({ paymentProvider: 'stripe' }),
+        planPrice({ priceId: 'row-2', paymentProvider: 'lemonsqueezy', providerPriceId: 'variant-1' }),
+      ],
+      {
+        providerStatuses: {
+          stripe: runtime,
+          lemonsqueezy: { ...runtime, enabled: false },
+        },
+      },
+    )
+
+    expect(summary.isPurchasable).toBe(true)
+    expect(summary.automatedProviders.map((provider) => provider.provider)).toEqual(['stripe'])
+    expect(summary.providerDiagnostics.find((item) => item.provider === 'lemonsqueezy')?.unavailable[0].reason).toBe('disabled')
+  })
+})

--- a/tests/unit/platform-checkout-availability.test.ts
+++ b/tests/unit/platform-checkout-availability.test.ts
@@ -1,9 +1,11 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { SupabaseClient } from '@supabase/supabase-js'
 import {
   evaluatePlatformCheckoutAvailability,
   type PlatformProviderRuntimeStatus,
 } from '@/lib/billing/platform-checkout-availability'
 import { summarizePlanPurchasability, type PlatformPlanInput, type PlatformPlanPriceInput } from '@/lib/billing/plan-prices'
+import { getPlatformProviderRuntimeStatuses } from '@/lib/billing/platform-checkout-runtime'
 
 const runtime: PlatformProviderRuntimeStatus = { enabled: true, configured: true, ready: true }
 const price = (overrides: Partial<NonNullable<Parameters<typeof evaluatePlatformCheckoutAvailability>[0]['price']>> = {}) => ({
@@ -78,6 +80,17 @@ describe('evaluatePlatformCheckoutAvailability', () => {
       }).reason,
     ).toBe('missing_price')
   })
+
+  it('requires the platform webhook secret for Stripe readiness', () => {
+    expect(
+      evaluatePlatformCheckoutAvailability({
+        provider: 'stripe',
+        interval: 'monthly',
+        price: price(),
+        runtime: { enabled: true, configured: false, ready: false },
+      }),
+    ).toMatchObject({ available: false, reason: 'missing_credentials' })
+  })
 })
 
 describe('plan purchasability uses executable methods', () => {
@@ -118,5 +131,59 @@ describe('plan purchasability uses executable methods', () => {
     expect(summary.isPurchasable).toBe(true)
     expect(summary.automatedProviders.map((provider) => provider.provider)).toEqual(['stripe'])
     expect(summary.providerDiagnostics.find((item) => item.provider === 'lemonsqueezy')?.unavailable[0].reason).toBe('disabled')
+  })
+})
+
+describe('platform provider runtime status', () => {
+  afterEach(() => vi.unstubAllEnvs())
+
+  const settingsClient = (result: { data: unknown[] | null; error: { message: string } | null }) =>
+    ({
+      from: () => ({
+        select: () => ({
+          eq: () => ({
+            in: () => Promise.resolve(result),
+          }),
+        }),
+      }),
+    }) as unknown as SupabaseClient
+
+  it('does not mark Stripe ready without its platform webhook secret', () => {
+    vi.stubEnv('STRIPE_SECRET_KEY', 'sk_test_platform')
+    vi.stubEnv('STRIPE_PLATFORM_WEBHOOK_SECRET', '')
+
+    expect(getPlatformProviderRuntimeStatuses().stripe).toMatchObject({
+      configured: false,
+      ready: false,
+    })
+  })
+
+  it('applies tenant toggles and preserves safe defaults for missing rows', async () => {
+    const { getTenantPlatformProviderStatuses } = await import('@/lib/billing/platform-checkout-runtime')
+    const statuses = await getTenantPlatformProviderStatuses(
+      settingsClient({
+        data: [
+          { setting_key: 'stripe_enabled', setting_value: { enabled: false } },
+          { setting_key: 'paypal_enabled', setting_value: { enabled: true } },
+        ],
+        error: null,
+      }),
+      'tenant-1',
+    )
+
+    expect(statuses.stripe.enabled).toBe(false)
+    expect(statuses.paypal.enabled).toBe(true)
+    expect(statuses.lemonsqueezy.enabled).toBe(false)
+  })
+
+  it('fails closed when tenant settings cannot be read', async () => {
+    const { getTenantPlatformProviderStatuses } = await import('@/lib/billing/platform-checkout-runtime')
+
+    await expect(
+      getTenantPlatformProviderStatuses(
+        settingsClient({ data: null, error: { message: 'database unavailable' } }),
+        'tenant-1',
+      ),
+    ).rejects.toThrow('database unavailable')
   })
 })


### PR DESCRIPTION
## What

Closes #626

- Add one shared platform-checkout availability predicate with explicit reason codes.
- Make platform plan health, price editing, tenant upgrade UI, and checkout API use the same capability, credential, setting, readiness, price, interval, and currency checks.
- Require the platform Stripe webhook secret for executable Stripe readiness and fail closed when tenant payment settings cannot be read.
- Keep manual transfer visible as a separate fallback; it never makes an automated provider purchasable.
- Add provider diagnostics and runtime-status tests for disabled, unsupported, unconfigured, not-ready, missing-price, interval, and currency cases.

## Why

Platform billing health previously treated any active provider price row as purchasable. That allowed unsupported or non-executable providers, including PayPal in platform checkout, to appear healthy while the upgrade UI and checkout API made different decisions.

## How to QA

1. Run `npm run dev` with the normal local environment and sign in as a super-admin.
2. Open `/en/platform/plans` and `/en/platform/billing-health`.
3. Configure a plan with only an unsupported provider (for example PayPal), only manual transfer, a disabled provider, a non-USD price, or a provider price with missing credentials. Confirm the editor and health page show the matching reason and that manual transfer is reported separately.
4. Configure at least one enabled, credentialed, executable automated provider with a matching active price for the charged interval. Confirm the plan is healthy and `/en/dashboard/admin/billing/upgrade` offers only that provider.
5. Send a checkout request selecting a disabled, unsupported, or otherwise unavailable provider. Confirm the API rejects it before creating a provider checkout session.

## Screenshots / GIF

UI recording was attempted with the local authenticated browser session, but login did not complete and the browser remained on the login page. No trustworthy before/after media was generated.

## Verification

- `npm run typecheck` ✅
- `npm run test:unit` ✅ 68 files / 902 tests
- `npm run build` ✅ (required elevated process permissions for Turbopack)
- Changed-file ESLint ✅ 0 errors
- `git diff --check` ✅
- Full-repo `npm run lint` remains blocked by 536 pre-existing errors and 697 warnings in unrelated repository files; the changed files pass independently.
- The targeted Playwright flow could not reach the dashboard because local Supabase was unavailable at `127.0.0.1:54321` (Docker is not running in the test environment).

## Checklist

- [x] `npm run typecheck` and `npm run test:unit` pass
- [x] `npm run build` passes
- [x] Tenant-scoped settings remain enforced by the existing RLS/admin client path
- [ ] Tested every relevant role in the browser (blocked by local Supabase/Docker availability)
- [x] Health and unavailable states include actionable reasons
- [ ] Screenshot/GIF attached (blocked by local Supabase/Docker availability)
