### PR TITLE
feat(payments): expire abandoned hosted checkouts so buyers can retry (#624)

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -36,7 +36,7 @@ on:
   schedule:
     # Keep these in sync with vercel.json and with the case block below.
     - cron: '*/10 * * * *' # payment + webhook + activation reconcilers
-    - cron: '0 * * * *' # daily-digest — hourly by design (each tenant sends at its own local hour)
+    - cron: '0 * * * *' # daily-digest — hourly by design (each tenant sends at its own local hour); expire-stale-checkouts rides along
     - cron: '0 0 * * *' # expire-subscriptions
     - cron: '0 1 * * 1' # league-rollover (pg_cron also runs it Mondays 00:05; this is the fallback)
     - cron: '0 2 * * *' # expire-platform-subscriptions
@@ -57,6 +57,7 @@ on:
           - binance-personal-reconcile
           - redeliver-webhook-events
           - reconcile-solana-platform-activations
+          - expire-stale-checkouts
           # Never scheduled: solana-pull submits on-chain USDC transfers and has
           # never had a scheduler in vercel.json either. Available here for
           # manual runs only — putting it on a timer needs its own review.
@@ -88,7 +89,7 @@ jobs:
           else
             case "${SCHEDULE:-}" in
               '*/10 * * * *') routes='solana-reconcile binance-personal-reconcile redeliver-webhook-events reconcile-solana-platform-activations' ;;
-              '0 * * * *')    routes='daily-digest' ;;
+              '0 * * * *')    routes='daily-digest expire-stale-checkouts' ;;
               '0 0 * * *')    routes='expire-subscriptions' ;;
               '0 1 * * 1')    routes='league-rollover' ;;
               '0 2 * * *')    routes='expire-platform-subscriptions' ;;

--- a/app/api/cron/expire-stale-checkouts/route.ts
+++ b/app/api/cron/expire-stale-checkouts/route.ts
@@ -1,0 +1,273 @@
+/**
+ * Cron job: reconcile or expire abandoned hosted checkouts (issue #624).
+ *
+ * A hosted checkout (PayPal, Lemon Squeezy, Binance Pay) inserts a `pending`
+ * transaction and redirects the buyer away. If they close the tab, that row
+ * lives forever inside transactions_unique_product / transactions_unique_plan
+ * (both cover status IN ('pending','successful')) and the buyer is permanently
+ * blocked from purchasing the same item again. PayPal expires abandoned orders
+ * on its own side with no guaranteed terminal webhook, and Lemon Squeezy emits
+ * no one-time failure event for this path — so nothing clears the row without
+ * this job.
+ *
+ * RECONCILE BEFORE EXPIRING. A lapsed TTL means "we stopped hearing about it",
+ * not "it failed". Where the provider gives us a queryable checkout identity we
+ * ask it what actually happened first, so a completed-but-undelivered payment
+ * is settled rather than cancelled. Only an unanswerable or genuinely dead
+ * checkout is expired.
+ *
+ * CAPABILITY-GATED, never provider name: `supportsHostedCheckout` is exactly
+ * the property that creates the hazard (we redirect away and may never hear
+ * back). Stripe Elements, Solana Pay and manual payments never set
+ * `checkout_expires_at` at all, so they cannot appear in this queue.
+ *
+ * Secured by CRON_SECRET. Scheduled from .github/workflows/cron.yml; operating
+ * notes in docs/CRON_RUNBOOK.md.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+import { getPaymentProvider } from '@/lib/payments'
+import type { PayPalPaymentProvider } from '@/lib/payments/paypal-provider'
+import { dispatchBillingEvent } from '@/lib/payments/webhook-dispatch'
+import { isHostedCheckoutProvider } from '@/lib/payments/checkout-expiry'
+import { ANALYTICS_EVENTS } from '@/lib/analytics/events'
+import { track } from '@/lib/analytics/server'
+
+export const runtime = 'nodejs'
+
+/** Cap one pass so a backlog cannot time the request out; the next tick continues. */
+const BATCH_LIMIT = 200
+
+function getSupabaseAdmin(): SupabaseClient {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (!url || !serviceKey) throw new Error('Supabase env vars not set')
+  return createClient(url, serviceKey)
+}
+
+interface StaleCheckout {
+  transaction_id: number
+  user_id: string
+  tenant_id: string
+  payment_provider: string | null
+  provider_checkout_id: string | null
+  amount: number | null
+  currency: string | null
+  plan_id: number | null
+  product_id: number | null
+  checkout_expires_at: string | null
+  transaction_date: string
+}
+
+/**
+ * Ask PayPal whether the order behind this checkout actually completed.
+ *
+ * Returns true when the payment was recovered and dispatched — the caller must
+ * then leave the row alone, because the dispatcher has already flipped it.
+ *
+ * PayPal keeps an APPROVED order capturable for up to three days, well past our
+ * TTL, which is the precise case this exists for: the buyer approved, the
+ * redirect back to us never completed, and cancelling here would throw away a
+ * payment we can still take. A COMPLETED order is one where our own capture
+ * route succeeded but its dispatch did not.
+ */
+async function reconcilePayPal(
+  admin: SupabaseClient,
+  row: StaleCheckout,
+): Promise<boolean> {
+  if (!row.provider_checkout_id) return false
+
+  let paypal: PayPalPaymentProvider
+  try {
+    paypal = getPaymentProvider('paypal') as PayPalPaymentProvider
+  } catch {
+    // Not configured on this deployment — fall through to plain expiry.
+    return false
+  }
+
+  let order: Awaited<ReturnType<PayPalPaymentProvider['getOrder']>>
+  try {
+    order = await paypal.getOrder(row.provider_checkout_id)
+  } catch (err) {
+    // A provider outage must not be read as "abandoned". Leave the row pending
+    // and let the next tick retry; a genuinely dead order stays dead.
+    console.error(
+      `[expire-stale-checkouts] paypal getOrder failed for order ${row.provider_checkout_id} (tx ${row.transaction_id}) — leaving pending:`,
+      err,
+    )
+    return true
+  }
+
+  if (order.status === 'APPROVED') {
+    try {
+      const captured = await paypal.captureOrder(row.provider_checkout_id)
+      await dispatchBillingEvent(
+        {
+          type: 'payment.succeeded',
+          providerEventId: `paypal-capture:${captured.captureId}`,
+          providerPaymentId: captured.captureId,
+          reference: captured.reference,
+          metadata: captured.metadata,
+          raw: { source: 'expire-stale-checkouts', orderId: row.provider_checkout_id },
+        },
+        { provider: 'paypal', admin },
+      )
+      return true
+    } catch (err) {
+      console.error(
+        `[expire-stale-checkouts] paypal capture/dispatch failed for tx ${row.transaction_id} — leaving pending:`,
+        err,
+      )
+      return true
+    }
+  }
+
+  if (order.status === 'COMPLETED' && order.captureId) {
+    try {
+      await dispatchBillingEvent(
+        {
+          type: 'payment.succeeded',
+          providerEventId: `paypal-capture:${order.captureId}`,
+          providerPaymentId: order.captureId,
+          reference: order.reference,
+          metadata: order.metadata,
+          raw: { source: 'expire-stale-checkouts', orderId: row.provider_checkout_id },
+        },
+        { provider: 'paypal', admin },
+      )
+      return true
+    } catch (err) {
+      console.error(
+        `[expire-stale-checkouts] paypal dispatch failed for completed order, tx ${row.transaction_id} — leaving pending:`,
+        err,
+      )
+      return true
+    }
+  }
+
+  // CREATED / VOIDED / PAYER_ACTION_REQUIRED — nothing was ever taken.
+  return false
+}
+
+export async function GET(req: NextRequest) {
+  const cronSecret = process.env.CRON_SECRET
+  const provided = req.headers.get('authorization')?.replace('Bearer ', '')
+  if (!cronSecret || provided !== cronSecret) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const admin = getSupabaseAdmin()
+  const now = new Date().toISOString()
+
+  const { data: stale, error } = await admin
+    .from('transactions')
+    .select(
+      'transaction_id, user_id, tenant_id, payment_provider, provider_checkout_id, amount, currency, plan_id, product_id, checkout_expires_at, transaction_date',
+    )
+    .eq('status', 'pending')
+    .not('checkout_expires_at', 'is', null)
+    .lt('checkout_expires_at', now)
+    .order('checkout_expires_at', { ascending: true })
+    .limit(BATCH_LIMIT)
+
+  if (error) {
+    console.error('[expire-stale-checkouts] query failed:', error)
+    return NextResponse.json({ error: 'Query failed' }, { status: 500 })
+  }
+
+  const rows = (stale ?? []) as StaleCheckout[]
+
+  // Belt and braces: `checkout_expires_at` is only ever written for hosted
+  // rails, but the capability is the contract, so re-assert it here rather than
+  // trusting that no other writer ever sets the column.
+  const candidates = rows.filter(row => isHostedCheckoutProvider(row.payment_provider))
+
+  const recovered: number[] = []
+  const expired: StaleCheckout[] = []
+  let expiredCount = 0
+
+  for (const row of candidates) {
+    if (row.payment_provider === 'paypal') {
+      // PayPal is the one rail here with a queryable order and a capture window
+      // that outlives our TTL. Lemon Squeezy hands back no checkout id we can
+      // interrogate, and Binance Pay already sends a terminal PAY_CLOSED that
+      // the dispatcher turns into payment.failed — for both, a lapsed TTL with
+      // no terminal event is as much as we will ever know.
+      if (await reconcilePayPal(admin, row)) {
+        recovered.push(row.transaction_id)
+        continue
+      }
+    }
+    expired.push(row)
+  }
+
+  if (expired.length > 0) {
+    const ids = expired.map(row => row.transaction_id)
+    // 'canceled', NOT 'failed': trigger_manage_transactions runs
+    // cancel_subscription(user, plan) on a 'failed' plan row, so expiring an
+    // abandoned RENEWAL checkout as 'failed' would cancel the subscription the
+    // buyer is still paying for. The `.eq('status','pending')` guard keeps this
+    // safe against a webhook that settled the row since the SELECT above.
+    const { data: updated, error: updateError } = await admin
+      .from('transactions')
+      .update({ status: 'canceled', expired_at: now })
+      .in('transaction_id', ids)
+      .eq('status', 'pending')
+      .select('transaction_id')
+
+    if (updateError) {
+      console.error('[expire-stale-checkouts] update failed:', updateError)
+      return NextResponse.json({ error: 'Update failed' }, { status: 500 })
+    }
+
+    // Report only what the DB actually expired — a row a webhook settled
+    // between the SELECT and the UPDATE is not an abandonment.
+    const expiredIds = new Set((updated ?? []).map(r => r.transaction_id))
+    expiredCount = expiredIds.size
+    for (const row of expired) {
+      if (!expiredIds.has(row.transaction_id)) continue
+      await track(
+        ANALYTICS_EVENTS.CHECKOUT_ABANDONED,
+        {
+          provider: row.payment_provider ?? 'unknown',
+          amount: Number(row.amount ?? 0),
+          currency: row.currency ?? 'usd',
+          is_subscription: !!row.plan_id,
+          transaction_id: row.transaction_id,
+          ...(row.product_id ? { product_id: row.product_id } : {}),
+          ...(row.plan_id ? { plan_id: row.plan_id } : {}),
+          // How long the buyer had. Makes a TTL that is too aggressive visible
+          // as a cluster of abandonments at exactly the TTL boundary.
+          age_minutes: Math.round(
+            (Date.parse(now) - Date.parse(row.transaction_date)) / 60_000,
+          ),
+        },
+        // Backdated to when the checkout started, so the funnel attributes the
+        // abandonment to the day of the attempt rather than the day we noticed.
+        { userId: row.user_id, tenantId: row.tenant_id, timestamp: row.transaction_date },
+      )
+    }
+  }
+
+  // `stale_pending` is the queue depth AFTER this pass: a number that keeps
+  // climbing means reconciliation is failing (provider outage, bad credentials),
+  // which job-success alerting alone would never surface.
+  const { count: remaining } = await admin
+    .from('transactions')
+    .select('*', { count: 'exact', head: true })
+    .eq('status', 'pending')
+    .not('checkout_expires_at', 'is', null)
+    .lt('checkout_expires_at', new Date().toISOString())
+
+  const result = {
+    scanned: rows.length,
+    recovered: recovered.length,
+    // What the DB actually expired, not what this pass selected — the two
+    // differ whenever a webhook settled a row mid-pass.
+    expired: expiredCount,
+    stale_pending: remaining ?? 0,
+  }
+  console.log('[expire-stale-checkouts]', result)
+  return NextResponse.json(result)
+}

