### PR TITLE
fix(build): pin stripe exactly and match its apiVersion literal

### DIFF
--- a/lib/payments/stripe-provider.ts
+++ b/lib/payments/stripe-provider.ts
@@ -62,7 +62,13 @@ export class StripePaymentProvider implements IPaymentProvider {
 
   constructor(apiKey: string, webhookSecret?: string) {
     this.stripe = new Stripe(apiKey, {
-      apiVersion: '2026-07-29.dahlia',
+      // Must equal the SDK's own pinned ApiVersion exactly — stripe-node types
+      // this field as a single string literal, so any other value is a type
+      // error. It moves on a MINOR bump (22.5.0 → 22.6.0 shifted it from
+      // 2026-07-29 to 2026-08-26), and the production image installs without a
+      // lockfile (Dockerfile:18), so `stripe` is pinned exactly in package.json
+      // to stop a floating minor from breaking the build. Bump both together.
+      apiVersion: '2026-08-26.dahlia',
     })
     this.webhookSecret = webhookSecret
   }

--- a/lib/stripe.ts
+++ b/lib/stripe.ts
@@ -10,7 +10,13 @@ export function getStripe(): Stripe {
       throw new Error('STRIPE_SECRET_KEY is not set in environment variables')
     }
     _stripe = new Stripe(secretKey, {
-      apiVersion: '2026-07-29.dahlia',
+      // Must equal the SDK's own pinned ApiVersion exactly — stripe-node types
+      // this field as a single string literal, so any other value is a type
+      // error. It moves on a MINOR bump (22.5.0 → 22.6.0 shifted it from
+      // 2026-07-29 to 2026-08-26), and the production image installs without a
+      // lockfile (Dockerfile:18), so `stripe` is pinned exactly in package.json
+      // to stop a floating minor from breaking the build. Bump both together.
+      apiVersion: '2026-08-26.dahlia',
     })
   }
   return _stripe

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,7 +95,7 @@
         "shiki": "^3.23.0",
         "sonner": "^2.0.7",
         "streamdown": "^2.5.0",
-        "stripe": "^22.4.0",
+        "stripe": "22.6.0",
         "tailwind-merge": "^3.6.0",
         "tokenlens": "^1.3.1",
         "tw-animate-css": "^1.4.0",
@@ -22009,9 +22009,9 @@
       }
     },
     "node_modules/stripe": {
-      "version": "22.4.0",
-      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.4.0.tgz",
-      "integrity": "sha512-LVJ+tcSYeqOSnXr3i+Kz2tZ7y0crLLdP2uwD/4wccrmEVyn0g/Heo0pF7as7rxS/sOjJzrb1lxgZY0Y0Dx1pSA==",
+      "version": "22.6.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.6.0.tgz",
+      "integrity": "sha512-Ezk+WYEEwX2DLxFrKfb6coznlCMZvCaCYMNPXNHFSZkBIEzF5Hgm7RLb38q/0h9Ol5jsUJGJRorvhzAvckgfhw==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "shiki": "^3.23.0",
     "sonner": "^2.0.7",
     "streamdown": "^2.5.0",
-    "stripe": "^22.4.0",
+    "stripe": "22.6.0",
     "tailwind-merge": "^3.6.0",
     "tokenlens": "^1.3.1",
     "tw-animate-css": "^1.4.0",


### PR DESCRIPTION
## Production has not deployed since 2026-08-23

Every `Build and deploy to Dokploy` run today failed — including all four merges (#630, #592, #636, #637). None of that work is live.

```
./lib/payments/stripe-provider.ts:65:7
Type error: Type '"2026-07-29.dahlia"' is not assignable to type '"2026-08-26.dahlia"'.
```

## Why CI stayed green

`stripe-node` types `apiVersion` as a **single string literal** equal to the SDK's own pinned `ApiVersion`, and that literal moves on a **minor** bump:

| stripe | `ApiVersion` |
|---|---|
| 22.4.0 | `2026-07-29.dahlia` |
| 22.5.0 | `2026-07-29.dahlia` |
| **22.6.0** | **`2026-08-26.dahlia`** |

CI installs from `package-lock.json`, which pins 22.4.0 — so it compiles fine. The production image does not:

```dockerfile
# Dockerfile:18
RUN rm -f package-lock.json && npm install --include=optional --legacy-peer-deps
```

That line is deliberate (npm skips optional native deps for lightningcss/Tailwind v4 when a lockfile is present), but it means **every caret range floats at image-build time**. `^22.4.0` resolved to 22.6.0 and the build broke, invisibly to CI. Any dependency can do this; stripe is just the one that did.

## Fix

Pin `stripe` **exactly**, the way `next`, `react` and `react-dom` already are for the same reason, and move both `apiVersion` literals to match. A comment at each call site records that the two move together and why.

I did not touch `Dockerfile:18` — removing the lockfile is load-bearing for the native-binary resolution, and swapping it for `npm ci --include=optional` deserves its own change with a real image build behind it. Worth doing: exact-pinning stripe closes this recurrence, not the class.

## Verified

Ran the command that was actually failing, not a proxy for it:

- `npm run build` — **completes**
- `tsc --noEmit` — clean
- 994 unit tests / 77 files — pass, against 22.6.0 installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KquGPjUVeVY6X1ibSN59Nw