### PR TITLE
fix(join-school): hard-navigate after joining instead of push + refresh

### DIFF
--- a/components/join-school-form.tsx
+++ b/components/join-school-form.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useState } from 'react'
-import { useRouter } from 'next/navigation'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Alert, AlertDescription } from '@/components/ui/alert'
@@ -20,7 +19,6 @@ interface JoinSchoolFormProps {
 export function JoinSchoolForm({ tenant }: JoinSchoolFormProps) {
   const [isJoining, setIsJoining] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const router = useRouter()
 
   const handleJoin = async () => {
     setIsJoining(true)
@@ -31,16 +29,19 @@ export function JoinSchoolForm({ tenant }: JoinSchoolFormProps) {
 
       if (!result.success) {
         setError(result.error || 'Failed to join school. Please try again.')
+        setIsJoining(false)
         return
       }
 
-      // Redirect to student dashboard
-      router.push('/dashboard/student')
-      router.refresh()
+      // Hard navigation, not router.push + router.refresh: the pair interleaves
+      // two Router transitions and crashes Next's app-router with React #310
+      // (LMS-FRONT-9K/8F, upstream vercel/next.js#78396) — and the membership
+      // just changed, so a full request through proxy.ts with fresh claims is
+      // what we want anyway. The button stays disabled until the page unloads.
+      window.location.assign('/dashboard/student')
     } catch (err) {
       console.error('Join error:', err)
       setError('An unexpected error occurred')
-    } finally {
       setIsJoining(false)
     }
   }
@@ -61,7 +62,7 @@ export function JoinSchoolForm({ tenant }: JoinSchoolFormProps) {
         )}
 
         <div className="space-y-2">
-          <h4 className="font-medium text-sm">What you'll get:</h4>
+          <h4 className="font-medium text-sm">What you&apos;ll get:</h4>
           <ul className="space-y-2 text-sm text-muted-foreground">
             <li className="flex items-center gap-2">
               <Check className="h-4 w-4 text-green-600" />


### PR DESCRIPTION
## Problem

Every recent production crash on `test-school.preciopana.com` in Sentry issues [LMS-FRONT-9K](https://guillermoscript.sentry.io/issues/LMS-FRONT-9K) and [LMS-FRONT-8F](https://guillermoscript.sentry.io/issues/LMS-FRONT-8F) fires while the user sits on `/en/join-school` and the app transitions to `/dashboard/student`: `Error: Rendered more hooks than during the previous render` (React #310), thrown from **Next's own `Router` component** (`useActionQueue` → `useOptimistic`, `app-router.tsx`).

This is the known upstream framework bug [vercel/next.js#78396](https://github.com/vercel/next.js/issues/78396) (related: [#63121](https://github.com/vercel/next.js/issues/63121)): interleaved Router transitions corrupt the app-router's hook state. Our `JoinSchoolForm` triggers exactly that by calling `router.push('/dashboard/student')` immediately followed by `router.refresh()`.

## Fix

Replace the pair with `window.location.assign('/dashboard/student')`:

- Sidesteps the interleaved-transition bug entirely — no client Router transition at all.
- A full request through `proxy.ts` is what this flow wants anyway: the user's tenant membership just changed, so the fresh request re-resolves membership, claims, and role routing (CLAUDE.md: claims are stale after a tenant change).
- The button stays disabled until the page unloads (loading state no longer reset on the success path).

Note: `/dashboard/student/profile` sibling issue LMS-FRONT-9F is the same upstream bug via the standard server-action + `revalidatePath` pattern; left as-is pending the upstream fix.

## QA

1. `npm run dev`, sign up a fresh user on `default.lvh.me:3000`.
2. Visit `code-academy.lvh.me:3000` while signed in → redirected to `/join-school`.
3. Click **Join** → full page load lands on `/dashboard/student` with student role active; no console error.
4. Kill the network and click Join → inline error renders, button re-enables.

`npm run typecheck` and `npm run build` pass.

Fixes LMS-FRONT-9K · Fixes LMS-FRONT-8F

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013twfAqvyMkg8X9P7dF6dkg