### PR TITLE
fix(sentry): give sentry-cli the org/project it needs, and log why it fails

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,19 @@ ARG SENTRY_RELEASE
 # log.
 ENV CI=true
 
+# sentry-cli reported only "failed with exit code 1" for both `releases new`
+# and `sourcemaps upload`, and told us to set this to see why. Keep it: the
+# upload runs once per deploy, so the extra output costs nothing and is the
+# difference between a diagnosable failure and a silent one.
+ENV SENTRY_LOG_LEVEL=debug
+
+# The plugin passes -p to `sourcemaps upload` but NOT to `releases new`, which
+# leaves the org/project for that call to come from the environment. An org
+# auth token embeds the org, but nothing supplies the project — so state both
+# explicitly rather than relying on which sub-command infers what.
+ENV SENTRY_ORG=guillermoscript
+ENV SENTRY_PROJECT=lms-front
+
 ENV NEXT_PUBLIC_SUPABASE_URL=$NEXT_PUBLIC_SUPABASE_URL
 ENV NEXT_PUBLIC_SUPABASE_PUBLISHABLE_OR_ANON_KEY=$NEXT_PUBLIC_SUPABASE_PUBLISHABLE_OR_ANON_KEY
 ENV NEXT_PUBLIC_PLATFORM_DOMAIN=$NEXT_PUBLIC_PLATFORM_DOMAIN


### PR DESCRIPTION
#640 made the upload visible. It is failing:

```
[@sentry/nextjs - After Production Compile] Error: Command failed:
  sentry-cli ... releases new 02b63b1b91577d4a5f65d9c175b37bb66f9649c6
Add --log-level=[info|debug] or export SENTRY_LOG_LEVEL=[info|debug] to see more output.

[@sentry/nextjs - After Production Compile] Error: Command
  ... sourcemaps upload -p lms-front --release 02b63b1b... --rewrite
failed with exit code 1
```

So the release name from #640 is reaching the CLI correctly — and the CLI is rejecting the call for a reason it will not print by default.

## Two changes

**`SENTRY_LOG_LEVEL=debug`** — diagnostic. "Exit code 1" with no message is precisely what the CLI tells us to fix before reporting anything. It runs once per deploy, so the output costs nothing and turns a silent failure into a diagnosable one permanently.

**`SENTRY_ORG` / `SENTRY_PROJECT` explicitly** — the likely cause. Note the asymmetry in the two commands above: the plugin passes `-p lms-front` to `sourcemaps upload`, but `releases new` gets **no `-o` and no `-p`** — it resolves org and project from the environment. An org auth token (`sntrys_`) embeds the org, but nothing in this container supplies the project, and the create-release API requires one.

## Honesty about confidence

The second change is a hypothesis, not a diagnosis — I could not confirm it directly. I tried probing the token's write scope against the Sentry API, and the permission classifier blocked the call; I did not work around it, since it is a mutating request to an external service.

If the hypothesis is wrong, the debug output will now say what is actually wrong, and the next fix will be based on a message instead of a guess.

I will verify against Sentry's artifact-bundle list, not a green run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KquGPjUVeVY6X1ibSN59Nw