### PR TITLE
ci: build the production image on every PR, and stop the Dockerfile floating deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,38 @@ jobs:
         run: npm run typecheck
       - name: Unit tests
         run: npm run test:unit
+
+  # The production image, built exactly as deploy.yml builds it — but never
+  # pushed. `verify` above cannot catch a broken deploy: it installs from
+  # package-lock.json on the runner, while the image builds from the Dockerfile
+  # in a Linux container. When those two disagreed, master stayed green through
+  # six days of failed deploys (stripe floated to a minor whose types demand a
+  # different apiVersion literal, #638). This job is the check that would have
+  # caught it on the PR.
+  #
+  # Same build-args as deploy.yml so the Next.js build inlines the same
+  # NEXT_PUBLIC_* values and exercises the same code paths. Repo `vars` are
+  # readable from pull_request runs; SENTRY_AUTH_TOKEN is a secret and resolves
+  # empty here, which only skips source-map upload.
+  image:
+    name: Production image builds
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Build production image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          # Layer cache keyed to this workflow, so an unchanged package-lock.json
+          # reuses the install layer and only the source layers rebuild.
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            NEXT_PUBLIC_SUPABASE_URL=${{ vars.NEXT_PUBLIC_SUPABASE_URL }}
+            NEXT_PUBLIC_SUPABASE_PUBLISHABLE_OR_ANON_KEY=${{ vars.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_OR_ANON_KEY }}
+            NEXT_PUBLIC_PLATFORM_DOMAIN=${{ vars.NEXT_PUBLIC_PLATFORM_DOMAIN }}
+            NEXT_PUBLIC_APP_URL=${{ vars.NEXT_PUBLIC_APP_URL }}
+            NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=${{ vars.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY }}
+            NEXT_PUBLIC_SENTRY_DSN=${{ vars.NEXT_PUBLIC_SENTRY_DSN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,27 @@ COPY package.json package-lock.json ./
 # Workspace package manifests must exist at install time so npm links
 # @lms/core into node_modules (source-only package via transpilePackages).
 COPY packages/core/package.json ./packages/core/package.json
-# Remove the lockfile so npm freshly resolves platform-specific optional
-# native binaries (lightningcss/Tailwind v4) for this Linux image — npm has a
-# long-standing bug that skips optional native deps when a lockfile is present.
-RUN rm -f package-lock.json && npm install --include=optional --legacy-peer-deps
+# `npm ci`, NOT `npm install` with the lockfile deleted.
+#
+# This used to be `rm -f package-lock.json && npm install`, to work around an
+# old npm bug that skipped platform-specific optional native deps
+# (lightningcss / Tailwind v4 oxide / sharp) when a lockfile was present. That
+# workaround cost six days of production deploys: discarding the lockfile makes
+# every caret range re-resolve at image-build time, so a dependency's new MINOR
+# lands in production without any commit and without CI ever seeing it. stripe
+# 22.6.0 did exactly that — it moved the `apiVersion` literal its own types
+# demand, and `npm run build` failed here while master stayed green.
+#
+# The workaround is also no longer needed: this is a lockfileVersion 3 lockfile,
+# which records EVERY platform variant regardless of where it was generated
+# (`lightningcss-linux-x64-gnu`, `@tailwindcss/oxide-linux-x64-gnu`, the sharp
+# linux set are all in there), and npm installs the ones matching os/cpu.
+# `--include=optional` is kept explicit so a future `--omit=optional` default
+# cannot quietly strip them again.
+#
+# The image build now runs in CI too (.github/workflows/ci.yml), so a break here
+# fails the PR rather than the deploy.
+RUN npm ci --include=optional --legacy-peer-deps
 
 # Build
 FROM base AS builder


### PR DESCRIPTION
Follow-up to #638, which fixed the symptom. This fixes the class.

## What actually happened

`npm run build` broke inside the Docker image on 2026-08-23 and stayed broken for **six days**. Master was green throughout. Dokploy recorded no failure — `deploy.yml` dies at the build step, *before* it calls the deploy webhook, so Dokploy simply was never asked. It surfaced only because the MCP service looked red for an unrelated reason.

Four merged PRs (#630, #592, #636, #637) sat undeployed, and the `CRON_SECRET` added to Dokploy couldn't take effect, because env only applies on redeploy.

## Cause

```dockerfile
# Dockerfile:18, before
RUN rm -f package-lock.json && npm install --include=optional --legacy-peer-deps
```

Deleting the lockfile makes **every caret range re-resolve at image-build time**. A dependency's new minor lands in production with no commit behind it and no check capable of seeing it. `stripe@^22.4.0` floated to 22.6.0, which moved the `apiVersion` string literal its own types demand, and the build failed.

CI structurally could not catch this: `verify` installs from `package-lock.json` on the runner; the image did not.

## Fix — both halves

**1. `npm ci --include=optional`.** The workaround it replaces is obsolete. The comment cited an old npm bug that skipped optional native deps when a lockfile was present — but this is a **lockfileVersion 3** lockfile, which records every platform variant regardless of the machine that generated it. Verified present:

```
lightningcss-linux-x64-gnu          os=['linux'] cpu=['x64'] optional=True
@tailwindcss/oxide-linux-x64-gnu    os=['linux'] cpu=['x64'] optional=True
@img/sharp-linux-x64                os=['linux'] cpu=['x64'] optional=True
```

npm installs the ones matching `os`/`cpu`, so the Linux image gets its native binaries from the lockfile. `--include=optional` stays explicit so a future default change can't strip them silently.

**2. CI builds the production image on every PR.** Pinning stripe closed one recurrence; this closes the class. Same `build-args` as `deploy.yml` so the Next.js build inlines the same `NEXT_PUBLIC_*` values and exercises the same paths, `push: false`, GHA layer cache so an unchanged lockfile reuses the install layer.

## The proof is this PR's own CI

I can't build the image locally — Docker isn't running on this machine — and given how we got here, "it should work" is not good enough. **The `Production image builds` check on this PR is the verification.** If `npm ci` fails to produce working native binaries, that job fails and this PR does not merge. Please don't merge on green `verify` alone; the new job is the one that matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KquGPjUVeVY6X1ibSN59Nw