### PR TITLE
test(plans): regression suite for limits, cutoff, tiers and a signed Stripe webhook (#296)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,6 +166,8 @@ NEXT_PUBLIC_PLATFORM_DOMAIN=       # e.g. lvh.me for local dev, lmsplatform.com 
 
 E2E tests in `tests/playwright/` — 33 spec files (tenant isolation, auth security, payment flows, enrollment, entitlements, gamification, community, i18n, platform panel, plan change, teacher/admin CRUD). Read the directory rather than a list here; it changes often. Highest-priority: `tenant-isolation.spec.ts`, `auth-security.spec.ts`, `payment-flows.spec.ts`, `evaluations-security.spec.ts`.
 
+Plan-gate specs (`plan-limit-surfaces`, `access-cutoff-lifecycle`, `plan-feature-tiers`, `platform-billing-stripe-webhook`) each own a dedicated tenant and a hidden `platform_plans` row with tiny limits (`tests/playwright/utils/plan-gate-fixtures.ts`) — every enforcement path reads the plan by slug with no `is_active` filter, so "at the cap" costs one row, not fifty users. Never move the seeded tenants off their plan.
+
 The Playwright config has no `webServer` — start `npm run dev` yourself first, use `lvh.me` (never `localhost`), and keep `--workers=1` locally or GoTrue rate-limits the sign-ins. Unit tests: `npm run test:unit` (Vitest, `tests/unit/`).
 
 Test accounts (from `supabase/seed.sql`, seeded by `supabase db reset`):

--- a/mcp-server/tests/plan-limits.test.ts
+++ b/mcp-server/tests/plan-limits.test.ts
@@ -1,0 +1,85 @@
+/**
+ * The MCP server's side of the plan-limit contract (#658 / #296 Phase 5).
+ *
+ * `lms_create_course` and the status un-archive path call
+ * `courseLimitHeadroomError` before writing and map the trigger's `LM001` with
+ * `isPlanLimitError` after. Neither is reachable from Playwright without an
+ * OAuth session, so the pure logic is pinned here.
+ */
+import { describe, expect, it, vi } from 'vitest'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import {
+  PLAN_LIMIT_SQLSTATE,
+  courseLimitHeadroomError,
+  isPlanLimitError,
+  planLimitMessage,
+} from '../src/plan-limits.js'
+
+function fakeClient(rpcResult: { data?: unknown; error?: unknown }) {
+  const rpc = vi.fn().mockResolvedValue(rpcResult)
+  return { client: { rpc } as unknown as SupabaseClient, rpc }
+}
+
+describe('isPlanLimitError', () => {
+  it('recognises the trigger SQLSTATE', () => {
+    expect(isPlanLimitError({ code: PLAN_LIMIT_SQLSTATE, message: 'anything' })).toBe(true)
+  })
+
+  it('recognises the message when the code was lost in transit', () => {
+    expect(isPlanLimitError({ message: 'plan_limit_exceeded:courses' })).toBe(true)
+    expect(isPlanLimitError(new Error('plan_limit_exceeded:students'))).toBe(true)
+  })
+
+  it('ignores every other error', () => {
+    expect(isPlanLimitError({ code: '23505', message: 'duplicate key' })).toBe(false)
+    expect(isPlanLimitError(null)).toBe(false)
+    expect(isPlanLimitError('plan_limit_exceeded:courses')).toBe(false)
+  })
+})
+
+describe('courseLimitHeadroomError', () => {
+  it('refuses at the cap with the usage in the message', async () => {
+    const { client, rpc } = fakeClient({
+      data: { courses: 5, students: 3, max_courses: 5, max_students: 50 },
+    })
+
+    const message = await courseLimitHeadroomError(client, 'tenant-1')
+
+    expect(rpc).toHaveBeenCalledWith('get_tenant_plan_usage', { _tenant_id: 'tenant-1' })
+    expect(message).toContain('limited to 5 courses')
+    expect(message).toContain('currently has 5')
+    expect(message).toContain('Archive a course')
+  })
+
+  it('allows a write with headroom', async () => {
+    const { client } = fakeClient({ data: { courses: 4, max_courses: 5 } })
+    expect(await courseLimitHeadroomError(client, 'tenant-1')).toBeNull()
+  })
+
+  it('treats -1 and a missing limit as unlimited', async () => {
+    expect(
+      await courseLimitHeadroomError(fakeClient({ data: { courses: 999, max_courses: -1 } }).client, 't'),
+    ).toBeNull()
+    expect(await courseLimitHeadroomError(fakeClient({ data: { courses: 999 } }).client, 't')).toBeNull()
+  })
+
+  it('defers to the trigger when usage cannot be read', async () => {
+    const { client } = fakeClient({ error: { message: 'permission denied' } })
+    expect(await courseLimitHeadroomError(client, 'tenant-1')).toBeNull()
+  })
+})
+
+describe('planLimitMessage', () => {
+  it('still explains the refusal when usage is unavailable', async () => {
+    const { client } = fakeClient({ error: { message: 'nope' } })
+    const message = await planLimitMessage(client, 'tenant-1', 'students')
+    expect(message).toContain('does not allow more students')
+  })
+
+  it('names the student cap after an LM001 on tenant_users', async () => {
+    const { client } = fakeClient({ data: { students: 50, max_students: 50, courses: 1, max_courses: 5 } })
+    const message = await planLimitMessage(client, 'tenant-1', 'students')
+    expect(message).toContain('limited to 50 students')
+    expect(message).toContain('upgrade the plan')
+  })
+})

--- a/tests/playwright/access-cutoff-lifecycle.spec.ts
+++ b/tests/playwright/access-cutoff-lifecycle.spec.ts
@@ -1,0 +1,154 @@
+/**
+ * The over-limit access cutoff, end to end over HTTP (#296 Phase 5, case 3).
+ *
+ * A tenant with two live courses on a plan that allows one:
+ *   1. the nightly sweep schedules `access_cutoff_at` 14 days out and attempts
+ *      the first reminder rung (delivered → ledger row; undeliverable → counted
+ *      in `notifyFailures` and retried tomorrow)
+ *   2. once the cutoff is in the past, a student with a live entitlement lands
+ *      on the suspended page instead of the course
+ *   3. archiving the extra course and re-running the sweep clears the cutoff
+ *      and the same URL opens again
+ *
+ * The unit tests in tests/unit/access-cutoff*.test.ts own the decision table
+ * and the ladder timing with a fake mailer; this spec proves the route, the
+ * RPC the content pages call and the page itself agree with them.
+ */
+import { test, expect } from '@playwright/test'
+import { login } from './utils/auth'
+import { LOCALE } from './utils/constants'
+import {
+  DAY_MS,
+  SEEDED,
+  addMember,
+  createQaTenant,
+  destroyQaTenant,
+  getAdmin,
+  insertCourse,
+  runEnforceSweep,
+  setTenantPlan,
+  tenantBase,
+  tenantRow,
+  upsertTinyPlan,
+  type QaTenant,
+} from './utils/plan-gate-fixtures'
+
+const QA: QaTenant = {
+  id: '00000000-0000-0000-0000-000000000297',
+  slug: 'qa-cutoff-lifecycle',
+  name: 'QA Cutoff Lifecycle',
+  planSlug: 'e2e-tiny-cutoff',
+}
+const QA_BASE = tenantBase(QA.slug)
+
+let keptCourseId: number
+let extraCourseId: number
+
+test.describe.configure({ mode: 'serial' })
+
+test.describe('access cutoff lifecycle (#296)', () => {
+  test.skip(!process.env.CRON_SECRET, 'CRON_SECRET is required to call the sweep')
+
+  test.beforeAll(async () => {
+    const admin = getAdmin()
+    await destroyQaTenant(admin, QA)
+    await upsertTinyPlan(admin, QA.planSlug, { max_courses: 1, max_students: -1 })
+
+    await createQaTenant(admin, QA, 'free')
+    await addMember(admin, QA.id, SEEDED.owner.id, 'admin')
+    await addMember(admin, QA.id, SEEDED.student.id, 'student')
+    keptCourseId = await insertCourse(admin, QA.id, 'E2E #296 kept course')
+    extraCourseId = await insertCourse(admin, QA.id, 'E2E #296 extra course')
+
+    // The student owns the kept course outright, so the only thing that can
+    // refuse them is the tenant-wide cutoff.
+    const { error } = await admin.from('entitlements').insert({
+      user_id: SEEDED.student.id,
+      course_id: keptCourseId,
+      tenant_id: QA.id,
+      source_type: 'admin_grant',
+      status: 'active',
+    })
+    if (error) throw new Error(`could not grant entitlement: ${error.message}`)
+
+    // 2 live courses on a 1-course plan: over the limit from this point on.
+    await setTenantPlan(admin, QA.id, QA.planSlug)
+  })
+
+  test.afterAll(async () => {
+    await destroyQaTenant(getAdmin(), QA)
+  })
+
+  test.beforeEach(async ({}, testInfo) => {
+    test.skip(testInfo.project.name !== 'desktop-chromium', 'runs once — DB state is shared')
+  })
+
+  test('the sweep schedules the cutoff and attempts the first reminder', async ({ request }) => {
+    const admin = getAdmin()
+    expect((await tenantRow(admin, QA.id)).access_cutoff_at).toBeNull()
+
+    const first = await runEnforceSweep(request)
+    expect(first.success).toBe(true)
+    expect(first.scheduled).toBeGreaterThanOrEqual(1)
+
+    const scheduled = (await tenantRow(admin, QA.id)).access_cutoff_at
+    expect(scheduled).not.toBeNull()
+    const daysOut = (new Date(scheduled!).getTime() - Date.now()) / DAY_MS
+    expect(daysOut).toBeGreaterThan(13.9)
+    expect(daysOut).toBeLessThan(14.1)
+
+    // The `scheduled` rung is due the moment the cutoff exists. With a mailer
+    // configured it is delivered and written to the ledger; without one every
+    // send returns false, nothing is written, and the sweep reports the miss
+    // so tomorrow's run retries. Either way the rung was attempted.
+    const { data: ledger } = await admin
+      .from('access_cutoff_notifications')
+      .select('stage, recipient_count')
+      .eq('tenant_id', QA.id)
+    if (process.env.MAILGUN_API_KEY) {
+      expect(ledger).toEqual([expect.objectContaining({ stage: 'scheduled' })])
+      expect(first.notified.scheduled ?? 0).toBeGreaterThanOrEqual(1)
+    } else {
+      expect(ledger).toEqual([])
+      expect(first.notifyFailures).toBeGreaterThanOrEqual(1)
+    }
+
+    // Idempotent: a second sweep neither reschedules nor moves the date.
+    const second = await runEnforceSweep(request)
+    expect(second.success).toBe(true)
+    expect((await tenantRow(admin, QA.id)).access_cutoff_at).toBe(scheduled)
+  })
+
+  test('a student is sent to the suspended page once the cutoff is live', async ({ page }) => {
+    test.setTimeout(120_000)
+    const admin = getAdmin()
+    const { error } = await admin
+      .from('tenants')
+      .update({ access_cutoff_at: new Date(Date.now() - 60 * 60 * 1000).toISOString() })
+      .eq('id', QA.id)
+    expect(error).toBeNull()
+
+    await login(page, SEEDED.student.email, SEEDED.student.password, QA_BASE)
+    await page.goto(`${QA_BASE}/${LOCALE}/dashboard/student/courses/${keptCourseId}`)
+
+    await expect(page).toHaveURL(/\/dashboard\/student\/access-suspended/, { timeout: 20_000 })
+    await expect(page.getByRole('heading', { name: "Your school's access is suspended" })).toBeVisible()
+  })
+
+  test('archiving the extra course clears the cutoff and reopens the course', async ({ page, request }) => {
+    test.setTimeout(120_000)
+    const admin = getAdmin()
+    const { error } = await admin.from('courses').update({ status: 'archived' }).eq('course_id', extraCourseId)
+    expect(error).toBeNull()
+
+    const sweep = await runEnforceSweep(request)
+    expect(sweep.success).toBe(true)
+    expect(sweep.cleared).toBeGreaterThanOrEqual(1)
+    expect((await tenantRow(admin, QA.id)).access_cutoff_at).toBeNull()
+
+    await login(page, SEEDED.student.email, SEEDED.student.password, QA_BASE)
+    await page.goto(`${QA_BASE}/${LOCALE}/dashboard/student/courses/${keptCourseId}`)
+    await expect(page).toHaveURL(new RegExp(`/dashboard/student/courses/${keptCourseId}`), { timeout: 20_000 })
+    await expect(page).not.toHaveURL(/access-suspended/)
+  })
+})

--- a/tests/playwright/plan-feature-tiers.spec.ts
+++ b/tests/playwright/plan-feature-tiers.spec.ts
@@ -1,0 +1,100 @@
+/**
+ * Tiered plan features, both sides of the line (#296 Phase 5, case 4).
+ *
+ * plan-feature-gates.spec.ts pins Free (everything locked) and Enterprise
+ * (everything open) on the seeded tenants. This spec moves ONE dedicated
+ * tenant between plans to pin the tiers in between:
+ *
+ *   remove_branding  Free shows "Powered by" on the public site; Pro hides it
+ *   analytics        Starter is `basic` — page renders, export is withheld and
+ *                    the compact nudge says why; Pro is `advanced` — export back,
+ *                    nudge gone
+ *
+ * Both gates are server-side (lib/plans/server.ts), so a plan change is
+ * visible on the next request with no client state to reset.
+ */
+import { test, expect } from '@playwright/test'
+import { login } from './utils/auth'
+import { LOCALE } from './utils/constants'
+import {
+  SEEDED,
+  addMember,
+  createQaTenant,
+  destroyQaTenant,
+  getAdmin,
+  setTenantPlan,
+  tenantBase,
+  type QaTenant,
+} from './utils/plan-gate-fixtures'
+
+const QA: QaTenant = {
+  id: '00000000-0000-0000-0000-000000000299',
+  slug: 'qa-feature-tiers',
+  name: 'QA Feature Tiers',
+  planSlug: 'e2e-unused-tiers',
+}
+const QA_BASE = tenantBase(QA.slug)
+
+const analyticsNudge = '[data-testid="upgrade-nudge"][data-feature="analytics"]'
+
+test.describe.configure({ mode: 'serial' })
+
+test.describe('plan feature tiers (#296)', () => {
+  test.beforeAll(async () => {
+    const admin = getAdmin()
+    await destroyQaTenant(admin, QA)
+    await createQaTenant(admin, QA, 'free')
+    await addMember(admin, QA.id, SEEDED.owner.id, 'admin')
+  })
+
+  test.afterAll(async () => {
+    await destroyQaTenant(getAdmin(), QA)
+  })
+
+  test.beforeEach(async ({}, testInfo) => {
+    test.skip(testInfo.project.name !== 'desktop-chromium', 'runs once — DB state is shared')
+  })
+
+  test('"Powered by" stays on a Free school and leaves on Pro', async ({ page }) => {
+    const admin = getAdmin()
+    await setTenantPlan(admin, QA.id, 'free')
+    await page.goto(`${QA_BASE}/${LOCALE}`)
+    await expect(page.getByText('Powered by', { exact: false }).first()).toBeVisible({ timeout: 20_000 })
+
+    await setTenantPlan(admin, QA.id, 'pro')
+    await page.goto(`${QA_BASE}/${LOCALE}`)
+    await expect(page.getByText('Powered by', { exact: false })).toHaveCount(0)
+  })
+
+  test('Starter analytics is basic: no export, a nudge that says so', async ({ page }) => {
+    test.setTimeout(120_000)
+    await setTenantPlan(getAdmin(), QA.id, 'starter')
+    await login(page, SEEDED.owner.email, SEEDED.owner.password, QA_BASE)
+    await page.goto(`${QA_BASE}/${LOCALE}/dashboard/admin/analytics`)
+
+    await expect(page.getByTestId('analytics-page')).toBeVisible({ timeout: 20_000 })
+    await expect(page.locator(analyticsNudge)).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Export' })).toHaveCount(0)
+  })
+
+  test('Pro analytics is advanced: export is back, the nudge is gone', async ({ page }) => {
+    test.setTimeout(120_000)
+    await setTenantPlan(getAdmin(), QA.id, 'pro')
+    await login(page, SEEDED.owner.email, SEEDED.owner.password, QA_BASE)
+    await page.goto(`${QA_BASE}/${LOCALE}/dashboard/admin/analytics`)
+
+    await expect(page.getByTestId('analytics-page')).toBeVisible({ timeout: 20_000 })
+    await expect(page.getByRole('button', { name: 'Export' })).toBeVisible()
+    await expect(page.locator(analyticsNudge)).toHaveCount(0)
+  })
+
+  test('Free analytics is locked outright', async ({ page }) => {
+    test.setTimeout(120_000)
+    await setTenantPlan(getAdmin(), QA.id, 'free')
+    await login(page, SEEDED.owner.email, SEEDED.owner.password, QA_BASE)
+    await page.goto(`${QA_BASE}/${LOCALE}/dashboard/admin/analytics`)
+
+    await expect(page.locator(analyticsNudge)).toBeVisible({ timeout: 20_000 })
+    await expect(page.getByTestId('analytics-page')).toHaveCount(0)
+  })
+})

--- a/tests/playwright/plan-limit-surfaces.spec.ts
+++ b/tests/playwright/plan-limit-surfaces.spec.ts
@@ -1,0 +1,145 @@
+/**
+ * Every surface a plan LIMIT is supposed to stop, on a tenant at its caps
+ * (#296 Phase 5, cases 1–2; complements plan-limit-enforcement.spec.ts which
+ * pins the trigger itself on the Default School).
+ *
+ *   courses at cap  → teacher course form refuses, AI course wizard is disabled
+ *   students at cap → a direct seat insert dies with LM001, /join-school
+ *                     refuses with the student-limit copy, and a pending
+ *                     invitation does not buy a seat either
+ *
+ * The tenant sits on a hidden plan with `max_courses: 1` / `max_students: 1`
+ * (see utils/plan-gate-fixtures.ts), so "at the cap" is one course and one
+ * student — the same code paths a Free school at 5/50 goes through.
+ */
+import { test, expect } from '@playwright/test'
+import { login } from './utils/auth'
+import { LOCALE } from './utils/constants'
+import {
+  SEEDED,
+  addMember,
+  createQaTenant,
+  destroyQaTenant,
+  getAdmin,
+  insertCourse,
+  loginExpectingJoinSchool,
+  setTenantPlan,
+  tenantBase,
+  upsertTinyPlan,
+  usageOf,
+  type QaTenant,
+} from './utils/plan-gate-fixtures'
+
+const QA: QaTenant = {
+  id: '00000000-0000-0000-0000-000000000296',
+  slug: 'qa-plan-limits',
+  name: 'QA Plan Limits',
+  planSlug: 'e2e-tiny-limits',
+}
+const QA_BASE = tenantBase(QA.slug)
+
+test.describe.configure({ mode: 'serial' })
+
+test.describe('plan limits — every surface at the cap (#296)', () => {
+  test.beforeAll(async () => {
+    const admin = getAdmin()
+    await destroyQaTenant(admin, QA)
+    await upsertTinyPlan(admin, QA.planSlug, { max_courses: 1, max_students: 1 })
+
+    // Built on Free (limits 5/50) so the fixtures themselves never trip the
+    // triggers, then moved to the tiny plan — exactly the state a school is in
+    // the day after a downgrade.
+    await createQaTenant(admin, QA, 'free')
+    await addMember(admin, QA.id, SEEDED.owner.id, 'admin')
+    await addMember(admin, QA.id, SEEDED.student.id, 'student')
+    await insertCourse(admin, QA.id, 'E2E #296 the only course')
+    await setTenantPlan(admin, QA.id, QA.planSlug)
+  })
+
+  test.afterAll(async () => {
+    await destroyQaTenant(getAdmin(), QA)
+  })
+
+  test.beforeEach(async ({}, testInfo) => {
+    test.skip(testInfo.project.name !== 'desktop-chromium', 'runs once — DB state is shared')
+  })
+
+  test('the usage RPC reports the tenant at both caps', async () => {
+    expect(await usageOf(getAdmin(), QA.id)).toEqual({
+      courses: 1,
+      students: 1,
+      max_courses: 1,
+      max_students: 1,
+    })
+  })
+
+  test('the course form refuses before it renders a field', async ({ page }) => {
+    test.setTimeout(120_000)
+    await login(page, SEEDED.owner.email, SEEDED.owner.password, QA_BASE)
+    await page.goto(`${QA_BASE}/${LOCALE}/dashboard/teacher/courses/new`)
+
+    await expect(page.getByText('Course Limit Reached')).toBeVisible({ timeout: 20_000 })
+    await expect(page.getByText(/limited to 1 courses/)).toBeVisible()
+    await expect(page.getByLabel(/title/i)).toHaveCount(0)
+  })
+
+  test('the AI course wizard is disabled at the cap', async ({ page }) => {
+    test.setTimeout(120_000)
+    await login(page, SEEDED.owner.email, SEEDED.owner.password, QA_BASE)
+    await page.goto(`${QA_BASE}/${LOCALE}/dashboard/admin/products/new`)
+
+    await expect(page.getByText('Course limit reached')).toBeVisible({ timeout: 20_000 })
+    await expect(page.getByRole('button', { name: 'Generate draft' })).toBeDisabled()
+  })
+
+  test('a second student seat is refused by the database', async () => {
+    const admin = getAdmin()
+    const { error } = await admin
+      .from('tenant_users')
+      .insert({ tenant_id: QA.id, user_id: SEEDED.alice.id, role: 'student', status: 'active' })
+
+    expect(error?.code).toBe('LM001')
+    expect(error?.message).toContain('plan_limit_exceeded:students')
+    expect((await usageOf(admin, QA.id)).students).toBe(1)
+  })
+
+  test('joining the school is refused at the cap, invitation or not', async ({ page }) => {
+    test.setTimeout(120_000)
+    const admin = getAdmin()
+
+    // An invitation is the one path that could be argued to "reserve" a seat.
+    // It does not: the seat count is what the plan sells.
+    const { error: inviteError } = await admin.from('tenant_invitations').insert({
+      tenant_id: QA.id,
+      email: SEEDED.alice.email,
+      role: 'student',
+      invited_by: SEEDED.owner.id,
+      status: 'pending',
+    })
+    expect(inviteError).toBeNull()
+
+    await loginExpectingJoinSchool(page, QA_BASE, SEEDED.alice.email, SEEDED.alice.password)
+    const joinButton = page.getByRole('button', { name: `Join ${QA.name}` })
+    await expect(joinButton).toBeVisible({ timeout: 20_000 })
+    // base-ui Button: a real DOM click, not Playwright's synthesized one.
+    await joinButton.evaluate((el) => (el as HTMLElement).click())
+
+    await expect(page.getByText('This school has reached its student limit')).toBeVisible({ timeout: 20_000 })
+
+    const { data: membership } = await admin
+      .from('tenant_users')
+      .select('status')
+      .eq('tenant_id', QA.id)
+      .eq('user_id', SEEDED.alice.id)
+      .maybeSingle()
+    expect(membership).toBeNull()
+
+    const { data: invitation } = await admin
+      .from('tenant_invitations')
+      .select('status')
+      .eq('tenant_id', QA.id)
+      .eq('email', SEEDED.alice.email)
+      .single()
+    expect(invitation?.status).toBe('pending')
+  })
+})

--- a/tests/playwright/platform-billing-stripe-webhook.spec.ts
+++ b/tests/playwright/platform-billing-stripe-webhook.spec.ts
@@ -1,0 +1,193 @@
+/**
+ * A school pays the platform through Stripe — proven with a SIGNED synthetic
+ * `checkout.session.completed` (#296 Phase 5, case 5).
+ *
+ * `stripe listen` needs a live CLI session and a restart to pick up its
+ * secret; this signs the event with the `STRIPE_PLATFORM_WEBHOOK_SECRET`
+ * already in the environment (`t=<ts>,v1=HMAC_SHA256(secret, "<ts>.<body>")`,
+ * which is all `stripe.webhooks.constructEvent` checks) and POSTs it to the
+ * real endpoint. Everything after the signature — the `webhook_events` claim,
+ * the normalizer, `dispatchPlatformBillingEvent`, the tenant / subscription /
+ * revenue-split writes and the cutoff reconcile — runs for real.
+ *
+ * The unit test for the route stubs the signature check; this is the only
+ * test that exercises it.
+ */
+import { createHmac } from 'node:crypto'
+import { test, expect } from '@playwright/test'
+import { BASE } from './utils/constants'
+import {
+  DAY_MS,
+  createQaTenant,
+  destroyQaTenant,
+  getAdmin,
+  tenantRow,
+  usageOf,
+  type QaTenant,
+} from './utils/plan-gate-fixtures'
+
+const QA: QaTenant = {
+  id: '00000000-0000-0000-0000-000000000298',
+  slug: 'qa-stripe-webhook',
+  name: 'QA Stripe Webhook',
+  planSlug: 'e2e-unused-stripe', // no throwaway plan needed; destroy() tolerates its absence
+}
+
+const WEBHOOK_SECRET = process.env.STRIPE_PLATFORM_WEBHOOK_SECRET
+const WEBHOOK_URL = `${BASE}/api/billing/webhook/stripe`
+
+function sign(payload: string, secret: string, timestamp = Math.floor(Date.now() / 1000)): string {
+  const v1 = createHmac('sha256', secret).update(`${timestamp}.${payload}`).digest('hex')
+  return `t=${timestamp},v1=${v1}`
+}
+
+/** The event Stripe sends when a hosted Checkout in subscription mode completes. */
+function checkoutCompleted(opts: { eventId: string; subscriptionId: string; planId: string }) {
+  const created = Math.floor(Date.now() / 1000)
+  return JSON.stringify({
+    id: opts.eventId,
+    object: 'event',
+    api_version: '2025-01-27.acacia',
+    created,
+    livemode: false,
+    pending_webhooks: 1,
+    request: { id: null, idempotency_key: null },
+    type: 'checkout.session.completed',
+    data: {
+      object: {
+        id: `cs_test_${opts.eventId}`,
+        object: 'checkout.session',
+        mode: 'subscription',
+        status: 'complete',
+        payment_status: 'paid',
+        subscription: opts.subscriptionId,
+        customer: `cus_test_${QA.id.slice(-4)}`,
+        // Written by app/api/billing/checkout/route.ts; echoed back by Stripe.
+        metadata: {
+          tenant_id: QA.id,
+          plan_id: opts.planId,
+          plan_slug: 'starter',
+          interval: 'monthly',
+        },
+      },
+    },
+  })
+}
+
+test.describe.configure({ mode: 'serial' })
+
+test.describe('platform billing — signed Stripe webhook (#296)', () => {
+  test.skip(!WEBHOOK_SECRET, 'STRIPE_PLATFORM_WEBHOOK_SECRET is required')
+
+  let starterPlanId: string
+  const eventId = `evt_e2e_${Date.now()}`
+  const subscriptionId = `sub_e2e_${Date.now()}`
+
+  test.beforeAll(async () => {
+    const admin = getAdmin()
+    await destroyQaTenant(admin, QA)
+    await createQaTenant(admin, QA, 'free')
+
+    const { data: starter, error } = await admin.from('platform_plans').select('plan_id').eq('slug', 'starter').single()
+    if (error) throw new Error(`starter plan missing: ${error.message}`)
+    starterPlanId = starter.plan_id as string
+
+    // A cutoff already on the row — the upgrade must lift it (0 courses on
+    // Starter is not a violation), the same reconcile a manual confirm runs.
+    await admin
+      .from('tenants')
+      .update({ access_cutoff_at: new Date(Date.now() + 7 * DAY_MS).toISOString() })
+      .eq('id', QA.id)
+  })
+
+  test.afterAll(async () => {
+    const admin = getAdmin()
+    await admin.from('webhook_events').delete().eq('provider_event_id', eventId)
+    await destroyQaTenant(admin, QA)
+  })
+
+  test.beforeEach(async ({}, testInfo) => {
+    test.skip(testInfo.project.name !== 'desktop-chromium', 'runs once — DB state is shared')
+  })
+
+  test('an unsigned body is refused', async ({ request }) => {
+    const res = await request.post(WEBHOOK_URL, {
+      headers: { 'content-type': 'application/json' },
+      data: checkoutCompleted({ eventId: 'evt_e2e_unsigned', subscriptionId, planId: starterPlanId }),
+    })
+    expect(res.status()).toBe(400)
+  })
+
+  test('a body signed with the wrong secret is refused', async ({ request }) => {
+    const payload = checkoutCompleted({ eventId: 'evt_e2e_tampered', subscriptionId, planId: starterPlanId })
+    const res = await request.post(WEBHOOK_URL, {
+      headers: { 'content-type': 'application/json', 'stripe-signature': sign(payload, `${WEBHOOK_SECRET}x`) },
+      data: payload,
+    })
+    expect(res.status()).toBe(400)
+    expect((await tenantRow(getAdmin(), QA.id)).plan).toBe('free')
+  })
+
+  test('a signed checkout completion activates Starter and raises the caps', async ({ request }) => {
+    const admin = getAdmin()
+    const before = await usageOf(admin, QA.id)
+    expect(before.max_courses).toBe(5)
+
+    const payload = checkoutCompleted({ eventId, subscriptionId, planId: starterPlanId })
+    const res = await request.post(WEBHOOK_URL, {
+      headers: { 'content-type': 'application/json', 'stripe-signature': sign(payload, WEBHOOK_SECRET!) },
+      data: payload,
+    })
+    expect(res.status(), await res.text()).toBe(200)
+    expect(await res.json()).toMatchObject({ received: true })
+
+    const tenant = await tenantRow(admin, QA.id)
+    expect(tenant.plan).toBe('starter')
+    expect(tenant.billing_status).toBe('active')
+    expect(tenant.access_cutoff_at).toBeNull()
+
+    const { data: sub } = await admin
+      .from('platform_subscriptions')
+      .select('plan_id, status, payment_provider, provider_subscription_id, interval')
+      .eq('tenant_id', QA.id)
+      .single()
+    expect(sub).toMatchObject({
+      plan_id: starterPlanId,
+      status: 'active',
+      payment_provider: 'stripe',
+      provider_subscription_id: subscriptionId,
+      interval: 'monthly',
+    })
+
+    const { data: split } = await admin
+      .from('revenue_splits')
+      .select('platform_percentage, school_percentage')
+      .eq('tenant_id', QA.id)
+      .single()
+    expect(split).toEqual({ platform_percentage: 5, school_percentage: 95 })
+
+    const after = await usageOf(admin, QA.id)
+    expect(after.max_courses).toBe(15)
+    expect(after.max_students).toBe(200)
+
+    const { data: ledger } = await admin
+      .from('webhook_events')
+      .select('processed_at, error')
+      .eq('provider_event_id', eventId)
+    expect(ledger).toEqual([expect.objectContaining({ error: null })])
+    expect(ledger![0].processed_at).not.toBeNull()
+  })
+
+  test('replaying the same event is acknowledged as a duplicate', async ({ request }) => {
+    const payload = checkoutCompleted({ eventId, subscriptionId, planId: starterPlanId })
+    const res = await request.post(WEBHOOK_URL, {
+      headers: { 'content-type': 'application/json', 'stripe-signature': sign(payload, WEBHOOK_SECRET!) },
+      data: payload,
+    })
+    expect(res.status()).toBe(200)
+    expect(await res.json()).toMatchObject({ received: true, duplicate: true })
+
+    const { data: ledger } = await getAdmin().from('webhook_events').select('id').eq('provider_event_id', eventId)
+    expect(ledger).toHaveLength(1)
+  })
+})

--- a/tests/playwright/utils/plan-gate-fixtures.ts
+++ b/tests/playwright/utils/plan-gate-fixtures.ts
@@ -1,0 +1,213 @@
+/**
+ * Shared fixtures for the plan-gate regression specs (#296 Phase 5).
+ *
+ * Every spec gets its OWN tenant and its OWN throwaway plan row so the files
+ * can run under CI's `fullyParallel` without stepping on each other, and so
+ * the seeded default / code-academy tenants — load-bearing for a dozen other
+ * specs — are never moved off their plan.
+ *
+ * The throwaway plan is the trick that keeps these specs cheap: the DB
+ * triggers (#658), `getTenantPlanLimits` and the cutoff reconcile all read
+ * `platform_plans.limits` by `tenants.plan` slug with NO `is_active` filter,
+ * so a hidden plan with `max_courses: 1` puts a tenant "at the cap" with one
+ * row instead of fifty seeded students.
+ */
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+import type { Page } from '@playwright/test'
+import { expect } from '@playwright/test'
+import { BASE, LOCALE } from './constants'
+
+export const SEEDED = {
+  /** owner@e2etest.com — default-tenant admin + super admin. */
+  owner: { id: 'a1000000-0000-0000-0000-000000000002', email: 'owner@e2etest.com', password: 'password123' },
+  /** student@e2etest.com — default-tenant student. */
+  student: { id: 'a1000000-0000-0000-0000-000000000001', email: 'student@e2etest.com', password: 'password123' },
+  /** alice@student.com — code-academy student, NOT a member of any QA tenant. */
+  alice: { id: 'a1000000-0000-0000-0000-000000000004', email: 'alice@student.com', password: 'password123' },
+} as const
+
+export const DAY_MS = 24 * 60 * 60 * 1000
+
+export function getAdmin(): SupabaseClient {
+  return createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  })
+}
+
+/** `http://lvh.me:3005` → `http://<slug>.lvh.me:3005` — the tenant's subdomain. */
+export function tenantBase(slug: string): string {
+  return BASE.replace('://', `://${slug}.`)
+}
+
+export interface QaTenant {
+  id: string
+  slug: string
+  name: string
+  /** Hidden plan row owned by this spec. */
+  planSlug: string
+}
+
+export interface TinyPlanLimits {
+  max_courses: number
+  max_students: number
+}
+
+/**
+ * A hidden plan row with the given limits and Free's feature set. `is_active`
+ * is false so it never shows on the pricing page mid-run; every enforcement
+ * path reads the plan without that filter.
+ */
+export async function upsertTinyPlan(admin: SupabaseClient, slug: string, limits: TinyPlanLimits) {
+  const { data: free } = await admin.from('platform_plans').select('features').eq('slug', 'free').single()
+  const { error } = await admin.from('platform_plans').upsert(
+    {
+      slug,
+      name: `E2E ${slug}`,
+      description: 'Throwaway plan for the plan-gate regression suite',
+      price_monthly: 0,
+      price_yearly: 0,
+      transaction_fee_percent: 10,
+      sort_order: 999,
+      is_active: false,
+      features: free?.features ?? {},
+      limits: { ...limits, transaction_fee: 10 },
+    },
+    { onConflict: 'slug' },
+  )
+  if (error) throw new Error(`could not upsert plan ${slug}: ${error.message}`)
+}
+
+export async function createQaTenant(admin: SupabaseClient, t: QaTenant, plan = 'free') {
+  const { error } = await admin.from('tenants').upsert(
+    { id: t.id, slug: t.slug, name: t.name, plan, status: 'active', billing_status: 'free', access_cutoff_at: null },
+    { onConflict: 'id' },
+  )
+  if (error) throw new Error(`could not create tenant ${t.slug}: ${error.message}`)
+}
+
+export async function setTenantPlan(admin: SupabaseClient, tenantId: string, plan: string) {
+  const { error } = await admin.from('tenants').update({ plan }).eq('id', tenantId)
+  if (error) throw new Error(`could not set plan ${plan}: ${error.message}`)
+}
+
+export async function addMember(
+  admin: SupabaseClient,
+  tenantId: string,
+  userId: string,
+  role: 'admin' | 'teacher' | 'student',
+) {
+  const { error } = await admin
+    .from('tenant_users')
+    .upsert({ tenant_id: tenantId, user_id: userId, role, status: 'active' }, { onConflict: 'tenant_id,user_id' })
+  if (error) throw new Error(`could not add ${role} ${userId}: ${error.message}`)
+}
+
+export async function insertCourse(
+  admin: SupabaseClient,
+  tenantId: string,
+  title: string,
+  opts?: { status?: 'draft' | 'published' | 'archived'; authorId?: string },
+): Promise<number> {
+  const { data, error } = await admin
+    .from('courses')
+    .insert({
+      title,
+      tenant_id: tenantId,
+      author_id: opts?.authorId ?? SEEDED.owner.id,
+      status: opts?.status ?? 'published',
+      description: 'Plan-gate regression fixture',
+    })
+    .select('course_id')
+    .single()
+  if (error) throw new Error(`could not insert course "${title}": ${error.message}`)
+  return data.course_id as number
+}
+
+/** Everything a spec's tenant owns, then the tenant and its plan row. */
+export async function destroyQaTenant(admin: SupabaseClient, t: QaTenant) {
+  await admin.from('access_cutoff_notifications').delete().eq('tenant_id', t.id)
+  await admin.from('entitlements').delete().eq('tenant_id', t.id)
+  await admin.from('enrollments').delete().eq('tenant_id', t.id)
+  await admin.from('courses').delete().eq('tenant_id', t.id)
+  await admin.from('tenant_invitations').delete().eq('tenant_id', t.id)
+  await admin.from('tenant_users').delete().eq('tenant_id', t.id)
+  await admin.from('tenant_settings').delete().eq('tenant_id', t.id)
+  await admin.from('platform_subscriptions').delete().eq('tenant_id', t.id)
+  await admin.from('platform_payment_requests').delete().eq('tenant_id', t.id)
+  await admin.from('revenue_splits').delete().eq('tenant_id', t.id)
+  await admin.from('tenant_billing_customers').delete().eq('tenant_id', t.id)
+  await admin.from('tenants').delete().eq('id', t.id)
+  await admin.from('platform_plans').delete().eq('slug', t.planSlug)
+}
+
+export interface Usage {
+  courses: number
+  students: number
+  max_courses: number
+  max_students: number
+}
+
+export async function usageOf(admin: SupabaseClient, tenantId: string): Promise<Usage> {
+  const { data, error } = await admin.rpc('get_tenant_plan_usage', { _tenant_id: tenantId })
+  if (error) throw error
+  return data as Usage
+}
+
+export async function tenantRow(admin: SupabaseClient, tenantId: string) {
+  const { data, error } = await admin
+    .from('tenants')
+    .select('plan, billing_status, access_cutoff_at, billing_period_end')
+    .eq('id', tenantId)
+    .single()
+  if (error) throw error
+  return data
+}
+
+export interface SweepResult {
+  success: boolean
+  scheduled: number
+  cleared: number
+  none: number
+  errors: number
+  notified: Record<string, number>
+  notifyFailures: number
+}
+
+/** GET `/api/cron/enforce-plan-limits` the way pg_cron and GitHub do. */
+export async function runEnforceSweep(request: import('@playwright/test').APIRequestContext): Promise<SweepResult> {
+  const res = await request.get(`${BASE}/api/cron/enforce-plan-limits`, {
+    headers: { Authorization: `Bearer ${process.env.CRON_SECRET}` },
+  })
+  expect(res.status(), await res.text()).toBe(200)
+  return (await res.json()) as SweepResult
+}
+
+/**
+ * Login on a tenant subdomain for a user who is NOT a member there: the proxy
+ * bounces them to `/join-school` instead of a dashboard, which is the page the
+ * seat-limit spec wants. Mirrors `utils/auth.ts` (hydration poll + re-press),
+ * only the arrival check differs.
+ */
+export async function loginExpectingJoinSchool(page: Page, base: string, email: string, password: string) {
+  await page.goto(`${base}/${LOCALE}/auth/login`, { waitUntil: 'domcontentloaded' })
+  const emailField = page.getByTestId('login-email')
+  await emailField.waitFor({ state: 'visible', timeout: 30_000 })
+  await expect
+    .poll(
+      async () => {
+        await emailField.fill(email)
+        await page.getByTestId('login-password').fill(password)
+        await page.waitForTimeout(750)
+        return emailField.inputValue()
+      },
+      { timeout: 45_000, intervals: [500, 1000] },
+    )
+    .toBe(email)
+
+  const arrived = () => page.url().includes('/join-school')
+  for (let attempt = 0; attempt < 3 && !arrived(); attempt++) {
+    await page.getByTestId('login-submit').click().catch(() => undefined)
+    await page.waitForURL('**/join-school**', { timeout: 20_000, waitUntil: 'commit' }).catch(() => undefined)
+  }
+  if (!arrived()) throw new Error(`expected /join-school after login, still at ${page.url()}`)
+}

