### PR TITLE
fix(public): course CTA sends first-time visitors to sign-up, not login (#685)

### DIFF
--- a/app/[locale]/(public)/courses/[id]/page.tsx
+++ b/app/[locale]/(public)/courses/[id]/page.tsx
@@ -198,6 +198,14 @@ export default async function CourseDetailsPage(props: {
         ? t('pricing.free')
         : formatPrice(Number(courseProduct.price), courseProduct.currency);
 
+    // Where an anonymous visitor lands once they have an account. Unchanged
+    // from when the CTA pointed at login: the free path re-enters this page
+    // with `enroll=1` so `AutoFreeEnrollButton` finishes the job, the paid one
+    // goes straight to checkout.
+    const anonymousNext = isFree
+        ? `/courses/${params.id}?enroll=1`
+        : `/checkout?courseId=${course.course_id}`;
+
     const instructor = author ? {
         name: author.full_name || t('sections.instructor.defaultName'),
         avatar_url: author.avatar_url,
@@ -523,11 +531,26 @@ export default async function CourseDetailsPage(props: {
                                     {/* CTA */}
                                     <div className="space-y-3">
                                         {!userId ? (
-                                            <Link href={`/auth/login?next=${encodeURIComponent(isFree ? `/courses/${params.id}?enroll=1` : `/checkout?courseId=${course.course_id}`)}`}>
-                                                <Button data-testid="course-enroll-cta" className="w-full h-11 bg-cyan-500 hover:bg-cyan-400 text-black font-bold text-sm shadow-lg shadow-cyan-500/20">
-                                                    {isFree ? t('pricing.enrollFree') : t('pricing.enrollNow')}
-                                                </Button>
-                                            </Link>
+                                            <div className="space-y-2">
+                                                {/* A visitor who arrived by a shared link most likely has no
+                                                    account yet, so the button goes to sign-up; the login link
+                                                    below carries the same `next` for the ones who do (#685). */}
+                                                <Link href={`/auth/sign-up?next=${encodeURIComponent(anonymousNext)}`}>
+                                                    <Button data-testid="course-enroll-cta" className="w-full h-11 bg-cyan-500 hover:bg-cyan-400 text-black font-bold text-sm shadow-lg shadow-cyan-500/20">
+                                                        {isFree ? t('pricing.enrollFree') : t('pricing.enrollNow')}
+                                                    </Button>
+                                                </Link>
+                                                <p className="text-center text-xs text-zinc-400">
+                                                    {t('pricing.haveAccount')}{' '}
+                                                    <Link
+                                                        data-testid="course-enroll-login"
+                                                        href={`/auth/login?next=${encodeURIComponent(anonymousNext)}`}
+                                                        className="text-cyan-400 hover:underline"
+                                                    >
+                                                        {t('pricing.logIn')}
+                                                    </Link>
+                                                </p>
+                                            </div>
                                         ) : hasAccess ? (
                                             <Link href={`/dashboard/student/courses/${course.course_id}`}>
                                                 <Button data-testid="course-go-to-course" className="w-full h-11 bg-emerald-600 hover:bg-emerald-500 text-white font-bold text-sm">

--- a/messages/en.json
+++ b/messages/en.json
@@ -4813,6 +4813,8 @@
       "enrollNow": "Enroll Now",
       "goToCourse": "Go to Course",
       "buyNow": "Buy Now",
+      "haveAccount": "Already have an account?",
+      "logIn": "Log in",
       "or": "or",
       "subscription": "Get access via Subscription",
       "includes": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -4813,6 +4813,8 @@
       "enrollNow": "Inscribirse Ahora",
       "goToCourse": "Ir al Curso",
       "buyNow": "Comprar Ahora",
+      "haveAccount": "¿Ya tienes una cuenta?",
+      "logIn": "Inicia sesión",
       "or": "o",
       "subscription": "Obtén acceso mediante Suscripción",
       "includes": {

--- a/tests/playwright/loop-1-creator-publishes.spec.ts
+++ b/tests/playwright/loop-1-creator-publishes.spec.ts
@@ -462,9 +462,15 @@ test('a creator signs up, creates a school, publishes a course with a lesson and
       await expect(anon.getByText(lessonTitle)).toBeVisible()
       await expect(anon.getByText('Free', { exact: true }).first()).toBeVisible()
 
+      // A visitor with no account gets sign-up, not a login form (#685); the
+      // secondary link carries the same intent for a returning student.
       const cta = anon.getByRole('link', { name: /enroll for free/i })
       await expect(cta).toBeVisible()
-      await expect(cta).toHaveAttribute('href', /\/auth\/login\?next=/)
+      await expect(cta).toHaveAttribute('href', /\/auth\/sign-up\?next=/)
+      await expect(anon.getByTestId('course-enroll-login')).toHaveAttribute(
+        'href',
+        /\/auth\/login\?next=/,
+      )
 
       await anon.goto(`${base}/en/courses`, { waitUntil: 'domcontentloaded' })
       const card = anon.getByRole('link', { name: new RegExp(courseTitle) })
@@ -573,7 +579,11 @@ test('en español: crea la escuela y la página pública del curso se ve en espa
       await expect(anon.getByText('Gratis', { exact: true }).first()).toBeVisible()
       const cta = anon.getByRole('link', { name: /inscribirse gratis/i })
       await expect(cta).toBeVisible()
-      await expect(cta).toHaveAttribute('href', /\/auth\/login\?next=/)
+      await expect(cta).toHaveAttribute('href', /\/auth\/sign-up\?next=/)
+      await expect(anon.getByTestId('course-enroll-login')).toHaveAttribute(
+        'href',
+        /\/auth\/login\?next=/,
+      )
 
       await anon.goto(`${base}/es/courses`, { waitUntil: 'domcontentloaded' })
       const card = anon.getByRole('link', { name: new RegExp(courseTitle) })

--- a/tests/playwright/loop-2-student-learns.spec.ts
+++ b/tests/playwright/loop-2-student-learns.spec.ts
@@ -362,20 +362,22 @@ test.describe('Loop 2 — public link → join → learn → verifiable certific
     const admin = getServiceRoleClient()
 
     /* ---- 1. Public link → sign-up with `next` preserved → auto-enroll ---- */
-    await test.step('anonymous course page offers free enrollment and keeps the intent through login and sign-up', async () => {
+    await test.step('anonymous course page offers free enrollment and keeps the intent into sign-up', async () => {
       await page.goto(`${BASE}/${LOCALE}/courses/${courseId}`, { waitUntil: 'domcontentloaded' })
       const cta = page.getByTestId('course-enroll-cta')
       await expect(cta).toBeVisible({ timeout: 30_000 })
       await expect(cta).toHaveText(/enroll for free/i)
 
-      await domClick(page, 'course-enroll-cta')
-      await page.waitForURL(/\/auth\/login\?/, { timeout: 30_000 })
-      expect(new URL(page.url()).searchParams.get('next')).toBe(`/courses/${courseId}?enroll=1`)
+      // A first-time visitor arrived by a shared link and has no account, so
+      // the CTA goes straight to sign-up (#685); returning students take the
+      // secondary link, which carries the same intent.
+      const loginLink = page.getByTestId('course-enroll-login')
+      await expect(loginLink).toBeVisible({ timeout: 30_000 })
+      expect(await loginLink.getAttribute('href')).toContain(
+        encodeURIComponent(`/courses/${courseId}?enroll=1`),
+      )
 
-      // First-time visitors have no account: the login page forwards `next` to sign-up.
-      const signupLink = page.getByTestId('login-signup-link')
-      await expect(signupLink).toBeVisible({ timeout: 30_000 })
-      await signupLink.click()
+      await domClick(page, 'course-enroll-cta')
       await page.waitForURL(/\/auth\/sign-up\?/, { timeout: 30_000 })
       expect(new URL(page.url()).searchParams.get('next')).toBe(`/courses/${courseId}?enroll=1`)
     })

--- a/tests/playwright/paid-course-checkout-intent.spec.ts
+++ b/tests/playwright/paid-course-checkout-intent.spec.ts
@@ -147,19 +147,19 @@ test.describe('Paid course CTA keeps checkout intent for a new visitor (#684)', 
     const email = `paid684-${RUN}@e2etest.com`
     const checkoutPath = `/checkout?courseId=${courseId}`
 
-    await test.step('anonymous course page sends the visitor to login with the checkout as next', async () => {
+    await test.step('anonymous course page sends the visitor to sign-up with the checkout as next', async () => {
       await page.goto(`${BASE}/${LOCALE}/courses/${courseId}`, { waitUntil: 'domcontentloaded' })
       const cta = page.getByTestId('course-enroll-cta')
       await expect(cta).toBeVisible({ timeout: 30_000 })
       await expect(cta).toHaveText(/enroll now/i)
 
-      await domClick(page, cta)
-      await page.waitForURL(/\/auth\/login\?/, { timeout: 30_000 })
-      expect(new URL(page.url()).searchParams.get('next')).toBe(checkoutPath)
+      // Sign-up is the primary path for a first-time visitor (#685); the
+      // login link beside it carries the same checkout intent.
+      const loginLink = page.getByTestId('course-enroll-login')
+      await expect(loginLink).toBeVisible({ timeout: 30_000 })
+      expect(await loginLink.getAttribute('href')).toContain(encodeURIComponent(checkoutPath))
 
-      const signupLink = page.getByTestId('login-signup-link')
-      await expect(signupLink).toBeVisible({ timeout: 30_000 })
-      await signupLink.click()
+      await domClick(page, cta)
       await page.waitForURL(/\/auth\/sign-up\?/, { timeout: 30_000 })
       expect(new URL(page.url()).searchParams.get('next')).toBe(checkoutPath)
     })


### PR DESCRIPTION
Closes #685.

## What was wrong

`/courses/<id>` pointed both "Enroll for Free" and "Enroll Now" at `/auth/login?next=…`. The visitor most likely to click that button arrived by a shared public link and has **never had an account**, so at the moment of highest intent they met a form they could not fill, and had to spot the small "Don't have an account? Sign up" footer link to continue. Nothing broke — `next` survived the hop — it was one avoidable step in the wrong place.

## What changed

- Primary button → `/auth/sign-up?next=…`.
- A secondary **"Already have an account? Log in"** sits under it, carrying the same `next`, so the returning student loses nothing.
- The two destinations are hoisted into one `anonymousNext` const (`/courses/<id>?enroll=1` when free so `AutoFreeEnrollButton` still finishes the job, `/checkout?courseId=<id>` when paid) — unchanged values, but the two links can no longer drift apart.
- New keys `coursePublicDetails.pricing.haveAccount` / `.logIn` in **en** and **es**.

`sign-up-form.tsx` already reads `next` (via `getSafeNextPath`) and forwards it through the confirm and OAuth callback URLs, so nothing else needed touching.

## Tests

Two specs drove the old login → sign-up hop explicitly and now expect the direct path — each also asserts the secondary login link carries the same intent, which preserves what the old hop covered:

- `loop-2-student-learns.spec.ts` (#671) — free course, `next=/courses/<id>?enroll=1`
- `paid-course-checkout-intent.spec.ts` (#684) — paid course, `next=/checkout?courseId=<id>`

```bash
npm run typecheck    # clean
npm run test:unit    # 1099 passed, incl. en/es catalogue parity
npx eslint …         # 0 errors (2 pre-existing <img> warnings on this file)
```

The local Supabase stack was down, so the two specs were not run on this machine — they run on every PR in CI.

## Noticed, deliberately not in this PR

Two other public CTAs have the same first-visitor shape and are **not** touched here, to keep this reviewable against #685's scope — filed separately:

- `app/[locale]/(public)/products/[productId]/page.tsx:98` — anonymous visitors get a **Login** button; the copy there is also hardcoded English ("Please login to request payment information").
- `components/public/free-subscribe-button.tsx:52` — the free-plan CTA on `/pricing` goes to login with `next=/pricing?subscribe=<planId>`.

The server-side `redirect()`s in `/checkout`, `/checkout/manual`, `/checkout/success` and `/join-school` are guards on already-intentful flows rather than entry CTAs, and are fine as login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GsCUfngsjLWq1gqVXVNaVj
