### PR TITLE
fix(cron): pg_cron + pg_net primary scheduler for enforce-plan-limits, cron_runs ledger, Solana skip instead of 503

### DIFF
--- a/app/[locale]/platform/billing-health/page.tsx
+++ b/app/[locale]/platform/billing-health/page.tsx
@@ -3,6 +3,7 @@ import { format } from 'date-fns'
 import { IconCircleCheck } from '@tabler/icons-react'
 import {
   getAtRiskTenants,
+  getLastPlanLimitSweep,
   getPlanConfigurationHealth,
 } from '@/app/actions/platform/billing-health'
 import type { AtRiskReason } from '@/lib/billing/billing-health'
@@ -27,9 +28,10 @@ function reasonLabel(reason: AtRiskReason, cutoffActive: boolean): string {
 }
 
 export default async function PlatformBillingHealthPage() {
-  const [atRisk, planHealth] = await Promise.all([
+  const [atRisk, planHealth, sweep] = await Promise.all([
     getAtRiskTenants(),
     getPlanConfigurationHealth(),
+    getLastPlanLimitSweep(),
   ])
 
   // The metric cards deliberately keep counting past-due tenants only, so the
@@ -196,6 +198,57 @@ export default async function PlatformBillingHealthPage() {
             </p>
           </div>
         )}
+      </PlatformSection>
+
+      {/*
+        Enforcement liveness (#660). Every countdown below assumes the nightly
+        sweep runs; this is the ledger that proves it did. pg_cron writes a
+        `cron_runs` row per invocation, so "never" here means no scheduler has
+        reached the route from the database yet.
+      */}
+      <PlatformSection
+        title="Plan-limit sweep"
+        description="Last nightly enforce-plan-limits run from the pg_cron scheduler. Reminders, cutoffs and clearances only happen when this runs."
+        data-testid="billing-health-sweep"
+        className="mb-8"
+      >
+        <PlatformPanel>
+          <div className="flex flex-wrap items-center gap-x-6 gap-y-2 px-4 py-3 text-sm" data-state={sweep.state}>
+            <Badge
+              variant={sweep.state === 'ok' ? 'secondary' : sweep.state === 'running' ? 'outline' : 'destructive'}
+              data-testid="billing-health-sweep-state"
+            >
+              {sweep.state === 'ok' && 'Healthy'}
+              {sweep.state === 'running' && 'Running'}
+              {sweep.state === 'failed' && 'Failed'}
+              {sweep.state === 'unconfigured' && 'Not configured'}
+              {sweep.state === 'never' && 'Never run'}
+            </Badge>
+            {sweep.requestedAt ? (
+              <span className="text-muted-foreground">
+                Last run {format(new Date(sweep.requestedAt), 'PPp')}
+                {sweep.statusCode !== null && ` · HTTP ${sweep.statusCode}`}
+              </span>
+            ) : (
+              <span className="text-muted-foreground">
+                No pg_cron invocation recorded. Create the <code>cron_secret</code> and{' '}
+                <code>cron_base_url</code> Vault secrets (docs/CRON_RUNBOOK.md §1).
+              </span>
+            )}
+            {sweep.summary && (
+              <span className="text-muted-foreground">
+                {String(sweep.summary.none ?? 0)} unchanged · {String(sweep.summary.scheduled ?? 0)} cutoffs scheduled ·{' '}
+                {String(sweep.summary.cleared ?? 0)} cleared · {String(sweep.summary.errors ?? 0)} errors ·{' '}
+                {String(sweep.summary.notifyFailures ?? 0)} notify failures
+              </span>
+            )}
+            {sweep.error && (
+              <span className="text-destructive" data-testid="billing-health-sweep-error">
+                {sweep.error}
+              </span>
+            )}
+          </div>
+        </PlatformPanel>
       </PlatformSection>
 
       <StatStrip stats={metrics} className="mb-8" data-testid="billing-health-metrics" />

--- a/app/actions/platform/billing-health.ts
+++ b/app/actions/platform/billing-health.ts
@@ -239,3 +239,58 @@ export async function getPlanConfigurationHealth(): Promise<PlanConfigurationHea
     partiallyPriced: findPartiallyPricedPlans(plans, prices, { providerStatuses }),
   }
 }