--- a/tests/unit/cloudflare-custom-domain-gate.test.ts
+++ b/tests/unit/cloudflare-custom-domain-gate.test.ts
@@ -1,0 +1,66 @@
+/**
+ * `createCloudflareSubdomain` is the custom-domain write (#662 gate site for
+ * `custom_domain`). Nothing in the app calls it today, which is exactly why it
+ * needs a test: a future vanity-domain flow must not be able to reach
+ * Cloudflare from a plan that does not include the feature.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { PlanFeatureError } from '@/lib/plans/server'
+
+const requireAdmin = vi.fn()
+const requirePlanFeature = vi.fn()
+
+vi.mock('@/lib/actions/utils', () => ({ requireAdmin: (...args: unknown[]) => requireAdmin(...args) }))
+vi.mock('@/lib/plans/server', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/plans/server')>()
+  return { ...actual, requirePlanFeature: (...args: unknown[]) => requirePlanFeature(...args) }
+})
+
+import { createCloudflareSubdomain } from '@/app/actions/cloudflare'
+
+describe('createCloudflareSubdomain plan gate (#662)', () => {
+  const fetchSpy = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubGlobal('fetch', fetchSpy)
+    requireAdmin.mockResolvedValue({ tenantId: 'tenant-1', userId: 'user-1' })
+    delete process.env.CLOUDFLARE_ZONE_ID
+  })
+
+  it('refuses below Business before touching Cloudflare', async () => {
+    requirePlanFeature.mockRejectedValue(new PlanFeatureError('custom_domain', 'free', 'business'))
+
+    await expect(createCloudflareSubdomain('my-school')).rejects.toBeInstanceOf(PlanFeatureError)
+    expect(requirePlanFeature).toHaveBeenCalledWith('tenant-1', 'custom_domain')
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('requires an admin before it even asks about the plan', async () => {
+    requireAdmin.mockRejectedValue(new Error('Unauthorized'))
+
+    await expect(createCloudflareSubdomain('my-school')).rejects.toThrow('Unauthorized')
+    expect(requirePlanFeature).not.toHaveBeenCalled()
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('rejects a malformed subdomain once the plan allows it', async () => {
+    requirePlanFeature.mockResolvedValue({ slug: 'business', name: 'Business', features: {} })
+
+    await expect(createCloudflareSubdomain('Bad Slug!')).resolves.toEqual({
+      success: false,
+      reason: 'Invalid subdomain',
+    })
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('stops safely when Cloudflare is not configured', async () => {
+    requirePlanFeature.mockResolvedValue({ slug: 'business', name: 'Business', features: {} })
+
+    await expect(createCloudflareSubdomain('my-school')).resolves.toEqual({
+      success: false,
+      reason: 'Missing ENV vars',
+    })
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Refs #296 — Phase 5 of the plan-gate hardening handoff (after #659 DB triggers, #661 pg_cron, #663 server feature gates). Closes the regression gaps the coverage survey found: the enforcement now has a test for every surface it was promised on.

## What

**Shared fixture** — `tests/playwright/utils/plan-gate-fixtures.ts`
Each spec owns a dedicated tenant and a hidden `platform_plans` row with tiny limits (`max_courses: 1`, `max_students: 1`). Every enforcement path (DB triggers, `getTenantPlanLimits`, the cutoff reconcile) reads the plan by slug with no `is_active` filter, so "at the cap" costs one row instead of fifty seeded users, and the seeded tenants are never moved off their plan. Safe under CI `fullyParallel`: no two specs share a tenant or plan row.

**`plan-limit-surfaces.spec.ts`** (cases 1–2)
- usage RPC at both caps
- teacher course form refuses before rendering a field
- AI course wizard is disabled at the cap
- a second student seat dies with `LM001` at the database
- `/join-school` refuses with the student-limit copy, and a pending invitation does not buy a seat (stays `pending`, no membership row)

**`access-cutoff-lifecycle.spec.ts`** (case 3), over HTTP with `CRON_SECRET`
- sweep schedules `access_cutoff_at` 14 days out and attempts the `scheduled` rung (ledger row when a mailer is configured, `notifyFailures` otherwise); second sweep is a no-op
- student with a live entitlement is redirected to `/dashboard/student/access-suspended` once the cutoff is live
- archiving the extra course + sweep clears the cutoff and the course URL opens again

**`platform-billing-stripe-webhook.spec.ts`** (case 5)
Signs a synthetic `checkout.session.completed` with `STRIPE_PLATFORM_WEBHOOK_SECRET` (`t=<ts>,v1=HMAC-SHA256`) and POSTs it to the real endpoint: unsigned → 400, wrong secret → 400 and plan unchanged, signed → `tenants.plan = starter`, `platform_subscriptions` active on `stripe`, revenue split 5/95, `max_courses` 5 → 15, a pre-existing cutoff cleared, one `webhook_events` row; replay → `duplicate: true`. The route's unit test stubs the signature; this is the only test that exercises it.

**`plan-feature-tiers.spec.ts`** (case 4, the tiers between Free and Enterprise)
- `remove_branding`: "Powered by" on Free, gone on Pro
- `analytics`: Starter = basic (page renders, no Export, compact nudge), Pro = advanced (Export back, no nudge), Free = locked outright

**Unit**
- `tests/unit/cloudflare-custom-domain-gate.test.ts` — `createCloudflareSubdomain` refuses below Business before any fetch; admin check first; slug validation; env-missing path
- `mcp-server/tests/plan-limits.test.ts` — `isPlanLimitError`, `courseLimitHeadroomError`, `planLimitMessage` (MCP `lms_create_course` is not reachable from Playwright without OAuth)

## Not covered here, on purpose
- `ai_grading` end-to-end (needs a student exam submission through the AI path); the gate is pinned by `plan-feature-gate-contract.test.ts`.
- Ladder emails with a fake mailer over HTTP — impossible to inject into the route; `tests/unit/access-cutoff-notifications.test.ts` owns the T-7/T-1/enforced timing.

## QA
- `npm run typecheck` clean; `npm run test:unit` 1049/1049; mcp-server 9/9.
- Playwright on desktop-chromium, `--workers=1 --retries=1`: stripe 4/4, tiers 4/4, limits 5/5, cutoff 3/3. The only retried failures were the known login-hydration flake (`Login never reached the dashboard`), never an assertion.
- No QA rows left behind (`tenants`, `platform_plans`, `webhook_events` checked after the runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dpLyEb9URLQuD8qgMgp3g
