### PR TITLE
fix(certificates): lessons-only courses can earn a certificate again (#696)

### DIFF
--- a/lib/certificates/open-badges.ts
+++ b/lib/certificates/open-badges.ts
@@ -163,7 +163,14 @@ export function generateAchievementCredential(
             id: `${appUrl}/verify/${verificationCode}`,
             type: ['Evidence'],
             name: 'Course Completion Evidence',
-            description: `Completed ${completionData.completedLessons} of ${completionData.totalLessons} lessons (${completionData.completionPercentage}%) and achieved ${completionData.averageExamScore}% average on ${completionData.submittedExams} exams`,
+            // Courses with no exams are certifiable (#696), so the exam clause is
+            // omitted rather than baking "0% average on 0 exams" into a permanent
+            // credential.
+            description:
+                `Completed ${completionData.completedLessons} of ${completionData.totalLessons} lessons (${completionData.completionPercentage}%)` +
+                (completionData.totalExams > 0
+                    ? ` and achieved ${completionData.averageExamScore}% average on ${completionData.submittedExams} exams`
+                    : ''),
             genre: 'Certificate',
         },
     ];

--- a/supabase/migrations/20260911120000_lessons_only_certificate_eligibility.sql
+++ b/supabase/migrations/20260911120000_lessons_only_certificate_eligibility.sql
@@ -1,0 +1,180 @@
+-- A course with lessons but no exams could never earn a certificate (#696).
+--
+-- `calculate_course_completion()` decided eligibility with a single boolean
+-- expression:
+--
+--     v_completion_pct >= min_lesson_completion_pct
+--     AND (
+--       (requires_all_exams = true AND v_submitted_exams = v_total_exams AND v_all_exams_passed)
+--       OR (requires_all_exams = false AND v_avg_score >= min_exam_pass_score)
+--     )
+--
+-- `v_all_exams_passed` is `BOOL_AND(...)` and `v_avg_score` is `AVG(...)` over
+-- the student's scored submissions. For a course with zero published exams both
+-- aggregates run over an empty set and return NULL, so in three-valued logic the
+-- whole expression collapses to NULL — not false, but not true either. The
+-- function then emitted `"eligible": null`, and every caller
+-- (`check_and_issue_certificate` casting with `::BOOLEAN`, the TypeScript
+-- helpers using `data.eligible || false`) reads that as "not eligible". A
+-- lessons-only course was therefore un-certifiable at 100% lesson completion
+-- with an active template, and both auto-issuance triggers were dead for it.
+--
+-- Fix: decide the exam requirement in an explicit branch instead of inside the
+-- boolean expression, and treat "no published exams" as vacuously satisfied.
+-- The nullable template thresholds are read through COALESCE to their documented
+-- defaults for the same reason — an explicit NULL in `min_lesson_completion_pct`,
+-- `min_exam_pass_score` or `requires_all_exams` produced the identical
+-- `eligible: null` symptom by a different route — and the verdict itself is
+-- COALESCEd so the function can never again return a null eligibility.
+--
+-- A course with no published lessons AND no published exams is now explicitly
+-- not eligible. Without that guard, "no exams means passed" plus a template
+-- whose `min_lesson_completion_pct` is 0 would issue certificates for a
+-- completely empty course; today that case returns null (read as not eligible),
+-- so the guard preserves the current outcome rather than changing it.
+--
+-- The result JSON keeps its shape: same keys, `eligible` now always a real
+-- boolean, and `reason` present on the explicit not-eligible early returns.
+
+CREATE OR REPLACE FUNCTION public.calculate_course_completion(
+  p_user_id UUID,
+  p_course_id INTEGER
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+STABLE
+AS $$
+DECLARE
+  v_total_lessons INTEGER;
+  v_completed_lessons INTEGER;
+  v_completion_pct NUMERIC;
+  v_total_exams INTEGER;
+  v_submitted_exams INTEGER;
+  v_avg_score NUMERIC;
+  v_all_exams_passed BOOLEAN;
+  v_exams_ok BOOLEAN;
+  v_eligible BOOLEAN := false;
+  v_min_lesson_pct INTEGER;
+  v_min_exam_score INTEGER;
+  v_requires_all_exams BOOLEAN;
+  v_template RECORD;
+  v_result JSONB;
+BEGIN
+  -- Get certificate template for course
+  SELECT * INTO v_template
+  FROM public.certificate_templates
+  WHERE course_id = p_course_id AND is_active = true
+  LIMIT 1;
+
+  -- If no template, return not eligible
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object(
+      'eligible', false,
+      'reason', 'No active certificate template for this course'
+    );
+  END IF;
+
+  -- The criteria columns are nullable; fall back to the table defaults so a NULL
+  -- can never make the eligibility verdict itself NULL.
+  v_min_lesson_pct := COALESCE(v_template.min_lesson_completion_pct, 100);
+  v_min_exam_score := COALESCE(v_template.min_exam_pass_score, 70);
+  v_requires_all_exams := COALESCE(v_template.requires_all_exams, true);
+
+  -- Count total published lessons
+  SELECT COUNT(*) INTO v_total_lessons
+  FROM public.lessons
+  WHERE course_id = p_course_id AND status = 'published';
+
+  -- Count completed lessons
+  SELECT COUNT(DISTINCT lc.lesson_id) INTO v_completed_lessons
+  FROM public.lesson_completions lc
+  JOIN public.lessons l ON lc.lesson_id = l.id
+  WHERE lc.user_id = p_user_id
+    AND l.course_id = p_course_id
+    AND l.status = 'published';
+
+  -- Calculate completion percentage
+  IF v_total_lessons > 0 THEN
+    v_completion_pct := (v_completed_lessons::NUMERIC / v_total_lessons::NUMERIC) * 100;
+  ELSE
+    v_completion_pct := 0;
+  END IF;
+
+  -- Count total published exams
+  SELECT COUNT(*) INTO v_total_exams
+  FROM public.exams
+  WHERE course_id = p_course_id AND status = 'published';
+
+  -- Count submitted exams with scores
+  SELECT
+    COUNT(DISTINCT es.exam_id),
+    AVG(esc.score),
+    BOOL_AND(esc.score >= v_min_exam_score)
+  INTO v_submitted_exams, v_avg_score, v_all_exams_passed
+  FROM public.exam_submissions es
+  JOIN public.exam_scores esc ON es.submission_id = esc.submission_id
+  JOIN public.exams e ON es.exam_id = e.exam_id
+  WHERE es.student_id = p_user_id
+    AND e.course_id = p_course_id
+    AND e.status = 'published';
+
+  -- A course with nothing published has nothing to complete — never eligible,
+  -- whatever the template's thresholds say.
+  IF v_total_lessons = 0 AND v_total_exams = 0 THEN
+    RETURN jsonb_build_object(
+      'eligible', false,
+      'reason', 'Course has no published lessons or exams',
+      'completionPercentage', 0,
+      'totalLessons', 0,
+      'completedLessons', 0,
+      'totalExams', 0,
+      'submittedExams', 0,
+      'averageExamScore', 0,
+      'allExamsPassed', false,
+      'criteria', jsonb_build_object(
+        'minLessonCompletionPct', v_min_lesson_pct,
+        'minExamPassScore', v_min_exam_score,
+        'requiresAllExams', v_requires_all_exams
+      )
+    );
+  END IF;
+
+  -- Decide the exam requirement separately, so an empty aggregate cannot turn
+  -- the whole verdict into NULL.
+  IF v_total_exams = 0 THEN
+    -- Nothing to sit: the exam requirement is vacuously satisfied.
+    v_exams_ok := true;
+  ELSIF v_requires_all_exams THEN
+    v_exams_ok := (v_submitted_exams = v_total_exams AND COALESCE(v_all_exams_passed, false));
+  ELSE
+    v_exams_ok := (COALESCE(v_avg_score, 0) >= v_min_exam_score);
+  END IF;
+
+  v_eligible := COALESCE(
+    (v_completion_pct >= v_min_lesson_pct AND v_exams_ok),
+    false
+  );
+
+  -- Build result
+  v_result := jsonb_build_object(
+    'eligible', v_eligible,
+    'completionPercentage', ROUND(v_completion_pct, 2),
+    'totalLessons', v_total_lessons,
+    'completedLessons', v_completed_lessons,
+    'totalExams', v_total_exams,
+    'submittedExams', v_submitted_exams,
+    'averageExamScore', COALESCE(ROUND(v_avg_score, 2), 0),
+    'allExamsPassed', CASE WHEN v_total_exams = 0 THEN true ELSE COALESCE(v_all_exams_passed, false) END,
+    'criteria', jsonb_build_object(
+      'minLessonCompletionPct', v_min_lesson_pct,
+      'minExamPassScore', v_min_exam_score,
+      'requiresAllExams', v_requires_all_exams
+    )
+  );
+
+  RETURN v_result;
+END;
+$$;
+
+COMMENT ON FUNCTION public.calculate_course_completion IS
+  'Calculates if student meets certificate criteria for a course. A course with no published exams satisfies the exam requirement vacuously (#696); a course with nothing published at all is never eligible.';

--- a/tests/sql/issue-696-lessons-only-certificate.sql
+++ b/tests/sql/issue-696-lessons-only-certificate.sql
@@ -1,0 +1,168 @@
+-- Issue #696 — a course with lessons but no exams must be able to earn a
+-- certificate. `calculate_course_completion()` used to return `eligible: null`
+-- for such a course, because BOOL_AND()/AVG() over zero exam rows is NULL and
+-- three-valued logic collapsed the whole verdict.
+--
+-- Runs entirely inside a transaction that is rolled back, so it leaves the
+-- seeded database untouched.
+--
+--   docker exec -i supabase_db_lms-front psql -U postgres -d postgres -P pager=off \
+--     < tests/sql/issue-696-lessons-only-certificate.sql
+--
+-- Uses Default School and the seeded student. Each assertion RAISEs on failure
+-- and the script ends with a `PASS:` notice.
+begin;
+
+-- Fixture courses would otherwise trip the free plan's course cap (#658).
+set local app.bypass_plan_limits = 'on';
+
+do $$
+declare
+  v_tenant    constant uuid := '00000000-0000-0000-0000-000000000001';
+  v_student   constant uuid := 'a1000000-0000-0000-0000-000000000001'; -- student@e2etest.com
+  v_author    uuid;
+  v_course_a  int;   -- lessons only
+  v_course_b  int;   -- lessons + exam
+  v_course_c  int;   -- nothing published
+  v_lesson_a1 bigint;
+  v_lesson_a2 bigint;
+  v_lesson_b1 bigint;
+  v_exam_b    int;
+  v_submission int;
+  v_res       jsonb;
+  v_certs     int;
+begin
+  -- ── fixtures ──────────────────────────────────────────────────────────────
+  select user_id into v_author from tenant_users
+   where tenant_id = v_tenant and role in ('admin','teacher') and status = 'active' limit 1;
+  if v_author is null then raise exception 'fixture: no staff member in Default School'; end if;
+
+  -- Course A: two published lessons, no exams at all.
+  insert into courses (title, author_id, tenant_id, status)
+  values ('696 lessons-only course', v_author, v_tenant, 'published')
+  returning course_id into v_course_a;
+
+  insert into lessons (course_id, tenant_id, title, sequence, status)
+  values (v_course_a, v_tenant, '696 A lesson 1', 1, 'published') returning id into v_lesson_a1;
+  insert into lessons (course_id, tenant_id, title, sequence, status)
+  values (v_course_a, v_tenant, '696 A lesson 2', 2, 'published') returning id into v_lesson_a2;
+
+  insert into certificate_templates (course_id, tenant_id, template_name, is_active)
+  values (v_course_a, v_tenant, '696 template A', true);
+
+  -- ── 1. no lessons completed yet: not eligible, and an actual boolean ──────
+  v_res := calculate_course_completion(v_student, v_course_a);
+  if jsonb_typeof(v_res->'eligible') <> 'boolean' then
+    raise exception '§1 eligible is %, expected a boolean (payload: %)',
+      jsonb_typeof(v_res->'eligible'), v_res;
+  end if;
+  if (v_res->>'eligible')::boolean then
+    raise exception '§1 a course with zero lessons completed must not be eligible (payload: %)', v_res;
+  end if;
+
+  -- ── 2. half the lessons done: still not eligible ──────────────────────────
+  insert into lesson_completions (user_id, lesson_id) values (v_student, v_lesson_a1);
+  v_res := calculate_course_completion(v_student, v_course_a);
+  if (v_res->>'eligible')::boolean is not false then
+    raise exception '§2 50%% lesson completion must not be eligible (payload: %)', v_res;
+  end if;
+  if (v_res->>'completionPercentage')::numeric <> 50 then
+    raise exception '§2 expected completionPercentage 50, got % (payload: %)',
+      v_res->>'completionPercentage', v_res;
+  end if;
+
+  -- ── 3. THE REGRESSION: all lessons done, no exams ⇒ eligible ──────────────
+  insert into lesson_completions (user_id, lesson_id) values (v_student, v_lesson_a2);
+  v_res := calculate_course_completion(v_student, v_course_a);
+  if jsonb_typeof(v_res->'eligible') <> 'boolean' then
+    raise exception '§3 eligible is % — this is the #696 regression (payload: %)',
+      jsonb_typeof(v_res->'eligible'), v_res;
+  end if;
+  if not (v_res->>'eligible')::boolean then
+    raise exception '§3 a fully completed lessons-only course must be eligible (payload: %)', v_res;
+  end if;
+  if (v_res->>'totalExams')::int <> 0 then
+    raise exception '§3 fixture drift: course A should have no exams (payload: %)', v_res;
+  end if;
+
+  -- ── 4. the lesson-completion trigger actually issued the certificate ──────
+  select count(*) into v_certs
+  from certificates where user_id = v_student and course_id = v_course_a and revoked_at is null;
+  if v_certs <> 1 then
+    raise exception '§4 expected exactly 1 auto-issued certificate for the lessons-only course, got %', v_certs;
+  end if;
+
+  -- ── 5. NULL template thresholds still produce a boolean verdict ───────────
+  update certificate_templates
+     set min_lesson_completion_pct = null,
+         min_exam_pass_score = null,
+         requires_all_exams = null
+   where course_id = v_course_a;
+  v_res := calculate_course_completion(v_student, v_course_a);
+  if jsonb_typeof(v_res->'eligible') <> 'boolean' then
+    raise exception '§5 NULL template thresholds must not produce a null verdict (payload: %)', v_res;
+  end if;
+  if not (v_res->>'eligible')::boolean then
+    raise exception '§5 NULL thresholds should fall back to the defaults and stay eligible (payload: %)', v_res;
+  end if;
+
+  -- ── 6. a course WITH an exam is unchanged: unpassed exam ⇒ not eligible ───
+  insert into courses (title, author_id, tenant_id, status)
+  values ('696 course with exam', v_author, v_tenant, 'published')
+  returning course_id into v_course_b;
+
+  insert into lessons (course_id, tenant_id, title, sequence, status)
+  values (v_course_b, v_tenant, '696 B lesson 1', 1, 'published') returning id into v_lesson_b1;
+
+  insert into exams (course_id, tenant_id, title, duration, status, created_by)
+  values (v_course_b, v_tenant, '696 B exam', 60, 'published', v_author)
+  returning exam_id into v_exam_b;
+
+  insert into certificate_templates (course_id, tenant_id, template_name, is_active, min_exam_pass_score)
+  values (v_course_b, v_tenant, '696 template B', true, 70);
+
+  insert into lesson_completions (user_id, lesson_id) values (v_student, v_lesson_b1);
+
+  v_res := calculate_course_completion(v_student, v_course_b);
+  if (v_res->>'eligible')::boolean is not false then
+    raise exception '§6 lessons done but exam unsubmitted must not be eligible (payload: %)', v_res;
+  end if;
+
+  -- a submitted-but-failed exam is still not eligible
+  insert into exam_submissions (exam_id, student_id, tenant_id)
+  values (v_exam_b, v_student, v_tenant) returning submission_id into v_submission;
+  insert into exam_scores (submission_id, student_id, exam_id, score)
+  values (v_submission, v_student, v_exam_b, 40);
+
+  v_res := calculate_course_completion(v_student, v_course_b);
+  if (v_res->>'eligible')::boolean is not false then
+    raise exception '§6 a failed exam must not be eligible (payload: %)', v_res;
+  end if;
+
+  -- ── 7. …and a passed exam with all lessons done IS eligible ───────────────
+  update exam_scores set score = 90 where submission_id = v_submission;
+  v_res := calculate_course_completion(v_student, v_course_b);
+  if not (v_res->>'eligible')::boolean then
+    raise exception '§7 passed exam + complete lessons must be eligible (payload: %)', v_res;
+  end if;
+
+  -- ── 8. a course with nothing published is never eligible ──────────────────
+  insert into courses (title, author_id, tenant_id, status)
+  values ('696 empty course', v_author, v_tenant, 'published')
+  returning course_id into v_course_c;
+
+  insert into certificate_templates (course_id, tenant_id, template_name, is_active, min_lesson_completion_pct)
+  values (v_course_c, v_tenant, '696 template C', true, 0);
+
+  v_res := calculate_course_completion(v_student, v_course_c);
+  if jsonb_typeof(v_res->'eligible') <> 'boolean' then
+    raise exception '§8 empty course must return a boolean verdict (payload: %)', v_res;
+  end if;
+  if (v_res->>'eligible')::boolean then
+    raise exception '§8 a course with no published lessons or exams must never be eligible (payload: %)', v_res;
+  end if;
+
+  raise notice 'PASS: #696 — lessons-only courses are certificate-eligible, exam courses and empty courses unchanged';
+end $$;
+
+rollback;

--- a/tests/unit/certificate-credential-evidence.test.ts
+++ b/tests/unit/certificate-credential-evidence.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+    generateAchievementCredential,
+    type AchievementCredentialInput,
+    type CompletionData,
+} from '@/lib/certificates/open-badges'
+
+const APP_URL = 'https://school.example.com'
+
+function buildInput(completion: Partial<CompletionData>): AchievementCredentialInput {
+    return {
+        certificateId: 'cert-1',
+        userId: 'user-1',
+        userEmail: 'student@example.com',
+        userName: 'Ada Lovelace',
+        courseId: 1002,
+        courseTitle: 'Web Development Basics',
+        courseDescription: 'The basics',
+        verificationCode: 'CODE123',
+        issuedAt: new Date('2026-09-11T00:00:00Z'),
+        template: {
+            name: 'Web Development Basics Certificate',
+            achievement_type: 'Certificate',
+            min_lesson_completion_pct: 100,
+            min_exam_pass_score: 70,
+            requires_all_exams: true,
+        },
+        completionData: {
+            totalLessons: 1,
+            completedLessons: 1,
+            completionPercentage: 100,
+            totalExams: 0,
+            submittedExams: 0,
+            averageExamScore: 0,
+            allExamsPassed: true,
+            completedAt: '2026-09-11T00:00:00Z',
+            ...completion,
+        },
+    } as AchievementCredentialInput
+}
+
+describe('certificate credential evidence (#696)', () => {
+    it('omits the exam clause for a course with no exams', () => {
+        const credential = generateAchievementCredential(buildInput({}), APP_URL, 'Example School')
+
+        const description = credential.evidence?.[0]?.description ?? ''
+        expect(description).toBe('Completed 1 of 1 lessons (100%)')
+        expect(description).not.toContain('exams')
+    })
+
+    it('keeps the exam clause when the course actually has exams', () => {
+        const credential = generateAchievementCredential(
+            buildInput({
+                totalLessons: 4,
+                completedLessons: 4,
+                totalExams: 2,
+                submittedExams: 2,
+                averageExamScore: 88,
+            }),
+            APP_URL,
+            'Example School'
+        )
+
+        expect(credential.evidence?.[0]?.description).toBe(
+            'Completed 4 of 4 lessons (100%) and achieved 88% average on 2 exams'
+        )
+    })
+})


### PR DESCRIPTION
## What

`calculate_course_completion()` returned `"eligible": null` for any course with no published exams, so a course made of lessons alone could never issue a certificate. A new migration decides the exam requirement in an explicit branch and treats "no published exams" as vacuously satisfied, and a rolled-back SQL regression script pins the behaviour. One follow-on: the Open Badges evidence string now omits its exam clause for a course with no exams, instead of baking "0% average on 0 exams" into a permanent credential.

Closes #696

## Why

The function decided eligibility inside one boolean expression:

```sql
v_eligible := (
  v_completion_pct >= v_template.min_lesson_completion_pct
  AND (
    (v_template.requires_all_exams = true AND v_submitted_exams = v_total_exams AND v_all_exams_passed)
    OR (v_template.requires_all_exams = false AND v_avg_score >= v_template.min_exam_pass_score)
  )
);
```

`v_all_exams_passed` is `BOOL_AND(...)` and `v_avg_score` is `AVG(...)` over the student's scored submissions. With zero published exams both aggregates run over an empty set and return `NULL`, and in three-valued logic `true AND NULL` is `NULL` and `NULL OR NULL` is `NULL` — so the verdict was neither true nor false. `jsonb_build_object` emitted it faithfully as `"eligible": null`, and every consumer reads that as "not eligible": `check_and_issue_certificate` casts it with `(v_completion->>'eligible')::BOOLEAN`, and the TypeScript helpers in `lib/certificates/issue-certificate.ts` use `data.eligible || false`.

Because both auto-issuance triggers (`lesson_completions` and `exam_scores`) route through this function, the entire certificate automation was dead for lessons-only courses — at any completion percentage, with any active template. Exactly the payload reported in the issue, reproduced on `master`:

```
ERROR:  §3 eligible is null — this is the #696 regression (payload: {"eligible": null,
  "totalExams": 0, "totalLessons": 2, "completedLessons": 2, "completionPercentage": 100.00,
  "allExamsPassed": false, "submittedExams": 0, ...})
```

### What the migration changes

- **"No published exams" satisfies the exam requirement.** Decided in an `IF`/`ELSIF` ladder over a dedicated `v_exams_ok` variable *before* the `requires_all_exams` branch, so it covers both template modes at once rather than patching each separately.
- **The nullable template thresholds are read through `COALESCE`** to their table defaults (100 / 70 / true). `min_lesson_completion_pct`, `min_exam_pass_score` and `requires_all_exams` all have defaults but are nullable, so an explicit `NULL` in any of them produced the identical `eligible: null` symptom by a different route.
- **The verdict itself is `COALESCE`d to `false`**, so the function can never again return a null eligibility regardless of what a future edit does upstream of it.
- **A course with no published lessons *and* no published exams is explicitly not eligible.** Without this guard, "no exams means passed" plus a template whose `min_lesson_completion_pct` is `0` would hand out certificates for a completely empty course. That case returns `null` today (read as not eligible), so the guard preserves the current outcome rather than changing it.

The result JSON keeps its shape and keys. The only differences are that `eligible` is now always a real boolean, `allExamsPassed` reports `true` rather than `false` when there are no exams to pass, and `reason` accompanies the explicit not-eligible early returns.

The replacement keeps the original's `STABLE` / `SECURITY INVOKER` attributes (verified against `pg_proc`, not just the migration text). Nothing in the application duplicates the verdict — `lib/certificates/issue-certificate.ts` and the MCP `certificates` tool both delegate entirely to this RPC.

### The one application-code consequence

Making lessons-only courses certifiable makes `generateAchievementCredential()` in `lib/certificates/open-badges.ts` reachable for a course with no exams, where its evidence string read:

> Completed 1 of 1 lessons (100%) **and achieved 0% average on 0 exams**

That text is baked into a permanent Open Badges credential and served from the public `/verify/<code>` page, so the exam clause is now omitted entirely when `totalExams` is 0. `tests/unit/certificate-credential-evidence.test.ts` covers both shapes.

### Deliberately out of scope

- **No retroactive backfill.** Students who already finished a lessons-only course get nothing until a trigger fires for them again. Issuing certificates retroactively is a data migration with its own blast radius and belongs in its own change.
- `required_lesson_ids` / `required_exam_ids` on the template are still unread by this function, as they always have been.
- Heads-up on a doc drift found while surveying, not fixed here: `docs/DATABASE_SCHEMA.md` (lines 671 and 891) describes `calculate_course_completion()` and `check_and_issue_certificate()` as `SECURITY DEFINER`. Neither ever was — `pg_proc.prosecdef` is `false` for both. Only `issue_certificate_if_eligible()` is a definer function.

## How to QA

The regression lives at the database level, so the script is the QA — it builds its own fixtures, asserts, and rolls everything back, leaving the seeded database untouched.

1. `npm run db:reset`
2. Run the regression script:
   ```bash
   docker exec -i supabase_db_lms-front psql -U postgres -d postgres -P pager=off \
     < tests/sql/issue-696-lessons-only-certificate.sql
   ```
   Expected: `NOTICE: PASS: #696 — lessons-only courses are certificate-eligible, exam courses and empty courses unchanged`, followed by `ROLLBACK`.
3. To see the bug it fixes, check out `master` (or just run the script *before* applying `supabase/migrations/20260911120000_lessons_only_certificate_eligibility.sql`) and run the same script. It fails at `§3` with the `eligible: null` payload quoted above.

The eight assertions, in order:

| § | Case | Expected |
|---|---|---|
| 1 | Lessons-only course, nothing completed | `eligible` is a **boolean**, and `false` |
| 2 | Lessons-only course, 1 of 2 lessons done | `false`, `completionPercentage` 50 |
| 3 | **The regression** — lessons-only, 2 of 2 done | `true` (was `null`) |
| 4 | The `lesson_completions` trigger chain | exactly one certificate row auto-issued |
| 5 | Template with NULL thresholds | boolean verdict, falls back to the defaults |
| 6 | Course *with* an exam: unsubmitted, then failed | `false` both times — unchanged behaviour |
| 7 | Course with an exam: passed, lessons done | `true` — unchanged behaviour |
| 8 | Course with nothing published, 0% threshold | `false` — the new guard |

§4 is worth a look: it asserts the real trigger chain (`lesson_completions` → `on_lesson_completed_trigger` → `issue_certificate_if_eligible` → `check_and_issue_certificate` → this function) actually writes a `certificates` row, which is the user-visible symptom from the #676 QA recording.

For the credential evidence string, `npm run test:unit` is the check — `tests/unit/certificate-credential-evidence.test.ts` asserts both shapes (no exams: no exam clause; exams: clause intact).

There is no seeded course affected by this locally — the local seed has no `certificate_templates` rows at all, which is why the bug survived this long.

## Screenshots / GIF

None — this is a database function plus one string inside the machine-readable Open Badges credential. Neither has a rendered surface: no component or page reads the credential's `evidence` block (the `/verify/<code>` page renders `completion_data`, not the credential JSON). The verification evidence is the before/after script run quoted above.

## Checklist

- [x] `npm run typecheck` and `npm run test:unit` pass — typecheck clean, 1099 tests across 88 files green
- [x] `npm run build` passes — clean, exit 0
- [x] Every new tenant-scoped query filters by `tenant_id` (or the table genuinely has no such column) — no new queries; the function's existing reads are scoped by `course_id`/`user_id` as before
- [x] Tested with every relevant role (student / teacher / admin) — the function is role-agnostic; the script exercises it for a student, which is the only role that earns certificates
- [x] Loading and error states handled — n/a, no UI
- [x] New UI strings added to both `messages/en.json` and `messages/es.json` — n/a, no new UI strings (the credential evidence text is machine-readable Open Badges payload, untranslated today as before)
- [x] Migration applies cleanly, has RLS policies, and `lib/database.types.ts` was regenerated — applied cleanly to the fully-migrated local database; it is a standalone `CREATE OR REPLACE FUNCTION` with no ordering dependency, so no RLS policy is involved and the RPC signature is unchanged, leaving `lib/database.types.ts` correct as-is (and `npm run db:types` reads `--linked`, i.e. cloud, so regenerating it here would pull unrelated drift)

> **After merge:** this migration still needs `supabase db push` to reach the cloud database — it is not applied there yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qd5dVvZZAWKjJfqQwFajUU
