### PR TITLE
fix(sentry): install ca-certificates in the builder so source maps can upload

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,14 @@ RUN npm ci --include=optional --legacy-peer-deps
 # Build
 FROM base AS builder
 WORKDIR /app
+# sentry-cli is a static Rust binary with its own TLS stack, so it reads the OS
+# CA bundle — unlike Node, which bundles its own and therefore made npm work
+# here while every sentry-cli call failed with
+#   [60] SSL certificate problem: unable to get local issuer certificate
+# The `deps` stage installs system packages; this stage never did, so the source
+# map upload has failed on every build this image has ever produced.
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 ENV NEXT_TELEMETRY_DISABLED=1
@@ -74,10 +82,10 @@ ENV CI=true
 # difference between a diagnosable failure and a silent one.
 ENV SENTRY_LOG_LEVEL=debug
 
-# The plugin passes -p to `sourcemaps upload` but NOT to `releases new`, which
-# leaves the org/project for that call to come from the environment. An org
-# auth token embeds the org, but nothing supplies the project — so state both
-# explicitly rather than relying on which sub-command infers what.
+# Explicit rather than inferred. Note these were NOT the cause of the upload
+# failing — the debug log showed `releases new` already sending
+# {"projects":["lms-front"]} — but stating them costs nothing and removes a
+# variable from the next investigation.
 ENV SENTRY_ORG=guillermoscript
 ENV SENTRY_PROJECT=lms-front
 


### PR DESCRIPTION
The debug logging from #641 found the cause. It was **not** the org/project hypothesis that shipped alongside it.

```
error: API request failed
Caused by:
  0: API request failed
  1: [60] SSL peer certificate or SSH remote key was not OK
     (SSL certificate problem: unable to get local issuer certificate)
```

`sentry-cli` is a static Rust binary with its own TLS stack, so it reads the **OS** CA bundle. Node bundles its own — which is exactly why `npm install` worked fine in this stage while every `sentry-cli` call failed. The `deps` stage installs system packages; `builder` never did.

So the source-map upload has failed on **every image this Dockerfile has ever produced**. Silent until #640, and without a reason until #641.

## Also corrected

The debug log shows `releases new` was already sending `{"projects":["lms-front"]}`, so #641's `SENTRY_ORG`/`SENTRY_PROJECT` were never the problem. I've kept them as explicit config but rewritten the comment so it doesn't read as the fix — it wasn't.

## Sequence, for the record

| PR | intent | outcome |
|---|---|---|
| — | set `SENTRY_AUTH_TOKEN` | necessary, not sufficient |
| #640 | pass `SENTRY_RELEASE`, un-silence the plugin | made the failure **visible** |
| #641 | debug logging + org/project guess | logging found it; the guess was wrong |
| **#642** | install `ca-certificates` | the actual cause |

Three of those four steps were wrong about the cause. The one that mattered was making the thing observable — and both diagnostics (`ENV CI=true`, `SENTRY_LOG_LEVEL=debug`) stay in the image permanently, so the next failure here reports itself.

## Verification

Not a green run. After merge I'll check Sentry's artifact-bundle list for an entry at this commit, which is the only evidence that means anything here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KquGPjUVeVY6X1ibSN59Nw