### PR TITLE
refactor(lesson): flip the flashcard with one face instead of two

### DIFF
--- a/components/lesson/flashcard-set.tsx
+++ b/components/lesson/flashcard-set.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef, useSyncExternalStore } from 'react'
 import { cn } from '@/lib/utils'
 import { IconChevronLeft, IconChevronRight } from '@tabler/icons-react'
 
@@ -9,20 +9,51 @@ interface FlashcardSetProps {
   className?: string
 }
 
+const HALF_FLIP_MS = 220
+
+const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)'
+
+function subscribeToReducedMotion(onChange: () => void) {
+  const query = window.matchMedia(REDUCED_MOTION_QUERY)
+  query.addEventListener('change', onChange)
+  return () => query.removeEventListener('change', onChange)
+}
+
+const serverFalse = () => false
+
 export function FlashcardSet({ cards, className }: FlashcardSetProps) {
   const [currentIndex, setCurrentIndex] = useState(0)
   const [flipped, setFlipped] = useState(false)
-  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false)
+  const prefersReducedMotion = useSyncExternalStore(
+    subscribeToReducedMotion,
+    () => window.matchMedia(REDUCED_MOTION_QUERY).matches,
+    serverFalse
+  )
+  // Mid-flip: the card is edge-on (rotateY(90deg)) and swaps its text there.
+  const [edgeOn, setEdgeOn] = useState(false)
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  useEffect(() => {
-    const mq = window.matchMedia('(prefers-reduced-motion: reduce)')
-    setPrefersReducedMotion(mq.matches)
-    const handler = (e: MediaQueryListEvent) => setPrefersReducedMotion(e.matches)
-    mq.addEventListener('change', handler)
-    return () => mq.removeEventListener('change', handler)
-  }, [])
+  useEffect(() => () => { if (timer.current) clearTimeout(timer.current) }, [])
+
+  // Only ever one face in the DOM: a two-faced 3D flip breaks (both texts
+  // overlap, or the card vanishes) whenever an ancestor flattens the 3D
+  // context — overflow/filter/transform on the lesson shell all do that.
+  const flip = () => {
+    if (prefersReducedMotion) {
+      setFlipped((f) => !f)
+      return
+    }
+    if (edgeOn) return
+    setEdgeOn(true)
+    timer.current = setTimeout(() => {
+      setFlipped((f) => !f)
+      setEdgeOn(false)
+    }, HALF_FLIP_MS)
+  }
 
   const goTo = (index: number) => {
+    if (timer.current) clearTimeout(timer.current)
+    setEdgeOn(false)
     setFlipped(false)
     setCurrentIndex(index)
   }
@@ -34,46 +65,27 @@ export function FlashcardSet({ cards, className }: FlashcardSetProps) {
     <div className={cn('my-6', className)}>
       {/* Card */}
       <div
-        onClick={() => setFlipped((f) => !f)}
-        onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setFlipped((f) => !f) } }}
+        onClick={flip}
+        onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); flip() } }}
         role="button"
         tabIndex={0}
         aria-label={flipped ? 'Mostrando reverso. Clic para voltear.' : 'Mostrando frente. Clic para voltear.'}
-        className="relative mx-auto h-48 w-full max-w-md cursor-pointer select-none"
+        className="mx-auto h-48 w-full max-w-md cursor-pointer select-none"
         style={prefersReducedMotion ? undefined : { perspective: '1000px' }}
       >
         <div
-          className="relative h-full w-full"
+          className={cn(
+            'flex h-full items-center justify-center overflow-y-auto rounded-xl border p-6 shadow-sm',
+            flipped ? 'border-primary/30 bg-muted' : 'bg-card'
+          )}
           style={prefersReducedMotion ? undefined : {
-            transformStyle: 'preserve-3d',
-            transition: 'transform 0.5s',
-            transform: flipped ? 'rotateY(180deg)' : 'rotateY(0deg)',
+            transition: `transform ${HALF_FLIP_MS}ms ${edgeOn ? 'ease-in' : 'ease-out'}`,
+            transform: edgeOn ? 'rotateY(90deg)' : 'rotateY(0deg)',
           }}
         >
