### PR TITLE
feat(ops): monitor the cron schedule in Sentry and document how to run it (#620)

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -22,6 +22,13 @@
 #     activity. Re-enable from the Actions tab if that happens.
 #   * Run ONE mechanism. If a Dokploy schedule is added later, remove the
 #     corresponding schedule here so routes don't fire twice.
+#
+# Runs report to Sentry cron monitors (slug `cron-<route>`) so a run that never
+# happens is visible — a disabled workflow or a dropped tick fails nothing and
+# logs nothing, so job failure alone cannot catch it.
+#
+# Operating this: docs/CRON_RUNBOOK.md (scheduler of record, replay, secret
+# rotation, partial failure, and why solana-pull is dispatch-only).
 
 name: Scheduled cron routes
 
@@ -99,7 +106,9 @@ jobs:
         env:
           CRON_SECRET: ${{ secrets.CRON_SECRET }}
           CRON_BASE_URL: ${{ vars.CRON_BASE_URL }}
+          SENTRY_DSN: ${{ vars.NEXT_PUBLIC_SENTRY_DSN }}
           ROUTES: ${{ steps.resolve.outputs.routes }}
+          MONITOR_SCHEDULE: ${{ github.event.schedule }}
         run: |
           set -euo pipefail
 
@@ -112,12 +121,65 @@ jobs:
             exit 1
           fi
 
+          # ---- Sentry Crons monitoring (issue #620) ----
+          #
+          # A failed run already fails this job, and GitHub emails on that. What
+          # that cannot catch is the run that never happened: a workflow
+          # disabled by hand, a dropped */10 tick, or the 60-day inactivity
+          # shutdown that silently turned this file off once already. Sentry
+          # cron monitors close that gap — one monitor per route, and a check-in
+          # that never arrives raises an issue by itself.
+          #
+          # Ingest host, project id and public key are derived from the DSN
+          # (https://<key>@<host>/<project_id>) rather than written out, for the
+          # same reason Sentry.init reads it from the environment.
+          #
+          # One terminal check-in per route, no in_progress: the ingest endpoint
+          # answers 202 with an EMPTY body, so there is no check-in id to close
+          # a started run with. Verified against the live project — opening one
+          # and never closing it just leaves every run hanging.
+          #
+          # Monitoring is strictly additive. Every call swallows its own errors,
+          # because an unreachable Sentry must never fail a billing job.
+          checkin_url_base=''
+          checkin_margin=120
+          if [ -z "${MONITOR_SCHEDULE:-}" ]; then
+            echo "Manual run — no schedule to check in against, skipping Sentry monitors."
+          elif [ -z "${SENTRY_DSN:-}" ]; then
+            echo "::warning::NEXT_PUBLIC_SENTRY_DSN is not set — this run is unmonitored."
+          else
+            sentry_key="${SENTRY_DSN#*//}"; sentry_key="${sentry_key%%@*}"
+            sentry_rest="${SENTRY_DSN##*@}"
+            checkin_url_base="https://${sentry_rest%%/*}/api/${sentry_rest##*/}/cron"
+            # GitHub delays scheduled runs under load and drops high-frequency
+            # ones first, so the */10 group needs a wider margin than the daily
+            # jobs or every busy hour pages us. Misses that persist here are the
+            # signal to move to a Dokploy schedule — see docs/CRON_RUNBOOK.md.
+            case "$MONITOR_SCHEDULE" in
+              '*/10 * * * *') checkin_margin=30 ;;
+            esac
+          fi
+
+          # $1 route, $2 ok|error. Upserts the monitor so its schedule in Sentry
+          # can never drift from the schedule that actually invoked it.
+          checkin() {
+            [ -n "$checkin_url_base" ] || return 0
+            curl -sS --max-time 15 -o /dev/null -X POST \
+              -H 'Content-Type: application/json' \
+              -d "{\"status\":\"$2\",\"monitor_config\":{\"schedule\":{\"type\":\"crontab\",\"value\":\"$MONITOR_SCHEDULE\"},\"checkin_margin\":$checkin_margin,\"max_runtime\":20,\"timezone\":\"Etc/UTC\"}}" \
+              "$checkin_url_base/cron-$1/$sentry_key/" 2>/dev/null || true
+          }
+
           base="${CRON_BASE_URL%/}"
           failed=0
 
           for route in $ROUTES; do
             url="$base/api/cron/$route"
             echo "--- GET $url"
+            # Cleared per route: curl writes no body when it cannot connect, so
+            # a leftover file would print the PREVIOUS route's response under
+            # this route's failure — exactly the wrong thing during an incident.
+            rm -f /tmp/cron-body.txt
             # The secret is passed via env into the header and never printed;
             # GitHub also masks it in logs. Body is capped so a large digest
             # response can't flood the log.
