### PR TITLE
fix(auth): paid-course CTA keeps checkout intent through join-school for a new visitor (#684)

### DIFF
--- a/app/[locale]/join-school/page.tsx
+++ b/app/[locale]/join-school/page.tsx
@@ -9,6 +9,7 @@ import { Button } from '@/components/ui/button'
 import type { Metadata } from 'next'
 import { getTranslations } from 'next-intl/server'
 import { buildPageMetadata } from '@/lib/seo'
+import { getSafeNextPath } from '@/lib/auth/safe-next-path'
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }): Promise<Metadata> {
   const { locale } = await params
@@ -16,12 +17,27 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
   return buildPageMetadata({ title: t('joinSchool.title'), description: t('joinSchool.description'), path: '/join-school', locale })
 }
 
-export default async function JoinSchoolPage() {
+export default async function JoinSchoolPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ next?: string | string[] }>
+}) {
+  const { next: requestedNext } = await searchParams
+  // Where to go once the visitor is a member (#684). proxy.ts sets it when it
+  // bounces a non-member off a protected page such as /checkout; a missing or
+  // unsafe value falls back to the dashboard, never off-origin.
+  const nextPath = getSafeNextPath(
+    Array.isArray(requestedNext) ? requestedNext[0] : requestedNext,
+    ''
+  )
+  const destination = nextPath || '/dashboard/student'
+
   const supabase = await createClient()
   const userId = await getCurrentUserId()
-  // Redirect to login if not authenticated
+  // Redirect to login if not authenticated, keeping the intent through login
   if (!userId) {
-    redirect('/auth/login?next=/join-school')
+    const returnTo = nextPath ? `/join-school?next=${encodeURIComponent(nextPath)}` : '/join-school'
+    redirect(`/auth/login?next=${encodeURIComponent(returnTo)}`)
   }
 
   const tenantId = await getCurrentTenantId()
@@ -79,8 +95,8 @@ export default async function JoinSchoolPage() {
               You have access to all courses and resources at {tenant.name}.
             </p>
             <div className="flex gap-2">
-              <Link href="/dashboard/student" className="flex-1">
-                <Button className="w-full">Go to Dashboard</Button>
+              <Link href={destination} className="flex-1">
+                <Button className="w-full">{nextPath ? 'Continue' : 'Go to Dashboard'}</Button>
               </Link>
               <Link href="/dashboard/student/browse" className="flex-1">
                 <Button variant="outline" className="w-full">Browse Courses</Button>
@@ -147,7 +163,7 @@ export default async function JoinSchoolPage() {
         </Card>
       )}
 
-      <JoinSchoolForm tenant={tenant} />
+      <JoinSchoolForm tenant={tenant} next={nextPath || null} />
     </div>
   )
 }

--- a/app/[locale]/join-school/page.tsx
+++ b/app/[locale]/join-school/page.tsx
@@ -22,18 +22,23 @@ export default async function JoinSchoolPage({
 }: {
   searchParams: Promise<{ next?: string | string[] }>
 }) {
-  const { next: requestedNext } = await searchParams
-  // Where to go once the visitor is a member (#684). proxy.ts sets it when it
-  // bounces a non-member off a protected page such as /checkout; a missing or
-  // unsafe value falls back to the dashboard, never off-origin.
+  // The three inputs are independent — resolve them together, not as a
+  // waterfall of awaits.
+  const [{ next: requestedNext }, supabase, userId] = await Promise.all([
+    searchParams,
+    createClient(),
+    getCurrentUserId(),
+  ])
+  // Where to go once the visitor is a member (#684). proxy.ts sets `next` when
+  // it bounces a non-member off a protected page such as /checkout; a missing
+  // or unsafe value falls back to the dashboard, never off-origin. Resolved
+  // once here so the form and the member card share a single destination.
   const nextPath = getSafeNextPath(
     Array.isArray(requestedNext) ? requestedNext[0] : requestedNext,
     ''
   )
   const destination = nextPath || '/dashboard/student'
 
-  const supabase = await createClient()
-  const userId = await getCurrentUserId()
   // Redirect to login if not authenticated, keeping the intent through login
   if (!userId) {
     const returnTo = nextPath ? `/join-school?next=${encodeURIComponent(nextPath)}` : '/join-school'
@@ -163,7 +168,7 @@ export default async function JoinSchoolPage({
         </Card>
       )}
 
-      <JoinSchoolForm tenant={tenant} next={nextPath || null} />
+      <JoinSchoolForm tenant={tenant} destination={destination} />
     </div>
   )
 }

