### PR TITLE
fix(rls): authorise teacher reads of completions through tenant_users

### DIFF
--- a/supabase/migrations/20260830120000_completion_rls_tenant_users.sql
+++ b/supabase/migrations/20260830120000_completion_rls_tenant_users.sql
@@ -1,0 +1,66 @@
+-- Teacher/admin reads of lesson_completions and exercise_completions must be
+-- authorised by tenant_users, not by the global user_roles table (#649).
+--
+-- WHY
+--   The Students tab (#647) showed 0 % / "No activity yet" for every student
+--   of a production course that had 8 lesson completions. The teacher-facing
+--   SELECT policy on lesson_completions was
+--
+--     EXISTS (SELECT 1 FROM user_roles WHERE user_id = auth.uid()
+--                                        AND role IN ('teacher','admin'))
+--
+--   `user_roles` is the GLOBAL role — the course author is a tenant admin in
+--   `tenant_users` (the authoritative table, see CLAUDE.md) but 'student' in
+--   `user_roles`, so the policy matched nothing and RLS returned zero rows
+--   without an error. Nothing upstream could tell "no rows" from "no access".
+--
+--   exercise_completions had the opposite defect: `get_tenant_role() IN
+--   ('teacher','admin')` with no tenant predicate at all, so any teacher in
+--   any tenant could read every school's completions (the table has no
+--   tenant_id, so the check has to go through exercises.tenant_id).
+--
+-- WHAT
+--   Both teacher policies now resolve the row's tenant through its parent
+--   (lessons.tenant_id / exercises.tenant_id) and require an ACTIVE
+--   teacher/admin membership in that tenant — the same shape
+--   `teachers_view_tenant_evaluations` and
+--   `lesson_checkpoint_attempts_teachers_read_tenant` already use, which is
+--   why the analytics page worked while this tab did not.
+--
+--   Student self-access policies are untouched.
+
+DROP POLICY IF EXISTS "Teachers and admins view all completions" ON public.lesson_completions;
+
+CREATE POLICY "Teachers and admins view tenant completions"
+  ON public.lesson_completions FOR SELECT TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.lessons l
+      JOIN public.tenant_users tu ON tu.tenant_id = l.tenant_id
+      WHERE l.id = lesson_completions.lesson_id
+        AND tu.user_id = (SELECT auth.uid())
+        AND tu.role IN ('teacher', 'admin')
+        AND tu.status = 'active'
+    )
+  );
+
+DROP POLICY IF EXISTS "Teachers and admins can view all exercise completions" ON public.exercise_completions;
+
+CREATE POLICY "Teachers and admins view tenant exercise completions"
+  ON public.exercise_completions FOR SELECT TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.exercises x
+      JOIN public.tenant_users tu ON tu.tenant_id = x.tenant_id
+      WHERE x.id = exercise_completions.exercise_id
+        AND tu.user_id = (SELECT auth.uid())
+        AND tu.role IN ('teacher', 'admin')
+        AND tu.status = 'active'
+    )
+  );
+
+-- The policy subqueries hit these on every row.
+CREATE INDEX IF NOT EXISTS idx_lesson_completions_lesson_id ON public.lesson_completions (lesson_id);
+CREATE INDEX IF NOT EXISTS idx_exercise_completions_exercise_id ON public.exercise_completions (exercise_id);


### PR DESCRIPTION
## What

Rewrites the teacher/admin SELECT policies on `lesson_completions` and `exercise_completions` to authorise through an active `tenant_users` membership in the row's tenant (resolved via the parent lesson / exercise), instead of the global `user_roles` table / an unscoped `get_tenant_role()` check. Adds supporting indexes on `lesson_id` / `exercise_id`.

Closes #649

## Why

Production: `test-school` course 7 has 8 lesson completions, yet the new Students tab (#647) showed every student at 0 % / "No activity yet". The author is `admin` in `tenant_users` but `student` in `user_roles`, so the old policy matched nothing and RLS returned zero rows silently. Same class of bug the confusion-hotspots page avoided by using `tenant_users`-shaped policies. `exercise_completions` additionally let staff of any tenant read every tenant's completions.

## How to QA

1. `npm run db:reset` (applies the migration).
2. As `creator@codeacademy.com` open `/en/dashboard/teacher/courses/2001` → Students: completions render (after some student activity).
3. RLS proof without the UI — in `psql` against local:
   ```sql
   begin; set local role authenticated;
   select set_config('request.jwt.claims','{"sub":"a1000000-0000-0000-0000-000000000003","role":"authenticated","tenant_id":"00000000-0000-0000-0000-000000000002","tenant_role":"admin"}',true);
   select count(*) from lesson_completions;  -- only Code Academy rows
   rollback;
   ```
   Repeat with `owner@e2etest.com` (`…0002`, tenant `…0001`) → 0 rows for Code Academy lessons; with `alice` → own rows only.
4. Cloud: apply the same migration (`supabase/migrations/20260830120000_completion_rls_tenant_users.sql`), then reload `test-school.preciopana.com/en/dashboard/teacher/courses/7` → Students shows real progress.

## Screenshots / GIF

DB-only change; no UI diff. Before/after evidence is the production Students tab going from all-zero to real progress once applied.

## Checklist

- [x] `npm run typecheck` and `npm run test:unit` pass (no TS change)
- [x] `npm run build` passes (no code change)
- [x] Every new tenant-scoped query filters by `tenant_id` — the policies resolve tenant via `lessons.tenant_id` / `exercises.tenant_id`
- [x] Tested with every relevant role (same-tenant admin, other-tenant admin, student) via simulated JWTs
- [x] Loading and error states handled (n/a)
- [x] No new UI strings
- [x] Migration applies cleanly locally; has RLS policies; no type changes (`lib/database.types.ts` unaffected)

Follow-up sweep of the other `user_roles`-based policies: see the issue opened alongside this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YacrPDU1dqNPSbUpgUe3ot