### PR TITLE
fix(a11y): stop rendering a button inside an anchor in the public shell

### DIFF
--- a/components/public/navbar.tsx
+++ b/components/public/navbar.tsx
@@ -125,38 +125,32 @@ export async function Navbar({ headerSettings }: NavbarProps = {}) {
                     {(headerSettings?.showLanguageSwitcher !== false) && <LanguageSwitcher />}
 
                     {userId ? (
-                        <Link href="/dashboard/student">
-                            <Button variant="outline">
-                                {t('dashboard')}
-                            </Button>
-                        </Link>
+                        <Button variant="outline" render={<Link href="/dashboard/student" />}>
+                            {t('dashboard')}
+                        </Button>
                     ) : (
                         <>
                             {(headerSettings?.showLoginButton !== false) && (
-                                <Link href="/auth/login" className="hidden sm:inline-block">
-                                    <Button variant="ghost" className="text-muted-foreground hover:text-foreground">
-                                        {t('login')}
-                                    </Button>
-                                </Link>
+                                <Button
+                                    variant="ghost"
+                                    className="hidden text-muted-foreground hover:text-foreground sm:inline-flex"
+                                    render={<Link href="/auth/login" />}
+                                >
+                                    {t('login')}
+                                </Button>
                             )}
                             {headerSettings?.ctaText && headerSettings?.ctaLink ? (
-                                <Link href={headerSettings.ctaLink}>
-                                    <Button className="font-medium">
-                                        {headerSettings.ctaText}
-                                    </Button>
-                                </Link>
+                                <Button className="font-medium" render={<Link href={headerSettings.ctaLink} />}>
+                                    {headerSettings.ctaText}
+                                </Button>
                             ) : isMainPlatform ? (
-                                <Link href="/create-school">
-                                    <Button className="font-medium">
-                                        {t('startFree')} →
-                                    </Button>
-                                </Link>
+                                <Button className="font-medium" render={<Link href="/create-school" />}>
+                                    {t('startFree')} →
+                                </Button>
                             ) : (
-                                <Link href="/auth/sign-up?next=/join-school">
-                                    <Button className="font-medium">
-                                        {t('join')} {tenant?.name}
-                                    </Button>
-                                </Link>
+                                <Button className="font-medium" render={<Link href="/auth/sign-up?next=/join-school" />}>
+                                    {t('join')} {tenant?.name}
+                                </Button>
                             )}
                         </>
                     )}

--- a/components/public/school-landing-page.tsx
+++ b/components/public/school-landing-page.tsx
@@ -62,25 +62,23 @@ export async function SchoolLandingPage({ tenant, products }: Props) {
             </p>
 
             <div className="flex flex-wrap gap-4 justify-center pt-2">
-              <Link href="/auth/sign-up?next=/join-school">
-                <Button
-                  size="lg"
-                  className="h-14 px-10 text-white font-bold rounded-xl text-lg transition-all duration-200 active:scale-95 border-0"
-                  style={{ backgroundColor: accentColor }}
-                >
-                  {t('join', { name: tenant.name })}
-                  <ArrowRight className="ml-2 w-5 h-5" aria-hidden="true" />
-                </Button>
-              </Link>
-              <Link href="/auth/login">
-                <Button
-                  size="lg"
-                  variant="outline"
-                  className="h-14 px-10 bg-zinc-900/50 border-zinc-800 text-zinc-300 hover:text-white hover:bg-zinc-800/80 rounded-xl text-lg backdrop-blur-sm transition-all duration-200"
-                >
-                  {t('alreadyMember')}
-                </Button>
-              </Link>
+              <Button
+                size="lg"
+                className="h-14 px-10 text-white font-bold rounded-xl text-lg transition-all duration-200 active:scale-95 border-0"
+                style={{ backgroundColor: accentColor }}
+                render={<Link href="/auth/sign-up?next=/join-school" />}
+              >
+                {t('join', { name: tenant.name })}
+                <ArrowRight className="ml-2 w-5 h-5" aria-hidden="true" />
+              </Button>
+              <Button
+                size="lg"
+                variant="outline"
+                className="h-14 px-10 bg-zinc-900/50 border-zinc-800 text-zinc-300 hover:text-white hover:bg-zinc-800/80 rounded-xl text-lg backdrop-blur-sm transition-all duration-200"
+                render={<Link href="/auth/login" />}
+              >
+                {t('alreadyMember')}
+              </Button>
             </div>
           </div>
         </div>
@@ -169,16 +167,15 @@ export async function SchoolLandingPage({ tenant, products }: Props) {
               >
                 {t('ctaTitle', { name: tenant.name })}
               </h2>
-              <Link href="/auth/sign-up?next=/join-school">
-                <Button
-                  size="lg"
-                  className="h-14 px-10 bg-white font-bold rounded-xl text-lg shadow-xl shadow-black/20 active:scale-95 transition-all duration-200 border-0"
-                  style={{ color: accentColor }}
-                >
-                  {t('ctaButton', { name: tenant.name })}
-                  <ArrowRight className="ml-2 w-5 h-5" aria-hidden="true" />
-                </Button>
-              </Link>
+              <Button
+                size="lg"
+                className="h-14 px-10 bg-white font-bold rounded-xl text-lg shadow-xl shadow-black/20 active:scale-95 transition-all duration-200 border-0"
+                style={{ color: accentColor }}
+                render={<Link href="/auth/sign-up?next=/join-school" />}
+              >
+                {t('ctaButton', { name: tenant.name })}
+                <ArrowRight className="ml-2 w-5 h-5" aria-hidden="true" />
+              </Button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## What

Every CTA in the public navbar and on the default school landing page rendered `<Link><Button>…</Button></Link>`, which serves a `<button>` as a child of an `<a>`. Rewritten to `<Button render={<Link … />}>`, which emits a single `<a>` carrying the button classes.

No issue number — this came out of a Sentry triage sweep, as an incidental finding rather than a reported error.

## Why

Interactive content is not allowed inside an anchor. It is invalid HTML, and it hands assistive tech two nested controls for one destination.

Parsing the live HTML of a tenant landing page (`parse5`, walking for interactive-in-anchor) turns up **five** `button`-inside-`a` pairs, all originating in these two files:

| Path in the served document | Source |
|---|---|
| `nav > div > div > a` | navbar right-hand CTA |
| `section > div > div > div > a` ×2 | landing hero CTAs |

`components/ui/button.tsx` wraps `@base-ui/react`'s Button, which takes a `render` prop, so the fix needs no new component. This is already the established pattern in this tree — `SidebarMenuButton render={<Link/>}` in `platform-sidebar.tsx`, `DropdownMenuItem render={<Link/>}` in `user-nav.tsx`.

One incidental class change: the login CTA's `hidden sm:inline-block` moves from the wrapper onto the Button as `hidden sm:inline-flex`. The button's own display is `inline-flex`; `inline-block` on the wrapper existed only to undo the wrapper's default.

### Verified

`renderToStaticMarkup(<Button variant="outline" render={<a href="…" />}>Dashboard</Button>)` produces an `<a>` with `data-slot="button"` and the full variant class list, and contains no `<button>` at all.

## How to QA

On a fresh `npm run db:reset`, `npm run dev`:

1. Open `code-academy.lvh.me:3000/en` (a non-default tenant, so the default school landing page renders). Devtools → Elements: the hero's "Join …" and "Already a member" CTAs are now `<a>` elements, with no `<button>` inside them. Same for the navbar's join CTA and the "Log in" link.
2. Click each one — they navigate exactly as before, and client-side (they are still `next/link`).
3. Tab through the header and hero: one focus stop per CTA, ring renders as before.
4. Sign in as `alice@student.com` / `password123` and reload — the navbar's "Dashboard" CTA takes the same treatment; confirm it still routes to `/dashboard/student`.
5. `default.lvh.me:3000/en` — the main-platform branch of the navbar ("Start free →") is covered by the same change.

## Screenshots / GIF

No visual change is intended and none was observed — the rendered element changes tag, not its classes or box. Happy to attach a before/after if you'd rather see it.

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm run lint` on both files reports nothing new (the 4 `no-explicit-any` errors and 4 `no-img-element` warnings are all pre-existing lines I did not touch)
- [ ] `npm run build` — not run; this worktree has no `.env.local`
- [x] Every new tenant-scoped query filters by `tenant_id` — no queries added or changed
- [x] Tested with every relevant role — the navbar branches on signed-in / signed-out and on main-platform / tenant; all four branches are in the diff
- [x] Loading and error states handled — n/a, no state added
- [x] New UI strings — none; every label is an existing `t()` call, unmoved
- [x] Migration — none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016yikG2XKxw22UWLXCgg7fD