### PR TITLE
fix(#679): version-skew protection and narrow Sentry noise filters for the three open production issues

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -142,6 +142,15 @@ SENTRY_AUTH_TOKEN=                                 # Optional — without it `wi
                                                    # offsets), which is why browser issues cannot be traced back to a
                                                    # component. Generate at Sentry → Settings → Auth Tokens.
 
+# ─── VERSION SKEW ─────────────────────────────────────────────────────────────
+# Next.js `deploymentId`. Set it and Next stamps `?dpl=<id>` on every asset and
+# `x-deployment-id` on client navigations, so a browser still holding the last
+# deploy's bundle hard-navigates instead of firing requests the new server
+# cannot serve (LMS-FRONT-82, "Failed to find Server Action"). Build-time only.
+# It defaults to SENTRY_RELEASE — the commit SHA deploy.yml already passes in —
+# so there is normally nothing to set here; this exists to override that.
+NEXT_DEPLOYMENT_ID=                                # Optional — unique per deploy; unset falls back to SENTRY_RELEASE
+
 # ─── TESTING ──────────────────────────────────────────────────────────────────
 # Use lvh.me, not localhost: it resolves to 127.0.0.1 with wildcard subdomains, which
 # tenant routing needs. On localhost no subdomain resolves and every authenticated

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -1,6 +1,7 @@
 import * as Sentry from "@sentry/nextjs";
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 import { shouldDropEvent } from "@/lib/analytics/exclusions";
+import { classifyDomMutationError } from "@/lib/sentry/noise";
 
 // The OpenPanel tracker installs a queueing `window.op` stub before the script
 // loads, so calling it here is safe at any point in the page lifecycle — but it
@@ -73,6 +74,21 @@ Sentry.init({
   // and joined back to the full Sentry event by id. Nothing here may ever block
   // or drop the Sentry event itself — the pointer is strictly best-effort.
   beforeSend(event) {
+    // LMS-FRONT-9M. A `removeChild` NotFoundError raised while a page
+    // translator is rewriting our text nodes is React losing a race with code
+    // we do not control; the same error with no translator present may be a
+    // real reconciliation bug, so that one is kept and tagged rather than
+    // dropped. Runs before the OpenPanel pointer so a dropped event never
+    // leaves an `error_captured` row pointing at nothing.
+    const domVerdict = classifyDomMutationError(
+      event,
+      typeof document === "undefined" ? null : document
+    );
+    if (domVerdict.kind === "drop") return null;
+    if (domVerdict.kind === "keep") {
+      event.tags = { ...event.tags, "dom.third_party_mutation": "none-detected" };
+    }
+
     try {
       const op = (window as { op?: OpenPanelGlobal }).op;
       if (

--- a/lib/build/deployment-id.ts
+++ b/lib/build/deployment-id.ts
@@ -1,0 +1,29 @@
+/**
+ * The build's deployment identifier, read at build time by `next.config.ts`.
+ *
+ * Next.js uses it for version-skew protection: it stamps `?dpl=<id>` on every
+ * static asset, sends `x-deployment-id` with client navigations and Server
+ * Action requests, and returns `x-nextjs-deployment-id` on navigation
+ * responses. A client still holding the previous deployment's bundle sees the
+ * mismatch and performs a hard navigation instead of firing requests the new
+ * deployment cannot serve — which is the condition behind LMS-FRONT-82
+ * (`Failed to find Server Action`, issue #679).
+ *
+ * Nothing about this is Sentry-specific; `SENTRY_RELEASE` is simply where the
+ * commit SHA already lives. `.github/workflows/deploy.yml` passes `github.sha`
+ * as a Docker build arg and the Dockerfile exports it before `npm run build`,
+ * so it is the one value that is (a) unique per deploy and (b) already present
+ * at build time. `.dockerignore` excludes `.git`, so the SHA cannot be inferred
+ * from the repo inside the image. `NEXT_DEPLOYMENT_ID` — Next's own convention
+ * — wins when set, so an operator can override without touching Sentry.
+ *
+ * Unset (local dev, `npm run build` on a laptop) resolves to `undefined`, which
+ * is exactly "no deployment id" and leaves Next's behaviour unchanged.
+ */
+export function resolveDeploymentId(
+  env: Record<string, string | undefined> = process.env
+): string | undefined {
+  const candidate = env.NEXT_DEPLOYMENT_ID ?? env.SENTRY_RELEASE
+  const trimmed = candidate?.trim()
+  return trimmed ? trimmed : undefined
+}

--- a/lib/sentry/noise.ts
+++ b/lib/sentry/noise.ts
@@ -1,0 +1,123 @@
+/**
+ * Sentry noise filters — the errors we deliberately do NOT store, and why.
+ *
+ * Every drop rule here is a liability: an over-broad one hides a real crash and
+ * nobody finds out until a user complains. So each predicate is written as
+ * narrowly as the evidence allows, is a pure function over the event (no
+ * globals, no SDK types), and is pinned by `tests/unit/sentry-noise.test.ts`.
+ * Prefer adding a rule here over an `ignoreErrors` entry in the Sentry config:
+ * `ignoreErrors` matches a substring of the message and nothing else, which is
+ * exactly the blunt instrument we want to avoid for these two cases.
+ *
+ * Imported by BOTH `sentry.server.config.ts` and `instrumentation-client.ts`.
+ * Keep it free of browser-only and node-only APIs: the `Document` it inspects
+ * is passed in by the caller.
+ */
+
+/**
+ * The only fields these predicates read. Structural rather than
+ * `@sentry/nextjs`'s `ErrorEvent` so the unit tests can build a literal and the
+ * module never drags the SDK into a node test environment.
+ */
+export interface SentryNoiseEvent {
+  exception?: {
+    values?: Array<{ type?: string; value?: string }>
+  }
+}
+
+function firstException(event: SentryNoiseEvent): { type?: string; value?: string } | undefined {
+  return event.exception?.values?.[0]
+}
+
+/* -------------------------------------------------------------------------- */
+/* LMS-FRONT-82 — "Failed to find Server Action"                              */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Next.js throws this (error code `E975`) from
+ * `server/app-render/action-handler.ts` on exactly one path: a POST whose
+ * content type is `multipart/form-data`, carrying no `next-action` header and
+ * no resolvable `$ACTION_ID_` field. Two things reach it, neither of them a bug
+ * in our code:
+ *
+ * - a client running a superseded bundle submitting a progressive-enhancement
+ *   form (`<form action={serverAction}>`) across a deploy boundary, which
+ *   `deploymentId` in `next.config.ts` now turns into a hard navigation; and
+ * - any third party POSTing a form body at a page URL — `/auth/login` renders
+ *   no Server Action at all, yet it is where this fires in production, which is
+ *   what scanner traffic looks like.
+ *
+ * Next itself treats the equivalent fetch-action case as a `console.warn` and a
+ * 404 (`handleUnrecognizedFetchAction`); only the MPA path throws. We mirror
+ * that judgement instead of paging on traffic we do not control.
+ */
+export function isServerActionNotFoundError(event: SentryNoiseEvent): boolean {
+  const value = firstException(event)?.value ?? ''
+  return value.includes('Failed to find Server Action')
+}
+
+/* -------------------------------------------------------------------------- */
+/* LMS-FRONT-9M — NotFoundError: Failed to execute 'removeChild' on 'Node'    */
+/* -------------------------------------------------------------------------- */
+
+const DOM_RECONCILIATION_ERROR =
+  /Failed to execute '(?:removeChild|insertBefore|appendChild)' on 'Node'/
+
+/** The error shape React produces when the DOM moved under it. */
+function isDomReconciliationError(event: SentryNoiseEvent): boolean {
+  const exception = firstException(event)
+  if (exception?.type !== 'NotFoundError') return false
+  return DOM_RECONCILIATION_ERROR.test(exception.value ?? '')
+}
+
+/**
+ * Markers left in the document by the page translators that cause this. They
+ * rewrite React-owned text nodes into `<font>` wrappers, so React's next
+ * `removeChild` names a node that is no longer a child of the parent it
+ * remembers. Nothing we can fix from inside the app.
+ */
+const TRANSLATOR_MARKERS: Array<{ by: string; selector: string }> = [
+  // Google Translate: the widget stamps the direction class on <html> and
+  // injects its tooltip host into the body.
+  { by: 'google-translate', selector: 'html.translated-ltr, html.translated-rtl' },
+  { by: 'google-translate', selector: '#goog-gt-tt, .goog-te-banner-frame, .skiptranslate' },
+  // Microsoft Translator (Edge's built-in): hashes every text node it replaces.
+  { by: 'microsoft-translator', selector: 'font[_msttexthash], [_msthash]' },
+]
+
+export type DomNoiseVerdict =
+  /** Not this class of error — the caller should not change anything. */
+  | { kind: 'not-applicable' }
+  /** React-vs-translator. Drop it; `mutatedBy` says which one. */
+  | { kind: 'drop'; mutatedBy: string }
+  /**
+   * The error shape matches but no third-party marker is present, so this may
+   * be a genuine reconciliation bug of ours. Keep it, tagged, so it is
+   * separable from the noise in the Sentry UI.
+   */
+  | { kind: 'keep' }
+
+/**
+ * Decide what to do with a `removeChild`/`insertBefore` `NotFoundError`.
+ *
+ * `doc` is the live document, or `null` where there is none (server, prerender)
+ * — with no document we cannot prove a translator was involved, so the event is
+ * kept rather than dropped.
+ */
+export function classifyDomMutationError(
+  event: SentryNoiseEvent,
+  doc: Document | null
+): DomNoiseVerdict {
+  if (!isDomReconciliationError(event)) return { kind: 'not-applicable' }
+  if (!doc) return { kind: 'keep' }
+
+  for (const marker of TRANSLATOR_MARKERS) {
+    try {
+      if (doc.querySelector(marker.selector)) return { kind: 'drop', mutatedBy: marker.by }
+    } catch {
+      // A malformed selector must never cost us the event.
+    }
+  }
+
+  return { kind: 'keep' }
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,11 +1,20 @@
 import type { NextConfig } from "next";
 import createNextIntlPlugin from 'next-intl/plugin';
 import { withSentryConfig } from "@sentry/nextjs/config";
+import { resolveDeploymentId } from "./lib/build/deployment-id";
 
 const withNextIntl = createNextIntlPlugin('./i18n.ts');
 
 const nextConfig: NextConfig = {
   output: 'standalone',
+  // Version-skew protection (#679). Rolling deploys leave browsers holding the
+  // previous build's JS; without an id they keep talking to the new server and
+  // a Server Action id that no longer exists 500s (LMS-FRONT-82). With one, the
+  // mismatch is detected on the response header and the client hard-navigates
+  // to the new deployment instead. Resolves from the build SHA — see the
+  // module for why that env var, and note it also busts asset caches per
+  // deploy, which is the point.
+  deploymentId: resolveDeploymentId(),
   // Local multi-tenant dev is served on subdomains (e.g. code-academy.lvh.me),
   // which differ from the dev server origin (localhost). Next.js 16 blocks
   // cross-origin access to /_next/* dev resources (HMR + client chunks) by

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -3,6 +3,7 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from "@sentry/nextjs";
+import { isServerActionNotFoundError } from "@/lib/sentry/noise";
 
 // The DSN comes from the environment, never a literal. It used to be hardcoded,
 // which meant every fork of this repo deployed elsewhere reported its crashes into
@@ -34,6 +35,11 @@ Sentry.init({
   // Loop-safety: `lib/analytics/server.ts` reports its own failures only as
   // breadcrumbs, never as captured events, so this cannot ping-pong.
   beforeSend(event) {
+    // Before the OpenPanel pointer, never after: a dropped Sentry event must
+    // not leave an `error_captured` row pointing at an event that was never
+    // stored. See `lib/sentry/noise.ts` for why this one is not ours to fix.
+    if (isServerActionNotFoundError(event)) return null;
+
     try {
       if (event.event_id) {
         // Dynamic import keeps Sentry init free of the analytics module (and

--- a/tests/playwright/dashboard-client-errors.spec.ts
+++ b/tests/playwright/dashboard-client-errors.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect, type ConsoleMessage, type Page } from '@playwright/test'
+import { loginAsStudent } from './utils/auth'
+import { BASE, LOCALE } from './utils/constants'
+
+/**
+ * Regression net for LMS-FRONT-9F / 8F (issue #679).
+ *
+ * Production reports `Rendered more hooks than during the previous render` on
+ * `/dashboard/student/profile` and on `/dashboard/student`. Two exhaustive
+ * static audits — a line-by-line read of every client component and custom hook
+ * on both routes, plus a repo-wide `react-hooks/rules-of-hooks` run whose only
+ * hits are Puck's lowercase `render()` factories — found no conditional hook,
+ * and the source-mapped stack that would name the component has not arrived.
+ *
+ * So this spec does not assert a fix. It asserts the *symptom* is absent, on
+ * both routes, on every CI run: a hooks-order violation is a hard React crash,
+ * so it always surfaces as a page error or a console error carrying one of the
+ * signatures below. If the bug returns — or is introduced by a refactor — this
+ * fails instead of silently reaching production again.
+ *
+ * It deliberately does not assert "no console errors at all": these pages log
+ * benign warnings (a missing local gamification edge function, analytics
+ * beacons blocked on http) and a blanket assertion would rot within a week.
+ */
+
+/**
+ * React's hook-order crash, in every form it reaches a browser console.
+ * `#310` is the minified code for "Rendered more hooks than during the previous
+ * render"; `#300`/`#301` are its dev-build siblings for the same invariant.
+ */
+const HOOK_ORDER_SIGNATURES = [
+  /Rendered more hooks than during the previous render/i,
+  /Rendered fewer hooks than expected/i,
+  /Should have a queue\. This is likely a bug in React/i,
+  /Minified React error #(?:300|301|310)\b/,
+]
+
+function isHookOrderCrash(text: string): boolean {
+  return HOOK_ORDER_SIGNATURES.some((signature) => signature.test(text))
+}
+
+/** Collect everything the page reports, so a failure can name the offender. */
+function captureClientErrors(page: Page): string[] {
+  const messages: string[] = []
+  page.on('pageerror', (error) => messages.push(`pageerror: ${error.message}\n${error.stack ?? ''}`))
+  page.on('console', (message: ConsoleMessage) => {
+    if (message.type() === 'error') messages.push(`console.error: ${message.text()}`)
+  })
+  return messages
+}
+
+const ROUTES = [
+  { name: 'student dashboard (LMS-FRONT-8F)', path: `/${LOCALE}/dashboard/student` },
+  { name: 'student profile (LMS-FRONT-9F)', path: `/${LOCALE}/dashboard/student/profile` },
+]
+
+test.describe('Student dashboard renders without a React hook-order crash (#679)', () => {
+  for (const route of ROUTES) {
+    test(route.name, async ({ page }) => {
+      const clientErrors = captureClientErrors(page)
+
+      await loginAsStudent(page)
+      await page.goto(`${BASE}${route.path}`)
+
+      // The crash happens during a client render, which is after the server
+      // HTML lands — so waiting for the network to settle is what gives the
+      // client the chance to fail. The gamification widgets on both routes
+      // fetch on mount, which is exactly the state transition under suspicion.
+      await page.waitForLoadState('networkidle')
+      await expect(page.locator('main, [data-slot="sidebar-inset"]').first()).toBeVisible({
+        timeout: 30_000,
+      })
+
+      const hookCrashes = clientErrors.filter(isHookOrderCrash)
+      expect(
+        hookCrashes,
+        `React hook-order crash on ${route.path}. This is LMS-FRONT-9F/8F reproducing — ` +
+          `the stack below names the component that changed its hook count:\n${hookCrashes.join('\n\n')}`
+      ).toEqual([])
+
+      // A hooks crash that escapes to the route's error boundary shows this
+      // copy instead of the page, which is worth failing on even if the console
+      // message was swallowed.
+      await expect(page.getByText(/Couldn't load your courses/i)).toHaveCount(0)
+    })
+  }
+})

--- a/tests/unit/sentry-noise.test.ts
+++ b/tests/unit/sentry-noise.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest'
+import {
+  classifyDomMutationError,
+  isServerActionNotFoundError,
+  type SentryNoiseEvent,
+} from '@/lib/sentry/noise'
+import { resolveDeploymentId } from '@/lib/build/deployment-id'
+
+function errorEvent(type: string, value: string): SentryNoiseEvent {
+  return { exception: { values: [{ type, value }] } }
+}
+
+/**
+ * Minimal stand-in for `document` — the predicate only ever calls
+ * `querySelector`, and the vitest environment is `node`, so there is no real
+ * DOM to build. The stub answers for an explicit list of selectors it should
+ * match, which is also the readable way to say "this marker was present".
+ */
+function documentWithMarkers(matching: string[]): Document {
+  return {
+    querySelector(selector: string) {
+      return matching.includes(selector) ? ({} as Element) : null
+    },
+  } as unknown as Document
+}
+
+describe('isServerActionNotFoundError (LMS-FRONT-82)', () => {
+  it('matches the error Next throws for an unresolvable action id', () => {
+    const event = errorEvent(
+      'Error',
+      'Failed to find Server Action "7f3a1c". This request might be from an older or newer deployment.\n' +
+        'Read more: https://nextjs.org/docs/messages/failed-to-find-server-action'
+    )
+    expect(isServerActionNotFoundError(event)).toBe(true)
+  })
+
+  it('matches the id-less variant thrown from the MPA form path', () => {
+    // The `areAllActionIdsValid` branch has no id to interpolate — this is the
+    // exact string a form-shaped POST with no action field produces.
+    const event = errorEvent(
+      'Error',
+      'Failed to find Server Action. This request might be from an older or newer deployment.'
+    )
+    expect(isServerActionNotFoundError(event)).toBe(true)
+  })
+
+  it('leaves every other server error alone', () => {
+    expect(isServerActionNotFoundError(errorEvent('TypeError', 'x is not a function'))).toBe(false)
+    expect(
+      isServerActionNotFoundError(errorEvent('Error', 'permission denied for table transactions'))
+    ).toBe(false)
+    // A Server Action that ran and threw must always be reported.
+    expect(
+      isServerActionNotFoundError(errorEvent('Error', 'Server Action failed: enroll_user'))
+    ).toBe(false)
+    expect(isServerActionNotFoundError({})).toBe(false)
+  })
+})
+
+describe('classifyDomMutationError (LMS-FRONT-9M)', () => {
+  const removeChild = errorEvent(
+    'NotFoundError',
+    "Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node."
+  )
+
+  it('drops the error when Google Translate has rewritten the page', () => {
+    const verdict = classifyDomMutationError(
+      removeChild,
+      documentWithMarkers(['html.translated-ltr, html.translated-rtl'])
+    )
+    expect(verdict).toEqual({ kind: 'drop', mutatedBy: 'google-translate' })
+  })
+
+  it('drops the error when Microsoft Translator has rewritten the page', () => {
+    const verdict = classifyDomMutationError(
+      removeChild,
+      documentWithMarkers(['font[_msttexthash], [_msthash]'])
+    )
+    expect(verdict).toEqual({ kind: 'drop', mutatedBy: 'microsoft-translator' })
+  })
+
+  it('KEEPS the same error when no translator marker is present', () => {
+    // The whole point of the narrow predicate: an unexplained removeChild is a
+    // candidate React bug and must still reach us.
+    expect(classifyDomMutationError(removeChild, documentWithMarkers([]))).toEqual({ kind: 'keep' })
+  })
+
+  it('keeps the error when there is no document to inspect', () => {
+    expect(classifyDomMutationError(removeChild, null)).toEqual({ kind: 'keep' })
+  })
+
+  it('covers insertBefore, which fails the same way', () => {
+    const insertBefore = errorEvent(
+      'NotFoundError',
+      "Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node."
+    )
+    expect(
+      classifyDomMutationError(insertBefore, documentWithMarkers(['#goog-gt-tt, .goog-te-banner-frame, .skiptranslate']))
+    ).toEqual({ kind: 'drop', mutatedBy: 'google-translate' })
+  })
+
+  it('ignores unrelated errors even on a translated page', () => {
+    const translated = documentWithMarkers(['html.translated-ltr, html.translated-rtl'])
+    expect(classifyDomMutationError(errorEvent('TypeError', 'undefined is not an object'), translated)).toEqual({
+      kind: 'not-applicable',
+    })
+    // Same message shape, different error type — not React's DOM race.
+    expect(
+      classifyDomMutationError(errorEvent('Error', "Failed to execute 'removeChild' on 'Node'"), translated)
+    ).toEqual({ kind: 'not-applicable' })
+    expect(classifyDomMutationError({}, translated)).toEqual({ kind: 'not-applicable' })
+  })
+})
+
+describe('resolveDeploymentId (LMS-FRONT-82)', () => {
+  it('uses the build SHA the deploy workflow passes in', () => {
+    expect(resolveDeploymentId({ SENTRY_RELEASE: 'ffd76563' })).toBe('ffd76563')
+  })
+
+  it('lets NEXT_DEPLOYMENT_ID override it', () => {
+    expect(
+      resolveDeploymentId({ NEXT_DEPLOYMENT_ID: 'manual-1', SENTRY_RELEASE: 'ffd76563' })
+    ).toBe('manual-1')
+  })
+
+  it('is undefined when unset or blank, so local builds are unchanged', () => {
+    expect(resolveDeploymentId({})).toBeUndefined()
+    expect(resolveDeploymentId({ SENTRY_RELEASE: '' })).toBeUndefined()
+    expect(resolveDeploymentId({ SENTRY_RELEASE: '   ' })).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## What

Wires Next.js version-skew protection (`deploymentId`) and adds two deliberately narrow Sentry drop rules for the production issues in #679. Two of the three are resolved with the reasoning recorded in code; the third (LMS-FRONT-9F) is **not fixed** — it gets a regression net instead, and why is spelled out below.

Closes #679

## Why

### LMS-FRONT-82 — `Failed to find Server Action` on `POST /[locale]/auth/login/page`

Reading Next 16.2's `server/app-render/action-handler.js` changes the diagnosis. There is exactly **one** path that throws this; every other one only warns:

| Request shape | Handling |
|---|---|
| fetch action (hydrated client, `next-action` header) with an unknown id | `handleUnrecognizedFetchAction()` → `console.warn` + `404` + `x-nextjs-action-not-found`. **Never throws.** |
| `application/x-www-form-urlencoded` POST, no action header | returns `null`, falls through to a normal page render. |
| **`multipart/form-data` POST, no action header, no valid `$ACTION_ID_`** | **throws** → 500 → Sentry. |

`getServerActionRequestMetadata()` marks *any* POST carrying a form content type as `isPossibleServerAction`, so an arbitrary multipart POST at a page URL enters the Server Action handler and dies there. `/auth/login` renders no Server Action at all (`components/login-form.tsx` calls `supabase-js` from an `onSubmit` handler; the layout adds none), so a genuine action POST cannot originate on that route — which leaves deploy skew on the routes that *do* have progressive-enhancement forms, and third parties POSTing form bodies at page URLs. Either way, the app had **no version-skew protection configured at all**.

### LMS-FRONT-9M — `NotFoundError: Failed to execute 'removeChild' on 'Node'`

Confirmed before chasing, as the issue asked. There is no in-app DOM mutation on `/dashboard/student/courses/[courseId]`: no `removeChild`/`insertBefore`/`appendChild`/`dangerouslySetInnerHTML` anywhere in that route's tree (the only direct DOM write in all of `components/` is `onboarding-checklist.tsx`'s clipboard textarea, which creates and removes its own detached node, and is not on this route). This is the React-vs-page-translator class: the translator rewrites React-owned text nodes into `<font>` wrappers, and React's next `removeChild` names a node that is no longer a child.

### LMS-FRONT-9F — `Rendered more hooks than during the previous render`

**Not fixed.** No conditional-hook pattern exists on the route, verified three ways:

1. A line-by-line read of every client component the page renders (`profile-form`, the five `gamification/*` components, `tours-toggle`, `student-certificate-card`, `social-share-modal`) and their custom hooks (`useGamificationSummary`, `useAchievements`, `useLeagueOptOut`, `useLeague`), plus the shared dashboard chrome — which matters, because the sibling route `/dashboard/student` reports the same error as LMS-FRONT-8F, so the common denominator is the shell.
2. A repo-wide `react-hooks/rules-of-hooks` run. All 12 findings are `render()` methods in `lib/puck/components/**` — Puck's lowercase-named component factories, false positives, and not on this route.
3. Base UI's `useRender`, used by the sidebar primitives on both routes, was checked directly: `useRenderElementProps` switches between `useMergedRefs` and `useMergedRefsN` and calls `void useMergedRefs(null, null)` in the disabled branch specifically to keep the hook count constant. Both helpers call exactly one hook. Ruled out.

This matches the repo's own prior triage — 9561748d (#632) deferred 9F and 8F as un-diagnosable without source maps. That upload wiring landed in the same commit, and nothing in this tree has changed since, so the next production occurrence should finally be symbolicated. Local reproduction was not possible in this session (Docker daemon down, so no local Supabase). Rather than guess at a fix, this PR adds a test that fails on the symptom.

## How to QA

On a fresh `npm run db:reset`, with the dev server on `lvh.me` (never `localhost`):

1. `npm run test:unit` — 87 files / 1097 tests pass, including the 12 new ones in `tests/unit/sentry-noise.test.ts`. Read that file first: it is the specification for both drop rules, including the cases that must **not** be dropped.
2. `SENTRY_RELEASE=deadbeefcafe npm run build`, then confirm the deployment id is baked in: `grep -o 'data-dpl-id="[^"]*"' .next/server/app/_not-found.html` prints `data-dpl-id="deadbeefcafe"`, and `grep -rl 'dpl=deadbeefcafe' .next/server/app` is non-empty (assets now carry `?dpl=`).
3. `npm run build` with `SENTRY_RELEASE` unset — `deploymentId` resolves to `undefined` and nothing changes, so local builds and local dev are unaffected.
4. `npx playwright test dashboard-client-errors --workers=1` — signs in as `student@e2etest.com` / `password123` on `http://lvh.me:3005`, loads `/en/dashboard/student` and `/en/dashboard/student/profile`, and fails if either emits a React hook-order crash. Expected to pass; it is a net for a bug that is not currently reproducible on demand.
5. Sanity-check the 9M keep path by hand: in the browser console on any dashboard page, run `Sentry.captureException(Object.assign(new Error("Failed to execute 'removeChild' on 'Node'"), { name: 'NotFoundError' }))`. With no translator active the event should still arrive in Sentry, tagged `dom.third_party_mutation: none-detected`. Right-click → Translate to Spanish first and the same call should produce no event at all.

## Screenshots / GIF

Not applicable — no user-visible surface changes. The diff is build config, two Sentry `beforeSend` predicates, and tests.

## Checklist

- [x] `npm run typecheck` and `npm run test:unit` pass
- [x] `npm run build` passes
- [x] Every new tenant-scoped query filters by `tenant_id` (or the table genuinely has no such column) — no queries added
- [ ] Tested with every relevant role (student / teacher / admin) — no role-dependent behaviour; the new Playwright spec covers the student routes only
- [x] Loading and error states handled — unchanged
- [x] New UI strings added to both `messages/en.json` and `messages/es.json` — none added
- [x] Migration (if any) applies cleanly on `npm run db:reset`, has RLS policies, and `lib/database.types.ts` was regenerated — no migration

## Reviewer notes

- **The risk in this PR is the two `beforeSend` drops**, since a rule that is too broad hides a real crash silently. Both are pure predicates in `lib/sentry/noise.ts` rather than `ignoreErrors` substrings, both are pinned by tests that assert what is *kept* as well as what is dropped, and the 9M rule drops only with positive evidence of a third-party translator — otherwise it keeps the event and tags it. Both run **before** the OpenPanel pointer, so a dropped event never leaves an `error_captured` row pointing at an event Sentry never stored.
- `deploymentId` changes every asset URL on each deploy (`?dpl=<sha>`), which busts CDN and browser caches per release. That is the intended trade for skew protection, but it is a real behaviour change worth agreeing on.
- It resolves from `SENTRY_RELEASE` because that is where the commit SHA already is: `.dockerignore` excludes `.git`, so the SHA cannot be inferred inside the image, and `deploy.yml` already passes `github.sha` as a build arg the Dockerfile exports before `npm run build`. `NEXT_DEPLOYMENT_ID` overrides it and is documented in `.env.example`. **No Dokploy change is needed** — this is build-time only, and per `CLAUDE.md` the Dokploy service environment would be a silent no-op anyway.
- **LMS-FRONT-9F is being resolved in Sentry** with the one-line reason `#679`'s acceptance allows: *no conditional hook exists on this route (three independent audits); PR #713 lands a CI guard that fails on the symptom, so any recurrence re-opens this issue with a source-mapped stack.* Resolving rather than ignoring is the point — a resolved Sentry issue auto-reopens as a regression on the next event, and that event will finally carry a symbolicated stack, so nothing is lost. The `dashboard-client-errors` spec is the second net, in CI, before it can reach production again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U2i9mdjTkFajBYsAQa2Jaf
