### PR TITLE
ci: run mcp-server unit tests in CI and gate the MCP deploy on a green run (#669)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,40 @@ jobs:
       - name: Unit tests
         run: npm run test:unit
 
+  # The MCP server package (#669). It carries its own vitest.config.ts with
+  # ~90 tests that the root config never includes, and until this job existed
+  # nothing in CI ran them: deploy-mcp.yml shipped the image untested.
+  #
+  # Two installs on purpose: mcp-server/vitest.config.ts resolves the ROOT
+  # Vitest binary through the ancestor node_modules/.bin on PATH (the package
+  # has no Vitest of its own), so the root install is what provides the
+  # runner, and the package install provides what the tools import.
+  # Unconditional (no paths filter) so the check name is stable enough to be
+  # required by branch protection; the job costs well under a minute.
+  mcp-server:
+    name: MCP server unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            mcp-server/package-lock.json
+      - name: Install (root, provides Vitest)
+        run: npm ci
+      - name: Install (mcp-server)
+        run: npm ci
+        working-directory: mcp-server
+      - name: Typecheck
+        run: npm run typecheck
+        working-directory: mcp-server
+      - name: Unit tests
+        run: npm test
+        working-directory: mcp-server
+
   # The Playwright suite (#667). Until this job existed, 374 E2E tests ran only
   # on whoever remembered to run them locally.
   #

--- a/.github/workflows/deploy-mcp.yml
+++ b/.github/workflows/deploy-mcp.yml
@@ -1,17 +1,56 @@
 name: Build and deploy MCP server to Dokploy
 
+# Runs after the CI workflow (which includes the `MCP server unit tests` job,
+# #669) has passed on master — a red merge commit is not shipped, same
+# contract as deploy.yml. The image is only rebuilt when the verified commit
+# touches mcp-server/**; the `changed` job below stands in for the `paths:`
+# filter that a `workflow_run` trigger cannot express. If CI is wrong and a
+# hotfix has to go out anyway, trigger this workflow by hand from the Actions
+# tab (workflow_dispatch) — that path skips both the CI gate and the paths
+# check.
 on:
-  push:
-    branches: ["master", "feature/mcp"]
-    paths:
-      - "mcp-server/**"
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: ["master"]
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}-mcp
 
 jobs:
+  changed:
+    name: mcp-server changed?
+    # workflow_run fires on failure too; only consider a green run. Manual
+    # dispatch has no upstream run and always proceeds.
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    outputs:
+      deploy: ${{ steps.diff.outputs.deploy }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          # HEAD and its first parent: master receives squash merges, so the
+          # merge commit's own diff is the whole PR.
+          fetch-depth: 2
+      - id: diff
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "deploy=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if git diff --quiet HEAD^ HEAD -- mcp-server; then
+            echo "mcp-server/ untouched by ${GITHUB_SHA::7}; skipping deploy"
+            echo "deploy=false" >> "$GITHUB_OUTPUT"
+          else
+            git diff --name-only HEAD^ HEAD -- mcp-server
+            echo "deploy=true" >> "$GITHUB_OUTPUT"
+          fi
+
   build-and-push:
+    needs: changed
+    if: needs.changed.outputs.deploy == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -20,6 +59,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          # On workflow_run `github.sha` is the default-branch head, which is
+          # what we want on master; pin to the verified commit anyway.
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3


### PR DESCRIPTION
## What

CI now runs the `mcp-server/` unit tests and typecheck as their own job (`MCP server unit tests`), and the MCP deploy workflow waits for a green CI run on master instead of building straight from a push.

Closes #669

## Why

`mcp-server/` has its own `vitest.config.ts` with 88 tests across 7 files (`practice`, `flashcards`, `certificates`, `branding`, `contrast`, `missing-data-display`, `plan-limits`). The root Vitest config only includes `tests/unit/**`, and no workflow ever ran `npm test` inside the package. `deploy-mcp.yml` fired on any push to `master` touching `mcp-server/**` and shipped the image with no test gate. Part of #682.

### `ci.yml` — new `mcp-server` job

- Root `npm ci` first: `mcp-server/vitest.config.ts` deliberately has no Vitest of its own and resolves the root binary through the ancestor `node_modules/.bin` on PATH (see the comment in that file). The root install is what provides the runner.
- Then `npm ci`, `npm run typecheck`, `npm test` inside `mcp-server/`, with `cache-dependency-path` covering both lockfiles.
- Unconditional (no `paths` filter) so the check name is stable enough for branch protection. It runs in well under a minute.
- Typecheck is a small addition beyond the issue's "run the tests" scope: `mcp-use typecheck` is what the Docker build runs into on deploy, so failing it on the PR is cheaper than failing it in `deploy-mcp.yml`. Say the word and I drop it.

### `deploy-mcp.yml` — gated on CI

- Trigger switches from `push` to `workflow_run` on the `CI` workflow for `master`, `success` only — the same contract `deploy.yml` already has for the app image. `workflow_dispatch` remains the manual escape hatch and skips both gates.
- `workflow_run` cannot express `paths:`, so a small `changed` job re-creates the old `mcp-server/**` filter with `git diff --quiet HEAD^ HEAD -- mcp-server` (`fetch-depth: 2`). Master receives squash merges, so the merge commit's own diff is the whole PR. Simulated locally against real master commits: the mcp-use v2 migration (`0c554c9d`) → deploy (101 files), the grading-queue merge (`2c7b4df7`) → skip.
- The `feature/mcp` branch trigger is gone; the branch no longer exists on origin.

Consequence worth knowing: because the gate is the whole CI workflow, a red Playwright shard now also holds the MCP deploy, exactly as it holds the app deploy. That is the intended contract (a red merge commit is not shipped), not a side effect.

## How to QA

No app change; nothing to run on a local `db:reset`.

1. On this PR, confirm the `MCP server unit tests` check is present and green in the checks list.
2. Open the job log: the `Unit tests` step should report `Test Files 7 passed`, `Tests 88 passed`; `Typecheck` should print `no type errors`.
3. Locally, the same commands the job runs: `cd mcp-server && npm run typecheck && npm test`.
4. After merge: watch the Actions tab. The `CI` run on master finishes, then `Build and deploy MCP server to Dokploy` starts from `workflow_run`. Its `mcp-server changed?` job logs `mcp-server/ untouched by <sha>; skipping deploy` for this merge (the PR touches only `.github/workflows/`), and `build-and-push` is skipped. The next merge that touches `mcp-server/**` builds and pushes as before.

## Screenshots / GIF

Not applicable: CI configuration only, nothing a user can see or click.

## Checklist

- [x] `npm run typecheck` and `npm run test:unit` pass — unchanged for the root; `mcp-server` typecheck + 88 tests green locally
- [x] `npm run build` passes — no source change; the `image` CI job builds the production image on this PR
- [x] Every new tenant-scoped query filters by `tenant_id` — no queries added
- [x] Tested with every relevant role — not applicable
- [x] Loading and error states handled — not applicable
- [x] New UI strings added to both `messages/en.json` and `messages/es.json` — none
- [x] Migration — none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RbBhtztZn21h9AC9PZC4ku
