### PR TITLE
fix(sentry): actually upload source maps, and stop the upload being silent

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,6 +50,7 @@ jobs:
             NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=${{ vars.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY }}
             NEXT_PUBLIC_SENTRY_DSN=${{ vars.NEXT_PUBLIC_SENTRY_DSN }}
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
+            SENTRY_RELEASE=${{ github.sha }}
 
       - name: Trigger Dokploy deployment
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,19 @@ ARG NEXT_PUBLIC_SENTRY_DSN
 # reaches the `runner` stage, so it is not present in the shipped image.
 ARG SENTRY_AUTH_TOKEN
 
+# The release name the uploaded source maps are keyed to. It has to be passed
+# in: `.dockerignore` excludes `.git`, so the Sentry plugin cannot infer a
+# release from the repo the way it does on a dev machine, and without one the
+# upload is skipped. deploy.yml passes github.sha.
+ARG SENTRY_RELEASE
+
+# next.config.ts sets `silent: !process.env.CI`, and CI is a GitHub Actions
+# runner variable that does NOT cross into this container — so the plugin ran
+# completely silently here and a skipped upload looked identical to a
+# successful one. Set it so the upload (or its failure) shows up in the build
+# log.
+ENV CI=true
+
 ENV NEXT_PUBLIC_SUPABASE_URL=$NEXT_PUBLIC_SUPABASE_URL
 ENV NEXT_PUBLIC_SUPABASE_PUBLISHABLE_OR_ANON_KEY=$NEXT_PUBLIC_SUPABASE_PUBLISHABLE_OR_ANON_KEY
 ENV NEXT_PUBLIC_PLATFORM_DOMAIN=$NEXT_PUBLIC_PLATFORM_DOMAIN
@@ -62,6 +75,7 @@ ENV NEXT_PUBLIC_APP_URL=$NEXT_PUBLIC_APP_URL
 ENV NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=$NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY
 ENV NEXT_PUBLIC_SENTRY_DSN=$NEXT_PUBLIC_SENTRY_DSN
 ENV SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN
+ENV SENTRY_RELEASE=$SENTRY_RELEASE
 
 RUN npm run build
 


### PR DESCRIPTION
Follow-up: setting `SENTRY_AUTH_TOKEN` was necessary but **not sufficient**.

I re-ran the deploy with the token in place. Still no upload — Sentry's newest artifact bundle for `lms-front` is **2026-08-22**, and every entry that endpoint returns is a release the SDK auto-created from an incoming event (`fileCount: -1`), not an upload. No source map has ever reached Sentry.

## Two causes, and the second is why the first went unnoticed

**1. No release name inside the image.** `.dockerignore` excludes `.git`, so the Sentry plugin can't infer a release from the repo the way it does on a dev machine — and without one it skips the upload. `deploy.yml` now passes `SENTRY_RELEASE=${{ github.sha }}`, and the builder stage takes the matching `ARG`/`ENV`.

**2. The upload was silent.** `next.config.ts` has:

```ts
silent: !process.env.CI,   // "Only print logs for uploading source maps in CI"
```

`CI` is a GitHub Actions **runner** variable. It does not cross into the build container. So `silent` was `true` for every production build ever made, and a skipped upload looked identical to a successful one. Setting `ENV CI=true` in the builder stage makes the upload — or its failure — visible.

## How this gets verified

Not by a green run; a green run is exactly what we already had. After merge I'll check both:
- the deploy log now prints the plugin's upload output
- Sentry's artifact-bundle list has an entry for this commit

If it still doesn't upload, the log will finally say why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KquGPjUVeVY6X1ibSN59Nw