+
+export interface PlanLimitSweepStatus {
+  /** `never` when no pg_cron invocation has ever been recorded. */
+  state: 'never' | 'running' | 'ok' | 'failed' | 'unconfigured'
+  requestedAt: string | null
+  completedAt: string | null
+  statusCode: number | null
+  error: string | null
+  /** The route's own JSON body when it answered 200 (`none`, `scheduled`, …). */
+  summary: Record<string, unknown> | null
+}
+
+/**
+ * Last `enforce-plan-limits` invocation from the pg_cron ledger (#660), so the
+ * page can say whether enforcement is alive rather than assuming a scheduler
+ * somewhere is doing its job. `cron_runs` is written by `invoke_cron_route()`
+ * and completed by `record_cron_run_results()` every 5 minutes; a row with no
+ * completion inside that window is simply still running.
+ */
+export async function getLastPlanLimitSweep(): Promise<PlanLimitSweepStatus> {
+  await verifySuperAdmin()
+  const admin = createAdminClient()
+
+  const { data: run } = await admin
+    .from('cron_runs')
+    .select('requested_at, completed_at, status_code, response, error')
+    .eq('route', 'enforce-plan-limits')
+    .order('requested_at', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+
+  if (!run) {
+    return { state: 'never', requestedAt: null, completedAt: null, statusCode: null, error: null, summary: null }
+  }
+
+  const summary =
+    run.response && typeof run.response === 'object' && !Array.isArray(run.response)
+      ? (run.response as Record<string, unknown>)
+      : null
+
+  let state: PlanLimitSweepStatus['state']
+  if (!run.completed_at) state = 'running'
+  else if (run.error?.startsWith('vault secrets')) state = 'unconfigured'
+  else if (run.status_code === 200 && !run.error) state = 'ok'
+  else state = 'failed'
+
+  return {
+    state,
+    requestedAt: run.requested_at,
+    completedAt: run.completed_at,
+    statusCode: run.status_code,
+    error: run.error,
+    summary,
+  }
+}

--- a/app/api/cron/enforce-plan-limits/route.ts
+++ b/app/api/cron/enforce-plan-limits/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import * as Sentry from '@sentry/nextjs'
 import { createClient, type SupabaseClient } from '@supabase/supabase-js'
 import { reconcileAccessCutoff } from '@/lib/billing/access-cutoff'
 import { fetchAllRows } from '@/lib/supabase/fetch-all-rows'
@@ -38,7 +39,7 @@ function getSupabaseAdmin(): SupabaseClient {
   return createClient(url, serviceKey)
 }
 
-export async function GET(req: NextRequest) {
+async function runSweep(req: NextRequest) {
   const cronSecret = process.env.CRON_SECRET
   const provided = req.headers.get('authorization')?.replace('Bearer ', '')
   if (!cronSecret || provided !== cronSecret) {
@@ -95,4 +96,20 @@ export async function GET(req: NextRequest) {
   }
 
   return NextResponse.json({ success: true, ...result })
+}
+
+/**
+ * Sentry cron monitor `cron-enforce-plan-limits` (#660). The GitHub workflow
+ * checks in for the runs it makes, but pg_cron is now the primary scheduler and
+ * the database cannot talk to Sentry — so the route reports its own check-in,
+ * whichever scheduler called it. With no DSN configured this is a no-op; a
+ * duplicate check-in from a GitHub-driven run is harmless.
+ */
+export async function GET(req: NextRequest) {
+  return Sentry.withMonitor('cron-enforce-plan-limits', () => runSweep(req), {
+    schedule: { type: 'crontab', value: '0 3 * * *' },
+    checkinMargin: 120,
+    maxRuntime: 20,
+    timezone: 'Etc/UTC',
+  })
 }

--- a/app/api/cron/solana-pull/route.ts
+++ b/app/api/cron/solana-pull/route.ts
@@ -74,7 +74,9 @@ export async function GET(req: NextRequest) {
   const platformWallet = process.env.SOLANA_PLATFORM_WALLET
   const mintEnv = process.env.SOLANA_USDC_MINT
   if (!rpcUrl || !pullerSecret || !platformWallet || !mintEnv) {
-    return NextResponse.json({ error: 'Solana subscriptions not configured' }, { status: 503 })
+    // Deliberately unconfigured rail → 200 + `skipped`, not 503 (see
+    // solana-reconcile, #660). This route is manual-only anyway.
+    return NextResponse.json({ success: true, skipped: 'solana_subscriptions_not_configured' })
   }
 
   const admin = getSupabaseAdmin()

--- a/app/api/cron/solana-reconcile/route.ts
+++ b/app/api/cron/solana-reconcile/route.ts
@@ -70,7 +70,11 @@ export async function GET(req: NextRequest) {
   const rpcUrl = process.env.SOLANA_RPC_URL
   const platformWallet = process.env.SOLANA_PLATFORM_WALLET
   if (!rpcUrl || !platformWallet) {
-    return NextResponse.json({ error: 'Solana not configured' }, { status: 503 })
+    // A rail that is deliberately not configured is not a failure (#660): a 503
+    // here failed the */10 scheduler run every ten minutes in prod and buried
+    // the real reconcilers' results under permanent red. 200 + `skipped` keeps
+    // the run green and the Sentry check-in `ok`, and the body still says why.
+    return NextResponse.json({ success: true, skipped: 'solana_not_configured' })
   }
 
   const admin = getSupabaseAdmin()

--- a/docs/CRON_RUNBOOK.md
+++ b/docs/CRON_RUNBOOK.md
@@ -22,6 +22,29 @@ these routes.
 - pg_cron runs `league-weekly-rollover` (Mondays 00:05) *inside* the database.
   The `league-rollover` route is a deliberate second path to the same idempotent
   RPC, not a duplicate to remove.
+- pg_cron is also **primary for `enforce-plan-limits`** (#660): job
+  `enforce-plan-limits-daily` at `0 3 * * *` calls
+  `public.invoke_cron_route('enforce-plan-limits')`, which reaches the route
+  over HTTP with pg_net using `cron_secret` + `cron_base_url` from Supabase
+  Vault. GitHub's `0 3` slot for that route is the fallback — GitHub has never
+  been observed firing a daily schedule for this repo. Every invocation lands
+  in `public.cron_runs`; `record-cron-run-results` (every 5 min) fills in the
+  HTTP status/body, and `/platform/billing-health` shows the last sweep.
+
+  ```sql
+  -- once per environment (values never leave Vault)
+  select vault.create_secret('<CRON_SECRET>',          'cron_secret');
+  select vault.create_secret('https://preciopana.com', 'cron_base_url');
+  -- is it alive?
+  select route, requested_at, status_code, response, error
+    from public.cron_runs order by requested_at desc limit 5;
+  -- run it now
+  select public.invoke_cron_route('enforce-plan-limits');
+  ```
+
+  With the Vault secrets missing the job records a `cron_runs` row with
+  `error` set and does nothing else, so an unconfigured environment is loud on
+  the billing-health page rather than silently idle.
 
 Running two schedulers means every route fires twice. The routes tolerate it,
 but it doubles load and makes logs unreadable. **If you move to Dokploy
@@ -63,7 +86,7 @@ gh workflow enable cron.yml
 | `expire-subscriptions` | `0 0` | Lapsed self-managed subscriptions (Solana, manual) keep their entitlements forever |
 | `league-rollover` | Mon `0 1` | Nothing — pg_cron is primary. This is the fallback |
 | `expire-platform-subscriptions` | `0 2` | No renewal reminders, no grace period, no downgrade to free: a school that stopped paying keeps its paid plan |
-| `enforce-plan-limits` | `0 3` | A tenant that grows past its plan limits with no plan-change event is never cut off, and a pending cutoff never completes |
+| `enforce-plan-limits` | `0 3` | pg_cron is primary (#660); this is the fallback. If neither runs: a tenant that grows past its plan limits with no plan-change event is never cut off, a pending cutoff never completes, and no reminder email is ever sent |
 | `solana-pull` | **never** | See §5 |
 
 Every route is idempotent, so a late or repeated run is safe. `league-rollover`
@@ -84,7 +107,7 @@ Three signals, and they catch different things:
 
 | Signal | Raised by | Means |
 |---|---|---|
-| Job failure | GitHub Actions (the job exits non-zero) | A route answered non-200 |
+| Job failure | GitHub Actions (the job exits non-zero) | A route answered non-200. A deliberately unconfigured rail (`solana-reconcile`, `solana-pull` without Solana env) answers **200 `{ skipped }`**, not 503 (#660) — absence is not failure |
 | Check-in `error` | Sentry | Same event, visible next to the run history |
 | **Missed check-in** | Sentry | The run never happened at all |
 

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -1480,6 +1480,42 @@ export type Database = {
           },
         ]
       }
+      cron_runs: {
+        Row: {
+          completed_at: string | null
+          error: string | null
+          id: number
+          request_id: number | null
+          requested_at: string
+          response: Json | null
+          route: string
+          scheduler: string
+          status_code: number | null
+        }
+        Insert: {
+          completed_at?: string | null
+          error?: string | null
+          id?: number
+          request_id?: number | null
+          requested_at?: string
+          response?: Json | null
+          route: string
+          scheduler?: string
+          status_code?: number | null
+        }
+        Update: {
+          completed_at?: string | null
+          error?: string | null
+          id?: number
+          request_id?: number | null
+          requested_at?: string
+          response?: Json | null
+          route?: string
+          scheduler?: string
+          status_code?: number | null
+        }
+        Relationships: []
+      }
       device_push_tokens: {
         Row: {
           created_at: string
@@ -6753,6 +6789,7 @@ export type Database = {
         Returns: string
       }
       get_tenant_plan_usage: { Args: { _tenant_id: string }; Returns: Json }
+      invoke_cron_route: { Args: { _route: string }; Returns: number }
       observe_solana_platform_payment: {
         Args: { _request_id: string; _signature: string; _tenant_id: string }
         Returns: {
@@ -7016,6 +7053,7 @@ export type Database = {
         Returns: undefined
       }
       publish_scheduled_lessons: { Args: never; Returns: undefined }
+      record_cron_run_results: { Args: never; Returns: number }
       redeem_store_item: {
         Args: { _item_id: string; _tenant_id: string; _user_id: string }
         Returns: Json

--- a/supabase/migrations/20260901150000_pg_cron_enforce_plan_limits.sql
+++ b/supabase/migrations/20260901150000_pg_cron_enforce_plan_limits.sql
@@ -1,0 +1,175 @@
+-- Issue #660: a scheduler that actually runs `enforce-plan-limits`.
+--
+-- `.github/workflows/cron.yml` schedules the route at `0 3 * * *`, but GitHub
+-- throttles low-frequency schedules so hard that the daily jobs have never been
+-- observed firing in production (only ~12 of 144 daily `*/10` ticks do). The
+-- access-cutoff reminder ladder therefore never sent a single email.
+--
+-- pg_cron already runs `league-weekly-rollover` inside the database; this makes
+-- it the primary scheduler for `enforce-plan-limits` too. The sweep itself
+-- stays in the Next.js route (it sends emails and reconciles through the app's
+-- own code), so the database reaches it over HTTP with pg_net, authenticating
+-- with the same `CRON_SECRET` the GitHub workflow uses — read from Supabase
+-- Vault, never stored in a table or a function body.
+--
+--   Vault secrets (create once per environment, see docs/CRON_RUNBOOK.md):
+--     select vault.create_secret('<CRON_SECRET>',          'cron_secret');
+--     select vault.create_secret('https://preciopana.com', 'cron_base_url');
+--
+-- Every invocation is written to `cron_runs` (route, when, pg_net request id),
+-- and `record_cron_run_results()` — itself on pg_cron every 5 minutes — copies
+-- the HTTP status and body back from `net._http_response` (pg_net keeps those
+-- for ~6 hours). `/platform/billing-health` shows the last sweep from that
+-- ledger, so "is enforcement alive" is a question the UI can answer.
+--
+-- Both schedules are guarded on pg_cron being installed so the migration also
+-- applies to a stack without it; with the Vault secrets missing the invoker
+-- records a run with `error` set and raises a NOTICE instead of failing, so a
+-- fresh environment is never broken by an unconfigured scheduler.
+--
+-- The GitHub schedule stays as the fallback, exactly like `league-rollover`:
+-- the route is idempotent, and a second daily run is cheaper than none.
+
+CREATE EXTENSION IF NOT EXISTS pg_net WITH SCHEMA extensions;
+
+-- ---------------------------------------------------------------------------
+-- 1. Ledger
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.cron_runs (
+  id            bigserial PRIMARY KEY,
+  route         text        NOT NULL,
+  scheduler     text        NOT NULL DEFAULT 'pg_cron',
+  requested_at  timestamptz NOT NULL DEFAULT now(),
+  request_id    bigint,
+  status_code   integer,
+  response      jsonb,
+  error         text,
+  completed_at  timestamptz
+);
+
+COMMENT ON TABLE public.cron_runs IS
+  'One row per scheduled invocation of an /api/cron/* route from pg_cron (issue #660). status/response are filled in asynchronously by record_cron_run_results().';
+
+CREATE INDEX IF NOT EXISTS idx_cron_runs_route_requested
+  ON public.cron_runs (route, requested_at DESC);
+
+-- Operators and the service role only. No policies: the platform page reads it
+-- through the admin client behind checkSuperAdmin().
+ALTER TABLE public.cron_runs ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON TABLE public.cron_runs FROM anon, authenticated;
+GRANT SELECT ON TABLE public.cron_runs TO service_role;
+
+-- ---------------------------------------------------------------------------
+-- 2. Invoker
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.invoke_cron_route(_route text)
+RETURNS bigint
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+DECLARE
+  _secret   text;
+  _base_url text;
+  _request  bigint;
+  _run_id   bigint;
+BEGIN
+  IF _route IS NULL OR _route !~ '^[a-z0-9-]+$' THEN
+    RAISE EXCEPTION 'invoke_cron_route: invalid route %', _route;
+  END IF;
+
+  SELECT decrypted_secret INTO _secret   FROM vault.decrypted_secrets WHERE name = 'cron_secret'   LIMIT 1;
+  SELECT decrypted_secret INTO _base_url FROM vault.decrypted_secrets WHERE name = 'cron_base_url' LIMIT 1;
+
+  INSERT INTO public.cron_runs (route) VALUES (_route) RETURNING id INTO _run_id;
+
+  IF _secret IS NULL OR _base_url IS NULL THEN
+    UPDATE public.cron_runs
+       SET error = 'vault secrets cron_secret / cron_base_url not configured',
+           completed_at = now()
+     WHERE id = _run_id;
+    RAISE NOTICE 'invoke_cron_route(%): vault secrets missing, nothing invoked', _route;
+    RETURN _run_id;
+  END IF;
+
+  -- Async: pg_net's worker performs the request; the response lands in
+  -- net._http_response keyed by this id. A sweep over every tenant can take a
+  -- while (20 tenants ≈ 11 s in prod), so the timeout is generous.
+  SELECT net.http_get(
+           url                  := rtrim(_base_url, '/') || '/api/cron/' || _route,
+           headers              := jsonb_build_object('Authorization', 'Bearer ' || _secret),
+           timeout_milliseconds := 300000
+         )
+    INTO _request;
+
+  UPDATE public.cron_runs SET request_id = _request WHERE id = _run_id;
+  RETURN _run_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.invoke_cron_route(text) FROM PUBLIC;
+
+-- ---------------------------------------------------------------------------
+-- 3. Result recorder
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.record_cron_run_results()
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+DECLARE
+  _updated integer;
+BEGIN
+  UPDATE public.cron_runs r
+     SET status_code  = h.status_code,
+         response     = CASE
+                          WHEN h.content IS NULL THEN NULL
+                          WHEN h.content ~ '^\s*[\[{]' THEN
+                            (SELECT j FROM (SELECT h.content::jsonb AS j) s)
+                          ELSE jsonb_build_object('raw', left(h.content, 2000))
+                        END,
+         error        = CASE
+                          WHEN h.timed_out THEN 'timed out'
+                          ELSE h.error_msg
+                        END,
+         completed_at = now()
+    FROM net._http_response h
+   WHERE h.id = r.request_id
+     AND r.completed_at IS NULL;
+  GET DIAGNOSTICS _updated = ROW_COUNT;
+
+  -- pg_net drops responses after ~6 h; a run older than that with no response
+  -- will never get one. Close it so the page does not show it as "running".
+  UPDATE public.cron_runs
+     SET error = 'no response recorded (pg_net response expired or worker down)',
+         completed_at = now()
+   WHERE completed_at IS NULL
+     AND requested_at < now() - interval '6 hours';
+
+  RETURN _updated;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.record_cron_run_results() FROM PUBLIC;
+
+-- ---------------------------------------------------------------------------
+-- 4. Schedules (pg_cron primary; cron.yml keeps the same slot as fallback)
+-- ---------------------------------------------------------------------------
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_cron') THEN
+    PERFORM cron.schedule(
+      'enforce-plan-limits-daily',
+      '0 3 * * *',
+      $cron$SELECT public.invoke_cron_route('enforce-plan-limits')$cron$
+    );
+    PERFORM cron.schedule(
+      'record-cron-run-results',
+      '*/5 * * * *',
+      $cron$SELECT public.record_cron_run_results()$cron$
+    );
+  ELSE
+    RAISE NOTICE 'pg_cron not installed; enforce-plan-limits stays on the GitHub schedule only';
+  END IF;
+END $$;

--- a/tests/playwright/platform-billing-health-sweep.spec.ts
+++ b/tests/playwright/platform-billing-health-sweep.spec.ts
@@ -1,0 +1,50 @@
+/**
+ * Issue #660 — the platform billing-health page shows the last
+ * `enforce-plan-limits` run from the pg_cron ledger (`cron_runs`).
+ *
+ * The service-role client invokes the scheduler function directly; without the
+ * Vault secrets (the local default) that records an `unconfigured` run, which
+ * is exactly the state the page must make loud rather than hide.
+ */
+import { test, expect } from '@playwright/test'
+import { createClient } from '@supabase/supabase-js'
+import { loginAsSuperAdmin } from './utils/auth'
+import { BASE, LOCALE } from './utils/constants'
+
+const admin = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  { auth: { persistSession: false } }
+)
+
+test.describe('Platform billing health — plan-limit sweep (#660)', () => {
+  test('shows the latest pg_cron invocation and its state', async ({ page, isMobile }) => {
+    test.skip(isMobile, 'platform console is desktop-only')
+    test.setTimeout(120_000)
+
+    const { data: runId, error } = await admin.rpc('invoke_cron_route', { _route: 'enforce-plan-limits' })
+    expect(error).toBeNull()
+    expect(typeof runId).toBe('number')
+
+    const { data: run } = await admin
+      .from('cron_runs')
+      .select('error, completed_at, request_id')
+      .eq('id', runId as number)
+      .single()
+    const expectedState = run?.error?.startsWith('vault secrets') ? 'unconfigured' : run?.completed_at ? 'ok' : 'running'
+
+    await loginAsSuperAdmin(page, BASE)
+    await page.goto(`${BASE}/${LOCALE}/platform/billing-health`)
+    await expect(page.getByTestId('platform-billing-health')).toBeVisible()
+
+    const section = page.getByTestId('billing-health-sweep')
+    await expect(section).toBeVisible()
+    await expect(section.locator('[data-state]')).toHaveAttribute('data-state', expectedState)
+    await expect(section.getByTestId('billing-health-sweep-state')).not.toHaveText('Never run')
+    if (expectedState === 'unconfigured') {
+      await expect(section.getByTestId('billing-health-sweep-error')).toContainText('vault secrets')
+    }
+
+    await page.screenshot({ path: 'test-results/billing-health-sweep.png', fullPage: true })
+  })
+})

--- a/tests/sql/issue-660-cron-runs.sql
+++ b/tests/sql/issue-660-cron-runs.sql
@@ -1,0 +1,61 @@
+-- Issue #660 — pg_cron scheduler for enforce-plan-limits. Rolled back; the
+-- HTTP path itself is asynchronous (pg_net worker) and is proven manually per
+-- docs/CRON_RUNBOOK.md — this covers everything that is synchronous.
+--
+--   docker exec -i supabase_db_lms-front psql -U postgres -d postgres -P pager=off \
+--     < tests/sql/issue-660-cron-runs.sql
+begin;
+
+do $$
+declare
+  run_id bigint; r record; secrets_present boolean;
+begin
+  -- §1 schedules exist when pg_cron does
+  if exists (select 1 from pg_extension where extname = 'pg_cron') then
+    if (select count(*) from cron.job where jobname in ('enforce-plan-limits-daily','record-cron-run-results')) <> 2 then
+      raise exception '§1 pg_cron jobs missing';
+    end if;
+    if (select schedule from cron.job where jobname = 'enforce-plan-limits-daily') <> '0 3 * * *' then
+      raise exception '§1 wrong schedule';
+    end if;
+  end if;
+
+  -- §2 invalid route names are refused before anything is written
+  begin
+    perform public.invoke_cron_route('../etc');
+    raise exception '§2 invalid route accepted';
+  exception when others then
+    if sqlerrm not like 'invoke_cron_route: invalid route%' then raise; end if;
+  end;
+
+  -- §3 missing Vault secrets → a ledger row with `error`, no request, no failure
+  select exists (select 1 from vault.secrets where name in ('cron_secret','cron_base_url')) into secrets_present;
+  if not secrets_present then
+    run_id := public.invoke_cron_route('enforce-plan-limits');
+    select * into r from public.cron_runs where id = run_id;
+    if r.request_id is not null or r.error is null or r.completed_at is null then
+      raise exception '§3 unconfigured invoke did not record an error row: %', to_jsonb(r);
+    end if;
+  else
+    raise notice '§3 skipped: vault secrets present in this environment';
+  end if;
+
+  -- §4 a run older than 6 h with no response is closed by the recorder
+  insert into public.cron_runs (route, request_id, requested_at)
+  values ('enforce-plan-limits', 2147483647, now() - interval '7 hours') returning id into run_id;
+  perform public.record_cron_run_results();
+  select * into r from public.cron_runs where id = run_id;
+  if r.completed_at is null or r.error not like 'no response recorded%' then
+    raise exception '§4 stale run not closed: %', to_jsonb(r);
+  end if;
+
+  -- §5 the ledger is not readable by app roles
+  if has_table_privilege('authenticated', 'public.cron_runs', 'SELECT')
+     or has_table_privilege('anon', 'public.cron_runs', 'SELECT') then
+    raise exception '§5 cron_runs readable by app roles';
+  end if;
+
+  raise notice 'PASS: issue #660 cron_runs + invoker';
+end $$;
+
+rollback;


### PR DESCRIPTION
Closes #660. Phase 2 of the plan-gate hardening plan (Phase 1: #659).

## Why

- `enforce-plan-limits` at `0 3 * * *` in `cron.yml` has never been observed firing in prod (GitHub throttles low-frequency schedules; only ~12 of 144 daily `*/10` ticks fire). The reminder ladder never sent; a manual `workflow_dispatch` today answered 200 with 20 tenants scanned, so the route and secrets are fine — only the scheduler is missing.
- `solana-reconcile` 503'd every 10 minutes because Solana is not configured in prod, so the workflow was permanently red.
- Nothing recorded when the last sweep happened.

## What

- **Migration `20260901150000_pg_cron_enforce_plan_limits.sql`** — enables `pg_net`; `cron_runs` ledger (RLS, service_role only); `invoke_cron_route(route)` reads `cron_secret` + `cron_base_url` from **Supabase Vault** (never a table/function body), `net.http_get`s the route with a 300 s timeout and records the run — with the secrets missing it records `error` + NOTICE and does nothing else; `record_cron_run_results()` copies status/body back from `net._http_response` and closes >6 h orphans; pg_cron jobs `enforce-plan-limits-daily` (`0 3 * * *`) and `record-cron-run-results` (`*/5`). Both guarded on pg_cron being installed. `cron.yml` keeps its slot as the fallback, same arrangement as `league-rollover`.
- **Route** wraps itself in `Sentry.withMonitor('cron-enforce-plan-limits')` so the check-in happens whichever scheduler calls it (no DSN → no-op).
- **Solana routes** answer `200 { success: true, skipped: '…_not_configured' }` instead of 503.
- **`/platform/billing-health`** — new "Plan-limit sweep" section: state badge (Healthy / Running / Failed / Not configured / Never run), last run time, HTTP status, the route's own counts, error text.
- **Runbook** — pg_cron section with the Vault setup and verification queries.

## After merge (ops)

1. Apply the migration to cloud (MCP `apply_migration`).
2. `select vault.create_secret('https://preciopana.com', 'cron_base_url');`
3. `select vault.create_secret('<CRON_SECRET from Dokploy/GitHub>', 'cron_secret');` — **needs the real value**, which only lives in Dokploy and GitHub secrets.
4. `select public.invoke_cron_route('enforce-plan-limits');` then check `/platform/billing-health` a few minutes later → Healthy, HTTP 200.

## QA (local, all green)

```bash
npm run db:reset
docker exec -i supabase_db_lms-front psql -U postgres -d postgres -P pager=off < tests/sql/issue-660-cron-runs.sql   # PASS
npm run typecheck && npx vitest run                                    # 1026 passed
npx playwright test platform-billing-health-sweep --project=desktop-chromium --workers=1   # 1 passed
```

End-to-end HTTP path proven locally by creating the two Vault secrets pointing at `http://host.docker.internal:3005`: `invoke_cron_route` → pg_net → route → `record_cron_run_results` stored HTTP 200 with the route's JSON (`none: 2, errors: 0 …`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dpLyEb9URLQuD8qgMgp3g