--- a/app/api/payments/checkout/route.ts
+++ b/app/api/payments/checkout/route.ts
@@ -30,6 +30,7 @@ import { getSolUsdPrice, usdToLamports } from '@/lib/payments/sol-price'
 import { getSolanaSettlementOptions } from '@/app/actions/admin/settings'
 import { paymentAuthLimiter } from '@/lib/rate-limit'
 import { DEFAULT_SCHOOL_PERCENTAGE } from '@/lib/payments/payouts-owed'
+import { checkoutExpiresAt, isHostedCheckoutProvider } from '@/lib/payments/checkout-expiry'
 import {
   findConflictingSubscription,
   PARALLEL_SUBSCRIPTION_CODE,
@@ -283,6 +284,11 @@ export async function POST(req: NextRequest) {
         status: 'pending',
         payment_provider: providerSlug,
         school_percentage_snapshot: schoolPercentageSnapshot,
+        // Local TTL for hosted rails only (#624). Without it an abandoned
+        // redirect leaves this pending row inside transactions_unique_product /
+        // transactions_unique_plan forever, and the buyer can never retry.
+        // Null for in-band rails, which keeps them out of the reconciler queue.
+        checkout_expires_at: checkoutExpiresAt(providerSlug),
         ...(settlement
           ? {
               settlement_currency: settlement.currency,
@@ -379,9 +385,26 @@ export async function POST(req: NextRequest) {
           providerSlug === 'binance') &&
         session.providerRef
       ) {
-        await supabase
+        // `provider_checkout_id` is the same value on hosted rails, stored under
+        // its own name (#624) because that is what the stale-checkout reconciler
+        // asks the provider about. It cannot read `provider_subscription_id`:
+        // for solana_subs that column marks the on-chain SUBSCRIBE reference,
+        // and handle_new_subscription copies it onto the subscription row on
+        // activation — two different meanings in one column. Splitting them
+        // keeps the reconciler from ever querying a non-checkout identifier.
+        //
+        // The admin client, not the user-scoped one: since #538 `authenticated`
+        // holds an UPDATE grant on only status / provider_subscription_id /
+        // stripe_payment_intent_id, so a user-scoped write of the new column is
+        // refused outright.
+        await adminClient
           .from('transactions')
-          .update({ provider_subscription_id: session.providerRef })
+          .update({
+            provider_subscription_id: session.providerRef,
+            ...(isHostedCheckoutProvider(providerSlug)
+              ? { provider_checkout_id: session.providerRef }
+              : {}),
+          })
           .eq('transaction_id', transaction.transaction_id)
       }
 

--- a/docs/CRON_RUNBOOK.md
+++ b/docs/CRON_RUNBOOK.md
@@ -59,6 +59,7 @@ gh workflow enable cron.yml
 | `redeliver-webhook-events` | `*/10` | An event whose worker died mid-lease is never processed by anyone — paid, never enrolled (#625) |
 | `reconcile-solana-platform-activations` | `*/10` | School paid the platform on chain, activation crashed, plan never applied (#622) |
 | `daily-digest` | hourly | No digests, no streak nudges. Must be **hourly** — each tenant sends at its own local hour |
+| `expire-stale-checkouts` | hourly | An abandoned PayPal/Lemon Squeezy/Binance redirect leaves a `pending` transaction inside both purchase-uniqueness indexes, and the buyer can never retry that item again (#624). Reconciles PayPal orders before expiring, so an approved-but-uncaptured payment is taken rather than thrown away |
 | `expire-subscriptions` | `0 0` | Lapsed self-managed subscriptions (Solana, manual) keep their entitlements forever |
 | `league-rollover` | Mon `0 1` | Nothing — pg_cron is primary. This is the fallback |
 | `expire-platform-subscriptions` | `0 2` | No renewal reminders, no grace period, no downgrade to free: a school that stopped paying keeps its paid plan |

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -6208,15 +6208,20 @@ export type Database = {
       transactions: {
         Row: {
           amount: number
+          checkout_expires_at: string | null
           currency: Database["public"]["Enums"]["currency_type"] | null
+          duplicate_settlement_at: string | null
+          expired_at: string | null
           payment_method: string | null
           payment_provider: string | null
           plan_id: number | null
           product_id: number | null
           provider_charge_id: string | null
+          provider_checkout_id: string | null
           provider_metadata: Json | null
           provider_subscription_id: string | null
           refunded_amount: number
+          revived_at: string | null
           school_percentage_snapshot: number | null
           settlement_base: number | null
           settlement_currency: string | null
@@ -6231,15 +6236,20 @@ export type Database = {
         }
         Insert: {
           amount: number
+          checkout_expires_at?: string | null
           currency?: Database["public"]["Enums"]["currency_type"] | null
+          duplicate_settlement_at?: string | null
+          expired_at?: string | null
           payment_method?: string | null
           payment_provider?: string | null
           plan_id?: number | null
           product_id?: number | null
           provider_charge_id?: string | null
+          provider_checkout_id?: string | null
           provider_metadata?: Json | null
           provider_subscription_id?: string | null
           refunded_amount?: number
+          revived_at?: string | null
           school_percentage_snapshot?: number | null
           settlement_base?: number | null
           settlement_currency?: string | null
@@ -6254,15 +6264,20 @@ export type Database = {
         }
         Update: {
           amount?: number
+          checkout_expires_at?: string | null
           currency?: Database["public"]["Enums"]["currency_type"] | null
+          duplicate_settlement_at?: string | null
+          expired_at?: string | null
           payment_method?: string | null
           payment_provider?: string | null
           plan_id?: number | null
           product_id?: number | null
           provider_charge_id?: string | null
+          provider_checkout_id?: string | null
           provider_metadata?: Json | null
           provider_subscription_id?: string | null
           refunded_amount?: number
+          revived_at?: string | null
           school_percentage_snapshot?: number | null
           settlement_base?: number | null
           settlement_currency?: string | null
@@ -7056,6 +7071,10 @@ export type Database = {
         Returns: undefined
       }
       set_league_opt_out: { Args: { _opt_out: boolean }; Returns: undefined }
+      settle_expired_checkout: {
+        Args: { _transaction_id: number }
+        Returns: string
+      }
       update_token_last_used: {
         Args: { ip_input: unknown; token_id_input: number }
         Returns: undefined

--- a/lib/payments/checkout-expiry.ts
+++ b/lib/payments/checkout-expiry.ts
@@ -1,0 +1,57 @@
+/**
+ * Local TTL for hosted-checkout redirects (issue #624).
+ *
+ * A hosted checkout inserts a `pending` transaction and then hands the buyer to
+ * the provider. If they never come back, that row sits inside both partial
+ * unique indexes (transactions_unique_product / transactions_unique_plan, which
+ * cover status IN ('pending','successful')) and blocks every replacement
+ * purchase of the same item. PayPal expires abandoned orders on its own side
+ * with no guaranteed terminal webhook; Lemon Squeezy emits no one-time failure
+ * event for this path. So the TTL has to be OURS.
+ *
+ * The window is gated on `supportsHostedCheckout`, never on provider name — the
+ * property that creates the hazard is "we redirect away and may never hear
+ * back", and that is exactly what the capability records.
+ */
+
+import { PROVIDER_CAPABILITIES, type PaymentProvider } from './types'
+
+/**
+ * Default local TTL, in minutes.
+ *
+ * 24h deliberately matches the definition already written down for
+ * ANALYTICS_EVENTS.CHECKOUT_ABANDONED ("checkout_started with no terminal event
+ * in 24h") so the funnel metric and the row's actual fate agree.
+ *
+ * Erring long is the safe direction: expiring early would cancel a checkout the
+ * buyer is still completing, and a provider success that lands after the TTL is
+ * recoverable (settle_expired_checkout revives it) while a premature expiry
+ * during payment is a live buyer hitting a dead page.
+ */
+export const DEFAULT_CHECKOUT_TTL_MINUTES = 24 * 60
+
+/** `CHECKOUT_TTL_MINUTES` env override, ignored unless it parses to a positive number. */
+export function checkoutTtlMinutes(): number {
+  const raw = Number(process.env.CHECKOUT_TTL_MINUTES)
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_CHECKOUT_TTL_MINUTES
+}
+
+/** Providers whose checkout is a redirect we may never hear back from. */
+export function isHostedCheckoutProvider(provider: string | null | undefined): boolean {
+  if (!provider) return false
+  return PROVIDER_CAPABILITIES[provider as PaymentProvider]?.supportsHostedCheckout === true
+}
+
+/**
+ * The `checkout_expires_at` to store at creation time, or null for a rail that
+ * settles in-band (Stripe Elements confirms client-side, Solana Pay is polled
+ * by our own verify endpoint, manual is an offline payment request). A null
+ * here is what keeps the reconciler's queue index scoped to hosted rails.
+ */
+export function checkoutExpiresAt(
+  provider: string | null | undefined,
+  now: Date = new Date(),
+): string | null {
+  if (!isHostedCheckoutProvider(provider)) return null
+  return new Date(now.getTime() + checkoutTtlMinutes() * 60_000).toISOString()
+}

--- a/lib/payments/webhook-dispatch.ts
+++ b/lib/payments/webhook-dispatch.ts
@@ -188,6 +188,82 @@ async function trackSettlement(
   }, 'payment settlement analytics')
 }
 
+/**
+ * A provider success for a checkout WE already expired (#624).
+ *
+ * The stale-checkout reconciler cancels an abandoned hosted checkout so the
+ * buyer can retry. That opens a window: the original payment can still land
+ * afterwards — PayPal captures an approved order for up to three days, and a
+ * Lemon Squeezy webhook can be retried for far longer than our TTL. Without
+ * this the settlement would hit the `status === 'pending'` guard, no-op, and
+ * the buyer would be charged with nothing to show for it.
+ *
+ * The decision is the RPC's, under a row lock, because it depends on whether a
+ * REPLACEMENT purchase settled in the meantime — a race the dispatcher cannot
+ * resolve from application code. The outcome is returned rather than a boolean
+ * because only 'revived' produced a live subscription for the caller to align a
+ * period against; 'duplicate' produced a refund liability and nothing else.
+ */
+type LateSettlementOutcome = 'revived' | 'duplicate' | 'ineligible'
+
+async function settleLateHostedCheckout(
+  admin: SupabaseClient,
+  provider: string,
+  tx: SettlementRow,
+  eventType: string,
+): Promise<LateSettlementOutcome> {
+  const { data: outcome, error } = await admin.rpc('settle_expired_checkout', {
+    _transaction_id: tx.transaction_id,
+  })
+  if (error) {
+    throw new Error(`dispatch ${eventType} late settlement failed: ${error.message}`)
+  }
+
+  if (outcome === 'revived') {
+    // The row is 'successful' now and after_transaction_update has already run
+    // enroll_user / handle_new_subscription, exactly as a normal flip would.
+    void trackSettlement(admin, provider, tx, {
+      event_type: eventType,
+      // Distinguishable in the funnel: this sale was counted as abandoned by
+      // the nightly checkout_abandoned metric before it settled.
+      late_settlement: true,
+    })
+    return 'revived'
+  }
+
+  if (outcome === 'duplicate') {
+    // The buyer paid twice — once on the expired checkout, once on the
+    // replacement that settled first. Deliberately NOT tracked as a settlement:
+    // this row stays non-revenue so `amount - refunded_amount` sums stay honest,
+    // and it must not enroll a second time. It needs a human refund, so it is
+    // loud rather than silent.
+    console.error(
+      `[webhook] ${provider} ${eventType}: duplicate settlement on expired checkout ${tx.transaction_id} — a replacement purchase already settled; this payment needs a refund`,
+    )
+    void safeAnalytics(
+      () =>
+        track(
+          ANALYTICS_EVENTS.PAYMENT_FAILED,
+          {
+            provider,
+            failure_reason: 'duplicate_settlement_after_checkout_expiry',
+            stage: 'late_settlement',
+            transaction_id: tx.transaction_id,
+            amount: Number(tx.amount ?? 0),
+            currency: tx.currency ?? 'usd',
+            is_subscription: !!tx.plan_id,
+            needs_refund: true,
+          },
+          { userId: tx.user_id, tenantId: tx.tenant_id ?? null },
+        ),
+      'duplicate settlement analytics',
+    )
+    return 'duplicate'
+  }
+
+  return 'ineligible'
+}
+
 export interface DispatchContext {
   /** Provider slug — used as the payment_provider match key. */
   provider: string
@@ -270,6 +346,47 @@ export async function dispatchBillingEvent(
             // handle_new_subscription set end_date from the plan duration; the
             // provider's schedule is authoritative, so align to renews_at.
             if (event.periodEnd) {
+              if (!event.providerEventId) {
+                throw new Error(`dispatch ${event.type}: provider event id is required for period alignment`)
+              }
+              const { error: extErr } = await admin.rpc('apply_webhook_subscription_period', {
+                _provider_event_id: event.providerEventId,
+                _provider_subscription_id: subId,
+                _provider: provider,
+                _new_period_end: event.periodEnd.toISOString(),
+                _allow_period_realign: true,
+              })
+              if (extErr) throw new Error(`dispatch ${event.type} period-align failed: ${extErr.message}`)
+            }
+            break
+          }
+
+          if (tx?.status === 'canceled') {
+            // Same late-settlement window as payment.succeeded (#624): the
+            // stale-checkout reconciler expired this subscription checkout
+            // before the provider activated it.
+            //
+            // The identity columns go on FIRST, while the row is still
+            // 'canceled'. after_transaction_update fires on every update but
+            // only acts when NEW.status = 'successful', so this write is inert
+            // — and it has to happen before the revive, because the flip is
+            // what runs handle_new_subscription, which copies
+            // provider_subscription_id and payment_provider OFF this row onto
+            // the subscription it creates. Reviving first would build the
+            // subscription with a null provider id.
+            const { error: idErr } = await admin
+              .from('transactions')
+              .update({ provider_subscription_id: subId, payment_provider: provider })
+              .eq('transaction_id', txnId)
+              .eq('status', 'canceled')
+            if (idErr) throw new Error(`dispatch ${event.type} late-settlement identity write failed: ${idErr.message}`)
+
+            // Only 'revived' created a subscription row to align. A 'duplicate'
+            // is a refund liability with no subscription behind it, so aligning
+            // a period there would rewrite the REPLACEMENT subscription's window
+            // from a payment that must not count.
+            const outcome = await settleLateHostedCheckout(admin, provider, tx, event.type)
+            if (outcome === 'revived' && event.periodEnd) {
               if (!event.providerEventId) {
                 throw new Error(`dispatch ${event.type}: provider event id is required for period alignment`)
               }
@@ -416,6 +533,11 @@ export async function dispatchBillingEvent(
         // two that dispatch this event (the PayPal capture route and the
         // webhook) emits nothing.
         void trackSettlement(admin, provider, tx, { event_type: event.type })
+      } else if (tx.status === 'canceled') {
+        // The stale-checkout reconciler may have expired this row before the
+        // provider's success landed (#624). Reviving it here is what keeps an
+        // abandoned-then-paid PayPal order from charging the buyer for nothing.
+        await settleLateHostedCheckout(admin, provider, tx, event.type)
       }
       break
     }

--- a/supabase/migrations/20260829120000_hosted_checkout_expiry.sql
+++ b/supabase/migrations/20260829120000_hosted_checkout_expiry.sql
@@ -1,0 +1,149 @@
+-- Expire abandoned hosted checkouts so a customer can retry (issue #624).
+--
+-- A hosted checkout (PayPal, Lemon Squeezy, Binance Pay) inserts a `pending`
+-- transaction and then redirects. Both partial unique indexes
+-- (transactions_unique_product / transactions_unique_plan) cover
+-- status IN ('pending','successful'), so an abandoned redirect leaves a row
+-- that blocks the buyer's replacement checkout forever. PayPal orders expire
+-- remotely with no guaranteed terminal webhook and Lemon Squeezy emits no
+-- one-time failure event for this path, so nothing clears the row today.
+--
+-- Terminal state for an abandoned checkout is 'canceled', deliberately NOT
+-- 'failed': trigger_manage_transactions runs `cancel_subscription(user, plan)`
+-- on a 'failed' plan row, so expiring an abandoned RENEWAL checkout as 'failed'
+-- would cancel the subscription the buyer is still paying for. 'canceled' is
+-- outside both unique predicates and outside every branch of that trigger.
+
+alter table public.transactions
+  add column if not exists checkout_expires_at timestamptz,
+  add column if not exists provider_checkout_id text,
+  add column if not exists expired_at timestamptz,
+  add column if not exists revived_at timestamptz,
+  add column if not exists duplicate_settlement_at timestamptz;
+
+comment on column public.transactions.checkout_expires_at is
+  'Local TTL for a hosted-checkout redirect. NULL for rails that settle in-band (Stripe Elements, Solana Pay, manual).';
+comment on column public.transactions.provider_checkout_id is
+  'Provider-side checkout/order identity captured at creation (PayPal order id, Binance prepayId). Lets the reconciler ask the provider what actually happened before expiring a row.';
+comment on column public.transactions.expired_at is
+  'Set when the reconciler expired an abandoned checkout. A non-NULL value plus status=''canceled'' is what makes a row eligible for late-settlement revival.';
+comment on column public.transactions.revived_at is
+  'Set when a provider success arrived AFTER local expiry and this row was revived to ''successful''.';
+comment on column public.transactions.duplicate_settlement_at is
+  'Set when a provider success arrived after local expiry but a REPLACEMENT purchase had already settled. The buyer paid twice; this row stays non-revenue and needs a refund.';
+
+-- One provider checkout maps to at most one local transaction. Mirrors
+-- transactions_provider_charge_id_unique: the identity, not the row, is unique.
+create unique index if not exists transactions_provider_checkout_id_unique
+  on public.transactions (payment_provider, provider_checkout_id)
+  where provider_checkout_id is not null;
+
+-- The reconciler's queue: pending rows whose local TTL has lapsed.
+create index if not exists transactions_stale_hosted_checkout
+  on public.transactions (checkout_expires_at)
+  where status = 'pending' and checkout_expires_at is not null;
+
+-- Settle a provider success that arrived after the local checkout expired.
+--
+-- The window this closes: the reconciler expires an abandoned checkout, the
+-- buyer retries, and only then does the original provider payment land. Three
+-- outcomes, decided under a row lock so a concurrent webhook cannot pick a
+-- different one:
+--
+--   'revived'    nothing else settled — this payment is the real one. Release
+--                any sibling checkout still pending (the buyer's replacement
+--                attempt is moot now, and leaving it would violate the partial
+--                unique index the moment this row goes 'successful'), then flip
+--                to 'successful' so after_transaction_update enrolls exactly
+--                once. That trigger keys off NEW.status alone, so a
+--                canceled → successful transition enrolls the same as
+--                pending → successful.
+--   'duplicate'  a REPLACEMENT purchase already settled — the buyer was charged
+--                twice. Never revive: it would double-enroll and double-count
+--                revenue. Stamp duplicate_settlement_at and leave the row
+--                non-revenue so `amount - refunded_amount` sums stay honest.
+--   'ineligible' not an expired checkout (already successful, still pending, or
+--                never expired). The caller keeps its normal status guard.
+create or replace function public.settle_expired_checkout(
+  _transaction_id bigint
+)
+returns text
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  transaction_row public.transactions%rowtype;
+  replacement_id bigint;
+begin
+  select * into transaction_row
+  from public.transactions
+  where transaction_id = _transaction_id
+  for update;
+
+  if not found then
+    return 'ineligible';
+  end if;
+
+  -- 'successful' is already settled; 'pending' is the caller's normal path.
+  -- Only a row this system expired can be revived — a refund or an admin
+  -- cancellation must never be resurrected by a replayed webhook.
+  if transaction_row.status <> 'canceled' or transaction_row.expired_at is null then
+    return 'ineligible';
+  end if;
+
+  -- Scope the sibling search the same way the partial unique indexes do:
+  -- product-shaped and plan-shaped purchases are separate namespaces.
+  select t.transaction_id into replacement_id
+  from public.transactions t
+  where t.user_id = transaction_row.user_id
+    and t.transaction_id <> transaction_row.transaction_id
+    and t.status = 'successful'
+    and (
+      (transaction_row.product_id is not null
+        and t.product_id = transaction_row.product_id
+        and t.plan_id is null)
+      or (transaction_row.plan_id is not null
+        and t.plan_id = transaction_row.plan_id
+        and t.product_id is null)
+    )
+  limit 1;
+
+  if replacement_id is not null then
+    update public.transactions
+    set duplicate_settlement_at = coalesce(duplicate_settlement_at, clock_timestamp())
+    where transaction_id = _transaction_id;
+    return 'duplicate';
+  end if;
+
+  -- Release the buyer's replacement attempt. It is still pending precisely
+  -- because it never settled, so nothing is lost and the unique index stays
+  -- satisfiable. Stamp expired_at so a late success on THAT row can revive in
+  -- turn if this one is later refunded.
+  update public.transactions t
+  set status = 'canceled',
+      expired_at = coalesce(t.expired_at, clock_timestamp())
+  where t.user_id = transaction_row.user_id
+    and t.transaction_id <> transaction_row.transaction_id
+    and t.status = 'pending'
+    and (
+      (transaction_row.product_id is not null
+        and t.product_id = transaction_row.product_id
+        and t.plan_id is null)
+      or (transaction_row.plan_id is not null
+        and t.plan_id = transaction_row.plan_id
+        and t.product_id is null)
+    );
+
+  update public.transactions
+  set status = 'successful',
+      revived_at = clock_timestamp()
+  where transaction_id = _transaction_id;
+
+  return 'revived';
+end;
+$$;
+
+revoke all on function public.settle_expired_checkout(bigint)
+  from public, anon, authenticated;
+grant execute on function public.settle_expired_checkout(bigint) to service_role;

--- a/tests/unit/checkout-expiry.test.ts
+++ b/tests/unit/checkout-expiry.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import {
+  checkoutExpiresAt,
+  isHostedCheckoutProvider,
+  checkoutTtlMinutes,
+  DEFAULT_CHECKOUT_TTL_MINUTES,
+} from '@/lib/payments/checkout-expiry'
+import { dispatchBillingEvent } from '@/lib/payments/webhook-dispatch'
+import type { NormalizedBillingEvent } from '@/lib/payments/types'
+
+/**
+ * The TTL contract and the late-settlement window it opens (issue #624).
+ *
+ * Expiring an abandoned checkout is only safe because a provider success that
+ * lands afterwards can still be settled. These two halves are tested together
+ * because the second is what makes the first defensible: without revival, this
+ * feature would take a buyer's money and give them nothing.
+ */
+
+describe('hosted checkout TTL', () => {
+  const original = process.env.CHECKOUT_TTL_MINUTES
+  afterEach(() => {
+    if (original === undefined) delete process.env.CHECKOUT_TTL_MINUTES
+    else process.env.CHECKOUT_TTL_MINUTES = original
+  })
+
+  // Gated on the capability, never the provider name: the hazard is "we
+  // redirect away and may never hear back", which is what the flag records.
+  it.each(['paypal', 'lemonsqueezy', 'binance'])('%s redirects away → gets a TTL', provider => {
+    expect(isHostedCheckoutProvider(provider)).toBe(true)
+    expect(checkoutExpiresAt(provider)).toBeTypeOf('string')
+  })
+
+  // Stripe confirms client-side with Elements, Solana Pay is polled by our own
+  // verify endpoint, manual is an offline payment request. None of them can be
+  // abandoned mid-redirect, and a TTL on them would cancel live payments.
+  it.each(['stripe', 'solana', 'solana_subs', 'manual', 'binance_personal'])(
+    '%s settles in-band → no TTL, so it never enters the reconciler queue',
+    provider => {
+      expect(isHostedCheckoutProvider(provider)).toBe(false)
+      expect(checkoutExpiresAt(provider)).toBeNull()
+    },
+  )
+
+  it('an unknown or missing provider gets no TTL', () => {
+    expect(checkoutExpiresAt(null)).toBeNull()
+    expect(checkoutExpiresAt('not-a-provider')).toBeNull()
+  })
+
+  it('defaults to 24h, matching the checkout_abandoned metric definition', () => {
+    delete process.env.CHECKOUT_TTL_MINUTES
+    expect(checkoutTtlMinutes()).toBe(DEFAULT_CHECKOUT_TTL_MINUTES)
+    const now = new Date('2026-08-29T00:00:00.000Z')
+    expect(checkoutExpiresAt('paypal', now)).toBe('2026-08-30T00:00:00.000Z')
+  })
+
+  it('honours a positive CHECKOUT_TTL_MINUTES override', () => {
+    process.env.CHECKOUT_TTL_MINUTES = '30'
+    const now = new Date('2026-08-29T00:00:00.000Z')
+    expect(checkoutExpiresAt('paypal', now)).toBe('2026-08-29T00:30:00.000Z')
+  })
+
+  // A typo'd or zeroed env var must not collapse the TTL to "already expired",
+  // which would cancel every hosted checkout on the next cron tick.
+  it.each(['0', '-5', 'soon', ''])('ignores the nonsense override %o', value => {
+    process.env.CHECKOUT_TTL_MINUTES = value
+    expect(checkoutTtlMinutes()).toBe(DEFAULT_CHECKOUT_TTL_MINUTES)
+  })
+})
+
+/** Records the writes and RPCs the dispatcher makes for one transaction row. */
+function makeFakeAdmin(tx: Record<string, unknown> | null, rpcOutcome: string | null = null) {
+  const updates: { table: string; values: Record<string, unknown> }[] = []
+  const rpc: { fn: string; args: Record<string, unknown> }[] = []
+
+  function builder(table: string) {
+    const b: Record<string, unknown> = {
+      select: () => b,
+      update(values: Record<string, unknown>) {
+        updates.push({ table, values })
+        return b
+      },
+      eq: () => b,
+      maybeSingle: () => Promise.resolve({ data: tx, error: null }),
+      then: (resolve: (v: unknown) => unknown) =>
+        Promise.resolve({ data: null, error: null }).then(resolve),
+    }
+    return b
+  }
+
+  const admin = {
+    from: (table: string) => builder(table),
+    rpc(fn: string, args: Record<string, unknown>) {
+      rpc.push({ fn, args })
+      if (fn === 'settle_expired_checkout') {
+        return Promise.resolve({ data: rpcOutcome, error: null })
+      }
+      return Promise.resolve({ data: null, error: null })
+    },
+  }
+
+  return { admin: admin as unknown as SupabaseClient, updates, rpc }
+}
+
+const OWNER = { userId: 'user-1', tenantId: 'tenant-1' }
+
+function expiredTx(over: Record<string, unknown> = {}) {
+  return {
+    transaction_id: 7,
+    status: 'canceled',
+    user_id: 'user-1',
+    tenant_id: 'tenant-1',
+    amount: 49,
+    currency: 'usd',
+    refunded_amount: 0,
+    school_percentage_snapshot: 80,
+    plan_id: null,
+    product_id: 10,
+    ...over,
+  }
+}
+
+function event(extra: Partial<NormalizedBillingEvent>): NormalizedBillingEvent {
+  return { type: 'payment.succeeded', providerEventId: 'evt-1', raw: {}, ...extra } as NormalizedBillingEvent
+}
+
+describe('late settlement after checkout expiry', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  // The core of the feature. Without this the reconciler would cancel a
+  // checkout, the buyer's PayPal payment would land an hour later, and the
+  // dispatcher's `status === 'pending'` guard would drop it: charged, no access.
+  it('revives an expired checkout when nothing else settled', async () => {
+    const { admin, rpc } = makeFakeAdmin(expiredTx(), 'revived')
+    await dispatchBillingEvent(
+      event({ reference: '7', metadata: OWNER }),
+      { provider: 'paypal', admin },
+    )
+    expect(rpc).toEqual([{ fn: 'settle_expired_checkout', args: { _transaction_id: 7 } }])
+  })
+
+  // The buyer retried and that purchase settled first — so they paid twice.
+  // Reviving would double-enroll and double-count revenue; the RPC refuses and
+  // the dispatcher must not paper over it.
+  it('does not revive when a replacement purchase already settled', async () => {
+    const { admin, updates, rpc } = makeFakeAdmin(expiredTx(), 'duplicate')
+    await dispatchBillingEvent(
+      event({ reference: '7', metadata: OWNER }),
+      { provider: 'paypal', admin },
+    )
+    expect(rpc).toHaveLength(1)
+    // The RPC owns every write in this path; the dispatcher adds none of its own.
+    expect(updates.filter(u => u.table === 'transactions')).toHaveLength(0)
+    expect(console.error).toHaveBeenCalled()
+  })
+
+  // A refunded or admin-cancelled transaction has expired_at = NULL, so the RPC
+  // returns 'ineligible' and a replayed webhook cannot resurrect it. Asserted
+  // from the dispatcher side: it still asks, and accepts the refusal.
+  it('accepts the RPC refusing a row that was never an expired checkout', async () => {
+    const { admin, updates } = makeFakeAdmin(expiredTx(), 'ineligible')
+    await dispatchBillingEvent(
+      event({ reference: '7', metadata: OWNER }),
+      { provider: 'paypal', admin },
+    )
+    expect(updates.filter(u => u.table === 'transactions')).toHaveLength(0)
+  })
+
+  it('leaves the normal pending flip untouched', async () => {
+    const { admin, updates, rpc } = makeFakeAdmin(expiredTx({ status: 'pending' }))
+    await dispatchBillingEvent(
+      event({ reference: '7', metadata: OWNER }),
+      { provider: 'paypal', admin },
+    )
+    expect(rpc.filter(r => r.fn === 'settle_expired_checkout')).toHaveLength(0)
+    expect(updates[0]).toMatchObject({ table: 'transactions', values: { status: 'successful' } })
+  })
+
+  // handle_new_subscription copies provider_subscription_id and
+  // payment_provider OFF the transaction when the flip fires its trigger.
+  // Reviving first would build the subscription row with a null provider id,
+  // leaving it unmatchable by every later renewal/cancel webhook.
+  it('writes the subscription identity BEFORE reviving, not after', async () => {
+    const { admin, updates, rpc } = makeFakeAdmin(expiredTx({ plan_id: 3, product_id: null }), 'revived')
+    await dispatchBillingEvent(
+      {
+        type: 'subscription.activated',
+        providerEventId: 'evt-2',
+        providerSubscriptionId: 'sub_ls_1',
+        reference: '7',
+        metadata: OWNER,
+        raw: {},
+      } as NormalizedBillingEvent,
+      { provider: 'lemonsqueezy', admin },
+    )
+    expect(updates[0]).toMatchObject({
+      table: 'transactions',
+      values: { provider_subscription_id: 'sub_ls_1', payment_provider: 'lemonsqueezy' },
+    })
+    expect(rpc.some(r => r.fn === 'settle_expired_checkout')).toBe(true)
+  })
+
+  // A 'duplicate' produced a refund liability, not a subscription. Aligning a
+  // period would rewrite the REPLACEMENT subscription's window from a payment
+  // that must never count.
+  it('does not align a billing period for a duplicate settlement', async () => {
+    const { admin, rpc } = makeFakeAdmin(expiredTx({ plan_id: 3, product_id: null }), 'duplicate')
+    await dispatchBillingEvent(
+      {
+        type: 'subscription.activated',
+        providerEventId: 'evt-3',
+        providerSubscriptionId: 'sub_ls_2',
+        reference: '7',
+        metadata: OWNER,
+        periodEnd: new Date('2026-09-29T00:00:00.000Z'),
+        raw: {},
+      } as NormalizedBillingEvent,
+      { provider: 'lemonsqueezy', admin },
+    )
+    expect(rpc.some(r => r.fn === 'apply_webhook_subscription_period')).toBe(false)
+  })
+
+  it('aligns the billing period after a revival', async () => {
+    const { admin, rpc } = makeFakeAdmin(expiredTx({ plan_id: 3, product_id: null }), 'revived')
+    await dispatchBillingEvent(
+      {
+        type: 'subscription.activated',
+        providerEventId: 'evt-4',
+        providerSubscriptionId: 'sub_ls_3',
+        reference: '7',
+        metadata: OWNER,
+        periodEnd: new Date('2026-09-29T00:00:00.000Z'),
+        raw: {},
+      } as NormalizedBillingEvent,
+      { provider: 'lemonsqueezy', admin },
+    )
+    expect(rpc.some(r => r.fn === 'apply_webhook_subscription_period')).toBe(true)
+  })
+
+  // The owner-binding guard (M1) must run BEFORE any revival: `reference` is a
+  // sequential id, so without it a signed event could revive — and enroll —
+  // another tenant's expired transaction by guessing the number.
+  it('refuses to revive on an owner mismatch', async () => {
+    const { admin, rpc } = makeFakeAdmin(expiredTx(), 'revived')
+    await expect(
+      dispatchBillingEvent(
+        event({ reference: '7', metadata: { userId: 'someone-else', tenantId: 'tenant-1' } }),
+        { provider: 'paypal', admin },
+      ),
+    ).rejects.toThrow(/owner mismatch/)
+    expect(rpc).toHaveLength(0)
+  })
+})

--- a/tests/unit/expire-stale-checkouts.test.ts
+++ b/tests/unit/expire-stale-checkouts.test.ts
@@ -1,0 +1,284 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { NextRequest } from 'next/server'
+
+/**
+ * The abandoned-hosted-checkout reconciler (issue #624).
+ *
+ * The bug this closes is not "a row is untidy" — it is that both purchase
+ * uniqueness indexes cover status IN ('pending','successful'), so one abandoned
+ * PayPal or Lemon Squeezy redirect blocks that buyer from ever purchasing the
+ * same item again. The cases worth pinning are therefore the ones where
+ * expiring is WRONG (an approved PayPal order still capturable, a plan checkout
+ * that would cancel a live subscription) and the one where it is right.
+ *
+ * Same in-memory-store fake as expire-platform-subscriptions.test.ts: the pass
+ * re-queries `transactions` after its own UPDATE to compute `stale_pending`, so
+ * canned per-call replies would hide whether that number reflects the write.
+ */
+
+type Row = Record<string, unknown>
+
+const db: Record<string, Row[]> = { transactions: [] }
+
+const tracked: { event: string; props: Row; ctx: Row }[] = []
+const dispatched: Row[] = []
+const paypalCalls: string[] = []
+
+let paypalOrder: { status: string; captureId?: string; reference?: string } = { status: 'CREATED' }
+let paypalGetThrows = false
+
+type Predicate = (row: Row) => boolean
+
+function makeSupabase() {
+  function builder(table: string) {
+    const preds: Predicate[] = []
+    let take = Infinity
+    let headCount = false
+    let pending: { values: Row } | null = null
+
+    const rows = () => {
+      const matched = (db[table] || []).filter(r => preds.every(p => p(r)))
+      return matched.slice(0, take === Infinity ? undefined : take)
+    }
+
+    function settle() {
+      if (headCount) return { data: null, count: rows().length, error: null }
+      if (pending) {
+        const changed = rows()
+        for (const row of changed) Object.assign(row, pending.values)
+        return { data: changed.map(r => ({ ...r })), error: null }
+      }
+      return { data: rows().map(r => ({ ...r })), error: null }
+    }
+
+    const b: Record<string, unknown> = {
+      select(_c: string, opts?: { head?: boolean; count?: string }) {
+        if (opts?.head) headCount = true
+        return b
+      },
+      update(values: Row) {
+        pending = { values }
+        return b
+      },
+      eq(col: string, val: unknown) {
+        preds.push(r => r[col] === val)
+        return b
+      },
+      in(col: string, vals: unknown[]) {
+        preds.push(r => vals.includes(r[col] as never))
+        return b
+      },
+      not(col: string, op: string, val: unknown) {
+        if (op !== 'is') throw new Error(`fake: unsupported not(${op})`)
+        preds.push(r => (val === null ? r[col] != null : r[col] !== val))
+        return b
+      },
+      lt(col: string, val: string) {
+        preds.push(r => r[col] != null && new Date(r[col] as string) < new Date(val))
+        return b
+      },
+      order() {
+        return b
+      },
+      limit(n: number) {
+        take = n
+        return b
+      },
+      then: (resolve: (v: unknown) => unknown) => Promise.resolve(settle()).then(resolve),
+    }
+    return b
+  }
+
+  return { from: (table: string) => builder(table) }
+}
+
+vi.mock('@supabase/supabase-js', () => ({ createClient: () => makeSupabase() }))
+
+vi.mock('@/lib/analytics/server', () => ({
+  track: (event: string, props: Row, ctx: Row) => {
+    tracked.push({ event, props, ctx })
+    return Promise.resolve()
+  },
+  safeAnalytics: (fn: () => Promise<unknown>) => fn(),
+}))
+
+vi.mock('@/lib/payments/webhook-dispatch', () => ({
+  dispatchBillingEvent: (event: Row) => {
+    dispatched.push(event)
+    return Promise.resolve()
+  },
+}))
+
+vi.mock('@/lib/payments', () => ({
+  getPaymentProvider: (slug: string) => {
+    if (slug !== 'paypal') throw new Error('not configured')
+    return {
+      getOrder: (orderId: string) => {
+        paypalCalls.push(`getOrder:${orderId}`)
+        if (paypalGetThrows) return Promise.reject(new Error('paypal 503'))
+        return Promise.resolve(paypalOrder)
+      },
+      captureOrder: (orderId: string) => {
+        paypalCalls.push(`captureOrder:${orderId}`)
+        return Promise.resolve({
+          captureId: 'cap_1',
+          status: 'COMPLETED',
+          reference: paypalOrder.reference,
+        })
+      },
+    }
+  },
+}))
+
+import { GET } from '@/app/api/cron/expire-stale-checkouts/route'
+
+const TENANT = '00000000-0000-0000-0000-000000000001'
+const USER = 'user-1'
+const HOUR = 60 * 60 * 1000
+
+const hoursFromNow = (h: number) => new Date(Date.now() + h * HOUR).toISOString()
+
+function req(secret = 'cron-secret'): NextRequest {
+  return {
+    headers: { get: (k: string) => (k === 'authorization' ? `Bearer ${secret}` : null) },
+  } as unknown as NextRequest
+}
+
+let nextId = 1
+function seedCheckout(over: Row = {}): Row {
+  const row: Row = {
+    transaction_id: nextId++,
+    user_id: USER,
+    tenant_id: TENANT,
+    payment_provider: 'lemonsqueezy',
+    provider_checkout_id: null,
+    amount: 49,
+    currency: 'usd',
+    plan_id: null,
+    product_id: 10,
+    status: 'pending',
+    checkout_expires_at: hoursFromNow(-1),
+    transaction_date: hoursFromNow(-25),
+    expired_at: null,
+    ...over,
+  }
+  db.transactions.push(row)
+  return row
+}
+
+beforeEach(() => {
+  db.transactions = []
+  tracked.length = 0
+  dispatched.length = 0
+  paypalCalls.length = 0
+  paypalOrder = { status: 'CREATED' }
+  paypalGetThrows = false
+  nextId = 1
+  process.env.CRON_SECRET = 'cron-secret'
+  process.env.NEXT_PUBLIC_SUPABASE_URL = 'http://localhost'
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-key'
+})
+
+describe('expire-stale-checkouts cron', () => {
+  it('rejects a request without the cron secret', async () => {
+    const res = await GET(req('wrong'))
+    expect(res.status).toBe(401)
+  })
+
+  it('expires a lapsed Lemon Squeezy checkout so the buyer can retry', async () => {
+    const row = seedCheckout()
+    const res = await GET(req())
+    expect(await res.json()).toMatchObject({ expired: 1, recovered: 0 })
+    expect(row.status).toBe('canceled')
+    expect(row.expired_at).toBeTypeOf('string')
+  })
+
+  // 'failed' would fire trigger_manage_transactions →
+  // cancel_subscription(user, plan), killing the subscription the buyer is
+  // still paying for when they abandon a RENEWAL checkout. Only 'canceled'
+  // misses every branch of that trigger.
+  it('expires to canceled, never failed — a failed plan row cancels a live subscription', async () => {
+    const row = seedCheckout({ plan_id: 5, product_id: null })
+    await GET(req())
+    expect(row.status).toBe('canceled')
+    expect(row.status).not.toBe('failed')
+  })
+
+  it('leaves a checkout whose TTL has not lapsed alone', async () => {
+    const row = seedCheckout({ checkout_expires_at: hoursFromNow(+2) })
+    const res = await GET(req())
+    expect(await res.json()).toMatchObject({ scanned: 0, expired: 0 })
+    expect(row.status).toBe('pending')
+  })
+
+  // In-band rails never write checkout_expires_at, so they can never enter the
+  // queue. A Solana Pay row is reconciled on chain by its own job; expiring it
+  // here would cancel a payment that may already be settled.
+  it('ignores in-band rails, which carry no checkout TTL at all', async () => {
+    const row = seedCheckout({ payment_provider: 'solana', checkout_expires_at: null })
+    const res = await GET(req())
+    expect(await res.json()).toMatchObject({ scanned: 0, expired: 0 })
+    expect(row.status).toBe('pending')
+  })
+
+  // The whole reason to reconcile before expiring: PayPal keeps an APPROVED
+  // order capturable for ~3 days, well past our 24h TTL. Cancelling here would
+  // throw away money the buyer already authorised.
+  it('captures an APPROVED PayPal order instead of expiring it', async () => {
+    paypalOrder = { status: 'APPROVED', reference: '1' }
+    const row = seedCheckout({ payment_provider: 'paypal', provider_checkout_id: 'ORDER-1' })
+    const res = await GET(req())
+
+    expect(paypalCalls).toEqual(['getOrder:ORDER-1', 'captureOrder:ORDER-1'])
+    expect(dispatched).toHaveLength(1)
+    expect(dispatched[0]).toMatchObject({ type: 'payment.succeeded', providerPaymentId: 'cap_1' })
+    expect(await res.json()).toMatchObject({ recovered: 1, expired: 0 })
+    expect(row.status).toBe('pending') // the dispatcher owns the flip, not this job
+  })
+
+  // A capture our own return route already made, whose dispatch died. The order
+  // is COMPLETED at PayPal and the money is taken — re-dispatch, never expire.
+  it('re-dispatches a COMPLETED PayPal order whose settlement never landed', async () => {
+    paypalOrder = { status: 'COMPLETED', captureId: 'cap_9', reference: '1' }
+    seedCheckout({ payment_provider: 'paypal', provider_checkout_id: 'ORDER-2' })
+    const res = await GET(req())
+    expect(dispatched[0]).toMatchObject({ providerPaymentId: 'cap_9' })
+    expect(await res.json()).toMatchObject({ recovered: 1, expired: 0 })
+  })
+
+  // A provider outage is not an abandonment. Expiring on a failed lookup would
+  // cancel live checkouts in a batch every time PayPal has a bad minute.
+  it('leaves the row pending when PayPal cannot be reached', async () => {
+    paypalGetThrows = true
+    const row = seedCheckout({ payment_provider: 'paypal', provider_checkout_id: 'ORDER-3' })
+    const res = await GET(req())
+    expect(await res.json()).toMatchObject({ expired: 0 })
+    expect(row.status).toBe('pending')
+  })
+
+  it('expires a PayPal order the buyer never approved', async () => {
+    paypalOrder = { status: 'VOIDED' }
+    const row = seedCheckout({ payment_provider: 'paypal', provider_checkout_id: 'ORDER-4' })
+    const res = await GET(req())
+    expect(await res.json()).toMatchObject({ expired: 1 })
+    expect(row.status).toBe('canceled')
+  })
+
+  it('emits checkout_abandoned backdated to when the checkout started', async () => {
+    const row = seedCheckout()
+    await GET(req())
+    const event = tracked.find(t => t.event === 'checkout_abandoned')
+    expect(event).toBeDefined()
+    expect(event!.props).toMatchObject({ provider: 'lemonsqueezy', transaction_id: 1, amount: 49 })
+    // Backdated, so the funnel attributes the abandonment to the attempt's day
+    // rather than the day the cron happened to notice.
+    expect(event!.ctx.timestamp).toBe(row.transaction_date)
+  })
+
+  it('reports stale_pending as the queue depth left after the pass', async () => {
+    seedCheckout()
+    seedCheckout()
+    const res = await GET(req())
+    expect(await res.json()).toMatchObject({ scanned: 2, expired: 2, stale_pending: 0 })
+  })
+})

--- a/tests/unit/unbounded-read-guard.test.ts
+++ b/tests/unit/unbounded-read-guard.test.ts
@@ -71,6 +71,8 @@ const KNOWN_UNBOUNDED: Record<string, string> = {
   'lib/hooks/use-course-access.ts::entitlements': 'scoped — one user’s entitlements',
   'lib/services/course-access.ts::entitlements': 'scoped — one user’s entitlements',
   'lib/payments/subscription-guard.ts::subscriptions': 'scoped — one user’s subscriptions',
+  'app/api/cron/expire-stale-checkouts/route.ts::transactions':
+    'scoped — the write-back `.in()` only ever carries the ids from the same pass’s own `.limit(BATCH_LIMIT)` read (200), so it cannot reach the API row cap',
 
   // scoped: one course (large, but bounded by a course roster)
   'app/[locale]/dashboard/teacher/courses/[courseId]/page.tsx::enrollments': 'scoped — one course roster',

--- a/vercel.json
+++ b/vercel.json
@@ -5,6 +5,10 @@
       "schedule": "0 0 * * *"
     },
     {
+      "path": "/api/cron/expire-stale-checkouts",
+      "schedule": "0 * * * *"
+    },
+    {
       "path": "/api/cron/daily-digest",
       "schedule": "0 * * * *"
     },


### PR DESCRIPTION
Closes #624 · epic #619

## The bug

A hosted checkout inserts a `pending` transaction and then redirects the buyer to PayPal / Lemon Squeezy / Binance Pay. Both purchase-uniqueness indexes (`transactions_unique_product`, `transactions_unique_plan`) cover `status IN ('pending','successful')` — so if the buyer closes the tab, that row **permanently blocks them from ever purchasing the same item again**. PayPal expires abandoned orders on its own side with no guaranteed terminal webhook; Lemon Squeezy emits no one-time failure event for this path. Nothing cleared the row.

## Approach

**Reconcile before expiring.** A lapsed TTL means "we stopped hearing about it", not "it failed".

- `checkout_expires_at` is written at creation for hosted rails only, gated on the `supportsHostedCheckout` capability, never on provider name — that flag *is* the hazard ("we redirect away and may never hear back"). Stripe Elements, Solana Pay and manual never get a TTL, so they can't enter the queue.
- `provider_checkout_id` stores the provider's own order identity under its own name. It can't reuse `provider_subscription_id`: for `solana_subs` that column marks the on-chain SUBSCRIBE reference, and `handle_new_subscription` copies it onto the subscription row — two meanings already.
- New hourly **`/api/cron/expire-stale-checkouts`**. For PayPal it asks `getOrder` first: `APPROVED` → capture + dispatch (PayPal stays capturable ~3 days, well past our 24h TTL, so cancelling would throw away authorised money); `COMPLETED` → re-dispatch a capture whose settlement died; a provider **outage leaves the row pending** rather than reading it as abandonment. LS and Binance have nothing queryable, so a lapsed TTL is all we'll ever know.

## Two decisions worth a reviewer's eye

**Expiry writes `canceled`, never `failed`.** `trigger_manage_transactions` runs `cancel_subscription(user, plan)` on a `failed` plan row. Expiring an abandoned *renewal* checkout as `failed` would therefore cancel the subscription the buyer is still paying for. `canceled` misses every branch of that trigger and both unique predicates.

**Late settlement is a real window, and it's the reason expiring is safe at all.** Once we cancel a checkout, the original payment can still land. Without handling, it hits the dispatcher's `status === 'pending'` guard and is silently dropped — charged, no access. New `settle_expired_checkout` RPC decides under a row lock, because the answer depends on whether a replacement purchase settled in the meantime:

| outcome | when | what happens |
|---|---|---|
| `revived` | nothing else settled | release the buyer's now-moot retry, flip to `successful` — `after_transaction_update` enrolls exactly once |
| `duplicate` | a replacement already settled | buyer paid twice. **Never** revive (would double-enroll and double-count revenue). Stamp `duplicate_settlement_at`, log loudly, leave non-revenue so `amount - refunded_amount` stays honest |
| `ineligible` | refunded / admin-cancelled / still pending | caller keeps its normal guard — a replayed webhook can't resurrect a refund |

On the subscription path the identity columns are written **before** the revive, because the flip is what runs `handle_new_subscription`, which copies `provider_subscription_id` off this row.

## Metrics

Emits `checkout_abandoned` — declared in `events.ts` as "derived, nightly" but never actually emitted until now — backdated to the attempt so the funnel attributes it to the right day, with `age_minutes` so a too-aggressive TTL shows up as a cluster at the boundary. The response also carries `stale_pending`, the queue depth *after* the pass: a number that keeps climbing means reconciliation is failing, which job-success alerting alone would never surface.

## Verification

- `npx tsc --noEmit` clean · `eslint` clean · **994 unit tests pass (77 files)**, 34 of them new.
- New coverage: TTL capability gating, env-override rejection of `0`/negative/garbage (which would otherwise collapse the TTL to "already expired" and cancel every hosted checkout on the next tick), PayPal APPROVED/COMPLETED/VOIDED/outage paths, `canceled`-not-`failed`, backdated analytics, revive/duplicate/ineligible, identity-before-revive ordering, and that the owner-binding guard still runs before any revival.
- The `unbounded-read-guard` suite flagged the write-back `.in()`; allowlisted with the reason (ids come from the same pass's own `.limit(200)` read).

## Not covered

`settle_expired_checkout` is exercised through a mocked RPC boundary, not against a real Postgres — Docker wasn't running locally, and I didn't want to `db:reset` your local stack unasked. The SQL logic itself is unverified. Worth a `supabase db reset` + a manual revive/duplicate run before merging, or I can do it if you start Docker.

**After merge:** apply `20260829120000_hosted_checkout_expiry.sql` to cloud — this repo has a repeated history of migrations sitting local-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KquGPjUVeVY6X1ibSN59Nw