@@ -127,10 +189,13 @@ jobs:
               "$url")" || code='000'
 
             echo "HTTP $code"
-            head -c 2000 /tmp/cron-body.txt || true
+            head -c 2000 /tmp/cron-body.txt 2>/dev/null || true
             echo
 
-            if [ "$code" != '200' ]; then
+            if [ "$code" = '200' ]; then
+              checkin "$route" ok
+            else
+              checkin "$route" error
               echo "::error::$route returned HTTP $code"
               failed=1
             fi

--- a/docs/CRON_RUNBOOK.md
+++ b/docs/CRON_RUNBOOK.md
@@ -1,0 +1,198 @@
+# Cron runbook
+
+Operational guide for the `/api/cron/*` jobs: who schedules them, how to tell
+they ran, and what to do when one fails. Written for issue #620 (epic #619).
+
+`docs/DEPLOYMENT.md` §3.5 describes the three schedulers you *could* use. This
+file records which one is actually in charge and how to operate it.
+
+---
+
+## 1. Scheduler of record: GitHub Actions
+
+**`.github/workflows/cron.yml` is the single scheduler.** Nothing else invokes
+these routes.
+
+- `vercel.json` still lists the same schedules. **It is inert** — production runs
+  on Dokploy, which never reads that file. It is kept only so a Vercel deploy of
+  this repo works out of the box. Changing a schedule means changing *both*, and
+  the workflow's `case` block is the one that takes effect.
+- Dokploy scheduled tasks: **none defined.** Verified via the Dokploy API on
+  2026-08-29 — `schedule.list` for the LMS application returned an empty list.
+- pg_cron runs `league-weekly-rollover` (Mondays 00:05) *inside* the database.
+  The `league-rollover` route is a deliberate second path to the same idempotent
+  RPC, not a duplicate to remove.
+
+Running two schedulers means every route fires twice. The routes tolerate it,
+but it doubles load and makes logs unreadable. **If you move to Dokploy
+schedules, delete the `schedule:` block here in the same change.**
+
+### Required configuration
+
+| Where | Kind | Name | Value |
+|---|---|---|---|
+| GitHub → Settings → Secrets and variables → Actions | Secret | `CRON_SECRET` | Must equal the app's `CRON_SECRET` |
+| same | Variable | `CRON_BASE_URL` | `https://preciopana.com` |
+| same | Variable | `NEXT_PUBLIC_SENTRY_DSN` | Already set; also used by the build |
+| Dokploy → guille → LMS → Environment | env | `CRON_SECRET` | Same value as the GitHub secret |
+
+A missing `CRON_BASE_URL` or `CRON_SECRET` fails the run with an `::error::`
+rather than silently no-opping. A missing DSN only drops monitoring, with a
+warning — the jobs still run.
+
+The workflow must also be **enabled**. It shipped `disabled_manually` and
+therefore never ran once, which is the whole reason #620 exists. Check with:
+
+```bash
+gh workflow list --all | grep 'Scheduled cron routes'   # want: active
+gh workflow enable cron.yml
+```
+
+---
+
+## 2. The jobs
+
+| Route | Cadence | If it does not run |
+|---|---|---|
+| `solana-reconcile` | `*/10` | Student paid on chain, closed the tab: money taken, no entitlement, and the `pending` row blocks a retry checkout |
+| `binance-personal-reconcile` | `*/10` | Same failure for personal Binance Pay (#482) |
+| `redeliver-webhook-events` | `*/10` | An event whose worker died mid-lease is never processed by anyone — paid, never enrolled (#625) |
+| `reconcile-solana-platform-activations` | `*/10` | School paid the platform on chain, activation crashed, plan never applied (#622) |
+| `daily-digest` | hourly | No digests, no streak nudges. Must be **hourly** — each tenant sends at its own local hour |
+| `expire-subscriptions` | `0 0` | Lapsed self-managed subscriptions (Solana, manual) keep their entitlements forever |
+| `league-rollover` | Mon `0 1` | Nothing — pg_cron is primary. This is the fallback |
+| `expire-platform-subscriptions` | `0 2` | No renewal reminders, no grace period, no downgrade to free: a school that stopped paying keeps its paid plan |
+| `enforce-plan-limits` | `0 3` | A tenant that grows past its plan limits with no plan-change event is never cut off, and a pending cutoff never completes |
+| `solana-pull` | **never** | See §5 |
+
+Every route is idempotent, so a late or repeated run is safe. `league-rollover`
+in particular resolves the previous week from the data and finalizes every
+unfinalized week, so running it late *is* the catch-up path (#549).
+
+---
+
+## 3. Monitoring
+
+Each route reports to its own **Sentry cron monitor**, slug `cron-<route>`
+(e.g. `cron-expire-platform-subscriptions`), in project `lms-front`,
+environment `production`.
+
+<https://guillermoscript.sentry.io/crons/>
+
+Three signals, and they catch different things:
+
+| Signal | Raised by | Means |
+|---|---|---|
+| Job failure | GitHub Actions (the job exits non-zero) | A route answered non-200 |
+| Check-in `error` | Sentry | Same event, visible next to the run history |
+| **Missed check-in** | Sentry | The run never happened at all |
+
+The third is the one that matters. A workflow disabled by hand, a `*/10` tick
+GitHub dropped, or the 60-day inactivity shutdown produces **no failure of any
+kind** — no job, no log, no email. Only the absent check-in shows it.
+
+The monitors are created and kept in sync by the workflow itself: each check-in
+upserts the schedule that actually invoked it, so a monitor's schedule in Sentry
+can never drift from `cron.yml`.
+
+**Check-in margins** are 30 minutes for the `*/10` group and 120 minutes for the
+daily jobs, because GitHub delays scheduled runs under load and drops
+high-frequency ones first. Tighter margins produce noise, not information. If
+the `*/10` monitors alert repeatedly while the workflow is healthy, that is
+GitHub dropping ticks — the fix is to move to a Dokploy schedule (§1), not to
+widen the margin further.
+
+Manual `workflow_dispatch` runs deliberately do **not** check in: there is no
+schedule to measure them against, and a manual run must never paper over a
+missed scheduled one.
+
+---
+
+## 4. Procedures
+
+### Verify end to end
+
+```bash
+gh workflow run cron.yml -f route=enforce-plan-limits
+gh run watch
+```
+
+Expect HTTP 200 and a JSON body of counters. Then confirm the check-in landed —
+note that a dispatch run does not check in, so verify monitoring on the first
+*scheduled* tick instead, in the Sentry Crons view.
+
+Direct call, bypassing Actions:
+
+```bash
+curl -sS -f -H "Authorization: Bearer $CRON_SECRET" \
+  https://preciopana.com/api/cron/enforce-plan-limits
+```
+
+401 means the secret does not match the app's. The routes **fail closed**: if
+`CRON_SECRET` is unset on the app, *every* request is rejected (plan 001), so a
+401 never means "auth is off".
+
+### One route failed, the others succeeded
+
+The loop runs every route in the group regardless, then exits 1 if any failed.
+The successful ones are done — do not re-run the whole group. Replay just the
+failed one:
+
+```bash
+gh workflow run cron.yml -f route=solana-reconcile
+```
+
+### Rotate `CRON_SECRET`
+
+There is one secret and no overlap window, so ordering matters:
+
+1. Generate: `openssl rand -hex 32`
+2. Set it in **Dokploy** first (guille → LMS → Environment), save, redeploy.
+3. From the redeploy until step 4, every scheduled run fails 401 — loudly, which
+   is intended. Do this outside the `0 0`–`0 3` block if you can.
+4. `gh secret set CRON_SECRET`
+5. `gh workflow run cron.yml -f route=enforce-plan-limits` and confirm 200.
+
+### The workflow stopped running
+
+GitHub disables scheduled workflows after 60 days with no repository activity,
+and does it silently. `gh workflow list --all` shows `disabled_inactivity`.
+Re-enable with `gh workflow enable cron.yml`, then run one route manually to
+confirm, and check Sentry for how many ticks were missed.
+
+---
+
+## 5. `solana-pull` is manual-only, on purpose
+
+`/api/cron/solana-pull` submits **real on-chain USDC transfers** — it pulls funds
+from subscribers' wallets for native `solana_subs` auto-pull subscriptions. It
+has never had a scheduler in `vercel.json` either, and `cron.yml` exposes it only
+under `workflow_dispatch`.
+
+**Consequence:** native Solana auto-pull subscriptions do not renew on their own.
+
+This is safe today and verifiably so: as of 2026-08-29 production has **zero
+rows in `subscriptions`** (19 tenants, all on the `free` plan), so there is
+nothing to pull.
+
+**Trigger to revisit:** the first `subscriptions` row with
+`payment_provider = 'solana_subs'`. At that point either schedule this route or
+disable that provider — leaving it as-is silently stops collecting money that is
+owed. Guard it with:
+
+```sql
+select count(*) from subscriptions where payment_provider = 'solana_subs';
+```
+
+Before scheduling it, confirm `SOLANA_RPC_URL`, `SOLANA_PLATFORM_WALLET` and
+`SOLANA_PULLER_SECRET_KEY` are set on the app and that the puller keypair holds
+SOL for fees.
+
+---
+
+## 6. What a healthy first run looks like
+
+Production carries no money yet — no subscriptions, no transactions, no webhook
+events — so **every counter comes back zero**. That is a pass, not a no-op: it
+proves auth, reachability, scheduling and monitoring, which is exactly what #620
+asks for. Re-run this evidence once the first school is actually paying.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -282,7 +282,11 @@ something on this side has to call the routes or they never run at all. Every
 fires twice; the routes are written to tolerate that, but it doubles the load and
 makes logs hard to read.
 
-#### Option A — GitHub Actions (default, and what the repo ships)
+> **Day-to-day operation of these jobs — replay, secret rotation, partial
+> failure, monitoring — lives in [`CRON_RUNBOOK.md`](./CRON_RUNBOOK.md).** This
+> section is the one-time setup; that one is the runbook.
+
+#### Option A — GitHub Actions (default, what the repo ships, and the scheduler of record for `preciopana.com`)
 
 `.github/workflows/cron.yml` runs all declared schedules. It needs two repository
 settings under **Settings → Secrets and variables → Actions**:


### PR DESCRIPTION
## What

Each `/api/cron/*` route now checks in to its own Sentry cron monitor, and `docs/CRON_RUNBOOK.md` records how the schedule is actually operated.

Refs #620 (epic #619). **Does not close it** — the secret, the enable and the production evidence run are settings work still outstanding.

## Why

`.github/workflows/cron.yml` has never run once. It shipped `disabled_manually` with no `CRON_SECRET` and no `CRON_BASE_URL`, so every lifecycle job — subscription expiry, grace-period downgrade, access-cutoff reconciliation, the Solana/Binance reconcilers, webhook redelivery — has been inert in production. Merging a disabled workflow did not make it operational.

Job failure was already covered: a non-200 fails the job and GitHub emails. What nothing covered is **the run that never happens** — a workflow disabled by hand, a `*/10` tick GitHub dropped, or the 60-day inactivity shutdown. Those fail nothing and log nothing. An absent Sentry check-in is the only thing that surfaces them.

Worth stating plainly: production carries no money yet (`subscriptions`, `transactions` and `webhook_events` are all empty; 19 tenants, all `free`), so nothing is leaking today. This is pre-launch hygiene, meant to be in place before the first paying school.

## Notes for the reviewer

Two design points came from testing against the live Sentry project, not from the docs:

- The ingest endpoint answers **202 with an empty body**. No check-in id comes back, so the documented `in_progress` → `PUT <id>` flow is unusable from curl — it would leave every run hanging. One terminal check-in per route instead; missed-schedule detection is unaffected, only duration tracking is lost.
- `monitor_config` on the check-in **upserts** the monitor, so a schedule in Sentry cannot drift from the one that actually invoked the route. No manual UI setup.

Ingest host, project id and public key are derived from the DSN rather than written out, matching the `Sentry.init` rule in CLAUDE.md. Monitoring is strictly additive — every call swallows its own errors, because an unreachable Sentry must never fail a billing job. Manual dispatch runs deliberately do not check in.

Margins are 30 min (`*/10`) and 120 min (daily): GitHub delays scheduled runs under load and drops high-frequency ones first, so tighter margins produce noise rather than information.

Also fixes a real reporting bug in the loop: curl writes no body when it cannot connect, so a leftover `/tmp/cron-body.txt` made a failing route print the **previous** route's response as its own — exactly the wrong thing during an incident.

## How to QA

No app surface changes; this is a workflow and two docs.

1. `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/cron.yml'))"` — parses.
2. Extract the `Invoke` step's `run:` block and `bash -n` it — clean.
3. Behaviour was dry-run locally with a stubbed curl: 200 → `ok` check-in, exit 0; unreachable host → HTTP 000, `::error::`, exit 1; no `github.event.schedule` → monitoring skipped.
4. Live check-in verified end to end against project `lms-front`: the monitor was auto-created with the schedule/margin from `monitor_config`, environment `production`, status `ok`.
5. Read `docs/CRON_RUNBOOK.md` §1 and confirm the scheduler-of-record claim against `gh workflow list --all` and the Dokploy schedules list (empty).

Once merged, the remaining #620 steps are in the runbook: set `CRON_SECRET` on the Dokploy app and as a repo secret, `gh workflow enable cron.yml`, then one dispatch run for evidence. `CRON_BASE_URL` is already set.

**Cleanup:** a throwaway monitor `cron-selftest-620` (1-year interval, harmless) is left in Sentry from the verification and should be deleted in the UI — the Sentry MCP has no delete for cron monitors.

## Screenshots / GIF

N/A — no user-visible surface.

## Checklist

- [x] `npm run typecheck` and `npm run test:unit` pass — unaffected, no TS or test files touched
- [x] `npm run build` passes — unaffected
- [x] Every new tenant-scoped query filters by `tenant_id` — no queries added
- [x] Tested with every relevant role — N/A
- [x] Loading and error states handled — N/A
- [x] New UI strings added to both `messages/en.json` and `messages/es.json` — no UI strings
- [x] Migration — none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KquGPjUVeVY6X1ibSN59Nw