### PR TITLE
fix(rls): drop the global-role gate on teacher course notifications

### DIFF
--- a/supabase/migrations/20260830150000_notifications_teacher_insert_policy.sql
+++ b/supabase/migrations/20260830150000_notifications_teacher_insert_policy.sql
@@ -1,0 +1,14 @@
+-- Straggler from the #650 sweep: the teacher INSERT policy on notifications
+-- still required a GLOBAL user_roles 'teacher' row, so a real tenant teacher
+-- (global role 'student') could not create notifications for their own
+-- courses. Authorship of the target course is the real authority here — the
+-- global-role branch added nothing but the silent denial — plus the tenant
+-- predicate every other notifications policy already carries.
+DROP POLICY IF EXISTS "Teachers can create course notifications" ON public.notifications;
+CREATE POLICY "Teachers can create course notifications"
+  ON public.notifications FOR INSERT TO authenticated
+  WITH CHECK (
+    tenant_id = (SELECT get_tenant_id())
+    AND target_type = 'course'
+    AND target_course_id IN (SELECT c.course_id FROM courses c WHERE c.author_id = (SELECT auth.uid()))
+  );


### PR DESCRIPTION
## What
Rewrites the `notifications` teacher INSERT policy: course authorship + `tenant_id = get_tenant_id()`, no global `user_roles` branch.

Follow-up straggler of #650 (found by a post-apply audit: it was the one remaining `WITH CHECK` referencing `user_roles` in production).

## Why
A tenant teacher whose global role is `student` — the normal case — could not create notifications for their own courses; the global-role branch added nothing but that silent denial.

## How to QA
Local psql, simulated JWTs: insert with `target_course_id` of an own course succeeds as the author (no global teacher role needed); the same insert as a non-author student fails the policy check. Verified both.

## Checklist
- [x] No TS change; migration applies cleanly locally
- [x] Tested author vs non-author via simulated JWTs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YacrPDU1dqNPSbUpgUe3ot