--- a/components/join-school-form.tsx
+++ b/components/join-school-form.tsx
@@ -15,14 +15,14 @@ interface JoinSchoolFormProps {
     description?: string
   }
   /**
-   * Same-origin path to land on after joining, already validated by the page
-   * with `getSafeNextPath`. Carries a purchase/enroll intent through the join
-   * step (#684); absent, the student dashboard is the destination.
+   * Same-origin path to land on after a successful join. The page resolves it
+   * (a sanitised `next` such as `/checkout?courseId=42`, or the student
+   * dashboard) so a purchase or enroll intent survives the join step (#684).
    */
-  next?: string | null
+  destination: string
 }
 
-export function JoinSchoolForm({ tenant, next }: JoinSchoolFormProps) {
+export function JoinSchoolForm({ tenant, destination }: JoinSchoolFormProps) {
   const [isJoining, setIsJoining] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -44,7 +44,7 @@ export function JoinSchoolForm({ tenant, next }: JoinSchoolFormProps) {
       // (LMS-FRONT-9K/8F, upstream vercel/next.js#78396) — and the membership
       // just changed, so a full request through proxy.ts with fresh claims is
       // what we want anyway. The button stays disabled until the page unloads.
-      window.location.assign(next || '/dashboard/student')
+      window.location.assign(destination)
     } catch (err) {
       console.error('Join error:', err)
       setError('An unexpected error occurred')

--- a/components/join-school-form.tsx
+++ b/components/join-school-form.tsx
@@ -14,9 +14,15 @@ interface JoinSchoolFormProps {
     slug: string
     description?: string
   }
+  /**
+   * Same-origin path to land on after joining, already validated by the page
+   * with `getSafeNextPath`. Carries a purchase/enroll intent through the join
+   * step (#684); absent, the student dashboard is the destination.
+   */
+  next?: string | null
 }
 
-export function JoinSchoolForm({ tenant }: JoinSchoolFormProps) {
+export function JoinSchoolForm({ tenant, next }: JoinSchoolFormProps) {
   const [isJoining, setIsJoining] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -38,7 +44,7 @@ export function JoinSchoolForm({ tenant }: JoinSchoolFormProps) {
       // (LMS-FRONT-9K/8F, upstream vercel/next.js#78396) — and the membership
       // just changed, so a full request through proxy.ts with fresh claims is
       // what we want anyway. The button stays disabled until the page unloads.
-      window.location.assign('/dashboard/student')
+      window.location.assign(next || '/dashboard/student')
     } catch (err) {
       console.error('Join error:', err)
       setError('An unexpected error occurred')
@@ -94,6 +100,7 @@ export function JoinSchoolForm({ tenant }: JoinSchoolFormProps) {
           disabled={isJoining}
           className="w-full"
           size="lg"
+          data-testid="join-school-submit"
         >
           {isJoining ? (
             <>

--- a/proxy.ts
+++ b/proxy.ts
@@ -2,6 +2,7 @@ import createIntlMiddleware from 'next-intl/middleware'
 import { type NextRequest, NextResponse } from 'next/server'
 import { updateSession } from '@/lib/supabase/proxy'
 import { accessTokenFromCookies, jwtClaims } from '@/lib/supabase/session-cookie'
+import { getSafeNextPath } from '@/lib/auth/safe-next-path'
 import { createServerClient } from '@supabase/ssr'
 import { locales, defaultLocale } from './i18n'
 
@@ -434,6 +435,15 @@ export default async function proxy(request: NextRequest) {
 
     if (!membership) {
       const joinUrl = publicRedirectUrl(request, `/${locale}/join-school`)
+      // Keep the destination so a purchase or enroll intent survives the join
+      // step (#684): a first-time visitor who clicked a paid CTA arrives here
+      // as a member of no school, and without `next` the join form could only
+      // send them to an empty dashboard. Sanitised again by the join page and
+      // form; skipped for `/` so the plain case keeps a clean URL.
+      const intended = getSafeNextPath(normalizedPath + request.nextUrl.search, '/')
+      if (intended !== '/') {
+        joinUrl.searchParams.set('next', intended)
+      }
       return NextResponse.redirect(joinUrl)
     }
 

--- a/tests/playwright/paid-course-checkout-intent.spec.ts
+++ b/tests/playwright/paid-course-checkout-intent.spec.ts
@@ -1,0 +1,219 @@
+/**
+ * Paid-course CTA keeps checkout intent for a brand-new visitor (#684).
+ *
+ * The free path (loop-2-student-learns.spec.ts) survives sign-up because
+ * `enrollFree` joins the school itself. The paid path did not: `/checkout` is a
+ * protected route, so after sign-up proxy.ts bounced the still-memberless
+ * visitor to `/join-school` with no `next`, and the Join button always sent
+ * them to the student dashboard. This spec pins the repaired chain:
+ *
+ *   anonymous /courses/<id> → "Enroll Now" → login (next kept) → sign-up
+ *   (next kept) → /join-school?next=/checkout?courseId=<id> → Join →
+ *   checkout for that course
+ *
+ * plus the guard that a tampered `next` (cross-origin) degrades to the
+ * dashboard instead of redirecting off-site.
+ *
+ * Fixture: one `[E2E] #684` published course on Code Academy with a $49
+ * manual product (no Stripe needed — the checkout page hands a manual product
+ * to /checkout/manual, which is still "the checkout for that course").
+ */
+import { test, expect, type Page } from '@playwright/test'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { TENANT_BASE, LOCALE } from './utils/constants'
+import { getServiceRoleClient, CODE_ACADEMY_TENANT } from './utils/seed-state'
+
+const BASE = TENANT_BASE
+const CREATOR_ID = 'a1000000-0000-0000-0000-000000000003' // creator@codeacademy.com
+const FIXTURE_PREFIX = '[E2E] #684'
+const RUN = Date.now()
+const PASSWORD = 'password123'
+
+let courseId: number
+let productId: number
+const createdUserIds: string[] = []
+
+function must<T>(res: { data: T; error: { message: string } | null }, what: string): NonNullable<T> {
+  if (res.error || res.data == null) throw new Error(`${what}: ${res.error?.message ?? 'no data'}`)
+  return res.data as NonNullable<T>
+}
+
+async function removeStaleFixtures(admin: SupabaseClient) {
+  const { data: courses } = await admin
+    .from('courses')
+    .select('course_id')
+    .eq('tenant_id', CODE_ACADEMY_TENANT)
+    .like('title', `${FIXTURE_PREFIX}%`)
+  for (const c of courses ?? []) await admin.from('courses').delete().eq('course_id', c.course_id)
+  await admin.from('products').delete().eq('tenant_id', CODE_ACADEMY_TENANT).like('name', `${FIXTURE_PREFIX}%`)
+
+  const { data: users } = await admin.auth.admin.listUsers({ perPage: 1000 })
+  for (const u of users?.users ?? []) {
+    if (u.email?.startsWith('paid684-') && u.email.endsWith('@e2etest.com')) {
+      await admin.auth.admin.deleteUser(u.id)
+    }
+  }
+}
+
+test.beforeAll(async () => {
+  const admin = getServiceRoleClient()
+  await removeStaleFixtures(admin)
+
+  courseId = must(
+    await admin
+      .from('courses')
+      .insert({
+        title: `${FIXTURE_PREFIX} Paid Course ${RUN}`,
+        description: 'Seeded by paid-course-checkout-intent.spec.ts. Safe to delete.',
+        status: 'published',
+        author_id: CREATOR_ID,
+        tenant_id: CODE_ACADEMY_TENANT,
+      })
+      .select('course_id')
+      .single(),
+    'seed course'
+  ).course_id
+
+  productId = must(
+    await admin
+      .from('products')
+      .insert({
+        name: `${FIXTURE_PREFIX} Product ${RUN}`,
+        description: 'Paid access to the #684 course.',
+        price: 49,
+        currency: 'usd',
+        status: 'active',
+        payment_provider: 'manual',
+        tenant_id: CODE_ACADEMY_TENANT,
+      })
+      .select('product_id')
+      .single(),
+    'seed product'
+  ).product_id
+
+  must(
+    await admin
+      .from('product_courses')
+      .insert({ product_id: productId, course_id: courseId, tenant_id: CODE_ACADEMY_TENANT })
+      .select('product_id'),
+    'seed product_courses'
+  )
+})
+
+test.afterAll(async () => {
+  const admin = getServiceRoleClient()
+  for (const userId of createdUserIds) {
+    await admin.from('tenant_users').delete().eq('user_id', userId)
+    await admin.from('gamification_profiles').delete().eq('user_id', userId)
+    await admin.auth.admin.deleteUser(userId)
+  }
+  if (courseId) await admin.from('courses').delete().eq('course_id', courseId)
+  if (productId) await admin.from('products').delete().eq('product_id', productId)
+})
+
+/** Fill a React-controlled input and prove the value survived hydration. */
+async function fillSettled(page: Page, testId: string, value: string) {
+  const field = page.getByTestId(testId)
+  await field.waitFor({ state: 'visible', timeout: 30_000 })
+  await expect
+    .poll(
+      async () => {
+        await field.fill(value)
+        await page.waitForTimeout(500)
+        return field.inputValue()
+      },
+      { timeout: 30_000, intervals: [500, 1000] }
+    )
+    .toBe(value)
+}
+
+/** base-ui Buttons ignore Playwright's synthetic click; dispatch a DOM click. */
+async function domClick(page: Page, locator: ReturnType<Page['locator']>) {
+  await locator.first().waitFor({ state: 'visible', timeout: 30_000 })
+  await locator.first().evaluate((el) => (el as HTMLElement).click())
+}
+
+async function rememberUser(email: string) {
+  const admin = getServiceRoleClient()
+  const { data: users } = await admin.auth.admin.listUsers({ perPage: 1000 })
+  const id = users?.users.find((u) => u.email === email)?.id
+  if (id) createdUserIds.push(id)
+  return id ?? null
+}
+
+test.describe('Paid course CTA keeps checkout intent for a new visitor (#684)', () => {
+  test('sign-up from the paid CTA lands on the course checkout after joining the school', async ({ page }) => {
+    test.setTimeout(300_000)
+    const email = `paid684-${RUN}@e2etest.com`
+    const checkoutPath = `/checkout?courseId=${courseId}`
+
+    await test.step('anonymous course page sends the visitor to login with the checkout as next', async () => {
+      await page.goto(`${BASE}/${LOCALE}/courses/${courseId}`, { waitUntil: 'domcontentloaded' })
+      const cta = page.getByTestId('course-enroll-cta')
+      await expect(cta).toBeVisible({ timeout: 30_000 })
+      await expect(cta).toHaveText(/enroll now/i)
+
+      await domClick(page, cta)
+      await page.waitForURL(/\/auth\/login\?/, { timeout: 30_000 })
+      expect(new URL(page.url()).searchParams.get('next')).toBe(checkoutPath)
+
+      const signupLink = page.getByTestId('login-signup-link')
+      await expect(signupLink).toBeVisible({ timeout: 30_000 })
+      await signupLink.click()
+      await page.waitForURL(/\/auth\/sign-up\?/, { timeout: 30_000 })
+      expect(new URL(page.url()).searchParams.get('next')).toBe(checkoutPath)
+    })
+
+    await test.step('after sign-up the non-member is asked to join with the checkout preserved as next', async () => {
+      await fillSettled(page, 'signup-name', 'Paid Path Visitor')
+      await fillSettled(page, 'signup-email', email)
+      await fillSettled(page, 'signup-password', PASSWORD)
+      await domClick(page, page.getByTestId('signup-submit'))
+
+      await page.waitForURL(/\/join-school\?/, { timeout: 90_000 })
+      expect(new URL(page.url()).searchParams.get('next')).toBe(checkoutPath)
+      await expect(page.getByTestId('join-school-title')).toBeVisible({ timeout: 60_000 })
+      expect(await rememberUser(email), 'sign-up created an auth user').toBeTruthy()
+    })
+
+    await test.step('joining the school lands on the checkout for that course, not the dashboard', async () => {
+      await domClick(page, page.getByTestId('join-school-submit'))
+      // A manual product is handed from /checkout to /checkout/manual — still
+      // the checkout for this course. The dashboard is the failure mode.
+      await page.waitForURL(/\/checkout(?:\/manual)?\?/, { timeout: 90_000 })
+      const url = new URL(page.url())
+      expect(url.pathname).not.toContain('/dashboard')
+      expect(url.searchParams.get('courseId')).toBe(String(courseId))
+    })
+  })
+
+  test('a tampered cross-origin next falls back to the student dashboard', async ({ page }) => {
+    test.setTimeout(180_000)
+    const admin = getServiceRoleClient()
+    const email = `paid684-tamper-${RUN}@e2etest.com`
+    const { data: created, error: createError } = await admin.auth.admin.createUser({
+      email,
+      password: PASSWORD,
+      email_confirm: true,
+      user_metadata: { full_name: 'Tamper Visitor' },
+    })
+    if (createError || !created.user) throw new Error(`create tamper user: ${createError?.message ?? 'no user'}`)
+    createdUserIds.push(created.user.id)
+
+    await page.goto(`${BASE}/${LOCALE}/auth/login?next=${encodeURIComponent('/join-school')}`, {
+      waitUntil: 'domcontentloaded',
+    })
+    await fillSettled(page, 'login-email', email)
+    await fillSettled(page, 'login-password', PASSWORD)
+    await domClick(page, page.getByTestId('login-submit'))
+    await page.waitForURL(/\/join-school/, { timeout: 60_000 })
+
+    await page.goto(`${BASE}/${LOCALE}/join-school?next=${encodeURIComponent('https://evil.example/phish')}`, {
+      waitUntil: 'domcontentloaded',
+    })
+    await expect(page.getByTestId('join-school-title')).toBeVisible({ timeout: 60_000 })
+    await domClick(page, page.getByTestId('join-school-submit'))
+    await page.waitForURL(/\/dashboard\/student/, { timeout: 90_000 })
+    expect(new URL(page.url()).hostname).toBe(new URL(BASE).hostname)
+  })
+})


### PR DESCRIPTION
## What

A first-time visitor who clicks **Enroll Now** on a paid course now lands on that course's checkout after joining the school, instead of on an empty student dashboard. The `next` target is threaded through the one hop that dropped it: the `proxy.ts` non-member redirect → `/join-school` → the Join button.

Closes #684

## Why

The paid CTA links to `/auth/login?next=/checkout?courseId=<id>`, and the auth pages preserve `next` through login, sign-up, `/auth/confirm` and `/api/auth/callback`. But `/checkout` is a protected route: after sign-up the visitor is a member of no school, so `proxy.ts` bounced them to `/join-school` with an empty query, and `join-school-form.tsx` always hard-navigated to `/dashboard/student`. The free path survived only because `enrollFree` joins the school itself. Found while writing the Loop 2 E2E journey (#671); part of #682.

### Changes

- **`proxy.ts`** — the non-member redirect sets `next=<normalized path + query>`, validated by `getSafeNextPath`, omitted for `/`. The membership lookup, JWT sync and role guards are untouched.
- **`app/[locale]/join-school/page.tsx`** — reads `searchParams.next`, sanitises it, keeps it through its own signed-out login redirect, passes the resolved destination to the form, and points the "already a member" primary button at it (labelled *Continue* when a target exists). Its three independent inputs (`searchParams`, the Supabase client, the user id) are awaited in parallel.
- **`components/join-school-form.tsx`** — takes a required `destination` (resolved once by the page: the sanitised `next`, or the student dashboard) and runs `window.location.assign(destination)` after a successful join. Hard navigation stays on purpose (React #310 with `router.push` + `refresh`, and the membership just changed). Gains `data-testid="join-school-submit"`.
- **`tests/playwright/paid-course-checkout-intent.spec.ts`** — new spec: seeds a `[E2E] #684` course with a $49 manual product on Code Academy, signs up a fresh visitor from the paid CTA, asserts `/join-school?next=/checkout?courseId=<id>`, joins, and asserts the checkout for that course (a manual product is handed to `/checkout/manual`, still carrying `courseId`). A second test logs in a non-member, tampers `next` to `https://evil.example/phish`, joins, and asserts the student dashboard on the same host.

Not done: the issue's optional idea of letting the checkout server actions join on demand like `enrollFree`. It touches the payment actions and the student seat-limit path; the `next` chain alone restores the flow. Worth a follow-up if the extra Join screen proves to be a drop-off point.

## How to QA

Fresh browser profile on `http://code-academy.lvh.me:3005` (dev server on 3005, `.env.local` pins the E2E base URL there).

1. Signed out, open `/en/courses/2001` (Python for Beginners, $49 Stripe product) and click **Enroll Now**. Expect `/auth/login?next=%2Fcheckout%3FcourseId%3D2001`.
2. Click **Sign up** (still carries `next`) and register with a new email. Local Supabase autoconfirms.
3. Expect to land on `/join-school?next=%2Fcheckout%3FcourseId%3D2001` with the *Join Code Academy Pro* card.
4. Click **Join Code Academy Pro**. Expect the checkout for course 2001 — not `/dashboard/student`.
5. Regression: log in as `alice@student.com` / `password123` (already a member) and click the CTA on the same course page. Expect it to go straight to checkout as before.
6. Guard: with a fresh non-member account, open `/en/join-school?next=https%3A%2F%2Fevil.example%2Fphish` and join. Expect `/dashboard/student` on the same host.
7. Automated: `npx playwright test paid-course-checkout-intent --workers=1`. **Not yet run locally** — Docker Desktop hung mid-session and the author asked to ship the code change without waiting on E2E; CI's e2e job runs it, and step 7 should be confirmed green before merge.

## Screenshots / GIF

Before evidence (captured on the untouched code) is posted as a PR comment below: the visitor lands on `/join-school` with no `next` and ends on the empty dashboard. The after recording was not captured for the reason in QA step 7; the E2E spec is the after-proof once CI runs it.

## Checklist

- [x] `npm run typecheck` and `npm run test:unit` pass (1077 unit tests)
- [ ] `npm run build` passes
- [x] Every new tenant-scoped query filters by `tenant_id` (no new queries; the spec's admin-client seeds carry `tenant_id`)
- [ ] Tested with every relevant role — pending the E2E run above (student sign-up path and existing member; teacher/admin never hit the non-member redirect on their own tenant)
- [x] Loading and error states handled (unchanged: the Join button's pending state and error alert)
- [ ] New UI strings added to both `messages/en.json` and `messages/es.json` — the join-school page is not localised today (all its copy is inline English); the one new label *Continue* follows that, and localising the page is out of scope here
- [x] Migration (if any) — none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nT6ibUY6Eaf15GJmhnp96
