### PR TITLE
fix(admin): one clear way to create a course for school admins (#665)

### DIFF
--- a/app/[locale]/dashboard/admin/courses/new/page.tsx
+++ b/app/[locale]/dashboard/admin/courses/new/page.tsx
@@ -1,0 +1,63 @@
+import { redirect } from 'next/navigation'
+import { getTranslations } from 'next-intl/server'
+import { AdminBreadcrumb } from '@/components/admin/admin-breadcrumb'
+import { AiCourseGenerator } from '@/components/admin/ai-course-generator'
+import { QuickProductCreate } from '@/components/admin/quick-product-create'
+import { checkCourseLimit } from '@/app/actions/teacher/courses'
+import { getCurrentUserId } from '@/lib/supabase/tenant'
+
+// AI starter-course generation (issue #441) runs as a server action invoked
+// from this segment; give it headroom beyond the default function timeout.
+export const maxDuration = 60
+
+/**
+ * The single "create a course" entry point for school admins (#665).
+ *
+ * Every admin surface that offers course creation (sidebar, Courses page,
+ * getting-started checklist, onboarding wizard) lands here. Quick create
+ * makes the course and its offering in one screen and drops the admin into
+ * the course editor so the next step — adding lessons — is right there.
+ * The full product wizard (existing course, providers, after-purchase steps)
+ * stays at /dashboard/admin/products/new for the monetization context.
+ */
+export default async function AdminNewCoursePage() {
+  const t = await getTranslations('dashboard.admin.courses.new')
+  const tBreadcrumbs = await getTranslations('dashboard.admin.breadcrumbs')
+
+  const userId = await getCurrentUserId()
+  if (!userId) {
+    redirect('/auth/login')
+  }
+
+  const limitInfo = await checkCourseLimit()
+
+  return (
+    <div className="min-h-screen bg-background" data-testid="admin-new-course-page">
+      <header className="border-b bg-card">
+        <div className="mx-auto container px-4 py-5 sm:px-6 lg:px-8">
+          <div className="mb-4">
+            <AdminBreadcrumb
+              items={[
+                { label: tBreadcrumbs('admin'), href: '/dashboard/admin' },
+                { label: tBreadcrumbs('courses'), href: '/dashboard/admin/courses' },
+                { label: tBreadcrumbs('newCourse') },
+              ]}
+            />
+          </div>
+          <h1 className="text-2xl font-bold tracking-tight">{t('title')}</h1>
+          <p className="mt-0.5 text-sm text-muted-foreground">{t('description')}</p>
+        </div>
+      </header>
+
+      <main className="mx-auto container px-4 py-8 sm:px-6 lg:px-8">
+        <QuickProductCreate limitInfo={limitInfo} />
+        <div className="mx-auto my-6 flex w-full max-w-xl items-center gap-3">
+          <span className="h-px flex-1 bg-border" />
+          <span className="text-xs uppercase text-muted-foreground">{t('or')}</span>
+          <span className="h-px flex-1 bg-border" />
+        </div>
+        <AiCourseGenerator disabled={!limitInfo.canCreate} className="mx-auto w-full max-w-xl" />
+      </main>
+    </div>
+  )
+}

--- a/app/[locale]/dashboard/admin/courses/page.tsx
+++ b/app/[locale]/dashboard/admin/courses/page.tsx
@@ -85,7 +85,7 @@ export default async function AdminCoursesPage() {
             {/* Admins create courses through the teacher editor. Without this
                 entry point the page reads as a read-only report and admins
                 cannot find how to add a course (Sentry LMS-FRONT-9N). */}
-            <Button size="sm" className="gap-2" render={<Link href="/dashboard/teacher/courses/new" />} data-testid="admin-create-course">
+            <Button size="sm" className="gap-2" render={<Link href="/dashboard/admin/courses/new" />} data-testid="admin-create-course">
               <IconPlus className="h-3.5 w-3.5" />
               {t('createCourse')}
             </Button>

--- a/app/[locale]/dashboard/admin/courses/page.tsx
+++ b/app/[locale]/dashboard/admin/courses/page.tsx
@@ -1,12 +1,11 @@
 import { createAdminClient } from '@/lib/supabase/admin'
 import { redirect } from 'next/navigation'
-import { getUserRole } from '@/lib/supabase/get-user-role'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import Link from 'next/link'
 import {
-  IconArrowLeft,
   IconBook,
+  IconPlus,
 } from '@tabler/icons-react'
 import { CoursesTable } from '@/components/admin/courses-table'
 import { getTranslations } from 'next-intl/server'
@@ -78,8 +77,19 @@ export default async function AdminCoursesPage() {
               ]}
             />
           </div>
-          <h1 className="text-2xl font-bold tracking-tight">{t('title')}</h1>
-          <p className="mt-0.5 text-sm text-muted-foreground">{t('description')}</p>
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h1 className="text-2xl font-bold tracking-tight">{t('title')}</h1>
+              <p className="mt-0.5 text-sm text-muted-foreground">{t('description')}</p>
+            </div>
+            {/* Admins create courses through the teacher editor. Without this
+                entry point the page reads as a read-only report and admins
+                cannot find how to add a course (Sentry LMS-FRONT-9N). */}
+            <Button size="sm" className="gap-2" render={<Link href="/dashboard/teacher/courses/new" />} data-testid="admin-create-course">
+              <IconPlus className="h-3.5 w-3.5" />
+              {t('createCourse')}
+            </Button>
+          </div>
         </div>
       </header>
 

--- a/app/[locale]/dashboard/admin/page.tsx
+++ b/app/[locale]/dashboard/admin/page.tsx
@@ -231,7 +231,7 @@ export default async function AdminDashboardPage({
             id: 'add-course',
             label: t('onboarding.addCourse'),
             description: t('onboarding.addCourseDesc'),
-            href: '/dashboard/admin/products/new',
+            href: '/dashboard/admin/courses/new',
             completed: (publishedCourses || 0) > 0,
             timeHint: t('onboarding.addCourseTime'),
           },

--- a/app/[locale]/dashboard/admin/products/new/page.tsx
+++ b/app/[locale]/dashboard/admin/products/new/page.tsx
@@ -2,22 +2,15 @@ import { redirect } from 'next/navigation'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { getTranslations } from 'next-intl/server'
 import { AdminBreadcrumb } from '@/components/admin/admin-breadcrumb'
-import { AiCourseGenerator } from '@/components/admin/ai-course-generator'
 import { ProductCreationWizard } from '@/components/admin/product-creation-wizard'
-import { QuickProductCreate } from '@/components/admin/quick-product-create'
 import { getEnabledPaymentProviders } from '@/app/actions/admin/settings'
-import { checkCourseLimit } from '@/app/actions/teacher/courses'
 import { getCurrentTenantId, getCurrentUserId } from '@/lib/supabase/tenant'
 
-// AI starter-course generation (issue #441) runs as a server action invoked
-// from this segment; give it headroom beyond the default function timeout.
-export const maxDuration = 60
-
-export default async function NewProductPage({
-  searchParams,
-}: {
-  searchParams: Promise<{ advanced?: string }>
-}) {
+// The one-screen quick create + AI generator moved to
+// /dashboard/admin/courses/new (#665) so "create a course" has a single home.
+// This page is the full product wizard: existing course, providers, currency,
+// after-purchase steps. `?advanced=1` links from before the move still land here.
+export default async function NewProductPage() {
   const t = await getTranslations('dashboard.admin.products.new')
   const tBreadcrumbs = await getTranslations('dashboard.admin.breadcrumbs')
 
@@ -25,9 +18,6 @@ export default async function NewProductPage({
   if (!userId) {
     redirect('/auth/login')
   }
-
-  const { advanced } = await searchParams
-  const showAdvanced = advanced === '1'
 
   const breadcrumb = (
     <AdminBreadcrumb
@@ -39,37 +29,6 @@ export default async function NewProductPage({
       ]}
     />
   )
-
-  if (!showAdvanced) {
-    const limitInfo = await checkCourseLimit()
-
-    return (
-      <div className="min-h-screen bg-background">
-        <header className="border-b bg-card">
-          <div className="mx-auto max-w-6xl px-4 py-6 sm:px-6 lg:px-8">
-            <div className="mb-4">{breadcrumb}</div>
-            <div>
-              <h1 className="text-2xl font-bold md:text-3xl">{t('title')}</h1>
-              <p className="mt-1 text-muted-foreground">{t('description')}</p>
-            </div>
-          </div>
-        </header>
-
-        <main className="mx-auto max-w-6xl px-4 py-8 sm:px-6 lg:px-8">
-          <QuickProductCreate limitInfo={limitInfo} />
-          <div className="mx-auto my-6 flex w-full max-w-xl items-center gap-3">
-            <span className="h-px flex-1 bg-border" />
-            <span className="text-xs uppercase text-muted-foreground">{t('quick.or')}</span>
-            <span className="h-px flex-1 bg-border" />
-          </div>
-          <AiCourseGenerator
-            disabled={!limitInfo.canCreate}
-            className="mx-auto w-full max-w-xl"
-          />
-        </main>
-      </div>
-    )
-  }
 
   const supabase = createAdminClient()
   const tenantId = await getCurrentTenantId()

--- a/components/admin/courses-table.tsx
+++ b/components/admin/courses-table.tsx
@@ -25,7 +25,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
-import { IconUsers, IconSettings, IconBook, IconUserOff } from '@tabler/icons-react'
+import { IconUsers, IconSettings, IconBook, IconUserOff, IconPlus } from '@tabler/icons-react'
 import { CourseStatusActions } from './course-status-actions'
 import Link from 'next/link'
 
@@ -216,8 +216,22 @@ export function CoursesTable({
               })
             ) : (
               <TableRow>
-                <TableCell colSpan={7} className="py-8 text-center text-muted-foreground">
-                  {t('empty')}
+                <TableCell colSpan={7} className="py-12">
+                  <div className="flex flex-col items-center text-center">
+                    <div className="mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-muted">
+                      <IconBook className="h-6 w-6 text-muted-foreground/50" />
+                    </div>
+                    <p className="text-sm font-medium">{t('empty')}</p>
+                    {courses.length === 0 && (
+                      <>
+                        <p className="mt-1 max-w-sm text-sm text-muted-foreground">{t('emptyDesc')}</p>
+                        <Button size="sm" className="mt-4 gap-2" render={<Link href="/dashboard/teacher/courses/new" />}>
+                          <IconPlus className="h-3.5 w-3.5" />
+                          {t('createFirst')}
+                        </Button>
+                      </>
+                    )}
+                  </div>
                 </TableCell>
               </TableRow>
             )}

--- a/components/admin/courses-table.tsx
+++ b/components/admin/courses-table.tsx
@@ -225,7 +225,7 @@ export function CoursesTable({
                     {courses.length === 0 && (
                       <>
                         <p className="mt-1 max-w-sm text-sm text-muted-foreground">{t('emptyDesc')}</p>
-                        <Button size="sm" className="mt-4 gap-2" render={<Link href="/dashboard/teacher/courses/new" />}>
+                        <Button size="sm" className="mt-4 gap-2" render={<Link href="/dashboard/admin/courses/new" />}>
                           <IconPlus className="h-3.5 w-3.5" />
                           {t('createFirst')}
                         </Button>

--- a/components/admin/quick-product-create.tsx
+++ b/components/admin/quick-product-create.tsx
@@ -45,7 +45,7 @@ interface QuickProductCreateProps {
 /**
  * One-screen quick-create: title + free/paid + price + publish.
  * Everything else (category, thumbnail, after-purchase steps, provider choice)
- * is deferred with defaults — the full wizard stays at ?advanced=1.
+ * is deferred with defaults — the full wizard stays at /dashboard/admin/products/new.
  */
 export function QuickProductCreate({ limitInfo, className }: QuickProductCreateProps) {
   const t = useTranslations('dashboard.admin.products.new.quick')
@@ -85,13 +85,15 @@ export function QuickProductCreate({ limitInfo, className }: QuickProductCreateP
         postRegistrationSteps: [],
       })
 
-      if (!result.success) {
-        toast.error(result.error || t('saveError'))
+      if (!result.success || !result.data) {
+        toast.error((!result.success && result.error) || t('saveError'))
         return
       }
 
       toast.success(intent === 'publish' ? t('published') : t('draftSaved'))
-      router.push('/dashboard/admin/products')
+      // Land in the course editor, not the products list: the course has no
+      // lessons yet and that is the obvious next step (#665).
+      router.push(`/dashboard/teacher/courses/${result.data.courseId}`)
       router.refresh()
     } catch (error) {
       toast.error(error instanceof Error ? error.message : t('saveError'))
@@ -222,7 +224,7 @@ export function QuickProductCreate({ limitInfo, className }: QuickProductCreateP
             </Button>
           </div>
           <Link
-            href="/dashboard/admin/products/new?advanced=1"
+            href="/dashboard/admin/products/new"
             className="inline-flex items-center gap-1 text-sm text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
           >
             {t('moreOptions')}

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -146,7 +146,7 @@ export function AppSidebar({ userRole, ...props }: AppSidebarProps) {
                 {
                     title: t('courses'), href: "/dashboard/admin/courses", icon: IconBook,
                     items: [
-                        { title: t('createCourse'), href: "/dashboard/teacher/courses/new" },
+                        { title: t('createCourse'), href: "/dashboard/admin/courses/new" },
                         { title: t('myCourses'), href: "/dashboard/teacher/courses", tourId: 'sidebar-courses' },
                         { title: t('enrollments'), href: "/dashboard/admin/enrollments" },
                     ],

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -146,6 +146,7 @@ export function AppSidebar({ userRole, ...props }: AppSidebarProps) {
                 {
                     title: t('courses'), href: "/dashboard/admin/courses", icon: IconBook,
                     items: [
+                        { title: t('createCourse'), href: "/dashboard/teacher/courses/new" },
                         { title: t('myCourses'), href: "/dashboard/teacher/courses", tourId: 'sidebar-courses' },
                         { title: t('enrollments'), href: "/dashboard/admin/enrollments" },
                     ],

--- a/components/onboarding/onboarding-wizard.tsx
+++ b/components/onboarding/onboarding-wizard.tsx
@@ -105,7 +105,7 @@ export default function OnboardingWizard({ userName, currentSettings, redirectTo
       })
 
       if (result.success) {
-        router.push('/dashboard/teacher/courses/new')
+        router.push('/dashboard/admin/courses/new')
       } else {
         throw new Error(result.error)
       }

--- a/messages/en.json
+++ b/messages/en.json
@@ -2161,6 +2161,7 @@
         "upgrade": "Upgrade",
         "products": "Products",
         "newProduct": "New Product",
+        "newCourse": "New Course",
         "editProduct": "Edit Product",
         "plans": "Plans",
         "newPlan": "New Plan",
@@ -2889,7 +2890,12 @@
         "description": "View and manage all platform courses",
         "backToDashboard": "Back to Dashboard",
         "createCourse": "Create Course",
-        "stats": {
+
+        "new": {
+          "title": "Create a course",
+          "description": "Name it, pick a price, publish. You will land in the course editor to add lessons.",
+          "or": "or"
+        },        "stats": {
           "total": "Total Courses",
           "published": "Published",
           "drafts": "Drafts"

--- a/messages/en.json
+++ b/messages/en.json
@@ -2888,6 +2888,7 @@
         "title": "Course Management",
         "description": "View and manage all platform courses",
         "backToDashboard": "Back to Dashboard",
+        "createCourse": "Create Course",
         "stats": {
           "total": "Total Courses",
           "published": "Published",
@@ -2914,6 +2915,8 @@
           },
           "unknownAuthor": "No author assigned",
           "empty": "No courses found",
+          "emptyDesc": "No one has created a course in this school yet. Create the first one to get started.",
+          "createFirst": "Create your first course",
           "actions": {
             "manage": "Manage"
           }

--- a/messages/es.json
+++ b/messages/es.json
@@ -2161,6 +2161,7 @@
         "upgrade": "Mejorar",
         "products": "Productos",
         "newProduct": "Nuevo Producto",
+        "newCourse": "Nuevo Curso",
         "editProduct": "Editar Producto",
         "plans": "Planes",
         "newPlan": "Nuevo Plan",
@@ -2885,7 +2886,12 @@
         "description": "Ver y gestionar todos los cursos de la plataforma",
         "backToDashboard": "Volver al Panel",
         "createCourse": "Crear Curso",
-        "stats": {
+
+        "new": {
+          "title": "Crear un curso",
+          "description": "Ponle nombre, elige un precio y publícalo. Luego irás al editor del curso para añadir lecciones.",
+          "or": "o"
+        },        "stats": {
           "total": "Cursos Totales",
           "published": "Publicados",
           "drafts": "Borradores"

--- a/messages/es.json
+++ b/messages/es.json
@@ -2884,6 +2884,7 @@
         "title": "Gestión de Cursos",
         "description": "Ver y gestionar todos los cursos de la plataforma",
         "backToDashboard": "Volver al Panel",
+        "createCourse": "Crear Curso",
         "stats": {
           "total": "Cursos Totales",
           "published": "Publicados",
@@ -2910,6 +2911,8 @@
           },
           "unknownAuthor": "Sin autor asignado",
           "empty": "No se encontraron cursos",
+          "emptyDesc": "Nadie ha creado un curso en esta escuela todavía. Crea el primero para empezar.",
+          "createFirst": "Crea tu primer curso",
           "actions": {
             "manage": "Gestionar"
           }

--- a/tests/playwright/admin-pages.spec.ts
+++ b/tests/playwright/admin-pages.spec.ts
@@ -28,7 +28,7 @@ test.describe('Admin Pages', () => {
     const schoolDetails = checklist.getByRole('link', { name: /Configure school details/ })
 
     await expect(checklist.getByText(/^\d\/5$/)).toBeVisible()
-    await expect(createCourse).toHaveAttribute('href', '/dashboard/admin/products/new')
+    await expect(createCourse).toHaveAttribute('href', '/dashboard/admin/courses/new')
     await expect(payments).toHaveAttribute('href', '/dashboard/admin/settings?tab=payment')
     await expect(branding).toHaveAttribute('href', '/dashboard/admin/appearance')
     await expect(inviteStudents).toHaveAttribute('href', '/dashboard/admin/users')
@@ -88,7 +88,7 @@ test.describe('Admin Pages', () => {
     // that entry point or admins cannot find it (#665, Sentry LMS-FRONT-9N).
     const createCta = page.getByTestId('admin-create-course')
     await expect(createCta).toBeVisible()
-    await expect(createCta).toHaveAttribute('href', /\/dashboard\/teacher\/courses\/new$/)
+    await expect(createCta).toHaveAttribute('href', /\/dashboard\/admin\/courses\/new$/)
   })
 
   test('admin enrollments page loads', async ({ page }) => {

--- a/tests/playwright/admin-pages.spec.ts
+++ b/tests/playwright/admin-pages.spec.ts
@@ -84,6 +84,11 @@ test.describe('Admin Pages', () => {
   test('admin courses page loads', async ({ page }) => {
     await page.goto(`${TENANT_BASE}/en/dashboard/admin/courses`)
     await expect(page.getByTestId('admin-courses-page')).toBeVisible()
+    // Admins create courses through the teacher editor — the page must expose
+    // that entry point or admins cannot find it (#665, Sentry LMS-FRONT-9N).
+    const createCta = page.getByTestId('admin-create-course')
+    await expect(createCta).toBeVisible()
+    await expect(createCta).toHaveAttribute('href', /\/dashboard\/teacher\/courses\/new$/)
   })
 
   test('admin enrollments page loads', async ({ page }) => {

--- a/tests/playwright/admin-product-course-creation.spec.ts
+++ b/tests/playwright/admin-product-course-creation.spec.ts
@@ -2,10 +2,10 @@ import { expect, type Page, test } from '@playwright/test'
 import { loginAsAdmin } from './utils/auth'
 import { LOCALE, TENANT_BASE } from './utils/constants'
 
-// /products/new renders the one-screen quick create; the multi-step wizard
-// these helpers drive lives behind ?advanced=1.
-const wizardPath = `${TENANT_BASE}/${LOCALE}/dashboard/admin/products/new?advanced=1`
-const quickCreatePath = `${TENANT_BASE}/${LOCALE}/dashboard/admin/products/new`
+// /products/new is the multi-step product wizard these helpers drive; the
+// one-screen quick create is the admin "create a course" page (#665).
+const wizardPath = `${TENANT_BASE}/${LOCALE}/dashboard/admin/products/new`
+const quickCreatePath = `${TENANT_BASE}/${LOCALE}/dashboard/admin/courses/new`
 const productsPath = `${TENANT_BASE}/${LOCALE}/dashboard/admin/products`
 
 function uniqueTitle(prefix: string) {
@@ -241,6 +241,11 @@ test.describe('Admin Product/Course Creation Wizard', () => {
     // 'free' is the default pricing mode — publish straight away.
     await page.getByRole('button', { name: /publish|publicar/i }).first().click()
 
+    // Quick create lands in the course editor (the next step is adding
+    // lessons), not on the products list.
+    await expect(page).toHaveURL(/\/dashboard\/teacher\/courses\/\d+/, { timeout: 20_000 })
+
+    await page.goto(productsPath, { timeout: 30_000 })
     await expect(
       page.getByTestId('products-page').getByText(title).first()
     ).toBeVisible({ timeout: 20_000 })

--- a/tests/playwright/plan-limit-surfaces.spec.ts
+++ b/tests/playwright/plan-limit-surfaces.spec.ts
@@ -86,7 +86,7 @@ test.describe('plan limits — every surface at the cap (#296)', () => {
   test('the AI course wizard is disabled at the cap', async ({ page }) => {
     test.setTimeout(120_000)
     await login(page, SEEDED.owner.email, SEEDED.owner.password, QA_BASE)
-    await page.goto(`${QA_BASE}/${LOCALE}/dashboard/admin/products/new`)
+    await page.goto(`${QA_BASE}/${LOCALE}/dashboard/admin/courses/new`)
 
     await expect(page.getByText('Course limit reached')).toBeVisible({ timeout: 20_000 })
     await expect(page.getByRole('button', { name: 'Generate draft' })).toBeDisabled()


### PR DESCRIPTION
## Summary
Fixes #665 · Sentry user feedback [LMS-FRONT-9N](https://guillermoscript.sentry.io/issues/LMS-FRONT-9N)

A school admin on prod wrote "je ne vois pas comment faire cree des cours" after 1m18s of wandering between settings pages, no errors and no rage clicks.

**Before:** the admin Courses page had no Create button, and admins had two creation paths that behaved differently:
- Teacher course form (`/dashboard/teacher/courses/new`) → lands in the course editor.
- "Create Product" quick create (`/dashboard/admin/products/new`) → creates course + price, then drops you on the **Products list** with no next step. The getting-started checklist pointed here.

**After:** one page, `/dashboard/admin/courses/new`, reachable from every admin surface, and it ends in the course editor where lessons get added.

## Changes
- **New `/dashboard/admin/courses/new`**: quick create (title, free/paid, price, publish or draft) + AI starter generator. Breadcrumb Admin → Courses → New Course.
- **Quick create lands in the course editor** (`/dashboard/teacher/courses/<id>`), not the products list. "More options" opens the full product wizard.
- **`/dashboard/admin/products/new` is the product wizard only.** The `?advanced=1` split is removed; old `?advanced=1` links still land on the wizard.
- **Every entry point points at the one page:** sidebar (new "Create Course" sub-item under Courses), Courses page header button, courses table empty state, admin home getting-started checklist, onboarding wizard "skip to create".
- **i18n** en/es for the new page, breadcrumb, and empty state.
- **Specs:** `admin-pages` (checklist href + new CTA assertion), `admin-product-course-creation` (paths + quick-create now asserts the editor URL, then checks the product exists), `plan-limit-surfaces` (AI cap test on the new page). `admin-crud`'s expectation that `/products/new` shows the wizard is true again.

Uses base-ui `render={<Link/>}` on Buttons, not a wrapping `<Link>`.

## QA
- `npm run typecheck` ✅ · `eslint` on changed files ✅
- Playwright **not run locally** (Docker daemon was down, no local Supabase). Relevant specs, `--workers=1`:
  ```
  npx playwright test admin-pages admin-product-course-creation admin-crud plan-limit-surfaces --workers=1
  ```
- Manual, as `owner@e2etest.com` on `default.lvh.me:3005`:
  1. Sidebar → Courses → "Create Course" → lands on `/dashboard/admin/courses/new`.
  2. Type a title, leave Free, "Create & publish" → toast, then the course editor opens.
  3. `/dashboard/admin/products/new` → multi-step wizard, no quick form.
  4. Admin home checklist "Create your first course" → same new page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6TeYjJcqunFTZ5FR52SDA