### PR TITLE
fix(course-settings): status dropdown reads Draft / Published / Archived (#688)

### DIFF
--- a/components/teacher/course-form.tsx
+++ b/components/teacher/course-form.tsx
@@ -338,9 +338,9 @@ export function CourseForm({ categories, initialData }: CourseFormProps) {
                 <SelectValue placeholder={t('statusPlaceholder')} />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="draft">{t('statusHints.draft')}</SelectItem>
-                <SelectItem value="published">{t('statusHints.published')}</SelectItem>
-                <SelectItem value="archived">{t('statusHints.archived')}</SelectItem>
+                <SelectItem value="draft">{t('statusOptions.draft')}</SelectItem>
+                <SelectItem value="published">{t('statusOptions.published')}</SelectItem>
+                <SelectItem value="archived">{t('statusOptions.archived')}</SelectItem>
               </SelectContent>
             </Select>
             <p className="text-xs text-muted-foreground">

--- a/messages/en.json
+++ b/messages/en.json
@@ -1067,6 +1067,11 @@
         "categoryPlaceholder": "Select a category",
         "statusLabel": "Status",
         "statusPlaceholder": "Select status",
+        "statusOptions": {
+          "draft": "Draft",
+          "published": "Published",
+          "archived": "Archived"
+        },
         "statusHints": {
           "draft": "Only you can see this course.",
           "published": "Course is visible to students and ready for enrollment.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -1067,10 +1067,15 @@
         "categoryPlaceholder": "Selecciona una categoría",
         "statusLabel": "Estado",
         "statusPlaceholder": "Selecciona el estado",
+        "statusOptions": {
+          "draft": "Borrador",
+          "published": "Publicado",
+          "archived": "Archivado"
+        },
         "statusHints": {
           "draft": "Sólo tú puedes ver este curso.",
           "published": "El curso es visible para los estudiantes y está listo para la inscripción.",
-          "archived": "el curso está oculto del catálogo pero los estudiantes existentes conservan el acceso."
+          "archived": "El curso está oculto del catálogo pero los estudiantes existentes conservan el acceso."
         },
         "limitReached": "Límite de Cursos Alcanzado",
         "limitReachedDesc": "Tu plan {plan} está limitado a {limit} cursos. Actualmente tienes {current} cursos. Actualiza tu plan para crear más cursos.",

--- a/tests/playwright/loop-1-creator-publishes.spec.ts
+++ b/tests/playwright/loop-1-creator-publishes.spec.ts
@@ -433,9 +433,9 @@ test('a creator signs up, creates a school, publishes a course with a lesson and
     })
     const status = page.locator('#status')
     await expect(status).toBeVisible({ timeout: 20_000 })
-    // The option labels are the status hints today (see the ux gap linked
-    // from #670); match the one that describes "published".
-    const publishedOption = page.getByRole('option', { name: /visible to students/i })
+    // Short state labels since #688 — the hint sentence stays under the field,
+    // it is no longer what the options read.
+    const publishedOption = page.getByRole('option', { name: 'Published', exact: true })
     await clickUntil(status, () => publishedOption.isVisible())
     await clickUntil(publishedOption, async () => !(await publishedOption.isVisible()))
     await clickUntil(


### PR DESCRIPTION
Closes #688.

## What was wrong

On `/dashboard/teacher/courses/<id>/settings` the status `Select` rendered `statusHints.*` as its option labels, so the dropdown read:

> Only you can see this course.
> Course is visible to students and ready for enrollment.
> Course is hidden from catalog but existing students retain access.

A teacher looking for "Published" had to read a full sentence to find it — and the same sentence was already printed under the field for whatever was selected, so the options duplicated the hint rather than naming the state.

## What changed

- New `dashboard.teacher.courseForm.statusOptions.*` in **en** and **es** (Draft / Published / Archived · Borrador / Publicado / Archivado); the three `SelectItem`s point at it.
- The hint under the field is **unchanged** and still tracks the selection — that is where the explanation belongs.
- The Spanish `statusHints.archived` sentence started lowercase (`"el curso está oculto…"`). It is now the only sentence on screen for that state, so it is capitalised.
- `tests/playwright/loop-1-creator-publishes.spec.ts` step 4 matched the option by its hint text (`/visible to students/i`) and carried a comment pointing at this very gap; it now matches the exact label `Published`.

Short labels already existed at `dashboard.teacher.manageCourse.status.*`, but the component's `t` is scoped to `courseForm`, so local keys beat a second `useTranslations` call for three words.

## QA

```bash
npm run typecheck            # clean
npm run test:unit            # 1099 passed, incl. the catalogue-wide en/es parity test
npx playwright test -g "loop 1"   # step 4 now selects by the short label
```

Manually: open a course's settings as a teacher, open the Status dropdown — the three options read Draft / Published / Archived, and the sentence under the field still changes as you pick one. In `/es`, Borrador / Publicado / Archivado.

The local Supabase stack was down for this change, so the loop-1 spec was not run on this machine — it runs on every PR in CI (4 shards, no env-skips), which is what gates this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GsCUfngsjLWq1gqVXVNaVj