-          {prefersReducedMotion ? (
-            <div className="flex h-full items-center justify-center rounded-xl border bg-card p-6 shadow-sm">
-              <p className="text-center text-sm font-medium">
-                {flipped ? card.back : card.front}
-              </p>
-            </div>
-          ) : (
-            <>
-              {/* Front */}
-              <div
-                className="absolute inset-0 flex items-center justify-center rounded-xl border bg-card p-6 shadow-sm"
-                style={{ backfaceVisibility: 'hidden' }}
-              >
-                <p className="text-center text-sm font-medium">{card.front}</p>
-              </div>
-              {/* Back */}
-              <div
-                className="absolute inset-0 flex items-center justify-center rounded-xl border bg-primary/5 p-6 shadow-sm"
-                style={{ backfaceVisibility: 'hidden', transform: 'rotateY(180deg)' }}
-              >
-                <p className="text-center text-sm font-medium">{card.back}</p>
-              </div>
-            </>
-          )}
+          <p className="text-center text-sm font-medium">
+            {flipped ? card.back : card.front}
+          </p>
         </div>
       </div>
 


### PR DESCRIPTION
## What

Rewrites `FlashcardSet`'s flip so only one face is ever in the DOM. Instead of stacking a front and a back and spinning the wrapper 180° behind `preserve-3d` + `backface-visibility: hidden`, the card rotates to `rotateY(90deg)` (edge-on, nothing legible), swaps its text there, and rotates back.

Closes #

## Why

**Read this before approving — the change is honest but its original premise is not verified.**

This change was sitting uncommitted in my working tree, written to fix a reported symptom: the two faces overlapping, or the card blanking out, when an ancestor flattens the 3D context. I could not reproduce that symptom:

- An isolated harness with the old markup under a flattening ancestor (`overflow-y: auto` + `filter`) renders correctly in **both Chromium 1234 and WebKit 26.5**.
- The lesson shell that actually renders this component — the `<article className="prose …">` in `lesson-content.tsx` — has no `overflow`, `filter` or `transform` of its own, so there is no flattening ancestor in the real page either.

So I am **not** claiming this fixes a rendering bug. What it does stand on:

- It is simpler — one face, one element, no dependency on the 3D context surviving whatever wraps the MDX.
- The timer is cleared on unmount and on card navigation, so a flip in flight cannot rewrite the card you just moved to, and a repeat click is ignored mid-flip.
- Reading `prefers-reduced-motion` moves to the `useSyncExternalStore` pattern `feedback-button.tsx` already uses. The old setState-in-effect trips `react-hooks/set-state-in-effect`, which the pre-commit hook enforces — the file could not be committed without this.

The trade-off: the animation is no longer a true 180° spin, it is a half-flip with a text swap at the midpoint. Visually close, not identical.

**Draft** until someone confirms the original symptom is real. If it was never real, the honest options are to close this or land it purely as the lint + timer cleanup.

## How to QA

The local Supabase stack was down (Docker daemon not running) when I wrote this, so I could not capture the component in the running app. No lesson in `supabase/seed.sql` uses a `<FlashcardSet>` block, so QA needs one authored first:

1. `npm run db:reset && npm run dev`.
2. As a teacher, add a `<FlashcardSet cards={[{front:"…",back:"…"},{front:"…",back:"…"}]} />` block to any lesson's MDX.
3. As `student@e2etest.com` / `password123` on `default.lvh.me:3000`, open the lesson.
4. Click the card — it should turn edge-on, swap text, and turn back. Click again to return.
5. Flip, then immediately hit the next/prev arrow: the new card must show its **front**, not the previous card's back.
6. Enable Reduce Motion in System Settings and reload: the swap should be instant, with no rotation.
7. Repeat in Safari — that is the browser the 3D-flattening concern was about.

## Screenshots / GIF

Not included on purpose. I have an isolated before/after harness, but since it does not reproduce the failure it would be misleading to present it as proof. Real in-app capture is pending a working local stack.

## Checklist

- [x] `npm run typecheck` and `npm run test:unit` pass
- [x] `npm run build` passes
- [x] Every new tenant-scoped query filters by `tenant_id` (or the table genuinely has no such column) — no queries touched
- [ ] Tested with every relevant role (student / teacher / admin) — **not done, local stack down**
- [x] Loading and error states handled — n/a, component renders `null` with no cards
- [x] New UI strings added to both `messages/en.json` and `messages/es.json` — none added (the two `aria-label`s are pre-existing hardcoded Spanish, untouched)
- [x] Migration (if any) applies cleanly on `npm run db:reset` — no migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZmStQ3YnZMQkr2sp2FeGr